### PR TITLE
fix: support Hindsight imports from Hermes CLI

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -654,6 +654,11 @@ mnemosyne export backup.json
 mnemosyne import backup.json
 mnemosyne import-hindsight export.json [bank]      # Import Hindsight JSON
 mnemosyne import-hindsight http://localhost:8888    # Import from live API
+
+# Hermes CLI routes through the same HindsightImporter, preserving timestamps
+hermes mnemosyne import --from hindsight --file export.json --bank hermes
+hermes mnemosyne import --from hindsight --input export.json --bank hermes
+hermes mnemosyne import --from hindsight --base-url http://localhost:8888 --bank hermes
 mnemosyne bank list
 mnemosyne bank create work
 mnemosyne bank delete work

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -80,6 +80,12 @@ hermes mnemosyne inspect "query"    # Search memories
 hermes mnemosyne sleep              # Run consolidation
 hermes mnemosyne export --output backup.json
 hermes mnemosyne import --input backup.json
+
+# Import historical Hindsight memories via PR #28's timestamp-preserving importer
+hermes mnemosyne import --from hindsight --file hindsight-export.json --bank hermes
+hermes mnemosyne import --from hindsight --input hindsight-export.json --bank hermes
+hermes mnemosyne import --from hindsight --base-url http://localhost:8888 --bank hermes
+
 hermes mnemosyne clear              # Clear scratchpad
 hermes mnemosyne version            # Show version
 ```

--- a/hermes_memory_provider/cli.py
+++ b/hermes_memory_provider/cli.py
@@ -37,12 +37,14 @@ def register_cli(subparser):
 
     import_cmd = mn_cmds.add_parser("import", help="Import memories from a JSON file or another provider")
     import_cmd.add_argument("--input", "-i", type=str, help="Input JSON file path (for file imports)")
+    import_cmd.add_argument("--file", type=str, help="Provider file input, e.g. Hindsight JSON export")
     import_cmd.add_argument("--force", action="store_true", help="Overwrite existing records (file import)")
     import_cmd.add_argument("--from", dest="from_provider", type=str, help="Provider to import from (e.g., 'mem0')")
     import_cmd.add_argument("--api-key", type=str, help="Provider API key (or set env var)")
     import_cmd.add_argument("--user-id", type=str, help="Filter by user ID (provider-specific)")
     import_cmd.add_argument("--agent-id", type=str, help="Filter by agent ID (provider-specific)")
     import_cmd.add_argument("--base-url", type=str, help="Provider base URL (for self-hosted)")
+    import_cmd.add_argument("--bank", type=str, help="Provider memory bank, e.g. Hindsight bank")
     import_cmd.add_argument("--dry-run", action="store_true", help="Validate but don't import")
     import_cmd.add_argument("--session-id", type=str, help="Override session for imported memories")
     import_cmd.add_argument("--channel-id", type=str, help="Channel for imported memories")
@@ -187,6 +189,53 @@ def mnemosyne_command(args):
             agent_id = getattr(args, "agent_id", None)
             base_url = getattr(args, "base_url", None)
 
+            def _print_import_result(result):
+                print(f"\nImport complete:")
+                print(f"  Total found: {result.total}")
+                print(f"  Imported:    {result.imported}")
+                print(f"  Skipped:     {result.skipped}")
+                print(f"  Failed:      {result.failed}")
+                if result.errors:
+                    print(f"  Errors:")
+                    for err in result.errors[:10]:
+                        print(f"    - {err}")
+                    if len(result.errors) > 10:
+                        print(f"    ... and {len(result.errors) - 10} more")
+
+            if cross_provider == "hindsight":
+                file_path = getattr(args, "file", None) or input_path
+                bank = getattr(args, "bank", None) or "hermes"
+                if not file_path and not base_url:
+                    print("Error: Hindsight import requires --file/--input or --base-url.")
+                    return 1
+
+                print("Importing from hindsight...")
+                if dry_run:
+                    print("  (dry-run mode: no memories will be written)")
+
+                try:
+                    from mnemosyne.core.importers import import_from_provider
+                    import_kwargs = {
+                        "file_path": file_path,
+                        "base_url": base_url,
+                        "bank": bank,
+                        "dry_run": dry_run,
+                        "session_id": session_id,
+                        "channel_id": channel_id,
+                    }
+                    result = import_from_provider(
+                        "hindsight", mem,
+                        **import_kwargs,
+                    )
+                    _print_import_result(result)
+                    return 0 if result.failed == 0 else 1
+                except ValueError as e:
+                    print(f"Error: {e}")
+                    return 1
+                except Exception as e:
+                    print(f"Import failed: {e}")
+                    return 1
+
             # Try env var fallback
             import os
             if not api_key:
@@ -215,17 +264,7 @@ def mnemosyne_command(args):
                     session_id=session_id,
                     channel_id=channel_id,
                 )
-                print(f"\nImport complete:")
-                print(f"  Total found: {result.total}")
-                print(f"  Imported:    {result.imported}")
-                print(f"  Skipped:     {result.skipped}")
-                print(f"  Failed:      {result.failed}")
-                if result.errors:
-                    print(f"  Errors:")
-                    for err in result.errors[:10]:
-                        print(f"    - {err}")
-                    if len(result.errors) > 10:
-                        print(f"    ... and {len(result.errors) - 10} more")
+                _print_import_result(result)
                 return 0 if result.failed == 0 else 1
             except ValueError as e:
                 print(f"Error: {e}")

--- a/tests/test_hermes_hindsight_cli.py
+++ b/tests/test_hermes_hindsight_cli.py
@@ -1,0 +1,196 @@
+import json
+import sqlite3
+from types import SimpleNamespace
+
+from hermes_memory_provider.cli import mnemosyne_command
+from mnemosyne.core.importers.base import ImporterResult
+from mnemosyne.core.memory import Mnemosyne as RealMnemosyne
+
+
+def _sample_items():
+    return [
+        {
+            "id": "hs-world-1",
+            "text": "Hermes CLI Hindsight import must preserve timestamps.",
+            "fact_type": "world",
+            "mentioned_at": "2026-04-29T01:36:00+00:00",
+            "date": "2026-04-29",
+            "proof_count": 2,
+            "tags": ["session:cli-import"],
+        }
+    ]
+
+
+def _args(**overrides):
+    defaults = {
+        "mnemosyne_cmd": "import",
+        "list_providers": False,
+        "generate_script": False,
+        "agentic": False,
+        "from_provider": None,
+        "output_script": None,
+        "input": None,
+        "file": None,
+        "force": False,
+        "api_key": None,
+        "user_id": None,
+        "agent_id": None,
+        "base_url": None,
+        "bank": None,
+        "dry_run": False,
+        "session_id": None,
+        "channel_id": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _patch_cli_memory(monkeypatch, db_path):
+    class DummyBeamMemory:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    def make_memory(session_id="default", channel_id=None, **kwargs):
+        return RealMnemosyne(session_id=session_id, channel_id=channel_id, db_path=db_path)
+
+    # mnemosyne_command imports these symbols inside the function body, so
+    # patching their definition modules before invocation keeps tests isolated.
+    monkeypatch.setattr("mnemosyne.core.beam.BeamMemory", DummyBeamMemory)
+    monkeypatch.setattr("mnemosyne.core.memory.Mnemosyne", make_memory)
+
+
+def _write_export(tmp_path, items=None):
+    export = tmp_path / "hindsight-export.json"
+    export.write_text(json.dumps({"items": items or _sample_items()}), encoding="utf-8")
+    return export
+
+
+def _db_counts_and_row(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT timestamp, metadata_json FROM episodic_memory ORDER BY timestamp LIMIT 1"
+            ).fetchone()
+            working_count = conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0]
+            episodic_count = conn.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0]
+        except sqlite3.OperationalError as exc:
+            if "no such table" not in str(exc):
+                raise
+            return 0, 0, None
+    return working_count, episodic_count, row
+
+
+def test_hermes_cli_hindsight_file_import_preserves_timestamp(tmp_path, monkeypatch):
+    db_path = tmp_path / "mnemosyne.db"
+    _patch_cli_memory(monkeypatch, db_path)
+    export = _write_export(tmp_path)
+
+    rc = mnemosyne_command(
+        _args(from_provider="hindsight", file=str(export), bank="hermes")
+    )
+
+    assert rc == 0
+    working_count, _, row = _db_counts_and_row(db_path)
+    assert row["timestamp"] == "2026-04-29T01:36:00+00:00"
+    assert working_count == 0
+
+
+def test_hermes_cli_hindsight_accepts_input_alias(tmp_path, monkeypatch):
+    db_path = tmp_path / "mnemosyne.db"
+    _patch_cli_memory(monkeypatch, db_path)
+    export = _write_export(tmp_path)
+
+    rc = mnemosyne_command(
+        _args(from_provider="hindsight", input=str(export), bank="hermes")
+    )
+
+    assert rc == 0
+    working_count, _, row = _db_counts_and_row(db_path)
+    assert row["timestamp"] == "2026-04-29T01:36:00+00:00"
+    assert working_count == 0
+
+
+def test_hermes_cli_hindsight_base_url_does_not_require_api_key(tmp_path, monkeypatch):
+    db_path = tmp_path / "mnemosyne.db"
+    _patch_cli_memory(monkeypatch, db_path)
+    captured = {}
+
+    def fake_import_from_provider(provider, mem, **kwargs):
+        captured["provider"] = provider
+        captured["kwargs"] = kwargs
+        return ImporterResult(provider="hindsight", total=1, imported=1)
+
+    monkeypatch.setattr(
+        "mnemosyne.core.importers.import_from_provider", fake_import_from_provider
+    )
+
+    rc = mnemosyne_command(
+        _args(
+            from_provider="hindsight",
+            base_url="http://127.0.0.1:8888",
+            bank="personal",
+        )
+    )
+
+    assert rc == 0
+    assert captured["provider"] == "hindsight"
+    assert captured["kwargs"]["base_url"] == "http://127.0.0.1:8888"
+    assert captured["kwargs"]["file_path"] is None
+    assert captured["kwargs"]["bank"] == "personal"
+    assert "api_key" not in captured["kwargs"]
+
+
+def test_hermes_cli_hindsight_forwards_non_default_bank(tmp_path, monkeypatch):
+    db_path = tmp_path / "mnemosyne.db"
+    _patch_cli_memory(monkeypatch, db_path)
+    export = _write_export(tmp_path)
+
+    rc = mnemosyne_command(
+        _args(from_provider="hindsight", file=str(export), bank="personal")
+    )
+
+    assert rc == 0
+    _, _, row = _db_counts_and_row(db_path)
+    metadata = json.loads(row["metadata_json"])
+    assert "hindsight_bank" in metadata
+    assert metadata["hindsight_bank"] == "personal"
+
+
+def test_hermes_cli_hindsight_dry_run_writes_no_rows(tmp_path, monkeypatch):
+    db_path = tmp_path / "mnemosyne.db"
+    _patch_cli_memory(monkeypatch, db_path)
+    export = _write_export(tmp_path)
+
+    rc = mnemosyne_command(
+        _args(from_provider="hindsight", file=str(export), dry_run=True)
+    )
+
+    assert rc == 0
+    working_count, episodic_count, row = _db_counts_and_row(db_path)
+    assert working_count == 0
+    assert episodic_count == 0
+    assert row is None
+
+
+def test_hermes_cli_hindsight_requires_file_or_base_url(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "mnemosyne.db"
+    _patch_cli_memory(monkeypatch, db_path)
+
+    rc = mnemosyne_command(_args(from_provider="hindsight"))
+
+    assert rc == 1
+    output = capsys.readouterr().out
+    assert "Hindsight import requires --file/--input or --base-url" in output
+
+
+def test_hermes_cli_other_provider_still_requires_api_key(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "mnemosyne.db"
+    _patch_cli_memory(monkeypatch, db_path)
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
+
+    rc = mnemosyne_command(_args(from_provider="mem0"))
+
+    assert rc == 1
+    output = capsys.readouterr().out
+    assert "--api-key required for mem0 import" in output


### PR DESCRIPTION
# fix: support Hindsight imports from Hermes CLI

## Summary

This PR expands the Hindsight migration work from PR #28 by exposing the same timestamp-preserving Hindsight importer through the Hermes CLI import command.

PR #28 added the correct migration path for Hindsight data: `HindsightImporter` reads Hindsight JSON/API records and writes them directly to Mnemosyne `episodic_memory`, preserving historical fields such as `mentioned_at`, `fact_type`, session grouping, metadata, source, scope, and veracity. That behavior is intentionally different from the generic importer base path, which routes records through `remember()` and would assign current timestamps / working-memory semantics.

Before this PR, the standalone Mnemosyne CLI could use that logic via:

```bash
mnemosyne import-hindsight <file|url> [bank]
```

but the Hermes CLI provider import path could not. `hermes mnemosyne import --from <provider>` treated every provider as an API-key provider, so `--from hindsight` was blocked by the generic `--api-key required` check and did not expose the Hindsight-specific `file_path` / `bank` inputs.

This PR fixes that gap by making Hermes CLI route `--from hindsight` into the existing PR #28 importer instead of duplicating or replacing its timestamp logic.

## What changed

### Hermes CLI

Adds Hindsight-specific provider inputs to `hermes mnemosyne import`:

```bash
hermes mnemosyne import --from hindsight --file hindsight-export.json --bank hermes
hermes mnemosyne import --from hindsight --input hindsight-export.json --bank hermes
hermes mnemosyne import --from hindsight --base-url http://localhost:8888 --bank hermes
```

Implementation detail:

```python
result = import_from_provider(
    "hindsight",
    mem,
    file_path=file_path,
    base_url=base_url,
    bank=bank,
    dry_run=dry_run,
    session_id=session_id,
    channel_id=channel_id,
)
```

That means Hermes CLI now relies on the existing `HindsightImporter` registered by PR #28. It does not copy the importer, reimplement timestamp selection, or write directly to SQLite itself.

### Behavior

- `--from hindsight` no longer requires `--api-key`.
- Hindsight JSON exports can be passed via either `--file` or existing `--input`.
- Live Hindsight API imports can be passed via `--base-url`.
- `--bank` is forwarded to the Hindsight importer and defaults to `hermes`, matching PR #28.
- Hindsight imports continue to preserve historical timestamps because the real import still happens in `HindsightImporter`.
- Other providers still use the existing API-key flow unchanged.

### Docs

This PR also updates the Hermes-facing docs that were missing the new Hindsight CLI path:

- `docs/hermes-integration.md`
- `docs/api-reference.md`

The README already documented the `--from hindsight` Hermes examples; this PR brings the rest of the docs into alignment.

## Why this approach

The important design choice is not to generalize timestamp preservation across all importers.

Most providers still fit the generic importer model: transform provider records and store them through `remember()`. Hindsight is different because it is a historical migration of already-consolidated memory. Routing Hindsight through `remember()` would lose the original memory timeline and contaminate working memory with imported history.

PR #28 already encoded that distinction correctly. This PR keeps that architecture intact and simply exposes it through Hermes CLI.

Layering after this PR:

```text
Hermes CLI
  └── import_from_provider("hindsight", ...)
        └── HindsightImporter from PR #28
              └── direct episodic_memory insert preserving timestamps
```

## Tests

Added Hermes CLI regression tests covering:

- Hindsight file import via `--file` preserves `mentioned_at` in `episodic_memory`.
- Hindsight file import via `--input` also works.
- Hindsight `--base-url` path does not require an API key and forwards `base_url` / `bank`.
- Non-default `--bank` is forwarded into imported metadata.
- `--dry-run` returns success but writes no working or episodic rows.
- Missing `--file` / `--input` / `--base-url` gives a clear error.
- Non-Hindsight providers still require `--api-key`.

Verification commands run:

```bash
uv run --frozen --with pytest --with numpy python -m pytest tests/test_importers/test_hindsight.py tests/test_hermes_hindsight_cli.py -q
# 10 passed

uv run --frozen --with pytest --with numpy python -m pytest tests/test_importers tests/test_hermes_hindsight_cli.py -q
# 35 passed
```

## Review notes

Claude Code reviewed the implementation plan and final diff read-only. `gstack /review` was requested, but `gstack` is not installed in this environment, so Claude Code read-only diff review was used instead.

Claude's plan review suggested adding coverage for `--base-url`, non-default bank forwarding, and dry-run behavior; those tests were added before final verification.

## Non-goals

- Does not replace `mnemosyne import-hindsight`.
- Does not duplicate `HindsightImporter` logic in Hermes CLI.
- Does not change `BaseImporter`, `Mnemosyne.remember()`, or generic provider import semantics.
- Does not change API-key requirements for Mem0/Zep/Honcho/etc.
