### PR TITLE
fix: align triples db with data dir

### DIFF
--- a/mnemosyne/core/triples.py
+++ b/mnemosyne/core/triples.py
@@ -4,16 +4,59 @@ Time-aware knowledge graph on top of SQLite.
 Tracks when facts were true, enabling contradiction detection and historical queries.
 """
 
+import os
 import sqlite3
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import List, Dict, Optional
 
-DEFAULT_DB = Path.home() / ".hermes" / "mnemosyne" / "data" / "triples.db"
+LEGACY_DATA_DIR = Path.home() / ".hermes" / "mnemosyne" / "data"
+DEFAULT_DATA_DIR = Path(os.environ.get("MNEMOSYNE_DATA_DIR", LEGACY_DATA_DIR))
+DEFAULT_DB = DEFAULT_DATA_DIR / "triples.db"
+LEGACY_DB = LEGACY_DATA_DIR / "triples.db"
+
+
+def _copy_legacy_db(source: Path, destination: Path) -> None:
+    """Copy a SQLite DB using SQLite's backup API for a consistent snapshot."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+        delete=False,
+    ) as temp_file:
+        temp_path = Path(temp_file.name)
+
+    try:
+        source_conn = sqlite3.connect(f"file:{source}?mode=ro", uri=True)
+        try:
+            dest_conn = sqlite3.connect(str(temp_path))
+            try:
+                source_conn.backup(dest_conn)
+            finally:
+                dest_conn.close()
+        finally:
+            source_conn.close()
+
+        if not destination.exists():
+            temp_path.replace(destination)
+        else:
+            temp_path.unlink(missing_ok=True)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def _resolve_default_db() -> Path:
+    """Return the default triples DB, copying legacy data into place if needed."""
+    if DEFAULT_DATA_DIR != LEGACY_DATA_DIR and not DEFAULT_DB.exists() and LEGACY_DB.exists():
+        _copy_legacy_db(LEGACY_DB, DEFAULT_DB)
+    return DEFAULT_DB
 
 
 def _get_conn(db_path = None) -> sqlite3.Connection:
-    path = Path(db_path) if db_path else DEFAULT_DB
+    path = Path(db_path) if db_path else _resolve_default_db()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(path), check_same_thread=False)
     conn.row_factory = sqlite3.Row
@@ -57,7 +100,7 @@ class TripleStore:
     """
     
     def __init__(self, db_path: Path = None):
-        self.db_path = db_path or DEFAULT_DB
+        self.db_path = Path(db_path) if db_path else _resolve_default_db()
         init_triples(self.db_path)
         self.conn = _get_conn(self.db_path)
     

--- a/tests/test_triples_data_dir.py
+++ b/tests/test_triples_data_dir.py
@@ -1,0 +1,93 @@
+"""Regression tests for TripleStore default data-directory handling."""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def _run_python(script: str, *, home: Path, data_dir: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["MNEMOSYNE_DATA_DIR"] = str(data_dir)
+    env.pop("PYTHONHOME", None)
+
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_triplestore_default_db_uses_mnemosyne_data_dir(tmp_path):
+    """TripleStore() should keep triples.db beside the configured memory DBs."""
+    home = tmp_path / "home"
+    data_dir = tmp_path / "configured-data"
+
+    result = _run_python(
+        """
+        from mnemosyne.core.triples import TripleStore
+
+        store = TripleStore()
+        print(store.db_path)
+        """,
+        home=home,
+        data_dir=data_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()) == data_dir / "triples.db"
+    assert (data_dir / "triples.db").exists()
+    assert not (home / ".hermes" / "mnemosyne" / "data" / "triples.db").exists()
+
+
+def test_triplestore_copies_legacy_db_into_mnemosyne_data_dir(tmp_path):
+    """Existing misplaced triples should be copied into the configured data dir."""
+    home = tmp_path / "home"
+    data_dir = tmp_path / "configured-data"
+    legacy_db = home / ".hermes" / "mnemosyne" / "data" / "triples.db"
+
+    seed = _run_python(
+        """
+        from pathlib import Path
+        from mnemosyne.core.triples import TripleStore
+
+        legacy_db = Path.home() / ".hermes" / "mnemosyne" / "data" / "triples.db"
+        store = TripleStore(db_path=legacy_db)
+        store.add(
+            "legacy-subject",
+            "legacy-predicate",
+            "legacy-object",
+            valid_from="2026-05-08",
+        )
+        print(legacy_db)
+        """,
+        home=home,
+        data_dir=data_dir,
+    )
+    assert seed.returncode == 0, seed.stderr
+    assert legacy_db.exists()
+    assert not (data_dir / "triples.db").exists()
+
+    result = _run_python(
+        """
+        from mnemosyne.core.triples import TripleStore
+
+        store = TripleStore()
+        print(store.db_path)
+        print(store.query(subject="legacy-subject")[0]["object"])
+        """,
+        home=home,
+        data_dir=data_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        str(data_dir / "triples.db"),
+        "legacy-object",
+    ]
+    assert legacy_db.exists()
+    assert (data_dir / "triples.db").exists()


### PR DESCRIPTION
## Summary

Fixes `TripleStore()` so its default `triples.db` follows `MNEMOSYNE_DATA_DIR`, matching the rest of Mnemosyne's database files.

When `MNEMOSYNE_DATA_DIR` is set, Mnemosyne already stores the primary memory database under that configured directory. `TripleStore`, however, still defaulted to the hardcoded legacy path:

```text
~/.hermes/mnemosyne/data/triples.db
```

That created a split-brain data layout:

```text
$MNEMOSYNE_DATA_DIR/mnemosyne.db       # memory / beam data
~/.hermes/mnemosyne/data/triples.db   # triples data
```

This PR changes the default triples path to:

```text
$MNEMOSYNE_DATA_DIR/triples.db
```

and adds a one-time compatibility copy for users who already have a misplaced legacy `triples.db`.

## Root cause

`mnemosyne.core.memory` and `mnemosyne.core.beam` both honor `MNEMOSYNE_DATA_DIR` when choosing their default database path. `mnemosyne.core.triples` did not. It defined:

```python
DEFAULT_DB = Path.home() / ".hermes" / "mnemosyne" / "data" / "triples.db"
```

So any code using the documented default constructor:

```python
from mnemosyne.core.triples import TripleStore
store = TripleStore()
```

would ignore the configured Mnemosyne data directory and write triples to the old home-directory path instead.

## Fix

- Add `DEFAULT_DATA_DIR` for triples using `MNEMOSYNE_DATA_DIR`, falling back to the existing legacy home path when the env var is not set.
- Make default `TripleStore()` and `_get_conn()` resolve to `DEFAULT_DATA_DIR / "triples.db"`.
- Preserve explicit `TripleStore(db_path=...)` behavior unchanged.
- If `MNEMOSYNE_DATA_DIR` is set, the new configured `triples.db` does not exist, and the legacy home-path `triples.db` does exist, copy the legacy DB into the configured data directory before opening it.

The compatibility copy uses SQLite's backup API rather than a raw file copy. That gives a consistent SQLite snapshot and avoids missing uncheckpointed WAL content that a plain file copy could lose.

## Why copy the legacy DB

Without the copy, this bug fix would silently strand existing triples for affected users.

For example, a user with:

```text
MNEMOSYNE_DATA_DIR=/mnt/persistent/mnemosyne
```

may already have:

```text
/mnt/persistent/mnemosyne/mnemosyne.db
~/.hermes/mnemosyne/data/triples.db
```

After simply correcting the default path, Mnemosyne would start reading:

```text
/mnt/persistent/mnemosyne/triples.db
```

and the existing triples would appear to be gone. Worse, users may reasonably back up only `MNEMOSYNE_DATA_DIR`, because that is where Mnemosyne is configured to keep its data. In that case, the old misplaced `triples.db` might never have been included in their backups. Copying it into the configured data directory aligns the data layout now and reduces the chance that existing triples remain outside the user's backup boundary.

## Copy risk and tradeoff

The copy is intentionally narrow, but it is still a startup-time filesystem side effect.

Potential risks:

- If both old and new DB files exist, this PR does **not** overwrite the configured DB. The configured location wins.
- If the legacy DB is corrupt or unreadable, the copy can fail, surfacing the underlying SQLite/file problem instead of silently creating an empty replacement.
- If another process creates the configured DB at the same time, the code rechecks before replacing and avoids clobbering an existing destination.
- The legacy DB remains in place; this PR copies data into the correct location but does not delete user data from the old path.

That tradeoff is necessary here because doing no migration would make the corrected path safer for new installs but potentially harmful for existing configured installs: their triples would remain outside `MNEMOSYNE_DATA_DIR`, outside the expected database set, and possibly outside backups.

## Tests

Added subprocess regression tests so the import-time environment behavior is exercised the same way users hit it:

1. `TripleStore()` with `MNEMOSYNE_DATA_DIR` set creates/uses `$MNEMOSYNE_DATA_DIR/triples.db`, not the legacy home path.
2. If a legacy home-path `triples.db` exists and the configured triples DB is absent, `TripleStore()` copies the legacy DB into `$MNEMOSYNE_DATA_DIR/triples.db` and reads the existing triple data from the configured location.

## TDD proof

RED on current `origin/main`:

```text
FAILED tests/test_triples_data_dir.py::test_triplestore_default_db_uses_mnemosyne_data_dir
FAILED tests/test_triples_data_dir.py::test_triplestore_copies_legacy_db_into_mnemosyne_data_dir
```

GREEN after fix:

```text
uv run pytest tests/test_triples_data_dir.py -q
2 passed in 0.26s

uv run pytest -q
465 passed, 1 warning in 6.86s
```

The existing warning is unchanged:

```text
tests/test_mcp_server.py:228: DeprecationWarning: There is no current event loop
```

## Non-goals

- Does not delete the legacy `~/.hermes/mnemosyne/data/triples.db`.
- Does not merge two divergent triples databases if both old and new files already exist.
- Does not change explicit `db_path` handling.
- Does not introduce a general migration framework.
