### PR TITLE
fix: consolidate sleep across inactive sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ hermes mnemosyne stats     # Shows working + episodic memory counts
 
 - **BEAM architecture** — Three tiers: hot working memory, long-term episodic memory, temporary scratchpad
 - **Hybrid search** — 50% vector similarity + 30% FTS5 rank + 20% importance, all inside SQLite
-- **Automatic consolidation** — Old working memories are summarized and moved to episodic memory via `mnemosyne_sleep()`
+- **Automatic consolidation** — Old working memories are summarized and moved to episodic memory via `mnemosyne_sleep()`; use `hermes mnemosyne sleep --all-sessions` for scheduled maintenance across inactive sessions
 - **Temporal triples** — Time-aware knowledge graph with automatic invalidation
 - **Export / import** — Move your entire memory database to a new machine with one JSON file
 - **Cross-session scope** — `remember(..., scope="global")` makes facts visible everywhere
@@ -276,8 +276,11 @@ hermes mnemosyne stats --global
 # Search memories
 hermes mnemosyne inspect "dark mode preferences"
 
-# Run consolidation (compress old working memory into episodic summaries)
+# Run consolidation for the current session (compress old working memory into episodic summaries)
 hermes mnemosyne sleep
+
+# Run maintenance consolidation across all sessions with eligible old working memory
+hermes mnemosyne sleep --all-sessions
 
 # Export all memories to a JSON file
 hermes mnemosyne export --output mnemosyne_backup.json

--- a/hermes_memory_provider/README.md
+++ b/hermes_memory_provider/README.md
@@ -65,7 +65,7 @@ User plugins take precedence over bundled plugins on name collision.
 |------|---------|
 | `mnemosyne_remember` | Store durable memory with importance, scope, expiry |
 | `mnemosyne_recall` | Hybrid search (50% vector + 30% FTS + 20% importance) |
-| `mnemosyne_sleep` | Consolidate working → episodic memory |
+| `mnemosyne_sleep` | Consolidate working → episodic memory; pass `all_sessions=true` for inactive-session maintenance |
 | `mnemosyne_stats` | Show working + episodic counts |
 | `mnemosyne_invalidate` | Mark memory as expired/superseded |
 | `mnemosyne_triple_add` | Add temporal fact to knowledge graph |

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -106,9 +106,24 @@ SLEEP_SCHEMA = {
     "name": "mnemosyne_sleep",
     "description": (
         "Run the Mnemosyne consolidation cycle. Compresses old working memories "
-        "into episodic summaries. Call after long sessions or when memory feels stale."
+        "into episodic summaries. Call after long sessions or when memory feels stale. "
+        "Set all_sessions=true to consolidate eligible old working memories across inactive sessions."
     ),
-    "parameters": {"type": "object", "properties": {}},
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "all_sessions": {
+                "type": "boolean",
+                "description": "If true, consolidate eligible old working memories across all sessions instead of only the current session.",
+                "default": False,
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "If true, report what would be consolidated without writing changes.",
+                "default": False,
+            },
+        },
+    },
 }
 
 STATS_SCHEMA = {
@@ -304,7 +319,10 @@ class MnemosyneMemoryProvider(MemoryProvider):
             working = stats.get("total", 0)
             if working > self._auto_sleep_threshold:
                 logger.info("Mnemosyne auto-sleep: working=%d > threshold=%d", working, self._auto_sleep_threshold)
-                self._beam.sleep()
+                if hasattr(self._beam, "sleep_all_sessions"):
+                    self._beam.sleep_all_sessions()
+                else:
+                    self._beam.sleep()
         except Exception:
             pass
 
@@ -372,10 +390,15 @@ class MnemosyneMemoryProvider(MemoryProvider):
         return json.dumps({"query": query, "count": len(results), "temporal_weight": temporal_weight, "results": results})
 
     def _handle_sleep(self, args: Dict[str, Any]) -> str:
-        self._beam.sleep()
+        dry_run = bool(args.get("dry_run", False))
+        all_sessions = bool(args.get("all_sessions", False))
+        if all_sessions and hasattr(self._beam, "sleep_all_sessions"):
+            result = self._beam.sleep_all_sessions(dry_run=dry_run)
+        else:
+            result = self._beam.sleep(dry_run=dry_run)
         working = self._beam.get_working_stats()
         episodic = self._beam.get_episodic_stats()
-        return json.dumps({"status": "consolidated", "working": working, "episodic": episodic})
+        return json.dumps({"status": result.get("status", "consolidated"), "result": result, "working": working, "episodic": episodic})
 
     def _handle_stats(self, args: Dict[str, Any]) -> str:
         working = self._beam.get_working_stats()

--- a/hermes_memory_provider/cli.py
+++ b/hermes_memory_provider/cli.py
@@ -21,7 +21,9 @@ def register_cli(subparser):
     stats_cmd = mn_cmds.add_parser("stats", help="Show memory statistics")
     stats_cmd.add_argument("--global", "-g", action="store_true", help="Show global stats across all sessions")
 
-    mn_cmds.add_parser("sleep", help="Run consolidation cycle")
+    sleep_cmd = mn_cmds.add_parser("sleep", help="Run consolidation cycle")
+    sleep_cmd.add_argument("--all-sessions", action="store_true", help="Consolidate eligible old working memories across all sessions")
+    sleep_cmd.add_argument("--dry-run", action="store_true", help="Report what would be consolidated without writing changes")
     mn_cmds.add_parser("version", help="Show Mnemosyne version")
 
     inspect_cmd = mn_cmds.add_parser("inspect", help="Search memories")
@@ -67,10 +69,12 @@ def mnemosyne_command(args):
         print(f"Mnemosyne {__version__} by {__author__}")
 
     elif cmd == "sleep":
-        beam.sleep()
-        working = beam.get_working_stats()
-        episodic = beam.get_episodic_stats()
-        print(f"Consolidation complete. Working: {working.get('count', 0)}, Episodic: {episodic.get('count', 0)}")
+        dry_run = bool(getattr(args, "dry_run", False))
+        if getattr(args, "all_sessions", False):
+            result = beam.sleep_all_sessions(dry_run=dry_run)
+        else:
+            result = beam.sleep(dry_run=dry_run)
+        print(json.dumps(result, indent=2))
 
     elif cmd == "inspect":
         query = getattr(args, "query", "") or ""

--- a/hermes_plugin/tools.py
+++ b/hermes_plugin/tools.py
@@ -128,13 +128,18 @@ TRIPLE_QUERY_SCHEMA = {
 
 SLEEP_SCHEMA = {
     "name": "mnemosyne_sleep",
-    "description": "Run the Mnemosyne sleep/consolidation cycle. Old working memories are summarized and moved to episodic memory.",
+    "description": "Run the Mnemosyne sleep/consolidation cycle. Old working memories are summarized and moved to episodic memory. Set all_sessions=true to include inactive sessions.",
     "parameters": {
         "type": "object",
         "properties": {
             "dry_run": {
                 "type": "boolean",
                 "description": "If true, preview what would be consolidated without making changes",
+                "default": False
+            },
+            "all_sessions": {
+                "type": "boolean",
+                "description": "If true, consolidate eligible old working memories across all sessions instead of only the current session",
                 "default": False
             }
         }
@@ -394,8 +399,12 @@ def mnemosyne_sleep(args: dict, **kwargs) -> str:
     """Run consolidation sleep cycle"""
     try:
         dry_run = args.get("dry_run", False)
+        all_sessions = args.get("all_sessions", False)
         mem = _get_memory()
-        result = mem.sleep(dry_run=dry_run)
+        if all_sessions and hasattr(mem, "sleep_all_sessions"):
+            result = mem.sleep_all_sessions(dry_run=dry_run)
+        else:
+            result = mem.sleep(dry_run=dry_run)
         return json.dumps(result)
     except Exception as e:
         return json.dumps({"error": str(e)})

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1496,10 +1496,14 @@ class BeamMemory:
     # ------------------------------------------------------------------
     def sleep(self, dry_run: bool = False) -> Dict:
         """
-        Consolidate old working_memory into episodic_memory summaries.
+        Consolidate old working_memory for this session into episodic summaries.
         Uses a local lightweight LLM when available; falls back to aaak
         compression if the model is missing or inference fails.
         Returns summary of what was done.
+
+        Note: this method intentionally remains session-scoped. Use
+        sleep_all_sessions() for maintenance that consolidates eligible old
+        working memories across inactive sessions.
         """
         from mnemosyne.core.aaak import encode as aaak_encode
         from mnemosyne.core import local_llm
@@ -1609,6 +1613,79 @@ class BeamMemory:
             "llm_used": llm_used_count,
             "method": method,
             "consolidated_ids": consolidated_ids
+        }
+
+    def sleep_all_sessions(self, dry_run: bool = False) -> Dict:
+        """
+        Consolidate eligible old working memories across all sessions.
+
+        This is the maintenance-oriented counterpart to sleep(), which remains
+        scoped to self.session_id. It prevents inactive sessions from leaving
+        old working_memory rows stranded after they pass the sleep cutoff.
+        """
+        cursor = self.conn.cursor()
+        cutoff = (datetime.now() - timedelta(hours=WORKING_MEMORY_TTL_HOURS // 2)).isoformat()
+        cursor.execute("""
+            SELECT session_id, COUNT(*) AS eligible
+            FROM working_memory
+            WHERE timestamp < ?
+            GROUP BY session_id
+            ORDER BY MIN(timestamp) ASC
+        """, (cutoff,))
+        session_rows = cursor.fetchall()
+        if not session_rows:
+            return {
+                "status": "no_op",
+                "message": "No old working memories to consolidate",
+                "sessions_scanned": 0,
+                "sessions_consolidated": 0,
+                "items_consolidated": 0,
+                "summaries_created": 0,
+                "llm_used": 0,
+                "errors": 0,
+                "session_results": [],
+            }
+
+        session_results = []
+        sessions_consolidated = 0
+        items_consolidated = 0
+        summaries_created = 0
+        llm_used = 0
+        errors = []
+
+        for row in session_rows:
+            session_id = row["session_id"] if hasattr(row, "keys") else row[0]
+            if session_id is None:
+                session_id = "default"
+            try:
+                beam = self if session_id == self.session_id else BeamMemory(
+                    session_id=session_id,
+                    db_path=self.db_path,
+                )
+                result = beam.sleep(dry_run=dry_run)
+                result = dict(result)
+                result["session_id"] = session_id
+                result["eligible"] = row["eligible"] if hasattr(row, "keys") else row[1]
+                session_results.append(result)
+
+                if result.get("status") in ("consolidated", "dry_run"):
+                    sessions_consolidated += 1
+                    items_consolidated += int(result.get("items_consolidated", 0) or 0)
+                    summaries_created += int(result.get("summaries_created", 0) or 0)
+                    llm_used += int(result.get("llm_used", 0) or 0)
+            except Exception as exc:
+                errors.append({"session_id": session_id, "error": repr(exc)})
+
+        return {
+            "status": "dry_run" if dry_run else ("consolidated" if items_consolidated else "no_op"),
+            "sessions_scanned": len(session_rows),
+            "sessions_consolidated": sessions_consolidated,
+            "items_consolidated": items_consolidated,
+            "summaries_created": summaries_created,
+            "llm_used": llm_used,
+            "errors": len(errors),
+            "error_details": errors,
+            "session_results": session_results,
         }
 
     def get_consolidation_log(self, limit: int = 10) -> List[Dict]:

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -402,8 +402,12 @@ class Mnemosyne:
     # BEAM-specific public methods
     # ------------------------------------------------------------------
     def sleep(self, dry_run: bool = False) -> Dict:
-        """Run consolidation sleep cycle."""
+        """Run consolidation sleep cycle for the current session."""
         return self.beam.sleep(dry_run=dry_run)
+
+    def sleep_all_sessions(self, dry_run: bool = False) -> Dict:
+        """Run consolidation sleep cycle across all sessions with eligible old working memories."""
+        return self.beam.sleep_all_sessions(dry_run=dry_run)
 
     def scratchpad_write(self, content: str) -> str:
         """Write to scratchpad."""
@@ -634,8 +638,13 @@ def update(memory_id: str, content: str = None, importance: float = None, bank: 
 
 
 def sleep(dry_run: bool = False, bank: str = None) -> Dict:
-    """Run consolidation sleep cycle using the global instance"""
+    """Run consolidation sleep cycle for the global instance's current session"""
     return _get_default(bank).sleep(dry_run=dry_run)
+
+
+def sleep_all_sessions(dry_run: bool = False, bank: str = None) -> Dict:
+    """Run consolidation sleep cycle across all sessions using the global instance"""
+    return _get_default(bank).sleep_all_sessions(dry_run=dry_run)
 
 
 def scratchpad_write(content: str, bank: str = None) -> str:

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -293,14 +293,19 @@ def _handle_recall(arguments: Dict[str, Any]) -> Dict[str, Any]:
 def _handle_sleep(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_sleep tool call."""
     dry_run = arguments.get("dry_run", False)
+    all_sessions = arguments.get("all_sessions", False)
     bank = arguments.get("bank", "default")
 
     mem = _get_instance(bank)
-    result = mem.sleep(dry_run=dry_run)
+    if all_sessions and hasattr(mem, "sleep_all_sessions"):
+        result = mem.sleep_all_sessions(dry_run=dry_run)
+    else:
+        result = mem.sleep(dry_run=dry_run)
 
     return {
         "status": "ok",
         "dry_run": dry_run,
+        "all_sessions": all_sessions,
         "result": result,
         "bank": bank
     }

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -138,6 +138,91 @@ class TestSleepCycle:
         stats = beam.get_working_stats()
         assert stats["total"] == 1
 
+    def test_sleep_remains_session_scoped(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        conn = sqlite3.connect(temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        conn.executemany(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("s1-old", "session one task", "conversation", old_ts, "s1"),
+                ("s2-old", "session two task", "conversation", old_ts, "s2"),
+            ]
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.sleep(dry_run=False)
+        assert result["status"] == "consolidated"
+        assert result["items_consolidated"] == 1
+
+        conn = sqlite3.connect(temp_db)
+        remaining = conn.execute("SELECT session_id FROM working_memory ORDER BY session_id").fetchall()
+        conn.close()
+        assert remaining == [("s2",)]
+
+    def test_sleep_all_sessions_consolidates_inactive_sessions(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        conn = sqlite3.connect(temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        fresh_ts = datetime.now().isoformat()
+        conn.executemany(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("s1-old", "session one old task", "conversation", old_ts, "s1"),
+                ("s2-old", "session two old task", "conversation", old_ts, "s2"),
+                ("s2-fresh", "session two fresh task", "conversation", fresh_ts, "s2"),
+            ]
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.sleep_all_sessions(dry_run=False)
+        assert result["status"] == "consolidated"
+        assert result["sessions_scanned"] == 2
+        assert result["sessions_consolidated"] == 2
+        assert result["items_consolidated"] == 2
+        assert result["summaries_created"] == 2
+        assert result["errors"] == 0
+
+        conn = sqlite3.connect(temp_db)
+        remaining = conn.execute("SELECT id, session_id FROM working_memory").fetchall()
+        logs = conn.execute("SELECT session_id, items_consolidated FROM consolidation_log ORDER BY session_id").fetchall()
+        episodic_count = conn.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0]
+        conn.close()
+
+        assert remaining == [("s2-fresh", "s2")]
+        assert logs == [("s1", 1), ("s2", 1)]
+        assert episodic_count == 2
+
+    def test_sleep_all_sessions_dry_run_preserves_working_memory(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        conn = sqlite3.connect(temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        conn.executemany(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("s1-old", "session one task", "conversation", old_ts, "s1"),
+                ("s2-old", "session two task", "conversation", old_ts, "s2"),
+            ]
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.sleep_all_sessions(dry_run=True)
+        assert result["status"] == "dry_run"
+        assert result["sessions_scanned"] == 2
+        assert result["items_consolidated"] == 2
+
+        conn = sqlite3.connect(temp_db)
+        working_count = conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0]
+        episodic_count = conn.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0]
+        log_count = conn.execute("SELECT COUNT(*) FROM consolidation_log").fetchone()[0]
+        conn.close()
+        assert working_count == 2
+        assert episodic_count == 0
+        assert log_count == 0
+
 
 class TestMnemosyneIntegration:
     def test_legacy_and_beam_dual_write(self, temp_db):


### PR DESCRIPTION
## Summary

Fixes #19.

This adds an explicit all-session sleep maintenance path so old working memories from inactive sessions do not remain stranded indefinitely.

Changes:
- Keep `BeamMemory.sleep()` session-scoped for backwards-compatible semantics.
- Add `BeamMemory.sleep_all_sessions(dry_run=False)` to consolidate eligible old `working_memory` rows across all sessions.
- Expose the new behavior through:
  - `Mnemosyne.sleep_all_sessions()`
  - global `sleep_all_sessions()` helper
  - Hermes MemoryProvider `mnemosyne_sleep(all_sessions=true)`
  - Hermes plugin/MCP sleep handlers via `all_sessions`
  - CLI: `hermes mnemosyne sleep --all-sessions`
- Update provider auto-sleep to use all-session maintenance when available.
- Add tests covering:
  - `sleep()` remains session-scoped
  - `sleep_all_sessions()` consolidates inactive sessions
  - dry-run preserves working memory
- Clarify README/provider docs.

## Why

The current auto-sleep hook can run only while a session is active, while `BeamMemory.sleep()` only consolidates the current `session_id`. If rows are still younger than the sleep cutoff during active use, they can become eligible only after the session is inactive, then never be touched again.

`sleep_all_sessions()` provides a deterministic maintenance primitive without changing the existing `sleep()` API behavior.

## Test plan

- `python -m pytest tests/test_beam.py::TestSleepCycle -q`
- `python -m compileall hermes_memory_provider hermes_plugin mnemosyne`

Note: I also ran `python -m pytest tests/test_beam.py -q` locally. One pre-existing environment-sensitive test failed on my machine: `TestCrossSessionRecall::test_tools_session_singleton_updates` with a duplicate legacy memory id from the local default DB path. The new `TestSleepCycle` tests pass cleanly.
