### PR TITLE
fix: restore bank CLI commands

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -217,8 +217,7 @@ def cmd_mcp(args):
 def cmd_bank(args):
     """Manage memory banks."""
     if not args:
-        print("Usage: mnemosyne bank <list|create|delete> [name]")
-        return
+        _fail("Usage: mnemosyne bank <list|create|delete> [name]")
 
     from mnemosyne.core.banks import BankManager
     bm = BankManager(Path(DATA_DIR))
@@ -232,20 +231,18 @@ def cmd_bank(args):
                 print(f"  - {b}")
         elif subcmd == "create":
             if len(args) < 2:
-                print("Usage: mnemosyne bank create <name>")
-                return
+                _fail("Usage: mnemosyne bank create <name>")
             bm.create_bank(args[1])
             print(f"Created bank: {args[1]}")
         elif subcmd == "delete":
             if len(args) < 2:
-                print("Usage: mnemosyne bank delete <name>")
-                return
+                _fail("Usage: mnemosyne bank delete <name>")
             if bm.delete_bank(args[1]):
                 print(f"Deleted bank: {args[1]}")
             else:
-                print(f"Bank not found: {args[1]}")
+                _fail(f"Bank not found: {args[1]}", exit_code=1)
         else:
-            print(f"Unknown bank command: {subcmd}")
+            _fail(f"Unknown bank command: {subcmd}")
     except ValueError as e:
         _fail(str(e))
 

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -221,28 +221,33 @@ def cmd_bank(args):
         return
 
     from mnemosyne.core.banks import BankManager
-    bm = BankManager(db_path=os.path.join(DATA_DIR, "mnemosyne.db"))
+    bm = BankManager(Path(DATA_DIR))
 
     subcmd = args[0]
-    if subcmd == "list":
-        banks = bm.list_banks()
-        print("\nMemory Banks:\n")
-        for b in banks:
-            print(f"  - {b}")
-    elif subcmd == "create":
-        if len(args) < 2:
-            print("Usage: mnemosyne bank create <name>")
-            return
-        bm.create_bank(args[1])
-        print(f"Created bank: {args[1]}")
-    elif subcmd == "delete":
-        if len(args) < 2:
-            print("Usage: mnemosyne bank delete <name>")
-            return
-        bm.delete_bank(args[1])
-        print(f"Deleted bank: {args[1]}")
-    else:
-        print(f"Unknown bank command: {subcmd}")
+    try:
+        if subcmd == "list":
+            banks = bm.list_banks()
+            print("\nMemory Banks:\n")
+            for b in banks:
+                print(f"  - {b}")
+        elif subcmd == "create":
+            if len(args) < 2:
+                print("Usage: mnemosyne bank create <name>")
+                return
+            bm.create_bank(args[1])
+            print(f"Created bank: {args[1]}")
+        elif subcmd == "delete":
+            if len(args) < 2:
+                print("Usage: mnemosyne bank delete <name>")
+                return
+            if bm.delete_bank(args[1]):
+                print(f"Deleted bank: {args[1]}")
+            else:
+                print(f"Bank not found: {args[1]}")
+        else:
+            print(f"Unknown bank command: {subcmd}")
+    except ValueError as e:
+        _fail(str(e))
 
 
 COMMANDS = {

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -217,7 +217,8 @@ def cmd_mcp(args):
 def cmd_bank(args):
     """Manage memory banks."""
     if not args:
-        _fail("Usage: mnemosyne bank <list|create|delete> [name]")
+        print("Usage: mnemosyne bank <list|create|delete> [name]")
+        return
 
     from mnemosyne.core.banks import BankManager
     bm = BankManager(Path(DATA_DIR))

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -56,3 +56,32 @@ def test_import_malformed_json_reports_error_without_traceback(tmp_path):
     assert result.returncode != 0
     assert "Invalid JSON" in result.stderr
     assert "Traceback" not in result.stderr
+
+
+def test_bank_cli_list_create_delete_uses_configured_data_dir(tmp_path):
+    result = run_cli(["bank", "list"], tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "default" in result.stdout
+    assert "Traceback" not in result.stderr
+
+    result = run_cli(["bank", "create", "project_a"], tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "Created bank: project_a" in result.stdout
+    assert "Traceback" not in result.stderr
+
+    result = run_cli(["bank", "list"], tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "project_a" in result.stdout
+
+    result = run_cli(["bank", "delete", "project_a"], tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "Deleted bank: project_a" in result.stdout
+    assert "Traceback" not in result.stderr
+
+
+def test_bank_cli_validation_errors_are_user_facing(tmp_path):
+    result = run_cli(["bank", "create", "bad/name"], tmp_path)
+
+    assert result.returncode != 0
+    assert "Invalid bank name" in result.stderr
+    assert "Traceback" not in result.stderr

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -80,8 +80,18 @@ def test_bank_cli_list_create_delete_uses_configured_data_dir(tmp_path):
 
 
 def test_bank_cli_validation_errors_are_user_facing(tmp_path):
-    result = run_cli(["bank", "create", "bad/name"], tmp_path)
+    cases = [
+        (["bank", "create", "bad/name"], "Invalid bank name", 2),
+        (["bank", "create"], "Usage: mnemosyne bank create <name>", 2),
+        (["bank", "delete"], "Usage: mnemosyne bank delete <name>", 2),
+        (["bank", "nope"], "Unknown bank command: nope", 2),
+        (["bank", "delete", "missing_bank"], "Bank not found: missing_bank", 1),
+    ]
 
-    assert result.returncode != 0
-    assert "Invalid bank name" in result.stderr
-    assert "Traceback" not in result.stderr
+    for args, expected_error, expected_returncode in cases:
+        result = run_cli(args, tmp_path)
+
+        assert result.returncode == expected_returncode, args
+        assert result.stdout == ""
+        assert expected_error in result.stderr
+        assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary

Fixes the public `mnemosyne bank ...` CLI commands after the `BankManager` API changed to accept a data directory instead of a database path.

Before this change, documented bank commands crashed before dispatching the subcommand:

```text
TypeError: BankManager.__init__() got an unexpected keyword argument 'db_path'
```

## Root cause

`cmd_bank()` still constructed the manager with the old keyword contract:

```python
BankManager(db_path=os.path.join(DATA_DIR, "mnemosyne.db"))
```

but `BankManager.__init__()` now accepts `data_dir` and derives the bank database paths internally.

## Changes

- Construct `BankManager` with `Path(DATA_DIR)` in the CLI.
- Add subprocess regression coverage for the public bank CLI boundary:
  - `mnemosyne bank list`
  - `mnemosyne bank create <name>`
  - `mnemosyne bank delete <name>`
- Route `ValueError` from bank operations through the existing `_fail()` helper so invalid bank names produce user-facing CLI errors without Python tracebacks.
- Report `Bank not found` when deleting a missing bank instead of claiming deletion succeeded.

## Test plan

Watched new tests fail first on current `main` with the `BankManager.__init__()` traceback.

Then verified:

```bash
.venv/bin/python -m pytest tests/test_cli_errors.py tests/test_memory_banks.py -q
# 30 passed

.venv/bin/python -m pytest -q
# 465 passed, 1 warning

 git diff --check
# no output
```

## Non-goals

- This does not change the broader CLI command/usage exit-code policy.
- This does not alter `BankManager` or bank storage layout.
