### PR TITLE
fix(beam): preserve memory id across legacy and working memory

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -672,9 +672,15 @@ class BeamMemory:
     def remember(self, content: str, source: str = "conversation",
                  importance: float = 0.5, metadata: Dict = None,
                  valid_until: str = None, scope: str = "session",
+                 memory_id: str = None,
                  extract_entities: bool = False,
                  extract: bool = False) -> str:
         """Store into working_memory. Deduplicates exact content matches.
+
+        When called from the legacy-compatible Mnemosyne.remember() path,
+        memory_id is passed through so the legacy memories row and BEAM
+        working_memory row stay addressable by the same ID. Direct BEAM calls
+        still generate their own deterministic ID.
 
         Args:
             content: The text to remember
@@ -683,6 +689,7 @@ class BeamMemory:
             metadata: Optional dict of additional fields
             valid_until: ISO timestamp when this memory expires
             scope: "session" or "global"
+            memory_id: Optional pre-generated ID from legacy layer
             extract_entities: If True, extract and store entity mentions as triples
             extract: If True, extract structured facts from content using LLM
                 and store as triples. Default False.
@@ -702,7 +709,7 @@ class BeamMemory:
             self.conn.commit()
             return existing_id
 
-        memory_id = _generate_id(content)
+        memory_id = memory_id or _generate_id(content)
         timestamp = datetime.now().isoformat()
         cursor = self.conn.cursor()
         cursor.execute("""

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -265,6 +265,10 @@ class Mnemosyne:
 
         self.conn.commit()
 
+        # BEAM write (reuse the same ID so legacy and working-memory rows stay in sync)
+        self.beam.remember(content, source=source, importance=importance, metadata=metadata,
+                           valid_until=valid_until, scope=scope, memory_id=memory_id)
+
         # Entity extraction (best-effort, never fails the memory write)
         if extract_entities:
             try:

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -149,13 +149,24 @@ class TestMnemosyneIntegration:
         legacy = conn.execute("SELECT * FROM memories WHERE id = ?", (mid,)).fetchone()
         assert legacy is not None
 
-        # BEAM working_memory
-        wm = conn.execute("SELECT * FROM working_memory WHERE session_id = ?", ("s2",)).fetchone()
+        # BEAM working_memory should use the same ID now
+        wm = conn.execute("SELECT * FROM working_memory WHERE id = ? AND session_id = ?", (mid, "s2")).fetchone()
         assert wm is not None
         conn.close()
 
         results = mem.recall("pizza")
         assert len(results) >= 1
+
+    def test_forget_removes_both_layers(self, temp_db):
+        mem = Mnemosyne(session_id="s2", db_path=temp_db)
+        mid = mem.remember("Forget me please", source="preference", importance=0.8)
+        assert mem.forget(mid) is True
+        conn = sqlite3.connect(temp_db)
+        legacy = conn.execute("SELECT * FROM memories WHERE id = ?", (mid,)).fetchone()
+        wm = conn.execute("SELECT * FROM working_memory WHERE id = ? AND session_id = ?", (mid, "s2")).fetchone()
+        conn.close()
+        assert legacy is None
+        assert wm is None
 
     def test_beam_stats(self, temp_db):
         mem = Mnemosyne(session_id="s3", db_path=temp_db)


### PR DESCRIPTION
## Summary

This fixes legacy/BEAM dual-write ID drift by letting `Mnemosyne.remember()` pass the generated legacy memory ID into `BeamMemory.remember()`.

Without this, the legacy `memories` row and BEAM `working_memory` row can receive different IDs for the same memory. That makes ID-based operations such as `forget(memory_id)` only partially effective: the legacy row can be removed while the BEAM working-memory row remains as a ghost memory.

## Changes

- Add optional `memory_id` parameter to `BeamMemory.remember()`.
- Keep existing direct BEAM behavior unchanged by falling back to `_generate_id(content)` when `memory_id` is not supplied.
- Pass the generated legacy ID from `Mnemosyne.remember()` into the BEAM write.
- Strengthen tests to verify:
  - legacy and BEAM rows use the same ID
  - `forget()` removes both layers

## Validation

Ran against current upstream plus this patch:
text python -m pytest tests/test_beam.py -q 26 passed

Also validated through the Hermes Mnemosyne provider integration against this branch:
text MNEMOSYNE_REPO_PATH=/home/kyklis/workspace/Preprod/axdsan-mnemosyne-upstream \ python -m pytest tests/plugins/memory/test_mnemosyne_provider.py -q -o 'addopts=' 6 passed

Live Hermes provider write/recall/delete checks also confirmed that after delete both `memories` and `working_memory` have zero remaining rows for the stored ID.
