### PR TITLE
fix: forward recall scoring weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ hermes mnemosyne import --from zep --agentic
 
 The generic Hermes CLI exposes the common importer options. Provider-specific options are available through the Python importers; for example, offline Letta AgentFile imports can use `LettaImporter(agent_file_path="./agent.af")`.
 
-All importers preserve metadata, timestamps, user/agent identity, and relationships (graph edges → triples). Use `--dry-run` to validate without writing.
+Importers preserve source metadata where available. `HindsightImporter` uses a dedicated episodic import path to preserve original timestamps; other importers may store source timestamps in metadata while assigning a new Mnemosyne write timestamp. Use `--dry-run` to validate without writing.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -121,10 +121,14 @@ Search memories using hybrid vector + FTS + importance scoring.
 results = mem.recall(
     query: str,                           # Search query
     top_k: int = 5,                       # Number of results
+    from_date: str = None,                # Optional lower timestamp bound
+    to_date: str = None,                  # Optional upper timestamp bound
     source: str = None,                   # Filter by source
-    threshold: float = 0.0,               # Minimum score threshold
-    scope: str = None,                    # Filter by scope
-    temporal_weight: float = 0.0,         # 0.0–1.0, boosts recent memories
+    topic: str = None,                    # Filter by topic metadata
+    author_id: str = None,                # Filter by author identity
+    author_type: str = None,              # Filter by human/agent/system author type
+    channel_id: str = None,               # Filter by channel/group
+    temporal_weight: float = 0.0,         # 0.0–1.0, boosts memories near query_time
     query_time = None,                    # datetime or ISO string for temporal calculation
     temporal_halflife: float = None,      # Hours for decay (default: 24)
     vec_weight: float = None,             # Override vector scoring weight
@@ -494,6 +498,8 @@ mnemosyne mcp --bank project_a
 
 ### MCP Tools
 
+These are the standalone MCP server tools from `mnemosyne.mcp_tools`. The Hermes plugin exposes a larger tool surface and uses `mnemosyne_stats` rather than the MCP-only `mnemosyne_get_stats` name.
+
 | Tool | Description |
 |---|---|
 | `mnemosyne_remember` | Store a memory |
@@ -575,7 +581,7 @@ When `MNEMOSYNE_HOST_LLM_ENABLED=false` or unset:
 
 **Module:** `mnemosyne.core.importers`
 
-Mnemosyne can import memories from 7 external providers. All importers preserve metadata, timestamps, and identity.
+Mnemosyne can import memories from supported external providers. Importers preserve source metadata where available; `HindsightImporter` is the timestamp-preserving path for Hindsight history and writes directly to episodic memory.
 
 ### Supported Providers
 
@@ -649,8 +655,8 @@ result = import_from_provider("hindsight", mnemosyne, file_path="export.json")
 
 ```bash
 mnemosyne store "User prefers dark mode" --importance 0.9
-mnemosyne recall "user preferences" --top-k 10
-mnemosyne update <memory_id> --content "Updated content"
+mnemosyne recall "user preferences" 10
+mnemosyne update <memory_id> "Updated content"
 mnemosyne delete <memory_id>
 mnemosyne stats
 mnemosyne sleep

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -163,7 +163,7 @@ Expected: `Provider: mnemosyne` with `is_available: true`
 hermes tools list | grep mnemosyne
 ```
 
-Expected: 14 tools (remember, recall, stats, sleep, triple_add, triple_query, scratchpad_write, scratchpad_read, scratchpad_clear, invalidate, export, update, forget, import)
+Expected: 15 tools (remember, recall, stats, sleep, triple_add, triple_query, scratchpad_write, scratchpad_read, scratchpad_clear, invalidate, export, update, forget, import, diagnose)
 
 ### 3. Memory operations work
 

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -317,13 +317,17 @@ class Mnemosyne:
                channel_id: Optional[str] = None,
                temporal_weight: float = 0.0,
                query_time: Optional[Any] = None,
-               temporal_halflife: Optional[float] = None) -> List[Dict]:
+               temporal_halflife: Optional[float] = None,
+               vec_weight: float = None,
+               fts_weight: float = None,
+               importance_weight: float = None) -> List[Dict]:
         """
         Search memories with hybrid relevance scoring.
         Uses BEAM episodic + working memory retrieval (sqlite-vec + FTS5).
         Supports temporal filtering: from_date, to_date, source, topic.
         Supports multi-agent identity filtering: author_id, author_type, channel_id.
         Supports temporal scoring: temporal_weight, query_time, temporal_halflife.
+        Supports scoring weight overrides: vec_weight, fts_weight, importance_weight.
         """
         return self.beam.recall(query, top_k=top_k,
                                 from_date=from_date, to_date=to_date,
@@ -332,7 +336,10 @@ class Mnemosyne:
                                 channel_id=channel_id,
                                 temporal_weight=temporal_weight,
                                 query_time=query_time,
-                                temporal_halflife=temporal_halflife)
+                                temporal_halflife=temporal_halflife,
+                                vec_weight=vec_weight,
+                                fts_weight=fts_weight,
+                                importance_weight=importance_weight)
 
     def get_context(self, limit: int = 10) -> List[Dict]:
         """
@@ -629,6 +636,9 @@ def recall(query: str, top_k: int = 5, *,
            temporal_weight: float = 0.0,
            query_time: Optional[Any] = None,
            temporal_halflife: Optional[float] = None,
+           vec_weight: float = None,
+           fts_weight: float = None,
+           importance_weight: float = None,
            bank: str = None) -> List[Dict]:
     """Search memories using the global instance with temporal filtering and scoring"""
     return _get_default(bank).recall(query, top_k,
@@ -636,7 +646,10 @@ def recall(query: str, top_k: int = 5, *,
                                      source=source, topic=topic,
                                      temporal_weight=temporal_weight,
                                      query_time=query_time,
-                                     temporal_halflife=temporal_halflife)
+                                     temporal_halflife=temporal_halflife,
+                                     vec_weight=vec_weight,
+                                     fts_weight=fts_weight,
+                                     importance_weight=importance_weight)
 
 
 def get_context(limit: int = 10, bank: str = None) -> List[Dict]:

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -299,13 +299,19 @@ def _handle_recall(arguments: Dict[str, Any]) -> Dict[str, Any]:
     bank = arguments.get("bank", "default")
     temporal_weight = arguments.get("temporal_weight", 0.0)
     query_time = arguments.get("query_time")
+    vec_weight = arguments.get("vec_weight")
+    fts_weight = arguments.get("fts_weight")
+    importance_weight = arguments.get("importance_weight")
 
     mem = _create_instance(author_id=arguments.get("author_id"), author_type=arguments.get("author_type"), channel_id=arguments.get("channel_id"), bank=bank)
     results = mem.recall(
         query=query,
         top_k=top_k,
         temporal_weight=temporal_weight,
-        query_time=query_time
+        query_time=query_time,
+        vec_weight=vec_weight,
+        fts_weight=fts_weight,
+        importance_weight=importance_weight,
     )
 
     # Serialize for JSON — datetime objects aren't JSON serializable

--- a/tests/test_configurable_scoring.py
+++ b/tests/test_configurable_scoring.py
@@ -18,7 +18,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from mnemosyne.core.memory import Mnemosyne, recall as module_recall
+import mnemosyne.core.memory as memory_module
+from mnemosyne.core.memory import Mnemosyne
 from mnemosyne.core.beam import (
     _normalize_weights,
     BeamMemory,
@@ -253,13 +254,18 @@ class TestPublicRecallConfigurableWeights:
         assert isinstance(results, list)
         assert len(results) > 0
 
-    def test_module_recall_accepts_weight_params(self, temp_db, monkeypatch):
+    def test_module_recall_accepts_weight_params(self, monkeypatch):
         """mnemosyne.recall() module helper should expose the same scoring weights."""
-        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(temp_db.parent))
-        mem = Mnemosyne(session_id="test", db_path=temp_db)
-        mem.remember("Module helper weight forwarding", importance=0.8)
+        class FakeMemory:
+            def recall(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+                return [{"id": "test", "content": "weight forwarding"}]
 
-        results = module_recall(
+        fake = FakeMemory()
+        monkeypatch.setattr(memory_module, "_get_default", lambda bank=None: fake)
+
+        results = memory_module.recall(
             "weight forwarding",
             top_k=5,
             vec_weight=0.6,
@@ -269,6 +275,9 @@ class TestPublicRecallConfigurableWeights:
 
         assert isinstance(results, list)
         assert len(results) > 0
+        assert fake.kwargs["vec_weight"] == 0.6
+        assert fake.kwargs["fts_weight"] == 0.3
+        assert fake.kwargs["importance_weight"] == 0.1
 
 
 # ============================================================================

--- a/tests/test_configurable_scoring.py
+++ b/tests/test_configurable_scoring.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from mnemosyne.core.memory import Mnemosyne, recall as module_recall
 from mnemosyne.core.beam import (
     _normalize_weights,
     BeamMemory,
@@ -230,6 +231,43 @@ class TestRecallConfigurableWeights:
         # Should not crash; internally falls back to (0.5, 0.3, 0.2)
         results = beam.recall("content", top_k=1,
                               vec_weight=0.0, fts_weight=0.0, importance_weight=0.0)
+        assert len(results) > 0
+
+
+class TestPublicRecallConfigurableWeights:
+    """Public Mnemosyne recall wrappers should expose BeamMemory scoring weights."""
+
+    def test_mnemosyne_recall_accepts_weight_params(self, temp_db):
+        """Mnemosyne.recall() should forward scoring weights to BeamMemory.recall()."""
+        mem = Mnemosyne(session_id="test", db_path=temp_db)
+        mem.remember("Python is a programming language", importance=0.8)
+
+        results = mem.recall(
+            "programming language",
+            top_k=5,
+            vec_weight=0.6,
+            fts_weight=0.3,
+            importance_weight=0.1,
+        )
+
+        assert isinstance(results, list)
+        assert len(results) > 0
+
+    def test_module_recall_accepts_weight_params(self, temp_db, monkeypatch):
+        """mnemosyne.recall() module helper should expose the same scoring weights."""
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(temp_db.parent))
+        mem = Mnemosyne(session_id="test", db_path=temp_db)
+        mem.remember("Module helper weight forwarding", importance=0.8)
+
+        results = module_recall(
+            "weight forwarding",
+            top_k=5,
+            vec_weight=0.6,
+            fts_weight=0.3,
+            importance_weight=0.1,
+        )
+
+        assert isinstance(results, list)
         assert len(results) > 0
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -122,6 +122,23 @@ class TestToolHandlers:
         assert len(result["results"]) == 1
         mock_mnemosyne.recall.assert_called_once()
 
+    def test_handle_recall_forwards_scoring_weights(self, mock_mnemosyne):
+        """Schema-advertised recall weights should be forwarded to Mnemosyne.recall()."""
+        with patch("mnemosyne.mcp_tools._create_instance", return_value=mock_mnemosyne):
+            handle_tool_call("mnemosyne_recall", {
+                "query": "test query",
+                "top_k": 5,
+                "bank": "default",
+                "vec_weight": 0.6,
+                "fts_weight": 0.3,
+                "importance_weight": 0.1,
+            })
+
+        _, kwargs = mock_mnemosyne.recall.call_args
+        assert kwargs["vec_weight"] == 0.6
+        assert kwargs["fts_weight"] == 0.3
+        assert kwargs["importance_weight"] == 0.1
+
     def test_handle_sleep(self, mock_mnemosyne):
         """handle_sleep returns consolidation stats."""
         with patch("mnemosyne.mcp_tools._create_instance", return_value=mock_mnemosyne):


### PR DESCRIPTION
Closes #45.

## Summary

- forward per-query scoring weights through `Mnemosyne.recall()` and the module-level `mnemosyne.recall()` helper
- make the MCP `mnemosyne_recall` handler pass schema-advertised weight args to recall
- align docs with the public recall contract, importer timestamp behavior, MCP vs Hermes tool naming, and the current 15-tool Hermes surface

## Why

`BeamMemory.recall()` already supports `vec_weight`, `fts_weight`, and `importance_weight`, and the docs/MCP schema advertise those controls. The public wrappers did not accept or forward them, and the MCP handler silently ignored schema-valid weight arguments.

This made the docs/comparison claim that scoring weights are configurable per query true only for the lower-level `BeamMemory` API, not for the public `Mnemosyne` or MCP surfaces.

## Tests

```bash
uv run --frozen --with pytest --with numpy python -m pytest tests/test_configurable_scoring.py tests/test_mcp_server.py tests/test_hermes_memory_provider.py tests/test_plugins.py -q
```

Result: `120 passed`.

## Docs updates

- remove unsupported `threshold` / `scope` args from the public recall docs
- document actual recall filters and scoring-weight parameters
- correct CLI examples for positional `recall`/`update` syntax
- narrow broad importer preservation claims; Hindsight is the dedicated timestamp-preserving import path
- clarify MCP tools vs Hermes plugin tools
- update installation guide expected Hermes tool count from 14 to 15
