### PR TITLE
fix: forward MCP CLI arguments

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -208,7 +208,7 @@ def cmd_mcp(args):
     """Start MCP server."""
     try:
         from mnemosyne.mcp_server import main as mcp_main
-        mcp_main()
+        mcp_main(args)
     except ImportError:
         print("MCP not available. Install with: pip install mnemosyne-memory[mcp]")
         sys.exit(1)

--- a/mnemosyne/mcp_server.py
+++ b/mnemosyne/mcp_server.py
@@ -132,7 +132,7 @@ def run_mcp_server(transport: str = "stdio", port: int = 8080, bank: Optional[st
         raise ValueError(f"Unknown transport: {transport}. Use 'stdio' or 'sse'.")
 
 
-def main() -> None:
+def main(argv: Optional[list[str]] = None) -> None:
     """CLI entry point for `mnemosyne mcp`."""
     import argparse
 
@@ -155,7 +155,7 @@ def main() -> None:
         default=None,
         help="Default memory bank"
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     run_mcp_server(transport=args.transport, port=args.port, bank=args.bank)
 

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -261,6 +261,11 @@ def _create_instance(session_id: str = None, author_id: str = None,
     )
 
 
+def _resolve_bank(arguments: Dict[str, Any]) -> str:
+    """Resolve per-call bank, falling back to MCP server default bank."""
+    return arguments.get("bank") or os.environ.get("MNEMOSYNE_MCP_BANK") or "default"
+
+
 # ---------------------------------------------------------------------------
 # Tool Handlers
 # ---------------------------------------------------------------------------
@@ -273,7 +278,7 @@ def _handle_remember(arguments: Dict[str, Any]) -> Dict[str, Any]:
     metadata = arguments.get("metadata", {})
     extract_entities = arguments.get("extract_entities", False)
     extract = arguments.get("extract", False)
-    bank = arguments.get("bank", "default")
+    bank = _resolve_bank(arguments)
 
     mem = _create_instance(author_id=arguments.get("author_id"), author_type=arguments.get("author_type"), channel_id=arguments.get("channel_id"), bank=bank)
     memory_id = mem.remember(
@@ -296,7 +301,7 @@ def _handle_recall(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_recall tool call."""
     query = arguments["query"]
     top_k = arguments.get("top_k", 5)
-    bank = arguments.get("bank", "default")
+    bank = _resolve_bank(arguments)
     temporal_weight = arguments.get("temporal_weight", 0.0)
     query_time = arguments.get("query_time")
 
@@ -331,7 +336,7 @@ def _handle_sleep(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_sleep tool call."""
     dry_run = arguments.get("dry_run", False)
     all_sessions = arguments.get("all_sessions", False)
-    bank = arguments.get("bank", "default")
+    bank = _resolve_bank(arguments)
 
     mem = _create_instance(author_id=arguments.get("author_id"), author_type=arguments.get("author_type"), channel_id=arguments.get("channel_id"), bank=bank)
     if all_sessions and hasattr(mem, "sleep_all_sessions"):
@@ -350,7 +355,7 @@ def _handle_sleep(arguments: Dict[str, Any]) -> Dict[str, Any]:
 
 def _handle_scratchpad_read(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_scratchpad_read tool call."""
-    bank = arguments.get("bank", "default")
+    bank = _resolve_bank(arguments)
 
     mem = _create_instance(author_id=arguments.get("author_id"), author_type=arguments.get("author_type"), channel_id=arguments.get("channel_id"), bank=bank)
     entries = mem.scratchpad_read()
@@ -366,7 +371,7 @@ def _handle_scratchpad_read(arguments: Dict[str, Any]) -> Dict[str, Any]:
 def _handle_scratchpad_write(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_scratchpad_write tool call."""
     content = arguments["content"]
-    bank = arguments.get("bank", "default")
+    bank = _resolve_bank(arguments)
 
     mem = _create_instance(author_id=arguments.get("author_id"), author_type=arguments.get("author_type"), channel_id=arguments.get("channel_id"), bank=bank)
     entry_id = mem.scratchpad_write(content)
@@ -380,7 +385,7 @@ def _handle_scratchpad_write(arguments: Dict[str, Any]) -> Dict[str, Any]:
 
 def _handle_get_stats(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_get_stats tool call."""
-    bank = arguments.get("bank", "default")
+    bank = _resolve_bank(arguments)
 
     mem = _create_instance(author_id=arguments.get("author_id"), author_type=arguments.get("author_type"), channel_id=arguments.get("channel_id"), bank=bank)
     stats = mem.get_stats()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -112,6 +112,57 @@ class TestToolHandlers:
         assert result["bank"] == "default"
         mock_mnemosyne.remember.assert_called_once()
 
+    def test_handle_remember_uses_mcp_bank_env_default(self, mock_mnemosyne, monkeypatch):
+        """MCP server bank default applies when tool call omits bank."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_BANK", "work")
+
+        with patch(
+            "mnemosyne.mcp_tools._create_instance",
+            return_value=mock_mnemosyne,
+        ) as create_instance:
+            result = handle_tool_call("mnemosyne_remember", {
+                "content": "Test memory",
+                "source": "test",
+            })
+
+        assert result["status"] == "stored"
+        assert result["bank"] == "work"
+        assert create_instance.call_args.kwargs["bank"] == "work"
+
+    def test_handle_remember_bank_arg_overrides_mcp_bank_env(self, mock_mnemosyne, monkeypatch):
+        """Explicit per-call bank should override the server default bank."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_BANK", "work")
+
+        with patch(
+            "mnemosyne.mcp_tools._create_instance",
+            return_value=mock_mnemosyne,
+        ) as create_instance:
+            result = handle_tool_call("mnemosyne_remember", {
+                "content": "Test memory",
+                "source": "test",
+                "bank": "personal",
+            })
+
+        assert result["status"] == "stored"
+        assert result["bank"] == "personal"
+        assert create_instance.call_args.kwargs["bank"] == "personal"
+
+    def test_handle_recall_uses_mcp_bank_env_default(self, mock_mnemosyne, monkeypatch):
+        """MCP recall should use the server default bank when omitted."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_BANK", "work")
+
+        with patch(
+            "mnemosyne.mcp_tools._create_instance",
+            return_value=mock_mnemosyne,
+        ) as create_instance:
+            result = handle_tool_call("mnemosyne_recall", {
+                "query": "test query",
+            })
+
+        assert result["status"] == "ok"
+        assert result["bank"] == "work"
+        assert create_instance.call_args.kwargs["bank"] == "work"
+
     def test_handle_recall(self, mock_mnemosyne):
         """handle_recall returns list of results."""
         with patch("mnemosyne.mcp_tools._create_instance", return_value=mock_mnemosyne):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,6 +5,9 @@ Run with: pytest tests/test_mcp_server.py -v
 """
 
 import json
+import os
+import subprocess
+import sys
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -202,6 +205,57 @@ class TestMCPIntegration:
         assert len(tools) == 6
         names = [t["name"] for t in tools]
         assert "mnemosyne_remember" in names
+
+    def test_top_level_cli_forwards_mcp_arguments(self, tmp_path):
+        """`mnemosyne mcp ...` must pass subcommand args to the MCP parser."""
+        env = os.environ.copy()
+        env["HOME"] = str(tmp_path / "home")
+        env["MNEMOSYNE_DATA_DIR"] = str(tmp_path / "mnemosyne-data")
+        script = """
+import json
+import sys
+import mnemosyne.mcp_server
+
+def fake_main(argv):
+    print(json.dumps({"argv": argv}))
+
+mnemosyne.mcp_server.main = fake_main
+sys.argv = [
+    "mnemosyne",
+    "mcp",
+    "--transport",
+    "sse",
+    "--port",
+    "19090",
+    "--bank",
+    "work",
+]
+from mnemosyne.cli import run_cli
+run_cli()
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout) == {
+            "argv": ["--transport", "sse", "--port", "19090", "--bank", "work"]
+        }
+
+    def test_mcp_server_main_accepts_explicit_argv(self):
+        """MCP server parser should parse caller-provided argv, not global sys.argv."""
+        from mnemosyne.mcp_server import main
+
+        with patch("mnemosyne.mcp_server.run_mcp_server") as run_mcp_server:
+            main(["--transport", "sse", "--port", "19090", "--bank", "work"])
+
+        run_mcp_server.assert_called_once_with(
+            transport="sse", port=19090, bank="work"
+        )
 
 
 class TestImportGuard:


### PR DESCRIPTION
## Summary

Fixes the top-level `mnemosyne mcp ...` command so documented MCP server options are forwarded to the MCP server argument parser instead of being parsed from the original global `sys.argv`.

This restores documented invocations such as:

```bash
mnemosyne mcp --transport sse --port 8080
mnemosyne mcp --bank work
```

## Root cause

The top-level CLI dispatcher correctly strips the command name before calling command handlers:

```python
handler(sys.argv[2:])
```

However, `cmd_mcp(args)` ignored that already-stripped `args` list and called:

```python
mcp_main()
```

`mnemosyne.mcp_server.main()` then called `parser.parse_args()` with no explicit argv, so `argparse` read the original process-level `sys.argv`, which still contained the parent `mcp` token.

That made valid documented commands fail like this:

```text
usage: cli.py [-h] [--transport {stdio,sse}] [--port PORT] [--bank BANK]
cli.py: error: unrecognized arguments: mcp
```

The MCP server parser itself was fine; it was being given the wrong argument source when invoked through the top-level CLI.

## Changes

- Forward `cmd_mcp(args)` into `mnemosyne.mcp_server.main(args)`.
- Let `mnemosyne.mcp_server.main(argv=None)` accept an explicit argv list and pass it to `argparse.parse_args(argv)`.
- Preserve standalone behavior: when `argv` is omitted, `argparse` still uses normal process arguments.
- Add regression coverage at both boundaries:
  - top-level CLI dispatch forwards only MCP subcommand args, not the parent `mcp` token
  - MCP server `main([...])` parses explicit arguments and calls `run_mcp_server(...)` with the expected values

## Why this shape

This keeps the fix at the stale adapter boundary instead of changing MCP server lifecycle behavior or broadening the CLI framework. The MCP server still owns its parser; the parent CLI now just supplies the already-stripped subcommand arguments it had computed.

## Test plan

RED verified before the fix:

```bash
uv run pytest \
  tests/test_mcp_server.py::TestMCPIntegration::test_top_level_cli_forwards_mcp_arguments \
  tests/test_mcp_server.py::TestMCPIntegration::test_mcp_server_main_accepts_explicit_argv \
  -q
```

Both tests failed on current `origin/main` because `cmd_mcp` called `mcp_main()` without args and `main()` did not accept an argv parameter.

GREEN verified after the fix:

```bash
uv run pytest \
  tests/test_mcp_server.py::TestMCPIntegration::test_top_level_cli_forwards_mcp_arguments \
  tests/test_mcp_server.py::TestMCPIntegration::test_mcp_server_main_accepts_explicit_argv \
  -q
```

Result:

```text
2 passed
```

Full suite:

```bash
uv run pytest -q
```

Result:

```text
465 passed, 1 warning
```

The warning is the existing MCP optional-dependency test warning:

```text
DeprecationWarning: There is no current event loop
```

No production behavior outside MCP CLI argument forwarding is intentionally changed.

## Manual reproduction

Before this change, a valid documented command such as:

```bash
python -m mnemosyne.cli mcp --transport sse --port 19090
```

failed immediately with `unrecognized arguments: mcp` because the MCP parser saw the parent command token.

After this change, the parent CLI forwards only:

```python
["--transport", "sse", "--port", "19090"]
```

to the MCP parser.

## Non-goals

- Does not change MCP tool schemas.
- Does not change stdio or SSE server runtime behavior.
- Does not add/remove MCP dependencies.
- Does not alter Hermes provider CLI behavior.



## Follow-up: server default bank is now honored by MCP tools

While validating the `--bank` path end-to-end, I found one more boundary issue in the same MCP CLI/server contract: forwarding `mnemosyne mcp --bank work` into `mcp_server.run_mcp_server(bank="work")` set `MNEMOSYNE_MCP_BANK`, but the MCP tool handlers still defaulted missing per-call `bank` arguments to the literal `"default"`.

That meant an MCP client could launch the server with:

```bash
mnemosyne mcp --bank work
```

and still have calls like `mnemosyne_remember` write to the default bank unless every individual tool call also supplied `{"bank": "work"}`.

This PR now resolves the bank in MCP tool handlers as:

1. explicit per-call `bank` argument, if provided;
2. `MNEMOSYNE_MCP_BANK`, set by the server `--bank` option;
3. `"default"` as the backward-compatible fallback.

The follow-up remains in this PR because it is the same documented MCP `--bank` behavior, same review surface, and same user-facing contract as the original argument-forwarding fix. A separate PR would leave #50 technically forwarding the argument while the actual MCP tools still ignore the server default.

Additional TDD proof for this follow-up:

```text
RED:
FAILED test_handle_remember_uses_mcp_bank_env_default
FAILED test_handle_recall_uses_mcp_bank_env_default

GREEN:
uv run pytest tests/test_mcp_server.py -q
23 passed, 1 warning
```

Manual isolated probe after the fix:

```text
MNEMOSYNE_MCP_BANK=work
handle_tool_call("mnemosyne_remember", {"content": "..."})

RESULT_BANK work
DEFAULT_DB_EXISTS True
WORK_DB_EXISTS True
```
