### PR TITLE
fix: report CLI input errors without tracebacks

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -10,6 +10,7 @@ import os
 import sys
 import json
 from pathlib import Path
+from typing import NoReturn
 
 # Data directory — respects MNEMOSYNE_DATA_DIR env var
 DATA_DIR = os.environ.get(
@@ -17,6 +18,28 @@ DATA_DIR = os.environ.get(
     str(Path.home() / ".hermes" / "mnemosyne" / "data"),
 )
 os.makedirs(DATA_DIR, exist_ok=True)
+
+
+def _fail(message: str, exit_code: int = 2) -> NoReturn:
+    """Print a CLI error and exit without a Python traceback."""
+    print(f"Error: {message}", file=sys.stderr)
+    raise SystemExit(exit_code)
+
+
+def _parse_float(value: str, name: str) -> float:
+    """Parse a float argument or exit with a user-facing CLI error."""
+    try:
+        return float(value)
+    except ValueError:
+        _fail(f"{name} must be a number: {value}")
+
+
+def _parse_int(value: str, name: str) -> int:
+    """Parse an integer argument or exit with a user-facing CLI error."""
+    try:
+        return int(value)
+    except ValueError:
+        _fail(f"{name} must be an integer: {value}")
 
 
 def _get_memory():
@@ -32,7 +55,7 @@ def cmd_store(args):
         return
     content = args[0]
     source = args[1] if len(args) > 1 else "cli"
-    importance = float(args[2]) if len(args) > 2 else 0.5
+    importance = _parse_float(args[2], "importance") if len(args) > 2 else 0.5
 
     mem = _get_memory()
     memory_id = mem.remember(
@@ -50,7 +73,7 @@ def cmd_recall(args):
         print("Usage: mnemosyne recall <query> [top_k]")
         return
     query = args[0]
-    top_k = int(args[1]) if len(args) > 1 else 5
+    top_k = _parse_int(args[1], "top_k") if len(args) > 1 else 5
 
     mem = _get_memory()
     results = mem.recall(query, top_k=top_k)
@@ -73,7 +96,7 @@ def cmd_update(args):
         return
     memory_id = args[0]
     content = args[1]
-    importance = float(args[2]) if len(args) > 2 else None
+    importance = _parse_float(args[2], "importance") if len(args) > 2 else None
 
     mem = _get_memory()
     success = mem.update(memory_id, content=content, importance=importance)
@@ -154,7 +177,14 @@ def cmd_import(args):
         print("Usage: mnemosyne import <file.json>")
         return
     mem = _get_memory()
-    result = mem.import_from_file(args[0])
+    try:
+        result = mem.import_from_file(args[0])
+    except FileNotFoundError:
+        _fail(f"Import file not found: {args[0]}")
+    except json.JSONDecodeError as e:
+        _fail(f"Invalid JSON in import file {args[0]}: {e}")
+    except ValueError as e:
+        _fail(str(e))
     print(f"Imported {result.get('count', 0)} memories from {args[0]}")
 
 

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,0 +1,58 @@
+"""CLI error handling regression tests."""
+
+import os
+import subprocess
+import sys
+
+
+COMMANDS = [
+    (
+        ["store", "hello", "cli", "not-a-float"],
+        "importance must be a number",
+    ),
+    (
+        ["recall", "hello", "not-an-int"],
+        "top_k must be an integer",
+    ),
+    (
+        ["update", "missing-id", "new content", "not-a-float"],
+        "importance must be a number",
+    ),
+    (
+        ["import", "missing-file.json"],
+        "Import file not found",
+    ),
+]
+
+
+def run_cli(args, tmp_path):
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["MNEMOSYNE_DATA_DIR"] = str(tmp_path / "mnemosyne-data")
+    return subprocess.run(
+        [sys.executable, "-m", "mnemosyne.cli", *args],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_invalid_cli_input_reports_error_without_traceback(tmp_path):
+    for args, expected_error in COMMANDS:
+        result = run_cli(args, tmp_path)
+
+        assert result.returncode != 0, args
+        assert expected_error in result.stderr, result.stderr
+        assert "Traceback" not in result.stderr
+
+
+def test_import_malformed_json_reports_error_without_traceback(tmp_path):
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{not valid json", encoding="utf-8")
+
+    result = run_cli(["import", str(bad_json)], tmp_path)
+
+    assert result.returncode != 0
+    assert "Invalid JSON" in result.stderr
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary

Improves CLI validation for common bad inputs so users get concise error messages instead of raw Python tracebacks.

Examples covered:

```bash
mnemosyne store "hello" cli not-a-float
mnemosyne recall "hello" not-an-int
mnemosyne update missing-id "new content" not-a-float
mnemosyne import missing-file.json
mnemosyne import malformed.json
```

Before this change, those cases could surface `ValueError`, `FileNotFoundError`, or `JSONDecodeError` tracebacks directly to the CLI user.

## Changes

- Add a small `_fail()` helper that prints user-facing errors to stderr and exits with code `2`.
- Add `_parse_float()` and `_parse_int()` helpers for CLI numeric arguments.
- Validate:
  - `store` importance
  - `recall` top_k
  - `update` importance
- Catch import-file errors in `mnemosyne import`:
  - missing file
  - malformed JSON
  - unsupported export/schema `ValueError`
- Add subprocess-based CLI regression tests that assert:
  - non-zero exit code
  - expected stderr message
  - no `Traceback` in stderr

## Scope

This intentionally keeps the existing CLI structure. It does **not** migrate to argparse/click/typer or redesign command parsing.

## Test Plan

Observed RED first:

```text
.venv/bin/python -m pytest tests/test_cli_errors.py -q
# failed with raw traceback output from ValueError / JSONDecodeError
```

After the fix:

```text
.venv/bin/python -m pytest tests/test_cli_errors.py -q
# 2 passed
```

```text
.venv/bin/python -m pytest tests/test_cli_errors.py tests/test_mnemosyne_stats.py -q
# 37 passed
```

```text
.venv/bin/python -m pytest -q
# 454 passed
```

Note: this environment still emits an unrelated ignored `llama_cpp.Llama.__del__` cleanup traceback after the pytest summary, but pytest exits 0.

## Review

Also ran a read-only Claude Code review of the focused diff. It recommended adding `NoReturn` to `_fail()` for type correctness; that change is included.
