### PR TITLE
feat: export/import memory for cross-machine migration

### DIFF
--- a/hermes_memory_provider/cli.py
+++ b/hermes_memory_provider/cli.py
@@ -31,6 +31,14 @@ def register_cli(subparser):
     inspect_cmd.add_argument("--limit", type=int, default=10, help="Max results")
 
     mn_cmds.add_parser("clear", help="Clear scratchpad")
+
+    export_cmd = mn_cmds.add_parser("export", help="Export all memories to a JSON file")
+    export_cmd.add_argument("--output", "-o", type=str, required=True, help="Output JSON file path")
+
+    import_cmd = mn_cmds.add_parser("import", help="Import memories from a JSON file")
+    import_cmd.add_argument("--input", "-i", type=str, required=True, help="Input JSON file path")
+    import_cmd.add_argument("--force", action="store_true", help="Overwrite existing records")
+
     mnemosyne_parser.set_defaults(func=mnemosyne_command)
 
 
@@ -78,5 +86,43 @@ def mnemosyne_command(args):
             print("Scratchpad cleared.")
         else:
             print("Cancelled.")
+
+    elif cmd == "export":
+        output_path = getattr(args, "output", None)
+        if not output_path:
+            print("Usage: hermes mnemosyne export --output <path>")
+            return 1
+        try:
+            from mnemosyne.core.memory import Mnemosyne
+            mem = Mnemosyne(session_id="hermes_default")
+            result = mem.export_to_file(output_path)
+            print(f"Exported {result['working_memory_count']} working, {result['episodic_memory_count']} episodic, {result['legacy_memories_count']} legacy, {result['triples_count']} triples to {output_path}")
+        except Exception as e:
+            print(f"Export failed: {e}")
+            return 1
+
+    elif cmd == "import":
+        input_path = getattr(args, "input", None)
+        force = getattr(args, "force", False)
+        if not input_path:
+            print("Usage: hermes mnemosyne import --input <path> [--force]")
+            return 1
+        try:
+            from mnemosyne.core.memory import Mnemosyne
+            mem = Mnemosyne(session_id="hermes_default")
+            stats = mem.import_from_file(input_path, force=force)
+            beam_stats = stats.get("beam", {})
+            legacy_stats = stats.get("legacy", {})
+            triples_stats = stats.get("triples", {})
+            print(f"Import complete:")
+            print(f"  Working: +{beam_stats.get('working_memory', {}).get('inserted', 0)}")
+            print(f"  Episodic: +{beam_stats.get('episodic_memory', {}).get('inserted', 0)}")
+            print(f"  Legacy: +{legacy_stats.get('inserted', 0)}")
+            print(f"  Triples: +{triples_stats.get('inserted', 0)}")
+            if force:
+                print(f"  (force mode: overwrites applied)")
+        except Exception as e:
+            print(f"Import failed: {e}")
+            return 1
 
     return 0

--- a/hermes_plugin/tools.py
+++ b/hermes_plugin/tools.py
@@ -209,6 +209,41 @@ SCRATCHPAD_CLEAR_SCHEMA = {
     }
 }
 
+EXPORT_SCHEMA = {
+    "name": "mnemosyne_export",
+    "description": "Export all Mnemosyne memories to a JSON file for backup or migration to another machine.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "output_path": {
+                "type": "string",
+                "description": "File path to write the export JSON (e.g., /tmp/mnemosyne_backup.json)"
+            }
+        },
+        "required": ["output_path"]
+    }
+}
+
+IMPORT_SCHEMA = {
+    "name": "mnemosyne_import",
+    "description": "Import Mnemosyne memories from a JSON file. Idempotent by default.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "input_path": {
+                "type": "string",
+                "description": "File path to read the export JSON from"
+            },
+            "force": {
+                "type": "boolean",
+                "description": "If true, overwrite existing records instead of skipping",
+                "default": False
+            }
+        },
+        "required": ["input_path"]
+    }
+}
+
 
 # Tool Handlers
 def mnemosyne_remember(args: dict, **kwargs) -> str:
@@ -365,6 +400,38 @@ def mnemosyne_invalidate(args: dict, **kwargs) -> str:
             "status": "invalidated" if ok else "not_found",
             "memory_id": memory_id,
             "replacement_id": replacement_id
+        })
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def mnemosyne_export(args: dict, **kwargs) -> str:
+    """Export all memories to a JSON file"""
+    try:
+        output_path = args.get("output_path", "").strip()
+        if not output_path:
+            return json.dumps({"error": "output_path is required"})
+
+        mem = _get_memory()
+        result = mem.export_to_file(output_path)
+        return json.dumps(result)
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def mnemosyne_import(args: dict, **kwargs) -> str:
+    """Import memories from a JSON file"""
+    try:
+        input_path = args.get("input_path", "").strip()
+        force = args.get("force", False)
+        if not input_path:
+            return json.dumps({"error": "input_path is required"})
+
+        mem = _get_memory()
+        stats = mem.import_from_file(input_path, force=force)
+        return json.dumps({
+            "status": "imported",
+            "stats": stats
         })
     except Exception as e:
         return json.dumps({"error": str(e)})

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -882,3 +882,207 @@ class BeamMemory:
             LIMIT ?
         """, (self.session_id, limit))
         return [dict(row) for row in cursor.fetchall()]
+
+    # ------------------------------------------------------------------
+    # Export / Import
+    # ------------------------------------------------------------------
+    def export_to_dict(self) -> Dict:
+        """
+        Export all BEAM data to a portable dictionary.
+        Includes working_memory, episodic_memory, embeddings, scratchpad,
+        and consolidation_log across ALL sessions (not just current).
+        """
+        cursor = self.conn.cursor()
+        export = {
+            "mnemosyne_export": {
+                "version": "1.0",
+                "export_date": datetime.now().isoformat(),
+                "source_db": str(self.db_path),
+                "component": "beam"
+            }
+        }
+
+        # Working memory (all sessions)
+        cursor.execute("""
+            SELECT id, content, source, timestamp, session_id, importance,
+                   metadata_json, valid_until, superseded_by, scope,
+                   recall_count, last_recalled, created_at
+            FROM working_memory
+            ORDER BY session_id, timestamp
+        """)
+        export["working_memory"] = [dict(row) for row in cursor.fetchall()]
+
+        # Episodic memory (all sessions)
+        cursor.execute("""
+            SELECT rowid, id, content, source, timestamp, session_id, importance,
+                   metadata_json, summary_of, valid_until, superseded_by, scope,
+                   recall_count, last_recalled, created_at
+            FROM episodic_memory
+            ORDER BY session_id, timestamp
+        """)
+        export["episodic_memory"] = [dict(row) for row in cursor.fetchall()]
+
+        # Episodic embeddings from vec_episodes
+        export["episodic_embeddings"] = []
+        if _vec_available(self.conn):
+            try:
+                cursor.execute("SELECT rowid, embedding FROM vec_episodes")
+                for row in cursor.fetchall():
+                    emb = row["embedding"]
+                    if isinstance(emb, bytes):
+                        emb = list(emb)
+                    elif isinstance(emb, str):
+                        try:
+                            emb = json.loads(emb)
+                        except Exception:
+                            pass
+                    export["episodic_embeddings"].append({
+                        "rowid": row["rowid"],
+                        "embedding": emb
+                    })
+            except Exception:
+                pass
+
+        # Scratchpad (all sessions)
+        cursor.execute("""
+            SELECT id, content, session_id, created_at, updated_at
+            FROM scratchpad
+            ORDER BY session_id, updated_at
+        """)
+        export["scratchpad"] = [dict(row) for row in cursor.fetchall()]
+
+        # Consolidation log (all sessions)
+        cursor.execute("""
+            SELECT id, session_id, items_consolidated, summary_preview, created_at
+            FROM consolidation_log
+            ORDER BY session_id, created_at
+        """)
+        export["consolidation_log"] = [dict(row) for row in cursor.fetchall()]
+
+        return export
+
+    def import_from_dict(self, data: Dict, force: bool = False) -> Dict:
+        """
+        Import BEAM data from a dictionary produced by export_to_dict().
+        Idempotent by default: skips records whose id already exists.
+        Set force=True to overwrite existing records.
+        Returns import statistics.
+        """
+        stats = {
+            "working_memory": {"inserted": 0, "skipped": 0, "overwritten": 0},
+            "episodic_memory": {"inserted": 0, "skipped": 0, "overwritten": 0, "embeddings_inserted": 0},
+            "scratchpad": {"inserted": 0, "updated": 0},
+            "consolidation_log": {"inserted": 0},
+        }
+        cursor = self.conn.cursor()
+
+        # -- Working memory --
+        for item in data.get("working_memory", []):
+            mid = item.get("id")
+            cursor.execute("SELECT 1 FROM working_memory WHERE id = ?", (mid,))
+            exists = cursor.fetchone() is not None
+            if exists and not force:
+                stats["working_memory"]["skipped"] += 1
+                continue
+            if exists and force:
+                cursor.execute("DELETE FROM working_memory WHERE id = ?", (mid,))
+                stats["working_memory"]["overwritten"] += 1
+            else:
+                stats["working_memory"]["inserted"] += 1
+            cursor.execute("""
+                INSERT INTO working_memory
+                (id, content, source, timestamp, session_id, importance, metadata_json,
+                 valid_until, superseded_by, scope, recall_count, last_recalled, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                mid, item.get("content"), item.get("source"), item.get("timestamp"),
+                item.get("session_id", "default"), item.get("importance", 0.5),
+                item.get("metadata_json", "{}"), item.get("valid_until"),
+                item.get("superseded_by"), item.get("scope", "session"),
+                item.get("recall_count", 0), item.get("last_recalled"), item.get("created_at")
+            ))
+        self.conn.commit()
+
+        # -- Episodic memory --
+        old_to_new_rowid = {}
+        for item in data.get("episodic_memory", []):
+            mid = item.get("id")
+            cursor.execute("SELECT rowid FROM episodic_memory WHERE id = ?", (mid,))
+            existing = cursor.fetchone()
+            if existing and not force:
+                stats["episodic_memory"]["skipped"] += 1
+                old_to_new_rowid[item.get("rowid")] = existing["rowid"]
+                continue
+            if existing and force:
+                cursor.execute("DELETE FROM episodic_memory WHERE id = ?", (mid,))
+                stats["episodic_memory"]["overwritten"] += 1
+            else:
+                stats["episodic_memory"]["inserted"] += 1
+            cursor.execute("""
+                INSERT INTO episodic_memory
+                (id, content, source, timestamp, session_id, importance, metadata_json,
+                 summary_of, valid_until, superseded_by, scope, recall_count, last_recalled, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                mid, item.get("content"), item.get("source"), item.get("timestamp"),
+                item.get("session_id", "default"), item.get("importance", 0.5),
+                item.get("metadata_json", "{}"), item.get("summary_of", ""),
+                item.get("valid_until"), item.get("superseded_by"),
+                item.get("scope", "session"), item.get("recall_count", 0),
+                item.get("last_recalled"), item.get("created_at")
+            ))
+            new_rowid = cursor.lastrowid
+            old_to_new_rowid[item.get("rowid")] = new_rowid
+        self.conn.commit()
+
+        # -- Episodic embeddings --
+        vec_ok = _vec_available(self.conn)
+        for emb_item in data.get("episodic_embeddings", []):
+            old_rowid = emb_item.get("rowid")
+            new_rowid = old_to_new_rowid.get(old_rowid)
+            if not new_rowid:
+                continue
+            embedding = emb_item.get("embedding")
+            if not embedding:
+                continue
+            if vec_ok:
+                try:
+                    _vec_insert(self.conn, new_rowid, embedding)
+                    stats["episodic_memory"]["embeddings_inserted"] += 1
+                except Exception:
+                    pass
+        if vec_ok:
+            self.conn.commit()
+
+        # -- Scratchpad --
+        for item in data.get("scratchpad", []):
+            pid = item.get("id")
+            cursor.execute("SELECT 1 FROM scratchpad WHERE id = ?", (pid,))
+            exists = cursor.fetchone() is not None
+            if exists:
+                cursor.execute("""
+                    UPDATE scratchpad SET content=?, session_id=?, created_at=?, updated_at=?
+                    WHERE id=?
+                """, (item.get("content"), item.get("session_id", "default"),
+                      item.get("created_at"), item.get("updated_at"), pid))
+                stats["scratchpad"]["updated"] += 1
+            else:
+                cursor.execute("""
+                    INSERT INTO scratchpad (id, content, session_id, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?)
+                """, (pid, item.get("content"), item.get("session_id", "default"),
+                      item.get("created_at"), item.get("updated_at")))
+                stats["scratchpad"]["inserted"] += 1
+        self.conn.commit()
+
+        # -- Consolidation log --
+        for item in data.get("consolidation_log", []):
+            cursor.execute("""
+                INSERT INTO consolidation_log (session_id, items_consolidated, summary_preview, created_at)
+                VALUES (?, ?, ?, ?)
+            """, (item.get("session_id", "default"), item.get("items_consolidated", 0),
+                  item.get("summary_preview", ""), item.get("created_at")))
+            stats["consolidation_log"]["inserted"] += 1
+        self.conn.commit()
+
+        return stats

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -266,6 +266,138 @@ class Mnemosyne:
         """Get consolidation history."""
         return self.beam.get_consolidation_log(limit=limit)
 
+    def export_to_file(self, output_path: str) -> Dict:
+        """
+        Export all Mnemosyne data (legacy + BEAM + triples) to a JSON file.
+        Returns export metadata.
+        """
+        from mnemosyne.core.triples import TripleStore
+        import json as _json
+
+        export = {
+            "mnemosyne_export": {
+                "version": "1.0",
+                "export_date": datetime.now().isoformat(),
+                "source_db": str(self.db_path),
+            }
+        }
+
+        # BEAM data
+        beam_data = self.beam.export_to_dict()
+        export["working_memory"] = beam_data.get("working_memory", [])
+        export["episodic_memory"] = beam_data.get("episodic_memory", [])
+        export["episodic_embeddings"] = beam_data.get("episodic_embeddings", [])
+        export["scratchpad"] = beam_data.get("scratchpad", [])
+        export["consolidation_log"] = beam_data.get("consolidation_log", [])
+
+        # Legacy memories
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            SELECT id, content, source, timestamp, session_id, importance,
+                   metadata_json, created_at
+            FROM memories
+            ORDER BY session_id, timestamp
+        """)
+        export["legacy_memories"] = [dict(row) for row in cursor.fetchall()]
+
+        # Legacy embeddings
+        cursor.execute("""
+            SELECT memory_id, embedding_json, model, created_at
+            FROM memory_embeddings
+            ORDER BY memory_id
+        """)
+        export["legacy_embeddings"] = [dict(row) for row in cursor.fetchall()]
+
+        # Triples
+        triples = TripleStore(db_path=self.db_path)
+        export["triples"] = triples.export_all()
+
+        with open(output_path, "w", encoding="utf-8") as f:
+            _json.dump(export, f, indent=2, ensure_ascii=False, default=str)
+
+        return {
+            "status": "exported",
+            "path": output_path,
+            "working_memory_count": len(export["working_memory"]),
+            "episodic_memory_count": len(export["episodic_memory"]),
+            "scratchpad_count": len(export["scratchpad"]),
+            "legacy_memories_count": len(export["legacy_memories"]),
+            "triples_count": len(export["triples"]),
+        }
+
+    def import_from_file(self, input_path: str, force: bool = False) -> Dict:
+        """
+        Import Mnemosyne data from a JSON file produced by export_to_file().
+        Idempotent by default: skips existing records.
+        Set force=True to overwrite.
+        Returns import statistics.
+        """
+        from mnemosyne.core.triples import TripleStore
+        import json as _json
+
+        with open(input_path, "r", encoding="utf-8") as f:
+            data = _json.load(f)
+
+        # Validate
+        meta = data.get("mnemosyne_export", {})
+        if meta.get("version") != "1.0":
+            raise ValueError(f"Unsupported export version: {meta.get('version')}")
+
+        stats = {"beam": {}, "legacy": {}, "triples": {}}
+
+        # BEAM import
+        beam_stats = self.beam.import_from_dict(data, force=force)
+        stats["beam"] = beam_stats
+
+        # Legacy memories
+        l_stats = {"inserted": 0, "skipped": 0, "overwritten": 0}
+        cursor = self.conn.cursor()
+        for item in data.get("legacy_memories", []):
+            mid = item.get("id")
+            cursor.execute("SELECT 1 FROM memories WHERE id = ?", (mid,))
+            exists = cursor.fetchone() is not None
+            if exists and not force:
+                l_stats["skipped"] += 1
+                continue
+            if exists and force:
+                cursor.execute("DELETE FROM memories WHERE id = ?", (mid,))
+                l_stats["overwritten"] += 1
+            else:
+                l_stats["inserted"] += 1
+            cursor.execute("""
+                INSERT INTO memories (id, content, source, timestamp, session_id,
+                                      importance, metadata_json, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                mid, item.get("content"), item.get("source"), item.get("timestamp"),
+                item.get("session_id", "default"), item.get("importance", 0.5),
+                item.get("metadata_json", "{}"), item.get("created_at")
+            ))
+        self.conn.commit()
+
+        # Legacy embeddings
+        for item in data.get("legacy_embeddings", []):
+            mid = item.get("memory_id")
+            cursor.execute("SELECT 1 FROM memory_embeddings WHERE memory_id = ?", (mid,))
+            exists = cursor.fetchone() is not None
+            if exists and not force:
+                continue
+            if exists and force:
+                cursor.execute("DELETE FROM memory_embeddings WHERE memory_id = ?", (mid,))
+            cursor.execute("""
+                INSERT INTO memory_embeddings (memory_id, embedding_json, model, created_at)
+                VALUES (?, ?, ?, ?)
+            """, (mid, item.get("embedding_json"), item.get("model", "bge-small-en-v1.5"), item.get("created_at")))
+        self.conn.commit()
+        stats["legacy"] = l_stats
+
+        # Triples
+        triples = TripleStore(db_path=self.db_path)
+        t_stats = triples.import_all(data.get("triples", []), force=force)
+        stats["triples"] = t_stats
+
+        return stats
+
 
 # Global instance for module-level convenience functions
 _default_instance = None

--- a/mnemosyne/core/triples.py
+++ b/mnemosyne/core/triples.py
@@ -145,3 +145,48 @@ class TripleStore:
             ORDER BY valid_from DESC
         """, (subject, predicate))
         return [dict(row) for row in cursor.fetchall()]
+
+    def export_all(self) -> List[Dict]:
+        """Export all triples to a list of dictionaries."""
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            SELECT id, subject, predicate, object, valid_from, valid_until,
+                   source, confidence, created_at
+            FROM triples
+            ORDER BY id
+        """)
+        return [dict(row) for row in cursor.fetchall()]
+
+    def import_all(self, triples: List[Dict], force: bool = False) -> Dict:
+        """
+        Import triples from a list of dictionaries.
+        Idempotent by default: skips records whose id already exists.
+        Set force=True to overwrite.
+        Returns import statistics.
+        """
+        stats = {"inserted": 0, "skipped": 0, "overwritten": 0}
+        cursor = self.conn.cursor()
+        for item in triples:
+            tid = item.get("id")
+            cursor.execute("SELECT 1 FROM triples WHERE id = ?", (tid,))
+            exists = cursor.fetchone() is not None
+            if exists and not force:
+                stats["skipped"] += 1
+                continue
+            if exists and force:
+                cursor.execute("DELETE FROM triples WHERE id = ?", (tid,))
+                stats["overwritten"] += 1
+            else:
+                stats["inserted"] += 1
+            cursor.execute("""
+                INSERT INTO triples (id, subject, predicate, object, valid_from,
+                                     valid_until, source, confidence, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                tid, item.get("subject"), item.get("predicate"), item.get("object"),
+                item.get("valid_from"), item.get("valid_until"),
+                item.get("source", "imported"), item.get("confidence", 1.0),
+                item.get("created_at")
+            ))
+        self.conn.commit()
+        return stats

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -165,3 +165,59 @@ class TestMnemosyneIntegration:
         assert "beam" in stats
         assert "working_memory" in stats["beam"]
         assert "episodic_memory" in stats["beam"]
+
+
+class TestExportImport:
+    def test_beam_export_to_dict(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        beam.remember("Prefers dark mode", source="preference", importance=0.9)
+        beam.scratchpad_write("todo item")
+        beam.consolidate_to_episodic("User likes dark mode", ["wm1"], importance=0.8)
+
+        data = beam.export_to_dict()
+        assert "mnemosyne_export" in data
+        assert data["mnemosyne_export"]["version"] == "1.0"
+        assert len(data["working_memory"]) >= 1
+        assert len(data["scratchpad"]) >= 1
+        assert len(data["episodic_memory"]) >= 1
+
+    def test_beam_import_from_dict_idempotent(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        mid = beam.remember("Prefers dark mode", source="preference", importance=0.9)
+        data = beam.export_to_dict()
+
+        # Import into fresh DB
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fresh_db = Path(tmpdir) / "fresh.db"
+            fresh_beam = BeamMemory(session_id="s1", db_path=fresh_db)
+            stats = fresh_beam.import_from_dict(data)
+            assert stats["working_memory"]["inserted"] >= 1
+
+            # Verify
+            ctx = fresh_beam.get_context(limit=5)
+            assert any("dark mode" in c["content"] for c in ctx)
+
+            # Second import should skip
+            stats2 = fresh_beam.import_from_dict(data)
+            assert stats2["working_memory"]["skipped"] >= 1
+
+    def test_mnemosyne_export_import_roundtrip(self, temp_db):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Source
+            src = Mnemosyne(session_id="s1", db_path=temp_db)
+            src.remember("Likes pizza", source="preference", importance=0.8)
+            src.scratchpad_write("note")
+            export_path = Path(tmpdir) / "export.json"
+            src.export_to_file(str(export_path))
+            assert export_path.exists()
+
+            # Target
+            target_db = Path(tmpdir) / "target.db"
+            target = Mnemosyne(session_id="s1", db_path=target_db)
+            stats = target.import_from_file(str(export_path))
+            assert stats["legacy"]["inserted"] >= 1
+            assert stats["beam"]["working_memory"]["inserted"] >= 1
+
+            # Verify recall works
+            results = target.recall("pizza")
+            assert len(results) >= 1


### PR DESCRIPTION
## Summary
Closes #3

Adds full export/import capability so users can move their Mnemosyne memory to a new machine.

## What changed

### Core
- **BEAM** (`mnemosyne/core/beam.py`):
  - `BeamMemory.export_to_dict()` — exports working_memory, episodic_memory, embeddings, scratchpad, consolidation_log across ALL sessions
  - `BeamMemory.import_from_dict(data, force=False)` — idempotent import with optional overwrite
  - Embeddings remapped via old_rowid → new_rowid on re-insert

- **Triples** (`mnemosyne/core/triples.py`):
  - `TripleStore.export_all()` — dumps all temporal triples
  - `TripleStore.import_all(triples, force=False)` — idempotent restore

- **Mnemosyne** (`mnemosyne/core/memory.py`):
  - `Mnemosyne.export_to_file(path)` — orchestrates BEAM + legacy memories + embeddings + triples into a single JSON file
  - `Mnemosyne.import_from_file(path, force=False)` — validates version, restores all tiers

### CLI
- `hermes mnemosyne export --output <path>`
- `hermes mnemosyne import --input <path> [--force]`

### Hermes tools
- `mnemosyne_export` — `{"output_path": "..."}`
- `mnemosyne_import` — `{"input_path": "...", "force": false}`

### Tests
- `test_beam_export_to_dict` — verifies export structure
- `test_beam_import_from_dict_idempotent` — verifies skip-on-duplicate + force
- `test_mnemosyne_export_import_roundtrip` — end-to-end roundtrip

## Export format (v1.0)
```json
{
  "mnemosyne_export": {"version": "1.0", "export_date": "...", "source_db": "..."},
  "working_memory": [...],
  "episodic_memory": [...],
  "episodic_embeddings": [{"rowid": 1, "embedding": [...]}],
  "scratchpad": [...],
  "consolidation_log": [...],
  "legacy_memories": [...],
  "legacy_embeddings": [...],
  "triples": [...]
}
```

## Usage
```bash
# Export on old machine
hermes mnemosyne export --output mnemosyne_backup.json

# Import on new machine
hermes mnemosyne import --input mnemosyne_backup.json
```