### PR TITLE
fix: llm_used detection always False + remote fallback blocks local LLM + Llama token prompt

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2131,6 +2131,7 @@ class BeamMemory:
 
             # --- Try LLM summarization (chunked to fit context) ---
             summary = None
+            llm_succeeded = False
             if local_llm.llm_available():
                 chunks = local_llm.chunk_memories_by_budget(lines, source=source)
                 if chunks:
@@ -2158,6 +2159,7 @@ class BeamMemory:
                                     summary = " | ".join(chunk_summaries)
                     if summary:
                         llm_used_count += 1
+                        llm_succeeded = True
 
             # --- Fallback to aaak encoding ---
             if summary is None:
@@ -2176,7 +2178,7 @@ class BeamMemory:
                     metadata={
                         "original_count": len(items),
                         "source": source,
-                        "llm_used": summary != f"[{source}] {aaak_encode(' | '.join(lines))}"
+                        "llm_used": llm_succeeded
                     }
                 )
                 placeholders = ",".join("?" * len(ids))

--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -206,10 +206,9 @@ def _call_local_llm(prompt: str) -> Optional[str]:
 def _build_prompt(memories: List[str], source: str = "") -> str:
     """Build a consolidation prompt from a list of memory strings.
 
-    Uses TinyLlama chat-template tokens (<|user|>, </s>, <|assistant|>)
-    suitable for the local GGUF model. For host LLM calls, use
-    :func:`_build_host_prompt` instead — Codex/GPT-class providers treat
-    these tokens as garbage text.
+    Uses a plain-text instruction format (no special model tokens)
+    suitable for both local GGUF models and any LLM. For host LLM
+    calls, use :func:`_build_host_prompt` instead.
     """
     header = (
         "Summarize the following memories into 1-3 concise sentences. "
@@ -219,7 +218,7 @@ def _build_prompt(memories: List[str], source: str = "") -> str:
         header += f" Source: {source}."
 
     lines = "\n".join(f"- {m}" for m in memories if m)
-    prompt = f"<|user|>\n{header}\n\n{lines}\n</s>\n<|assistant|>\n"
+    prompt = f"{header}\n\n{lines}\n\nSummary:"
     return prompt
 
 
@@ -482,12 +481,14 @@ def summarize_memories(memories: List[str], source: str = "") -> Optional[str]:
             return cleaned if cleaned else None
         return None
 
-    # 1. Remote API.
-    if LLM_ENABLED and LLM_BASE_URL:
+    # 1. Remote API (skip if MNEMOSYNE_FORCE_LOCAL=1 or remote call fails).
+    # When remote fails, fall through to local LLM instead of returning None.
+    if LLM_ENABLED and LLM_BASE_URL and not os.environ.get("MNEMOSYNE_FORCE_LOCAL", "").lower() in ("1", "true", "yes"):
         raw = _call_remote_llm(prompt)
         if raw:
             cleaned = _clean_output(raw)
             return cleaned if cleaned else None
+        # Remote failed — fall through to local LLM
 
     # 2. Local LLM (llama-cpp-python or ctransformers fallback).
     raw = _call_local_llm(prompt)


### PR DESCRIPTION
## Bugs Fixed

### 1. `llm_used` metadata always `False` in sleep consolidation

**File:** `mnemosyne/core/beam.py` (sleep method)

The `llm_used` metadata field was computed as:
```python
"llm_used": summary != f"[{source}] {aaak_encode(' | '.join(lines))}"
```

This comparison always evaluates `True` when LLM succeeds (LLM output never matches AAAK compressed format), making `llm_used` persistently `False` even when LLM summarization fires.

**Fix:** Use an explicit `llm_succeeded` boolean flag set `True` when LLM produces a summary.

### 2. Remote API failure blocks local LLM fallback

**File:** `mnemosyne/core/local_llm.py` (`summarize_memories()`)

When `MNEMOSYNE_LLM_BASE_URL` was set but the remote call failed (timeout, 401, etc.), `summarize_memories()` returned `None` immediately — the local llama-cpp-python backend was never reached.

**Fix:** Remote failure now falls through to local LLM. Added `MNEMOSYNE_FORCE_LOCAL=1` env var to skip remote API entirely (useful when OpenRouter quota is exhausted).

### 3. Llama chat-template tokens in prompt

**File:** `mnemosyne/core/local_llm.py` (`_build_prompt()`)

The prompt used Llama-specific tokens (`tiert`, `</s>`, ` ins`) which:
- Get echoed verbatim by some GGUF models
- Break with non-Llama providers

**Fix:** Replaced with plain-text instruction format that works with any model.

## Testing

- Verified `llm_available()` returns `True` with TinyLlama 1.1B Q4_K_M on ARM64
- Tested `summarize_memories()` end-to-end: produces coherent 1-2 sentence summaries
- All 113 previously AAAK-encoded episodic memories re-consolidated successfully with local LLM