### PR TITLE
fix: align setup metadata with pyproject

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,13 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     keywords=[
         "ai",
         "memory",
@@ -57,13 +56,14 @@ setup(
     project_urls={
         "Bug Reports": "https://github.com/AxDSan/mnemosyne/issues",
         "Source": "https://github.com/AxDSan/mnemosyne",
-        "Documentation": "https://github.com/AxDSan/mnemosyne/blob/main/README.md",
+        "Documentation": "https://github.com/AxDSan/mnemosyne/blob/main/docs/README.md",
     },
     extras_require={
-        "llm": ["ctransformers>=0.2.27", "huggingface-hub>=0.20"],
+        "llm": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20"],
         "embeddings": ["fastembed>=0.3.0"],
         "mcp": ["mcp>=1.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
-        "all": ["ctransformers>=0.2.27", "huggingface-hub>=0.20", "fastembed>=0.3.0", "mcp>=1.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
+        "all": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "mcp>=1.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
+        "dev": ["pytest>=7.0", "build", "twine"],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary

Align `setup.py` package metadata with `pyproject.toml` so legacy/setup-backed builds advertise the same support matrix and extras as the modern metadata.

Changes:
- set `python_requires` to `>=3.9`
- remove the Python 3.8 classifier
- add `llama-cpp-python>=0.2.0` to the `llm` and `all` extras
- add the `dev` extra
- point the setup.py documentation URL at `docs/README.md`

## Why

The project docs, CI matrix, and `pyproject.toml` all advertise Python 3.9-3.12 support. `setup.py` still advertised Python 3.8 support, and wheel metadata built from the repo reported:

```text
Requires-Python: >=3.8
```

This PR keeps the package metadata consistent with the current supported range and optional extras declared in `pyproject.toml`.

## Verification

- Parsed `pyproject.toml` and `setup.py` and confirmed parity for:
  - `requires-python`
  - Python classifiers
  - optional extras
- Built a wheel with:

```bash
.venv/bin/python -m pip wheel . --no-deps -w /tmp/mnemosyne-wheel-probe
```

- Confirmed wheel metadata now reports:

```text
Requires-Python: >=3.9
Provides-Extra: llm, embeddings, mcp, all, dev
Requires-Dist: llama-cpp-python>=0.2.0; extra == "llm"
Requires-Dist: llama-cpp-python>=0.2.0; extra == "all"
```

- Ran `git diff --check`

## Notes

No runtime code changed.
