### PR TITLE
fix: reject non-object import files cleanly

### DIFF
--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -519,6 +519,9 @@ class Mnemosyne:
         with open(input_path, "r", encoding="utf-8") as f:
             data = _json.load(f)
 
+        if not isinstance(data, dict):
+            raise ValueError("Import file must contain a Mnemosyne export object")
+
         # Validate
         meta = data.get("mnemosyne_export", {})
         if meta.get("version") != "1.0":

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -56,3 +56,15 @@ def test_import_malformed_json_reports_error_without_traceback(tmp_path):
     assert result.returncode != 0
     assert "Invalid JSON" in result.stderr
     assert "Traceback" not in result.stderr
+
+
+def test_import_non_object_json_reports_error_without_traceback(tmp_path):
+    for payload in ("[]", '"not an export"'):
+        bad_export = tmp_path / "not-an-export.json"
+        bad_export.write_text(payload, encoding="utf-8")
+
+        result = run_cli(["import", str(bad_export)], tmp_path)
+
+        assert result.returncode != 0
+        assert "Import file must contain a Mnemosyne export object" in result.stderr
+        assert "Traceback" not in result.stderr

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -47,17 +47,6 @@ def test_invalid_cli_input_reports_error_without_traceback(tmp_path):
         assert "Traceback" not in result.stderr
 
 
-def test_import_malformed_json_reports_error_without_traceback(tmp_path):
-    bad_json = tmp_path / "bad.json"
-    bad_json.write_text("{not valid json", encoding="utf-8")
-
-    result = run_cli(["import", str(bad_json)], tmp_path)
-
-    assert result.returncode != 0
-    assert "Invalid JSON" in result.stderr
-    assert "Traceback" not in result.stderr
-
-
 def test_import_non_object_json_reports_error_without_traceback(tmp_path):
     for payload in ("[]", '"not an export"'):
         bad_export = tmp_path / "not-an-export.json"
@@ -68,3 +57,14 @@ def test_import_non_object_json_reports_error_without_traceback(tmp_path):
         assert result.returncode != 0
         assert "Import file must contain a Mnemosyne export object" in result.stderr
         assert "Traceback" not in result.stderr
+
+
+def test_import_malformed_json_reports_error_without_traceback(tmp_path):
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{not valid json", encoding="utf-8")
+
+    result = run_cli(["import", str(bad_json)], tmp_path)
+
+    assert result.returncode != 0
+    assert "Invalid JSON" in result.stderr
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary

Fixes a CLI traceback when `mnemosyne import` is given valid JSON that is not a Mnemosyne export object.

Before this change, files such as `[]` or `"not an export"` passed JSON parsing but crashed during export-schema validation:

```text
AttributeError: 'list' object has no attribute 'get'
```

The CLI already has a user-facing `ValueError` path for invalid import files, so this PR validates the decoded JSON shape before accessing export metadata and turns the case into a clean CLI error.

## User-visible behavior

Before:

```bash
printf '[]' > /tmp/not-export-array.json
python -m mnemosyne.cli import /tmp/not-export-array.json
```

produced a Python traceback:

```text
File "mnemosyne/core/memory.py", line 523, in import_from_file
    meta = data.get("mnemosyne_export", {})
AttributeError: 'list' object has no attribute 'get'
```

After:

```text
Error: Import file must contain a Mnemosyne export object
```

with a non-zero exit and no traceback.

## Root cause

`Mnemosyne.import_from_file()` assumes `json.load()` returns a mapping:

```python
meta = data.get("mnemosyne_export", {})
```

That assumption is valid for files produced by `export_to_file()`, but not for arbitrary valid JSON. Since `cmd_import()` already catches `ValueError` and reports it through `_fail()`, the minimal fix is to reject non-dict JSON immediately after decoding:

```python
if not isinstance(data, dict):
    raise ValueError("Import file must contain a Mnemosyne export object")
```

This preserves the existing behavior for malformed JSON, missing files, and unsupported export versions while covering the previously uncaught shape error.

## Changes

- Added a subprocess regression test for `mnemosyne import` with valid non-object JSON:
  - JSON array: `[]`
  - JSON string: `"not an export"`
- Added explicit decoded-type validation in `Mnemosyne.import_from_file()` before reading `mnemosyne_export` metadata.
- Reused the existing CLI `ValueError` handling path, so no broader CLI architecture changes were needed.

## Why this is intentionally narrow

This PR does **not** change the import format or try to accept generic JSON arrays as provider imports. `mnemosyne import` is documented as importing Mnemosyne export files produced by `export_to_file()`. Generic provider/file imports are a separate pathway in the importer framework.

The only behavior change here is replacing an internal traceback with a clear validation error when the input is valid JSON but not the expected export object.

## Verification

Confirmed the new test fails first on current `main` with the original traceback:

```text
AttributeError: 'list' object has no attribute 'get'
```

Then verified after the fix:

```bash
.venv/bin/python -m pytest tests/test_cli_errors.py::test_import_non_object_json_reports_error_without_traceback -q
# 1 passed

.venv/bin/python -m pytest tests/test_cli_errors.py -q
# 3 passed

.venv/bin/python -m pytest tests/test_cli_errors.py tests/test_beam.py -q
# 54 passed

unset MNEMOSYNE_DATA_DIR
export HOME=/home/openclaw
.venv/bin/python -m pytest -q
# 464 passed, 1 warning

git diff --check
# no output
```

## Non-goals

- Does not add support for importing arbitrary JSON arrays through `mnemosyne import`.
- Does not change `mnemosyne import-hindsight` behavior.
- Does not change export schema versioning or force/overwrite semantics.
- Does not broaden CLI error-handling policy beyond this import validation path.
