### PR TITLE
fix: fail CLI update delete when memory missing

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -103,7 +103,7 @@ def cmd_update(args):
     if success:
         print(f"Updated: {memory_id}")
     else:
-        print(f"Memory not found: {memory_id}")
+        _fail(f"Memory not found: {memory_id}", exit_code=1)
 
 
 def cmd_delete(args):
@@ -118,7 +118,7 @@ def cmd_delete(args):
     if success:
         print(f"Deleted: {memory_id}")
     else:
-        print(f"Memory not found: {memory_id}")
+        _fail(f"Memory not found: {memory_id}", exit_code=1)
 
 
 def cmd_stats(args):

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -56,13 +56,3 @@ def test_import_malformed_json_reports_error_without_traceback(tmp_path):
     assert result.returncode != 0
     assert "Invalid JSON" in result.stderr
     assert "Traceback" not in result.stderr
-
-
-def test_update_delete_missing_memory_report_operation_failure(tmp_path):
-    for args in (["update", "missing-id", "new content"], ["delete", "missing-id"]):
-        result = run_cli(args, tmp_path)
-
-        assert result.returncode == 1, args
-        assert result.stdout == ""
-        assert "Memory not found: missing-id" in result.stderr
-        assert "Traceback" not in result.stderr

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -56,3 +56,13 @@ def test_import_malformed_json_reports_error_without_traceback(tmp_path):
     assert result.returncode != 0
     assert "Invalid JSON" in result.stderr
     assert "Traceback" not in result.stderr
+
+
+def test_update_delete_missing_memory_report_operation_failure(tmp_path):
+    for args in (["update", "missing-id", "new content"], ["delete", "missing-id"]):
+        result = run_cli(args, tmp_path)
+
+        assert result.returncode == 1, args
+        assert result.stdout == ""
+        assert "Memory not found: missing-id" in result.stderr
+        assert "Traceback" not in result.stderr

--- a/tests/test_cli_operation_failures.py
+++ b/tests/test_cli_operation_failures.py
@@ -1,0 +1,28 @@
+"""CLI operation-failure regression tests."""
+
+import os
+import subprocess
+import sys
+
+
+def run_cli(args, tmp_path):
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["MNEMOSYNE_DATA_DIR"] = str(tmp_path / "mnemosyne-data")
+    return subprocess.run(
+        [sys.executable, "-m", "mnemosyne.cli", *args],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_update_delete_missing_memory_report_operation_failure(tmp_path):
+    for args in (["update", "missing-id", "new content"], ["delete", "missing-id"]):
+        result = run_cli(args, tmp_path)
+
+        assert result.returncode == 1, args
+        assert result.stdout == ""
+        assert "Memory not found: missing-id" in result.stderr
+        assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary

`mnemosyne update` and `mnemosyne delete` now exit non-zero when the requested memory ID is not found.

Before this change, both commands printed `Memory not found: ...` but returned exit code `0`, which made the failed operation look successful to shells, scripts, CI jobs, and cron jobs.

## User-visible behavior

### Before

```bash
mnemosyne update missing-id "new content"
echo $?
# 0
```

```bash
mnemosyne delete missing-id
echo $?
# 0
```

Both commands reported that the memory did not exist, but the process status indicated success.

### After

```bash
mnemosyne update missing-id "new content"
echo $?
# 1
```

```bash
mnemosyne delete missing-id
echo $?
# 1
```

The error is now written through the existing CLI error path:

```text
Error: Memory not found: missing-id
```

## Exit-code convention

This PR uses exit code `1` for this case because the command invocation is syntactically valid, but the requested operation cannot be completed.

That keeps a useful distinction from nearby CLI validation fixes:

- `2` for invocation/usage/input errors, such as missing required arguments, unknown commands, or invalid numeric argument values.
- `1` for valid invocations where the operation fails at runtime, such as updating or deleting a memory ID that does not exist.

This PR does not add a formal exit-code documentation section because the repository does not currently appear to have one; the convention is documented here in the PR body to make the behavioral choice explicit for review.

## Root cause

`cmd_update()` and `cmd_delete()` checked the boolean result from the underlying memory operation, but the failure branch only printed a message and then returned normally:

```python
success = mem.update(...)
if success:
    print(f"Updated: {memory_id}")
else:
    print(f"Memory not found: {memory_id}")
```

Normal return from the CLI entry point means process exit status `0`.

## Implementation

The fix is intentionally small and uses the existing `_fail()` helper:

```python
_fail(f"Memory not found: {memory_id}", exit_code=1)
```

This preserves the existing message content while making the process status reflect the failed operation.

## Tests

Added a subprocess CLI regression test covering both operation-failure cases:

- `mnemosyne update missing-id "new content"`
- `mnemosyne delete missing-id`

The test verifies:

- exit code is `1`
- stdout is empty
- stderr contains `Memory not found: missing-id`
- no Python traceback is printed

The test invokes the public CLI boundary via:

```bash
python -m mnemosyne.cli ...
```

and isolates `HOME` and `MNEMOSYNE_DATA_DIR` so it does not touch real user state.

## Verification

```bash
.venv/bin/python -m pytest tests/test_cli_errors.py::test_update_delete_missing_memory_report_operation_failure -q
# 1 passed

.venv/bin/python -m pytest tests/test_cli_errors.py -q
# 3 passed

.venv/bin/python -m pytest -q
# 464 passed, 1 warning

git diff --check
# clean
```

## Non-goals

- Does not change successful update/delete behavior.
- Does not change missing-required-argument handling; that is covered separately by #43.
- Does not migrate the CLI to argparse/click/typer.
- Does not add formal exit-code documentation to the repository without an existing place for it.
