### PR TITLE
docs: sync Hermes plugin docs and manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ hermes mnemosyne import --input mnemosyne_backup.json
 mnemosyne import-hindsight hindsight-export.json hermes
 mnemosyne import-hindsight http://localhost:8888 hermes
 
+# The same timestamp-preserving Hindsight importer is available inside Hermes
+hermes mnemosyne import --from hindsight --file hindsight-export.json --bank hermes
+hermes mnemosyne import --from hindsight --base-url http://localhost:8888 --bank hermes
+
 # Clear scratchpad
 hermes mnemosyne clear
 ```
@@ -542,7 +546,7 @@ hermes mnemosyne import --input mnemosyne_backup.json
 
 ### Migrate from other memory providers
 
-Import directly from 7 supported providers into Mnemosyne:
+Import directly from supported providers into Mnemosyne:
 
 ```bash
 # List all supported providers
@@ -560,6 +564,10 @@ hermes mnemosyne import --from zep --api-key sk-xxx
 # Hindsight → Mnemosyne (JSON export or live API)
 mnemosyne import-hindsight hindsight-export.json hermes
 mnemosyne import-hindsight http://localhost:8888 hermes
+
+# Hindsight → Mnemosyne via Hermes CLI
+hermes mnemosyne import --from hindsight --file hindsight-export.json --bank hermes
+hermes mnemosyne import --from hindsight --base-url http://localhost:8888 --bank hermes
 
 # Generate a migration script for any provider
 hermes mnemosyne import --from mem0 --generate-script --output-script migrate.py

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -575,7 +575,7 @@ When `MNEMOSYNE_HOST_LLM_ENABLED=false` or unset:
 
 **Module:** `mnemosyne.core.importers`
 
-Mnemosyne can import memories from 7 external providers. All importers preserve metadata, timestamps, and identity.
+Mnemosyne can import memories from supported external providers. All importers preserve metadata, timestamps, and identity.
 
 ### Supported Providers
 

--- a/hermes_memory_provider/README.md
+++ b/hermes_memory_provider/README.md
@@ -9,8 +9,8 @@ When deployed, Mnemosyne gets the **same integration tier** as Honcho, mem0, and
 - **System prompt injection** — `# Mnemosyne Memory` header in every prompt
 - **Pre-turn prefetch** — Relevant memories injected via `<memory-context>` fence before each API call
 - **Post-turn sync** — User and assistant messages automatically stored to episodic memory
-- **Tool dispatch** — 7 memory tools auto-injected into the model's tool surface
-- **CLI commands** — `hermes mnemosyne {stats|sleep|inspect|clear}`
+- **Tool dispatch** — 15 memory tools auto-injected into the model's tool surface
+- **CLI commands** — `hermes mnemosyne {stats|sleep|version|inspect|clear|export|import}`
 - **Setup wizard** — Listed in `hermes memory setup`
 
 **All of this without touching Hermes core.** Deployed purely through the plugin directory.
@@ -65,11 +65,19 @@ User plugins take precedence over bundled plugins on name collision.
 |------|---------|
 | `mnemosyne_remember` | Store durable memory with importance, scope, expiry |
 | `mnemosyne_recall` | Hybrid search (50% vector + 30% FTS + 20% importance) |
-| `mnemosyne_sleep` | Consolidate working → episodic memory |
 | `mnemosyne_stats` | Show working + episodic counts |
+| `mnemosyne_triple_add` | Add temporal facts to the knowledge graph |
+| `mnemosyne_triple_query` | Query temporal knowledge graph facts |
+| `mnemosyne_sleep` | Consolidate working → episodic memory |
+| `mnemosyne_scratchpad_write` | Write short-lived scratchpad context |
+| `mnemosyne_scratchpad_read` | Read scratchpad context |
+| `mnemosyne_scratchpad_clear` | Clear scratchpad context |
 | `mnemosyne_invalidate` | Mark memory as expired/superseded |
-| `mnemosyne_triple_add` | Add temporal fact to knowledge graph |
-| `mnemosyne_triple_query` | Query knowledge graph |
+| `mnemosyne_export` | Export memories for backup or migration |
+| `mnemosyne_import` | Import memories from backup files or providers |
+| `mnemosyne_update` | Update an existing memory |
+| `mnemosyne_forget` | Delete a memory |
+| `mnemosyne_diagnose` | Run diagnostics on the memory store |
 
 ## Undeploy
 

--- a/hermes_memory_provider/cli.py
+++ b/hermes_memory_provider/cli.py
@@ -60,7 +60,7 @@ def mnemosyne_command(args):
     """Dispatch ``hermes mnemosyne <subcommand>``."""
     cmd = getattr(args, "mnemosyne_cmd", None)
     if not cmd:
-        print("Usage: hermes mnemosyne {stats|sleep|inspect|clear}")
+        print("Usage: hermes mnemosyne {stats|sleep|version|inspect|clear|export|import}")
         return 1
 
     try:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -12,6 +12,12 @@ provides_tools:
   - mnemosyne_scratchpad_write
   - mnemosyne_scratchpad_read
   - mnemosyne_scratchpad_clear
+  - mnemosyne_invalidate
+  - mnemosyne_export
+  - mnemosyne_import
+  - mnemosyne_update
+  - mnemosyne_forget
+  - mnemosyne_diagnose
 provides_hooks:
   - pre_llm_call
   - on_session_start


### PR DESCRIPTION
## Summary

This PR syncs the Hermes plugin documentation and root plugin manifest with the current tool and CLI surface.

The recent import/CLI work left a few small docs/config contracts stale:

- `hermes_memory_provider/README.md` still described 7 auto-injected tools even though the Hermes provider manifest exposes 15.
- The provider README still listed only `stats|sleep|inspect|clear`, while the CLI also supports `version`, `export`, and `import`.
- The repository root `plugin.yaml` still exposed only 9 tools, while both Hermes plugin manifests exposed all 15.
- The README documented the standalone Hindsight import command but not the equivalent Hermes CLI path added in PR #37.
- Importer docs used a hard-coded provider count where a count-free phrase is less brittle.

## Changes

### Hermes provider README

Updates `hermes_memory_provider/README.md` to reflect the actual Hermes provider surface:

- Changes “7 memory tools” to “15 memory tools”.
- Updates CLI command summary to:
  - `stats`
  - `sleep`
  - `version`
  - `inspect`
  - `clear`
  - `export`
  - `import`
- Expands the auto-injected tool table to include:
  - scratchpad tools
  - invalidation
  - export/import
  - update/forget
  - diagnostics

### Root plugin manifest

Updates the root `plugin.yaml` so its `provides_tools` list matches both:

- `hermes_plugin/plugin.yaml`
- `hermes_memory_provider/plugin.yaml`

The added tools are:

- `mnemosyne_invalidate`
- `mnemosyne_export`
- `mnemosyne_import`
- `mnemosyne_update`
- `mnemosyne_forget`
- `mnemosyne_diagnose`

This also makes the existing docs claim that `plugin.yaml` registers 15 tools true when readers inspect the root manifest.

### README Hindsight examples

Adds Hermes CLI Hindsight examples next to the standalone `mnemosyne import-hindsight` examples:

```bash
hermes mnemosyne import --from hindsight --file hindsight-export.json --bank hermes
hermes mnemosyne import --from hindsight --base-url http://localhost:8888 --bank hermes
```

Both paths route through the timestamp-preserving Hindsight importer.

### Provider count wording

Replaces hard-coded “7 supported providers” wording in user-facing docs with count-free wording. The provider table still lists the supported providers explicitly, but the prose is less likely to become stale when another importer is added.

### CLI usage string

Updates the no-subcommand fallback usage string in `hermes_memory_provider/cli.py` so it matches the registered subcommands.

## Why this matters

This is a contract-sync cleanup: the code and manifests already expose the broader surface, but parts of the docs still described the older, smaller surface.

Without this cleanup, users can reasonably conclude that:

- only 7 tools are available through Hermes,
- `export` / `import` are not Hermes CLI commands,
- the root plugin manifest is intentionally smaller than the package manifests,
- Hindsight imports must use only the standalone `mnemosyne` CLI even when running through Hermes.

## Validation

Ran the focused Hermes CLI regression tests:

```bash
uv run --frozen --with pytest --with numpy python -m pytest tests/test_hermes_hindsight_cli.py -q
```

Result:

```text
7 passed
```

Also checked all three plugin manifests expose the same 15 tools:

```text
plugin.yaml                         15 tools
hermes_plugin/plugin.yaml           15 tools
hermes_memory_provider/plugin.yaml  15 tools
root == hermes_plugin tools         True
provider == hermes_plugin tools     True
```

## Non-goals

- Does not change importer behavior.
- Does not change memory storage behavior.
- Does not add a new provider.
- Does not alter the Hindsight importer implementation.
