### PR TITLE
feat(beam): temporal query capabilities for v1.13.0

### DIFF
--- a/.planning/workstreams/temporal-queries-v1.13.md
+++ b/.planning/workstreams/temporal-queries-v1.13.md
@@ -1,0 +1,546 @@
+# Planforge: Temporal Query Capabilities for Mnemosyne
+# Plan ID: mnemosyne-temporal-queries-v1.0
+# Version: 1.0.0
+# Status: DRAFT — Pending Abdias Review
+# Created: 2026-04-28
+# Target Release: Mnemosyne v1.13.0
+
+---
+
+## 1. EXECUTIVE SUMMARY
+
+### 1.1 Problem Statement
+
+Mnemosyne v1.12.0 has a critical temporal memory retrieval gap. The `recall()` function uses hybrid search (FTS5 + vector similarity) but **timestamps are metadata, not searchable content**. This means memories from specific dates (e.g., "what did I do last Monday") are stored in the database but **unfindable via normal recall queries**.
+
+**Impact:**
+- 3,177 working memories and 8,890 legacy memories exist with timestamp metadata that cannot be queried by date range
+- Users cannot ask time-bounded questions like "show me memories from April 21, 2026"
+- The BEAM architecture (working → episodic consolidation) loses temporal context during consolidation because summaries don't preserve date-range metadata
+- TripleStore exists as a separate temporal knowledge graph but is **not integrated** with BEAM memory tiers
+
+### 1.2 Goals
+
+1. **Date-range recall**: Enable `recall(from="2026-04-21", to="2026-04-21")` to retrieve memories within a date window
+2. **Temporal triples**: Auto-generate `(session, occurred_on, YYYY-MM-DD)` triples for each memory on write
+3. **Periodic memory tagging**: Cron-originated memories auto-tagged with `source="cron"` and `topic="CareerOps"`
+4. **Backward compatibility**: Existing `recall(query, top_k)` API must work unchanged
+5. **BEAM integration**: Temporal queries must span both working_memory and episodic_memory tiers
+6. **TripleStore bridge**: Connect temporal triples to BEAM memory lifecycle
+
+---
+
+## 2. TECHNICAL SOLUTIONS
+
+### 2.1 Solution A: Date-Range Filtering in `recall()`
+
+**Implementation:**
+
+Add optional `from_date` and `to_date` parameters to `BeamMemory.recall()` and `Mnemosyne.recall()`:
+
+```python
+def recall(self, query: str = None, top_k: int = 5,
+           from_date: str = None, to_date: str = None,
+           source: str = None, tier: str = None) -> List[Dict]:
+```
+
+**Behavior:**
+- If only `from_date`/`to_date` provided (no `query`): return all memories in date range, sorted by timestamp DESC
+- If `query` + date range provided: apply hybrid scoring first, then filter by timestamp
+- Date format: ISO 8601 (`YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SS`). Parsed via `datetime.fromisoformat()`
+- SQL filter uses indexed `timestamp` column with `BETWEEN` or `>= / <=` operators
+
+**Schema changes:**
+- None — `timestamp` column already exists and is indexed (`idx_wm_timestamp`, `idx_em_timestamp`)
+- Add composite index for efficient date+source filtering:
+  ```sql
+  CREATE INDEX IF NOT EXISTS idx_wm_timestamp_source ON working_memory(timestamp, source);
+  CREATE INDEX IF NOT EXISTS idx_em_timestamp_source ON episodic_memory(timestamp, source);
+  ```
+
+**Backward compatibility:**
+- `recall(query, top_k)` signature unchanged — new params are keyword-only with defaults `None`
+- Existing code paths unaffected when temporal params not provided
+
+### 2.2 Solution B: Temporal Triples Auto-Generation
+
+**Implementation:**
+
+On every `remember()` call, automatically write a temporal triple to TripleStore:
+
+```python
+# In Mnemosyne.remember() and BeamMemory.remember()
+from mnemosyne.core.triples import add_triple
+
+# Extract date portion from ISO timestamp
+date_str = timestamp[:10]  # "2026-04-21"
+add_triple(
+    subject=memory_id,           # or session_id
+    predicate="occurred_on",
+    object=date_str,
+    valid_from=timestamp,
+    source=source,
+    confidence=1.0,
+    db_path=self.db_path         # Align with BEAM DB
+)
+```
+
+**Schema changes:**
+- TripleStore currently uses a **separate database** (`triples.db`). For integration, support passing `db_path` to align with BEAM's `mnemosyne.db`
+- Add index on `(subject, predicate)` for fast temporal lookups:
+  ```sql
+  CREATE INDEX IF NOT EXISTS idx_triples_subject_predicate ON triples(subject, predicate);
+  ```
+
+**Migration:**
+- Backfill script to generate temporal triples for all existing memories (legacy + BEAM)
+- Batch processing: 1,000 memories at a time to avoid memory pressure
+
+### 2.3 Solution C: Periodic Memory Tagging
+
+**Implementation:**
+
+Extend `remember()` to accept and preserve `topic` metadata. Cron jobs set explicit tags:
+
+```python
+# Cron caller:
+mnemosyne.remember(
+    content="New job posting: Senior Rust Engineer at StarkWare",
+    source="cron",
+    metadata={"topic": "CareerOps", "frequency": "daily", "url": "..."}
+)
+```
+
+**Schema changes:**
+- None — `metadata_json` column already stores arbitrary JSON
+- Add `source` filtering to `recall()`:
+  ```python
+  recall(query="StarkWare", source="cron", from_date="2026-04-21")
+  ```
+
+**Indexing:**
+- `source` is already indexed (`idx_wm_source`, `idx_em_source`)
+- Add `topic` extraction helper for querying metadata JSON:
+  ```python
+  def _topic_filter(topic: str) -> str:
+      # SQLite JSON extraction for metadata_json.topic
+      return "json_extract(metadata_json, '$.topic') = ?"
+  ```
+
+### 2.4 Solution D: BEAM Tier-Aware Temporal Queries
+
+**Implementation:**
+
+When querying with date range, search both tiers and merge results:
+
+```python
+def _recall_temporal(self, from_date: str, to_date: str,
+                     query: str = None, top_k: int = 5,
+                     tier: str = None) -> List[Dict]:
+    """
+    tier=None → both working + episodic
+    tier="working" → working_memory only
+    tier="episodic" → episodic_memory only
+    """
+    results = []
+    
+    # Build WHERE clause for temporal filter
+    temporal_clause = "timestamp >= ? AND timestamp <= ?"
+    params = [from_date, to_date]
+    
+    if tier in (None, "working"):
+        # Query working_memory with optional FTS5 + temporal filter
+        ...
+    
+    if tier in (None, "episodic"):
+        # Query episodic_memory with optional vec/FTS5 + temporal filter
+        ...
+    
+    # Merge, score, deduplicate, sort
+    return results[:top_k]
+```
+
+**Consolidation awareness:**
+- When working memories are consolidated into episodic summaries, the summary's timestamp should reflect the **latest** timestamp in the group (not the consolidation time)
+- This preserves the ability to query "what happened on April 21" even after consolidation
+
+### 2.5 Solution E: TripleStore ↔ BEAM Bridge
+
+**Implementation:**
+
+Create a bridge module `mnemosyne/core/temporal_bridge.py`:
+
+```python
+def query_memories_by_date(session_id: str, date: str,
+                         db_path: Path = None) -> List[Dict]:
+    """
+    Use TripleStore temporal triples to find memory IDs,
+    then fetch full memory records from BEAM.
+    """
+    from mnemosyne.core.triples import query_triples
+    
+    triples = query_triples(
+        predicate="occurred_on",
+        object=date,
+        db_path=db_path
+    )
+    memory_ids = [t["subject"] for t in triples]
+    
+    # Fetch from BEAM working + episodic
+    return _fetch_memories_by_ids(memory_ids, db_path)
+```
+
+**Use case:**
+- Alternative query path when exact date matching is needed (vs. range filtering)
+- Enables "what happened exactly on 2026-04-21" queries with triple-backed precision
+
+---
+
+## 3. PHASES, TASKS & ACCEPTANCE CRITERIA
+
+### PHASE 1: Design & Specification (Days 1–2)
+
+| Task | Owner | Deliverable | Acceptance Criteria |
+|------|-------|-------------|-------------------|
+| 1.1 Finalize API signatures | Abdias | Updated docstrings + type hints | All new params have defaults; no positional signature changes |
+| 1.2 Index strategy review | Dev | EXPLAIN QUERY PLAN for date-range queries | Temporal queries use index scan (not full table scan) on 10k+ rows |
+| 1.3 TripleStore alignment decision | Dev | ADR: shared DB vs separate DB | Decision recorded with trade-offs; migration path defined |
+| 1.4 Backfill strategy | Dev | Migration script design | Script can process 12,000 memories without OOM; idempotent |
+
+**Phase 1 Exit Criteria:**
+- [ ] Abdias approves API design
+- [ ] Index strategy validated on production-sized dataset (12k memories)
+- [ ] ADR merged to `.planning/adr/`
+
+---
+
+### PHASE 2: Core Implementation (Days 3–7)
+
+| Task | Owner | File(s) | Acceptance Criteria |
+|------|-------|---------|-------------------|
+| 2.1 Add temporal params to `BeamMemory.recall()` | Dev | `beam.py` | `recall(from_date="2026-04-21", to_date="2026-04-21")` returns ≥1 result when memories exist on that date |
+| 2.2 Add temporal params to `Mnemosyne.recall()` | Dev | `memory.py` | Passes through to `beam.recall()`; legacy table fallback works |
+| 2.3 Composite index migration | Dev | `beam.py` | `EXPLAIN QUERY PLAN` shows `USING INDEX idx_wm_timestamp_source` |
+| 2.4 Auto-generate temporal triples on `remember()` | Dev | `memory.py`, `beam.py`, `triples.py` | Every `remember()` call creates exactly 1 `(memory_id, occurred_on, YYYY-MM-DD)` triple |
+| 2.5 TripleStore DB alignment | Dev | `triples.py` | `TripleStore(db_path=mnemosyne.db_path)` stores triples in same SQLite file as BEAM |
+| 2.6 Topic metadata extraction helper | Dev | `beam.py` | `json_extract(metadata_json, '$.topic')` queries work on SQLite ≥3.38 |
+| 2.7 Temporal bridge module | Dev | `temporal_bridge.py` | `query_memories_by_date()` returns correct memories within 50ms on 10k dataset |
+
+**Phase 2 Exit Criteria:**
+- [ ] All new code paths have unit tests (≥90% coverage for new lines)
+- [ ] `pytest tests/test_temporal.py` passes
+- [ ] No regression in `pytest tests/test_beam.py`
+- [ ] Benchmark: temporal query on 12k memories completes in <100ms (p95)
+
+---
+
+### PHASE 3: Integration & Cron Tagging (Days 8–10)
+
+| Task | Owner | File(s) | Acceptance Criteria |
+|------|-------|---------|-------------------|
+| 3.1 Cron memory tagging convention | Dev | `memory.py` docs | `source="cron"` + `metadata={"topic": "CareerOps"}` is documented and tested |
+| 3.2 `recall(source="cron", from_date=...)` filtering | Dev | `beam.py` | Returns only cron-sourced memories in date range |
+| 3.3 Consolidation timestamp preservation | Dev | `beam.py` | Episodic summary timestamp = max(timestamp) of source working memories, not `datetime.now()` |
+| 3.4 Backfill script for existing memories | Dev | `scripts/backfill_temporal_triples.py` | Processes 12,000 memories; generates ~12,000 triples; idempotent (re-run safe) |
+| 3.5 Legacy memory temporal fallback | Dev | `memory.py` | `recall()` on legacy table supports date filtering when BEAM has no matches |
+
+**Phase 3 Exit Criteria:**
+- [ ] Backfill script tested on copy of production DB
+- [ ] Cron-tagged memories queryable by date + source + topic
+- [ ] Consolidation preserves temporal bounds
+
+---
+
+### PHASE 4: Testing & Validation (Days 11–14)
+
+| Task | Owner | Deliverable | Acceptance Criteria |
+|------|-------|-------------|-------------------|
+| 4.1 Unit tests: date-range parsing | Dev | `tests/test_temporal.py` | Invalid dates raise `ValueError` with helpful message; edge cases (DST, leap years) covered |
+| 4.2 Unit tests: tier-aware queries | Dev | `tests/test_temporal.py` | `tier="working"` returns only working; `tier="episodic"` returns only episodic; `tier=None` merges |
+| 4.3 Unit tests: TripleStore bridge | Dev | `tests/test_temporal_bridge.py` | Bridge queries return same results as direct BEAM queries |
+| 4.4 Performance benchmark | Dev | `tests/benchmark_temporal.py` | Date-range query p95 <100ms on 12k memories; backfill completes in <5 minutes |
+| 4.5 Backward compatibility test | Dev | `tests/test_backward_compat.py` | All existing `recall(query, top_k)` calls return identical results to v1.12.0 |
+| 4.6 Integration test: end-to-end | Dev | `tests/test_temporal_e2e.py` | Full flow: remember → temporal triple → recall by date → verify content |
+
+**Phase 4 Exit Criteria:**
+- [ ] `pytest tests/` passes with 0 failures
+- [ ] Benchmark results recorded in `.planning/benchmarks/temporal-v1.13.md`
+- [ ] No API breakage detected by backward compatibility tests
+
+---
+
+### PHASE 5: Documentation (Days 15–16)
+
+| Task | Owner | Deliverable | Acceptance Criteria |
+|------|-------|-------------|-------------------|
+| 5.1 API documentation update | Dev | `README.md` | `recall()` signature documented with examples for date-range, source, topic |
+| 5.2 Temporal query guide | Dev | `docs/temporal-queries.md` | Step-by-step guide with 3+ real-world examples ("last Monday", "career ops this week") |
+| 5.3 CHANGELOG entry | Dev | `CHANGELOG.md` | v1.13.0 section lists all temporal features with migration notes |
+| 5.4 TripleStore integration doc | Dev | `docs/triples-integration.md` | Explains how temporal triples connect to BEAM; when to use triples vs direct date filter |
+| 5.5 Cron tagging convention doc | Dev | `docs/cron-tagging.md` | Standard metadata schema for cron-originated memories |
+
+**Phase 5 Exit Criteria:**
+- [ ] All docs reviewed for accuracy against implementation
+- [ ] Examples in docs are copy-paste runnable
+- [ ] CHANGELOG follows Keep a Changelog format
+
+---
+
+## 4. BACKWARD COMPATIBILITY PLAN
+
+### 4.1 API Compatibility
+
+| Current API | New API | Behavior |
+|-------------|---------|----------|
+| `recall(query, top_k=5)` | `recall(query, top_k=5)` | **Unchanged** — identical results |
+| `recall(query, top_k=5)` | `recall(query, top_k=5, from_date=None)` | `None` = no filter; same as before |
+| `remember(content, source="conversation")` | `remember(content, source="conversation", metadata=None)` | Metadata already accepted; no change |
+
+### 4.2 Database Compatibility
+
+- **No breaking schema changes** — only additive (new indexes, new table `triples` in shared DB)
+- Existing `mnemosyne.db` files work without migration (new indexes created on init)
+- TripleStore backfill is **optional** — new triples generated going forward; old memories queryable via direct date filter on `timestamp` column
+
+### 4.3 Deprecation Policy
+
+- No deprecations in this release
+- Legacy `memories` table continues to be dual-written; no removal timeline
+
+---
+
+## 5. INTEGRATION WITH EXISTING ARCHITECTURE
+
+### 5.1 BEAM Tiers
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    TEMPORAL QUERY                       │
+│         recall(from="2026-04-21", to="2026-04-21")       │
+├─────────────────────────────────────────────────────────┤
+│  Working Memory (hot)    │  Episodic Memory (long-term) │
+│  - idx_wm_timestamp      │  - idx_em_timestamp          │
+│  - FTS5 fts_working     │  - FTS5 fts_episodes         │
+│  - sqlite-vec (N/A)     │  - sqlite-vec vec_episodes   │
+├─────────────────────────────────────────────────────────┤
+│              MERGE → DEDUPLICATE → SORT                  │
+│              Return top_k by composite score              │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 5.2 TripleStore Integration
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  BEAM Memory Tier          │  TripleStore (temporal)    │
+│  ──────────────────────────┼──────────────────────────  │
+│  working_memory.id         │→ triples.subject          │
+│  working_memory.timestamp  │→ triples.valid_from        │
+│  "occurred_on"             │→ triples.predicate         │
+│  "2026-04-21"              │→ triples.object             │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Query paths:**
+1. **Fast path**: Direct SQL `BETWEEN` on `timestamp` column (no triples needed)
+2. **Precise path**: TripleStore `query_triples(predicate="occurred_on", object=date)` for exact date matching
+3. **Hybrid path**: TripleStore finds memory IDs → BEAM fetches full records with embeddings
+
+### 5.3 Consolidation (Sleep) Impact
+
+- **Before**: Consolidation summary gets `timestamp = datetime.now()` (loss of temporal context)
+- **After**: Consolidation summary gets `timestamp = max(item["timestamp"] for item in group)` (preserves latest date from source memories)
+- **Triple preservation**: Individual working memory triples remain; new summary triple added with same date logic
+
+---
+
+## 6. TIMELINE ESTIMATES
+
+| Phase | Duration | Calendar Days | Key Milestone |
+|-------|----------|---------------|---------------|
+| 1. Design & Spec | 2 days | Mon–Tue | Abdias approval |
+| 2. Core Implementation | 5 days | Wed–Sun (1 weekend) | All tests green |
+| 3. Integration & Cron | 3 days | Mon–Wed | Backfill complete |
+| 4. Testing & Validation | 4 days | Thu–Sun | Benchmarks pass |
+| 5. Documentation | 2 days | Mon–Tue | Docs merged |
+| **Buffer** | **2 days** | **Wed–Thu** | Contingency |
+| **TOTAL** | **18 days** | **~3 weeks** | **Release v1.13.0** |
+
+**Risk-adjusted timeline:**
+- If TripleStore DB alignment is complex (shared vs separate): +2 days
+- If index performance is poor on 12k rows: +1 day for query optimization
+- If backfill reveals data quality issues: +2 days for cleanup
+
+---
+
+## 7. RISK REGISTER
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| TripleStore DB migration breaks existing triples.db users | Medium | High | Keep `triples.db` as default; shared DB is opt-in via `db_path` param |
+| Date-range queries slow on large datasets | Low | Medium | Composite indexes + query plan validation; fallback to pagination |
+| Backfill script OOM on 12k memories | Low | Medium | Batch processing (1,000 rows/transaction); streaming JSON parse |
+| Cron tagging convention conflicts with existing metadata | Low | Low | Use nested key `metadata["topic"]"; no top-level schema change |
+| Consolidation timestamp change breaks existing queries | Medium | Medium | Gate behind env var `MNEMOSYNE_PRESERVE_TEMPORAL=1`; default off for one release |
+
+---
+
+## 8. ACCEPTANCE CRITERIA (Overall)
+
+The plan is approved for implementation when:
+
+- [ ] Abdias has reviewed and commented on this document
+- [ ] GitHub issue #<TBD> created with "temporal queries" label
+- [ ] Phase 1 tasks completed and design decisions recorded
+- [ ] No blocking risks remain in Risk Register
+
+The implementation is complete when:
+
+- [ ] All 5 phases finished with exit criteria met
+- [ ] `pytest tests/` passes (0 failures, ≥90% new code coverage)
+- [ ] Benchmark: temporal query p95 <100ms on 12k memories
+- [ ] Backward compatibility test: v1.12.0 `recall()` results identical
+- [ ] Documentation merged and examples verified runnable
+- [ ] PR reviewed and approved by Abdias
+- [ ] CHANGELOG.md updated for v1.13.0
+- [ ] Version bump in `__init__.py` and `pyproject.toml`
+
+---
+
+## 9. APPENDIX
+
+### A.1 Proposed `recall()` Signature (v1.13.0)
+
+```python
+def recall(
+    self,
+    query: str = None,
+    top_k: int = 5,
+    *,  # keyword-only from here
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    source: Optional[str] = None,
+    topic: Optional[str] = None,
+    tier: Optional[str] = None,  # "working" | "episodic" | None
+    min_importance: Optional[float] = None,
+) -> List[Dict]:
+    """
+    Hybrid memory retrieval with optional temporal filtering.
+    
+    Args:
+        query: Semantic search query. If None, returns all memories filtered by other criteria.
+        top_k: Maximum results to return.
+        from_date: ISO date string (YYYY-MM-DD) — inclusive lower bound.
+        to_date: ISO date string (YYYY-MM-DD) — inclusive upper bound.
+        source: Filter by memory source (e.g., "cron", "conversation").
+        topic: Filter by metadata topic (e.g., "CareerOps").
+        tier: "working", "episodic", or None (both).
+        min_importance: Minimum importance score (0.0–1.0).
+    
+    Returns:
+        List of memory dicts with keys: id, content, source, timestamp, tier, score, ...
+    
+    Examples:
+        >>> mnemosyne.recall("StarkWare", from_date="2026-04-21", to_date="2026-04-21")
+        >>> mnemosyne.recall(from_date="2026-04-01", to_date="2026-04-30", source="cron")
+        >>> mnemosyne.recall("career", topic="CareerOps", top_k=10)
+    """
+```
+
+### A.2 Database Index Additions
+
+```sql
+-- Phase 2.3: Composite indexes for temporal + source queries
+CREATE INDEX IF NOT EXISTS idx_wm_timestamp_source ON working_memory(timestamp, source);
+CREATE INDEX IF NOT EXISTS idx_em_timestamp_source ON episodic_memory(timestamp, source);
+
+-- Phase 2.5: TripleStore alignment
+CREATE INDEX IF NOT EXISTS idx_triples_subject_predicate ON triples(subject, predicate);
+CREATE INDEX IF NOT EXISTS idx_triples_predicate_object ON triples(predicate, object);
+```
+
+### A.3 Backfill Script Outline
+
+```python
+# scripts/backfill_temporal_triples.py
+"""One-time backfill of temporal triples for existing memories."""
+
+from mnemosyne.core.beam import _get_connection
+from mnemosyne.core.triples import add_triple
+from pathlib import Path
+
+BATCH_SIZE = 1000
+
+def backfill(db_path: Path = None):
+    conn = _get_connection(db_path)
+    cursor = conn.cursor()
+    
+    for table in ("working_memory", "episodic_memory", "memories"):
+        cursor.execute(f"SELECT id, timestamp, source FROM {table}")
+        batch = []
+        for row in cursor:
+            date_str = row["timestamp"][:10] if row["timestamp"] else None
+            if date_str:
+                batch.append((row["id"], "occurred_on", date_str, row["timestamp"], row["source"]))
+            if len(batch) >= BATCH_SIZE:
+                _insert_batch(batch, db_path)
+                batch = []
+        if batch:
+            _insert_batch(batch, db_path)
+    
+    print("Backfill complete.")
+
+def _insert_batch(batch, db_path):
+    for subject, predicate, obj, valid_from, source in batch:
+        add_triple(subject, predicate, obj, valid_from=valid_from, source=source, db_path=db_path)
+
+if __name__ == "__main__":
+    backfill()
+```
+
+### A.4 Test Cases (Phase 4)
+
+```python
+# tests/test_temporal.py — key test cases
+
+def test_recall_date_range_working_memory():
+    """Store 3 memories on different dates; query 1 date; expect 1 result."""
+    
+def test_recall_date_range_episodic_memory():
+    """Consolidate memories; query by date; expect summary in results."""
+    
+def test_recall_date_range_no_query():
+    """recall(from_date=X, to_date=Y) with no query returns all in range."""
+    
+def test_recall_source_filter():
+    """recall(source="cron") returns only cron memories."""
+    
+def test_recall_topic_filter():
+    """recall(topic="CareerOps") filters by metadata topic."""
+    
+def test_recall_backward_compat():
+    """recall(query, top_k) returns identical results to v1.12.0."""
+    
+def test_temporal_triple_auto_generated():
+    """remember() creates exactly 1 occurred_on triple."""
+    
+def test_backfill_idempotent():
+    """Running backfill twice doesn't create duplicate triples."""
+    
+def test_consolidation_preserves_temporal_bounds():
+    """Sleep consolidation sets summary timestamp = max(source timestamps)."""
+```
+
+---
+
+## 10. SIGN-OFF
+
+| Role | Name | Signature | Date |
+|------|------|-----------|------|
+| Product Owner | Abdias J | _______________ | _______ |
+| Technical Lead | <TBD> | _______________ | _______ |
+| Implementer | <TBD> | _______________ | _______ |
+
+---
+
+*This plan was generated by Planforge (Hermes Agent) on 2026-04-28. Version 1.0.0 — DRAFT.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ given a version number **MAJOR.MINOR**, increment the:
 
 ---
 
+## 1.13.0
+
+- **Add temporal queries to `recall()`** — Issue #16. `BeamMemory.recall()` now accepts `from_date`, `to_date`, `source`, and `topic` filters. Date filters are applied at the SQL layer for both working_memory and episodic_memory, reducing result sets before hybrid scoring. Source/topic filter by the `source` column (topic pending dedicated column). All filters are keyword-only and backward-compatible.
+- **Auto-generate temporal triples on `remember()`** — Every `remember()` call now creates a `occurred_on` triple in the TripleStore with the memory ID as subject and YYYY-MM-DD as object. Non-generic sources also get a `has_source` triple. TripleStore initialization is lazy and failure-safe — memory writes never fail if triples are unavailable.
+- **Propagate temporal params through API layers** — `Mnemosyne.recall()` (class), `recall()` (module-level), and `BeamMemory.recall()` all accept the same keyword-only filter signature.
+- **Fix `min_rank` UnboundLocalError in fallback scoring** — When FTS5 returns no working-memory matches but temporal filters are active, `wm_ranks` is empty. Precompute `min_rank`/`rng` before the row loop to avoid referencing undefined locals.
+- **Add 6 tests for temporal queries** — from_date, to_date, source, date range, episodic temporal filter, and auto-generated triples. All 25 tests passing.
+
 ## 1.12.0
 
 - **Fix: embeddings generated but discarded when sqlite-vec is absent** — Previously, installing `mnemosyne-memory[embeddings]` without `sqlite-vec` produced identical behavior to the core install. Embeddings were generated during consolidation but thrown away because `_vec_available()` returned False. Now embeddings fall back to the `memory_embeddings` table, and `recall()` uses in-memory numpy cosine similarity when sqlite-vec is unavailable. Semantic search works with just `[embeddings]` installed. Closes #15.

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -485,6 +485,10 @@ class BeamMemory:
               json.dumps(metadata or {}), valid_until, scope))
         self.conn.commit()
         self._trim_working_memory()
+        
+        # Auto-generate temporal triple
+        self._add_temporal_triple(memory_id, timestamp, source, content)
+        
         return memory_id
 
     def remember_batch(self, items: List[Dict]) -> List[str]:
@@ -513,6 +517,33 @@ class BeamMemory:
         self.conn.commit()
         self._trim_working_memory()
         return ids
+
+    def _add_temporal_triple(self, memory_id: str, timestamp: str, source: str, content: str):
+        """Auto-generate temporal triple for a memory. Bridges BEAM and TripleStore."""
+        try:
+            # Import triples module lazily to avoid circular dependency
+            from mnemosyne.core.triples import TripleStore, init_triples
+            date_str = timestamp[:10]  # YYYY-MM-DD
+            # Ensure triples table exists
+            init_triples(db_path=self.db_path)
+            triple_store = TripleStore(db_path=self.db_path)
+            triple_store.add(
+                subject=memory_id,
+                predicate="occurred_on",
+                object=date_str,
+                valid_from=date_str
+            )
+            # Also tag source type
+            if source and source not in ("conversation", "user", "assistant"):
+                triple_store.add(
+                    subject=memory_id,
+                    predicate="has_source",
+                    object=source,
+                    valid_from=date_str
+                )
+        except Exception:
+            # TripleStore is optional; don't fail memory write if triples fail
+            pass
 
     def _trim_working_memory(self):
         """Keep working_memory within size/time limits."""
@@ -652,11 +683,16 @@ class BeamMemory:
         self.conn.commit()
         return memory_id
 
-    def recall(self, query: str, top_k: int = 5) -> List[Dict]:
+    def recall(self, query: str, top_k: int = 5, *, from_date: Optional[str] = None, to_date: Optional[str] = None, source: Optional[str] = None, topic: Optional[str] = None) -> List[Dict]:
         """
         Hybrid recall across working_memory + episodic_memory.
         Uses sqlite-vec + FTS5 for episodic, FTS5 for working.
         Falls back to recency-only for working memory if FTS5 unavailable.
+        
+        Temporal filtering:
+            from_date/to_date: ISO date strings (YYYY-MM-DD) to filter by timestamp.
+            source: Filter by memory source (e.g., 'cron', 'user', 'conversation').
+            topic: Filter by topic tag (stored in source field for now, pending dedicated column).
         """
         results = []
         query_lower = query.lower()
@@ -671,6 +707,30 @@ class BeamMemory:
         wm_ids = {r["id"] for r in wm_fts}
         wm_ranks = {r["id"]: r["rank"] for r in wm_fts}
 
+        # Build temporal filter clause for working memory
+        wm_where_clauses = [
+            "(session_id = ? OR scope = 'global')",
+            "(valid_until IS NULL OR valid_until > ?)",
+            "superseded_by IS NULL"
+        ]
+        wm_params = [self.session_id, datetime.now().isoformat()]
+        
+        if from_date:
+            wm_where_clauses.append("timestamp >= ?")
+            wm_params.append(f"{from_date}T00:00:00")
+        if to_date:
+            wm_where_clauses.append("timestamp <= ?")
+            wm_params.append(f"{to_date}T23:59:59")
+        if source:
+            wm_where_clauses.append("source = ?")
+            wm_params.append(source)
+        if topic:
+            # Topic stored in source field for now (pending dedicated topic column)
+            wm_where_clauses.append("source = ?")
+            wm_params.append(topic)
+        
+        wm_where = " AND ".join(wm_where_clauses)
+
         if wm_ids:
             placeholders = ",".join("?" * len(wm_ids))
             cursor = self.conn.cursor()
@@ -678,10 +738,8 @@ class BeamMemory:
                 SELECT id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope
                 FROM working_memory
                 WHERE id IN ({placeholders})
-                  AND (session_id = ? OR scope = 'global')
-                  AND (valid_until IS NULL OR valid_until > ?)
-                  AND superseded_by IS NULL
-            """, (*tuple(wm_ids), self.session_id, datetime.now().isoformat()))
+                  AND {wm_where}
+            """, (*tuple(wm_ids), *wm_params))
             rows = cursor.fetchall()
         else:
             # Fallback: fetch recent items and score in Python (old path)
@@ -689,18 +747,20 @@ class BeamMemory:
             cursor.execute(f"""
                 SELECT id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope
                 FROM working_memory
-                WHERE (session_id = ? OR scope = 'global')
-                  AND (valid_until IS NULL OR valid_until > ?)
-                  AND superseded_by IS NULL
+                WHERE {wm_where}
                 ORDER BY timestamp DESC
                 LIMIT {min(EPISODIC_RECALL_LIMIT, 2000)}
-            """, (self.session_id, datetime.now().isoformat()))
+            """, wm_params)
             rows = cursor.fetchall()
 
+        # Precompute min_rank/rng for wm_ranks normalization
         if wm_ranks:
             min_rank = min(wm_ranks.values())
             max_rank = max(wm_ranks.values())
             rng = max_rank - min_rank if max_rank != min_rank else 1.0
+        else:
+            min_rank = 0.0
+            rng = 1.0
 
         for row in rows:
             content_lower = row["content"].lower()
@@ -772,6 +832,30 @@ class BeamMemory:
                 fts_results[fr["rowid"]] = normalized
 
         episodic_rowids = set(vec_results.keys()) | set(fts_results.keys())
+        
+        # Build temporal filter for episodic memory
+        em_where_clauses = [
+            "(session_id = ? OR scope = 'global')",
+            "(valid_until IS NULL OR valid_until > ?)",
+            "superseded_by IS NULL"
+        ]
+        em_params = [self.session_id, datetime.now().isoformat()]
+        
+        if from_date:
+            em_where_clauses.append("timestamp >= ?")
+            em_params.append(f"{from_date}T00:00:00")
+        if to_date:
+            em_where_clauses.append("timestamp <= ?")
+            em_params.append(f"{to_date}T23:59:59")
+        if source:
+            em_where_clauses.append("source = ?")
+            em_params.append(source)
+        if topic:
+            em_where_clauses.append("source = ?")
+            em_params.append(topic)
+        
+        em_where = " AND ".join(em_where_clauses)
+        
         if episodic_rowids:
             placeholders = ",".join("?" * len(episodic_rowids))
             cursor = self.conn.cursor()
@@ -779,10 +863,8 @@ class BeamMemory:
                 SELECT rowid, id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope
                 FROM episodic_memory
                 WHERE rowid IN ({placeholders})
-                  AND (session_id = ? OR scope = 'global')
-                  AND (valid_until IS NULL OR valid_until > ?)
-                  AND superseded_by IS NULL
-            """, (*tuple(episodic_rowids), self.session_id, datetime.now().isoformat()))
+                  AND {em_where}
+            """, (*tuple(episodic_rowids), *em_params))
             for row in cursor.fetchall():
                 rid = row["rowid"]
                 sim = vec_results.get(rid, 0.0)
@@ -815,12 +897,10 @@ class BeamMemory:
             cursor.execute(f"""
                 SELECT rowid, id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope
                 FROM episodic_memory
-                WHERE (session_id = ? OR scope = 'global')
-                  AND (valid_until IS NULL OR valid_until > ?)
-                  AND superseded_by IS NULL
+                WHERE {em_where}
                 ORDER BY timestamp DESC
                 LIMIT {min(EPISODIC_RECALL_LIMIT, 500)}
-            """, (self.session_id, datetime.now().isoformat()))
+            """, em_params)
             for row in cursor.fetchall():
                 content_lower = row["content"].lower()
                 exact = sum(1 for w in query_words if w in content_lower)

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -147,12 +147,13 @@ class Mnemosyne:
 
         return memory_id
 
-    def recall(self, query: str, top_k: int = 5) -> List[Dict]:
+    def recall(self, query: str, top_k: int = 5, *, from_date: Optional[str] = None, to_date: Optional[str] = None, source: Optional[str] = None, topic: Optional[str] = None) -> List[Dict]:
         """
         Search memories with hybrid relevance scoring.
         Uses BEAM episodic + working memory retrieval (sqlite-vec + FTS5).
+        Supports temporal filtering: from_date, to_date, source, topic.
         """
-        return self.beam.recall(query, top_k=top_k)
+        return self.beam.recall(query, top_k=top_k, from_date=from_date, to_date=to_date, source=source, topic=topic)
 
     def get_context(self, limit: int = 10) -> List[Dict]:
         """
@@ -414,9 +415,9 @@ def remember(content: str, source: str = "conversation",
                                    scope=scope, valid_until=valid_until)
 
 
-def recall(query: str, top_k: int = 5) -> List[Dict]:
-    """Search memories using the global instance"""
-    return _get_default().recall(query, top_k)
+def recall(query: str, top_k: int = 5, *, from_date: Optional[str] = None, to_date: Optional[str] = None, source: Optional[str] = None, topic: Optional[str] = None) -> List[Dict]:
+    """Search memories using the global instance with temporal filtering"""
+    return _get_default().recall(query, top_k, from_date=from_date, to_date=to_date, source=source, topic=topic)
 
 
 def get_context(limit: int = 10) -> List[Dict]:

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -358,6 +358,116 @@ class TestCrossSessionRecall:
         assert mem_a.session_id == "session-alpha"
 
 
+class TestTemporalQueries:
+    """Temporal filtering for BEAM recall — Issue #16."""
+
+    def test_recall_from_date_filter(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        beam.remember("Meeting about Q1 goals", source="meeting", importance=0.8)
+
+        # Backdate an old memory directly
+        conn = sqlite3.connect(temp_db)
+        old_ts = "2025-01-15T10:00:00"
+        conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("old1", "Old project kickoff", "meeting", old_ts, "s1", 0.7)
+        )
+        conn.commit()
+        conn.close()
+
+        # Filter from 2025-04-01 should exclude January memory
+        results = beam.recall("project", from_date="2025-04-01")
+        assert all("Old project kickoff" not in r["content"] for r in results)
+
+    def test_recall_to_date_filter(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        beam.remember("Recent standup notes", source="meeting", importance=0.8)
+
+        # Backdate an old memory
+        conn = sqlite3.connect(temp_db)
+        old_ts = "2025-01-15T10:00:00"
+        conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("old1", "January planning session", "meeting", old_ts, "s1", 0.7)
+        )
+        conn.commit()
+        conn.close()
+
+        # Filter to 2025-02-01 should only include January memory
+        results = beam.recall("planning", to_date="2025-02-01")
+        assert any("January" in r["content"] for r in results)
+        assert all("Recent" not in r["content"] for r in results)
+
+    def test_recall_source_filter(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        beam.remember("Bug fix for auth", source="github", importance=0.8)
+        beam.remember("Lunch with team", source="conversation", importance=0.5)
+
+        results = beam.recall("auth", source="github")
+        assert len(results) >= 1
+        assert all(r.get("source") == "github" for r in results)
+
+    def test_recall_date_range_filter(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+
+        # Insert memories on different dates
+        conn = sqlite3.connect(temp_db)
+        dates = [
+            ("2025-01-10T10:00:00", "January task A"),
+            ("2025-03-15T10:00:00", "March task B"),
+            ("2025-06-20T10:00:00", "June task C"),
+        ]
+        for ts, content in dates:
+            conn.execute(
+                "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+                (f"m_{content[:5]}", content, "test", ts, "s1", 0.7)
+            )
+        conn.commit()
+        conn.close()
+
+        # Range: March to May
+        results = beam.recall("task", from_date="2025-03-01", to_date="2025-05-31")
+        contents = [r["content"] for r in results]
+        assert any("March" in c for c in contents)
+        assert all("January" not in c for c in contents)
+        assert all("June" not in c for c in contents)
+
+    def test_recall_with_episodic_temporal_filter(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Consolidated memory with old timestamp
+        beam.consolidate_to_episodic(
+            summary="Q4 review discussion",
+            source_wm_ids=["wm1"],
+            source="meeting",
+            importance=0.8
+        )
+        # Backdate the episodic memory
+        conn = sqlite3.connect(temp_db)
+        conn.execute("UPDATE episodic_memory SET timestamp = ? WHERE content = ?", ("2024-12-01T10:00:00", "Q4 review discussion"))
+        conn.commit()
+        conn.close()
+
+        # Should find it without date filter
+        results_all = beam.recall("Q4 review")
+        assert any("Q4" in r["content"] for r in results_all)
+
+        # Should exclude it with from_date in 2025
+        results_filtered = beam.recall("Q4 review", from_date="2025-01-01")
+        assert all("Q4" not in r["content"] for r in results_filtered)
+
+    def test_temporal_triple_auto_generated(self, temp_db):
+        """Temporal triples should be auto-generated on remember()."""
+        from mnemosyne.core.triples import TripleStore
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        mid = beam.remember("Deploy script updated", source="dev", importance=0.8)
+
+        triple_store = TripleStore(db_path=temp_db)
+        triples = triple_store.query(subject=mid)
+        assert len(triples) >= 1
+        assert any(t["predicate"] == "occurred_on" for t in triples)
+
+
 class TestTokenAwareConsolidation:
     def test_sleep_chunks_large_batches(self, temp_db, monkeypatch):
         """BUG-1: sleep() must chunk memories to fit LLM context window."""


### PR DESCRIPTION
## Summary

Implements temporal query capabilities for Mnemosyne BEAM memory system.

## Changes

- **Date-range filtering**:  filters at SQL layer before hybrid ranking
- **Source/topic filtering**:  for periodic memory retrieval
- **Auto temporal triples**:  now generates  and  triples automatically
- **Bug fix**: Resolved  when FTS5 returns empty but temporal filters are active
- **Tests**: 6 new temporal query tests, all 25 tests passing
- **Version**: Bumped to 1.13.0

## Backward Compatibility

Existing  signature unchanged. New params are keyword-only with  defaults.

## Plan

Full spec: 

Closes #16