### PR TITLE
fix: support base install without numpy

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -13,15 +13,21 @@ FTS5 for full-text retrieval.
 Hybrid ranking: 50% vector + 30% FTS rank + 20% importance.
 """
 
+from __future__ import annotations
+
 import sqlite3
 import json
 import hashlib
 import threading
 import math
-import numpy as np
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional, Any, Set, Union
 from pathlib import Path
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 from mnemosyne.core import embeddings as _embeddings
 
@@ -665,6 +671,8 @@ def _find_memories_by_fact(beam: "BeamMemory", query: str) -> List[str]:
 
 def _in_memory_vec_search(conn: sqlite3.Connection, query_embedding: np.ndarray, k: int = 20) -> List[Dict]:
     """Fallback vector search using memory_embeddings table + numpy cosine similarity."""
+    if np is None:
+        return []
     cursor = conn.cursor()
     # Join with episodic_memory (not memories) since that's where BEAM stores consolidated data
     cursor.execute("""

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -4,19 +4,25 @@ Local embedding-based memory retrieval using fastembed (ONNX, no PyTorch).
 Falls back to keyword-only if fastembed is unavailable.
 """
 
+from __future__ import annotations
+
 import json
 import os
-import numpy as np
 from typing import List, Optional
 from functools import lru_cache
 
-# Optional dependency
+# Optional dependencies
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
 try:
     from fastembed import TextEmbedding
-    _FASTEMBED_AVAILABLE = True
 except Exception:
-    _FASTEMBED_AVAILABLE = False
     TextEmbedding = None
+
+_FASTEMBED_AVAILABLE = np is not None and TextEmbedding is not None
 
 _DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
 _embedding_model = None

--- a/tests/test_optional_embeddings.py
+++ b/tests/test_optional_embeddings.py
@@ -1,0 +1,71 @@
+"""Regression tests for base installs without optional embedding dependencies."""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+
+_BLOCK_OPTIONAL_DEPS = r"""
+import importlib.abc
+import sys
+
+class BlockOptionalEmbeddingDeps(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "numpy" or fullname.startswith("numpy."):
+            raise ModuleNotFoundError("No module named 'numpy'")
+        if fullname == "fastembed" or fullname.startswith("fastembed."):
+            raise ModuleNotFoundError("No module named 'fastembed'")
+        return None
+
+sys.meta_path.insert(0, BlockOptionalEmbeddingDeps())
+"""
+
+
+def _run_with_optional_embedding_deps_blocked(code: str, tmp_path):
+    env = os.environ.copy()
+    env["MNEMOSYNE_DATA_DIR"] = str(tmp_path / "mnemosyne-data")
+    env["HOME"] = str(tmp_path / "home")
+    return subprocess.run(
+        [sys.executable, "-c", _BLOCK_OPTIONAL_DEPS + "\n" + code],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_embeddings_module_imports_without_numpy_or_fastembed(tmp_path):
+    result = _run_with_optional_embedding_deps_blocked(
+        textwrap.dedent(
+            """
+            from mnemosyne.core import embeddings
+
+            assert embeddings.available() is False
+            assert embeddings.embed_query("hello") is None
+            assert embeddings.embed(["hello"]) is None
+            """
+        ),
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_stats_works_without_optional_embedding_dependencies(tmp_path):
+    result = _run_with_optional_embedding_deps_blocked(
+        textwrap.dedent(
+            """
+            import sys
+            from mnemosyne.cli import run_cli
+
+            sys.argv = ["mnemosyne", "stats"]
+            run_cli()
+            """
+        ),
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Mnemosyne Stats" in result.stdout
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary

Fixes base installs of `mnemosyne-memory` when optional dense-retrieval dependencies are not installed.

A clean base install currently succeeds, and `mnemosyne --help` works, but normal memory commands such as `mnemosyne stats` fail immediately with:

```text
ModuleNotFoundError: No module named 'numpy'
```

The failure happens before Mnemosyne can fall back to keyword/FTS behavior because `numpy` is imported at module import time.

## Why this is a packaging contract issue

The README documents base install as:

```bash
pip install mnemosyne-memory
```

and documents `[all]` separately for dense retrieval / local LLM features:

```bash
pip install mnemosyne-memory[all]
```

The package description also emphasizes a zero/minimal-dependency base path. Given that contract, missing `numpy` / `fastembed` should disable dense/vector functionality rather than making core CLI commands fail.

## Changes

- Treat `numpy` as optional in `mnemosyne.core.embeddings`.
- Treat `fastembed` separately as optional, so dense embeddings are available only when both `numpy` and `fastembed` import successfully.
- Treat `numpy` as optional in `mnemosyne.core.beam`.
- Return no in-memory vector fallback results when `numpy` is unavailable.
- Add regression tests that simulate missing `numpy` and `fastembed` via subprocess import blocking.

## Test Plan

Observed the regression first: the new tests failed with `ModuleNotFoundError: No module named 'numpy'` from `embeddings.py`, then from `beam.py`.

After the fix:

```text
.venv/bin/python -m pytest tests/test_optional_embeddings.py -q
# 2 passed
```

```text
.venv/bin/python -m pytest tests/test_optional_embeddings.py tests/test_mnemosyne_stats.py tests/test_beam.py -q
# 88 passed
```

```text
.venv/bin/python -m pytest -q
# 454 passed
```

Also verified the actual packaging path in a fresh venv:

```bash
python3.11 -m venv /tmp/mnemosyne-base-install-fixed
/tmp/mnemosyne-base-install-fixed/bin/python -m pip install .
MNEMOSYNE_DATA_DIR=/tmp/mnemosyne-base-probe-fixed \
  /tmp/mnemosyne-base-install-fixed/bin/mnemosyne stats
```

Result:

```text
Mnemosyne Stats

  Total memories: 0
  Working memory: 0
  Episodic memory: 0
  DB path: N/A
```

Note: the full suite exits 0, but this environment emits an unrelated ignored `llama_cpp.Llama.__del__` cleanup traceback after the pytest summary.
