### PR TITLE
docs: align examples with current CLI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,18 +317,19 @@ hermes mnemosyne export --output mnemosyne_backup.json
 hermes mnemosyne import --input mnemosyne_backup.json
 
 # Import from Hindsight (JSON export or live API)
-hermes mnemosyne import --from hindsight --file hindsight-export.json --bank hermes
-hermes mnemosyne import --from hindsight --base-url http://localhost:8888 --bank hermes
+mnemosyne import-hindsight hindsight-export.json hermes
+mnemosyne import-hindsight http://localhost:8888 hermes
 
 # Clear scratchpad
 hermes mnemosyne clear
 ```
 
-> **Optional REST API**: For external access or integration with non-Python services, you can run the standalone memory server:
+> **Optional MCP server**: For external access or integration with MCP-compatible services, run the MCP server:
 > ```bash
-> python mnemosyne/cli.py server  # Runs on http://localhost:8090
+> mnemosyne mcp                          # stdio transport
+> mnemosyne mcp --transport sse --port 8080  # SSE transport
 > ```
-> This is entirely optional -- the core library works without it.
+> Mnemosyne does not currently expose a standalone REST API server.
 
 ### Python API
 
@@ -496,7 +497,7 @@ mnemosyne mcp --transport sse --port 8080
 │                                            │ triples     │  │
 │                                            └─────────────┘  │
 │                                                              │
-│  Core runs in-process. Optional REST API available.          │
+│  Core runs in-process. Optional MCP server available.        │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -526,11 +527,11 @@ SQLite is already in your stack. Hermes uses it for session persistence. Mnemosy
 
 ## Backup, Export & Migration
 
-Mnemosyne stores everything in a single SQLite file at `~/.hermes/mnemosyne/data/mnemosyne.db`.
+By default, Mnemosyne stores its main database at `~/.hermes/mnemosyne/data/mnemosyne.db`. Named memory banks live under `~/.hermes/mnemosyne/data/banks/<name>/`, and standalone triple stores may create `triples.db` in the data directory.
 
 ```bash
-# Simple backup
-cp ~/.hermes/mnemosyne/data/mnemosyne.db ~/backups/mnemosyne_$(date +%Y%m%d).db
+# Simple backup of the full Mnemosyne data directory
+cp -a ~/.hermes/mnemosyne/data ~/backups/mnemosyne_data_$(date +%Y%m%d)
 
 # Export to JSON (portable across machines)
 hermes mnemosyne export --output mnemosyne_backup.json
@@ -541,7 +542,7 @@ hermes mnemosyne import --input mnemosyne_backup.json
 
 ### Migrate from other memory providers
 
-Import directly from 6 supported providers into Mnemosyne:
+Import directly from 7 supported providers into Mnemosyne:
 
 ```bash
 # List all supported providers
@@ -550,15 +551,15 @@ hermes mnemosyne import --list-providers
 # Mem0 → Mnemosyne
 hermes mnemosyne import --from mem0 --api-key sk-xxx
 
-# Letta → Mnemosyne (offline .af file)
-hermes mnemosyne import --from letta --agent-file-path ./agent.af
+# Letta → Mnemosyne
+hermes mnemosyne import --from letta --api-key sk-xxx
 
 # Zep → Mnemosyne
-hermes mnemosyne import --from zep --api-key sk-xxx --max-sessions 100
+hermes mnemosyne import --from zep --api-key sk-xxx
 
 # Hindsight → Mnemosyne (JSON export or live API)
-hermes mnemosyne import --from hindsight --file hindsight-export.json --bank hermes
-hermes mnemosyne import --from hindsight --base-url http://localhost:8888 --bank hermes
+mnemosyne import-hindsight hindsight-export.json hermes
+mnemosyne import-hindsight http://localhost:8888 hermes
 
 # Generate a migration script for any provider
 hermes mnemosyne import --from mem0 --generate-script --output-script migrate.py
@@ -568,6 +569,8 @@ hermes mnemosyne import --from zep --agentic
 ```
 
 **Supported providers:** Mem0, Letta (MemGPT), Zep, Cognee, Honcho, SuperMemory, **Hindsight**
+
+The generic Hermes CLI exposes the common importer options. Provider-specific options are available through the Python importers; for example, offline Letta AgentFile imports can use `LettaImporter(agent_file_path="./agent.af")`.
 
 All importers preserve metadata, timestamps, user/agent identity, and relationships (graph edges → triples). Use `--dry-run` to validate without writing.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -26,7 +26,7 @@ stats = mem.get_stats()
 from mnemosyne import remember, recall, get_stats, forget, update, get_context
 ```
 
-These functions create a default `Mnemosyne` instance and delegate to it.
+These functions create a default `Mnemosyne` instance and delegate to it. The optional `bank` parameter applies only to these module-level helpers; instance methods use the bank configured on `Mnemosyne(...)`.
 
 | Function | Signature | Description |
 |---|---|---|
@@ -35,7 +35,7 @@ These functions create a default `Mnemosyne` instance and delegate to it.
 | `get_stats()` | `() -> dict` | Memory statistics |
 | `forget()` | `(memory_id) -> bool` | Delete a memory |
 | `update()` | `(memory_id, **kwargs) -> bool` | Update a memory |
-| `get_context()` | `(query, top_k=5) -> str` | Get formatted context string |
+| `get_context()` | `(limit=10, bank=None) -> list[dict]` | Get recent working-memory context |
 
 ---
 
@@ -49,8 +49,9 @@ from mnemosyne.core.memory import Mnemosyne
 # Default instance
 mem = Mnemosyne()
 
-# With custom data directory
-mem = Mnemosyne(data_dir="/path/to/data")
+# With custom database path
+from pathlib import Path
+mem = Mnemosyne(db_path=Path("/path/to/mnemosyne.db"))
 
 # With memory bank
 mem = Mnemosyne(bank="work")
@@ -63,9 +64,12 @@ mem = Mnemosyne(session_id="my-agent-session")
 
 ```python
 Mnemosyne(
-    data_dir: str = None,        # Custom data directory (default: ~/.hermes/mnemosyne/data/)
-    session_id: str = None,      # Session identifier (default: auto-generated UUID)
-    bank: str = None             # Memory bank name for isolation
+    session_id: str = "default",     # Session identifier
+    db_path: Path = None,            # Custom database path
+    bank: str = None,                # Memory bank name for isolation
+    author_id: str = None,
+    author_type: str = None,
+    channel_id: str = None,
 )
 ```
 
@@ -189,11 +193,11 @@ stats = mem.get_stats()
 
 ### `get_context()`
 
-Get a formatted context string for LLM injection.
+Get recent working-memory context for prompt injection.
 
 ```python
-context = mem.get_context(query="recent tasks", top_k=5)
-# Returns formatted string ready for prompt injection
+context = mem.get_context(limit=5)
+# Returns a list of recent working-memory dictionaries
 ```
 
 ### `export_to_file()` / `import_from_file()`
@@ -240,9 +244,9 @@ beam = BeamMemory(
 | `recall(query, **kwargs) -> list` | Hybrid search across all tiers |
 | `sleep() -> dict` | Consolidate working → episodic |
 | `invalidate(memory_id, replacement_id=None) -> bool` | Mark memory as superseded |
-| `scratchpad_write(key, value) -> str` | Write to scratchpad |
-| `scratchpad_read(key) -> str` | Read from scratchpad |
-| `scratchpad_clear() -> int` | Clear scratchpad |
+| `scratchpad_write(content) -> str` | Write to scratchpad |
+| `scratchpad_read() -> list[dict]` | Read scratchpad entries |
+| `scratchpad_clear() -> None` | Clear scratchpad |
 
 ---
 
@@ -629,10 +633,10 @@ result.finished_at   # ISO timestamp
 ### Provider Registry
 
 ```python
-from mnemosyne.core.importers import import_from_provider, PROVIDER_REGISTRY
+from mnemosyne.core.importers import import_from_provider, PROVIDERS
 
 # See all supported providers
-print(PROVIDER_REGISTRY.keys())
+print(PROVIDERS.keys())
 # dict_keys(['mem0', 'letta', 'zep', 'cognee', 'honcho', 'supermemory', 'hindsight'])
 
 # Generic import dispatcher

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ print(f"Consolidated {result['consolidated']} memories")
 
 ## SQLite Backend
 
-All data lives in a single SQLite file at `~/.hermes/mnemosyne/data/mnemosyne.db`.
+By default, the main database lives at `~/.hermes/mnemosyne/data/mnemosyne.db`. Named memory banks use separate SQLite files under `~/.hermes/mnemosyne/data/banks/<name>/`, and standalone `TripleStore()` may use `triples.db` in the data directory.
 
 ### Tables
 

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -70,6 +70,7 @@ Mnemosyne registers these tools in the Hermes tool registry:
 | `mnemosyne_invalidate` | Mark a memory as superseded |
 | `mnemosyne_export` | Export all memories to JSON |
 | `mnemosyne_import` | Import memories from JSON |
+| `mnemosyne_diagnose` | Run PII-safe diagnostics |
 
 ## CLI Commands
 
@@ -86,13 +87,14 @@ hermes mnemosyne version            # Show version
 
 ## Data Location
 
-All data is stored in:
+By default, data is stored under:
 
 ```
 ~/.hermes/mnemosyne/
 ├── data/
-│   ├── mnemosyne.db    # Main SQLite database (BEAM + legacy)
-│   └── triples.db      # Knowledge graph (same directory)
+│   ├── mnemosyne.db              # Main SQLite database (BEAM + legacy)
+│   ├── triples.db                # Used by standalone TripleStore()
+│   └── banks/<name>/mnemosyne.db # Named memory banks
 └── ...
 ```
 
@@ -110,15 +112,16 @@ Set `MNEMOSYNE_HOST_LLM_ENABLED=true` to enable. See
 [hermes-llm-integration.md](hermes-llm-integration.md) for the full behavior
 model, configuration reference, and session-shutdown semantics.
 
-## Optional REST API
+## Optional MCP Server
 
-For integration with non-Python services:
+For integration with MCP-compatible clients:
 
 ```bash
-python mnemosyne/cli.py server  # Runs on http://localhost:8090
+mnemosyne mcp                          # stdio transport
+mnemosyne mcp --transport sse --port 8080  # SSE transport
 ```
 
-This is entirely optional — the core library works without it.
+Mnemosyne does not currently expose a standalone REST API server.
 
 ## Uninstall
 

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -308,4 +308,4 @@ If the `hermes_plugin` hook uses a different session ID than the MemoryProvider,
 
 ### Memory survives gateway restarts, machine reboots, and Fly.io VM recycles
 
-All data lives in `~/.hermes/mnemosyne/data/mnemosyne.db` — a single SQLite file. No Docker, no PostgreSQL, no network calls.
+By default, the main database lives at `~/.hermes/mnemosyne/data/mnemosyne.db`; named banks live under `~/.hermes/mnemosyne/data/banks/<name>/`. No Docker, no PostgreSQL, no required network calls.


### PR DESCRIPTION
## Summary

This is a docs-only synchronization pass to make the README and docs match the behavior currently exposed by the codebase.

The main goal is to remove stale examples that would fail for users today, while keeping the scope limited to documentation. I intentionally avoided packaging or implementation changes here so this can be reviewed independently from code-behavior PRs.

## What changed

### Replaced stale REST API references with MCP server documentation

The docs previously described an optional REST API / standalone memory server, including examples such as:

```bash
python mnemosyne/cli.py server
```

I could not find a current `server` command in the CLI. The exposed integration path is now the MCP server, so the docs now show:

```bash
mnemosyne mcp
mnemosyne mcp --transport sse --port 8080
```

I also added explicit wording that Mnemosyne does not currently expose a standalone REST API server, to avoid implying there is a missing command users should be able to run.

Files touched:
- `README.md`
- `docs/api-reference.md`
- `docs/architecture.md`
- `docs/hermes-integration.md`

### Corrected CLI examples for Hindsight imports

The README previously showed Hindsight import examples through the generic Hermes import command with flags such as `--file` and `--bank`:

```bash
hermes mnemosyne import --from hindsight --file hindsight-export.json --bank hermes
```

The current CLI exposes Hindsight import through the standalone command added for that importer:

```bash
mnemosyne import-hindsight hindsight-export.json hermes
mnemosyne import-hindsight http://localhost:8888 hermes
```

So the README examples now use that command instead of unsupported Hermes CLI flags.

### Corrected API reference drift

Updated `docs/api-reference.md` to match the current Python API surface, including:

- `Mnemosyne(...)` constructor arguments (`session_id`, `db_path`, `bank`, `author_id`, `author_type`, `channel_id`)
- `get_context(limit=...)` returning recent working-memory dictionaries rather than a formatted query-based string
- scratchpad methods:
  - `scratchpad_write(content)`
  - `scratchpad_read()`
  - `scratchpad_clear()`
- importer registry name from `PROVIDER_REGISTRY` to `PROVIDERS`

I also clarified that `bank=None` in the module-level helper signatures applies to the module-level convenience functions; instance methods use the bank configured on the `Mnemosyne(...)` instance.

### Corrected provider count and importer wording

The docs now consistently refer to 7 supported import providers:

- Mem0
- Letta
- Zep
- Cognee
- Honcho
- SuperMemory
- Hindsight

I kept the generic Hermes CLI examples to options currently exposed by that CLI. Where provider-specific importer options exist in Python but are not exposed through the generic Hermes command, I added clarifying wording instead of documenting unsupported CLI flags. For example, offline Letta AgentFile import is now mentioned as a Python importer option:

```python
LettaImporter(agent_file_path="./agent.af")
```

### Clarified SQLite storage / backup wording

The README and installation guide previously implied everything lived in a single SQLite file. The current layout can include:

- the main database at `~/.hermes/mnemosyne/data/mnemosyne.db`
- named bank databases under `~/.hermes/mnemosyne/data/banks/<name>/`
- standalone triple-store files such as `triples.db`

The backup example now copies the full Mnemosyne data directory rather than only the top-level `mnemosyne.db`.

### Updated Hermes plugin tool list

`docs/hermes-integration.md` now includes the registered diagnostic tool:

- `mnemosyne_diagnose`

## What this PR intentionally does not change

- No Python code changes.
- No package metadata changes.
- No dependency changes.
- No attempt to add a `mcp` extra in `pyproject.toml`.
- No attempt to change NumPy behavior or dependency declarations. I saw that separate work is already underway for base-install / NumPy fallback behavior, so I left that out of this docs-only PR.
- No attempt to add Hermes CLI parity for provider-specific importer flags. This PR documents what appears to work today rather than changing CLI behavior.

## Verification performed

- Checked the current CLI surface before replacing REST/Hindsight examples.
- Checked the public API signatures in `mnemosyne/core/memory.py` before updating API docs.
- Checked importer registry naming in `mnemosyne/core/importers/__init__.py`.
- Checked Hermes plugin tool registration before adding `mnemosyne_diagnose`.
- Ran:

```bash
git diff --check
```

No whitespace errors were reported.

## Review notes

This is meant as PR 1 in a small sequence:

1. **This PR:** docs-only correction of stale examples and API references.
2. Possible follow-up: packaging/docs alignment for optional MCP dependencies if desired.
3. Possible follow-up: provider-specific Hermes CLI importer options, if the project wants CLI parity for options that currently exist only in the Python importers.
