### PR TITLE
fix(C23): wire CLI stats to canonical nested shape, expose triples + banks (scoped)

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -133,8 +133,7 @@ def cmd_stats(args):
     print(f"  Total memories: {stats.get('total_memories', 0)}")
     print(f"  Working memory: {wm.get('total', 0)}")
     print(f"  Episodic memory: {ep.get('total', 0)}")
-    if triples.get("total"):
-        print(f"  Knowledge triples: {triples['total']}")
+    print(f"  Knowledge triples: {triples.get('total', 0)}")
     if stats.get("banks"):
         print(f"\n  Banks: {', '.join(stats['banks'])}")
     print(f"  DB path: {stats.get('database', 'N/A')}")

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -125,15 +125,19 @@ def cmd_stats(args):
     """Show memory system statistics."""
     mem = _get_memory()
     stats = mem.get_stats()
+    beam = stats.get("beam", {})
+    wm = beam.get("working_memory", {})
+    ep = beam.get("episodic_memory", {})
+    triples = beam.get("triples", {})
     print("\nMnemosyne Stats\n")
     print(f"  Total memories: {stats.get('total_memories', 0)}")
-    print(f"  Working memory: {stats.get('working_count', 0)}")
-    print(f"  Episodic memory: {stats.get('episodic_count', 0)}")
-    if stats.get("triple_count"):
-        print(f"  Knowledge triples: {stats['triple_count']}")
+    print(f"  Working memory: {wm.get('total', 0)}")
+    print(f"  Episodic memory: {ep.get('total', 0)}")
+    if triples.get("total"):
+        print(f"  Knowledge triples: {triples['total']}")
     if stats.get("banks"):
         print(f"\n  Banks: {', '.join(stats['banks'])}")
-    print(f"  DB path: {stats.get('db_path', 'N/A')}")
+    print(f"  DB path: {stats.get('database', 'N/A')}")
 
 
 def cmd_sleep(args):

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -365,17 +365,23 @@ class Mnemosyne:
 
         # Triples count — table is created lazily by TripleStore.init_triples;
         # if it does not exist yet (no triple has ever been written), report 0.
+        # Narrow the suppression to the missing-table case so DB locks, I/O
+        # errors, and corruption are not silently turned into "0 triples".
         triple_total = 0
         try:
             cursor.execute("SELECT COUNT(*) FROM triples")
             triple_total = cursor.fetchone()[0]
-        except sqlite3.OperationalError:
-            pass
+        except sqlite3.OperationalError as e:
+            if "no such table" not in str(e).lower():
+                raise
 
-        # Bank list — top-level because banks are a config concern, not a memory layer.
+        # Bank list — scoped to the same data dir as this Mnemosyne instance so
+        # a per-bank or per-tmp-dir caller does not get bank names from the
+        # default ~/.hermes tree. Banks live at <data_dir>/banks/, where
+        # data_dir is the parent of self.db_path.
         try:
             from mnemosyne.core.banks import BankManager
-            banks = BankManager().list_banks()
+            banks = BankManager(data_dir=Path(self.db_path).parent).list_banks()
         except Exception:
             banks = ["default"]
 

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -363,6 +363,22 @@ class Mnemosyne:
         beam_ep = self.beam.get_episodic_stats(author_id=author_id, author_type=author_type,
                                                 channel_id=channel_id)
 
+        # Triples count — table is created lazily by TripleStore.init_triples;
+        # if it does not exist yet (no triple has ever been written), report 0.
+        triple_total = 0
+        try:
+            cursor.execute("SELECT COUNT(*) FROM triples")
+            triple_total = cursor.fetchone()[0]
+        except sqlite3.OperationalError:
+            pass
+
+        # Bank list — top-level because banks are a config concern, not a memory layer.
+        try:
+            from mnemosyne.core.banks import BankManager
+            banks = BankManager().list_banks()
+        except Exception:
+            banks = ["default"]
+
         return {
             "total_memories": total_legacy,
             "total_sessions": sessions,
@@ -370,9 +386,11 @@ class Mnemosyne:
             "last_memory": last[0] if last else None,
             "database": str(self.db_path),
             "mode": "beam",
+            "banks": banks,
             "beam": {
                 "working_memory": beam_wm,
-                "episodic_memory": beam_ep
+                "episodic_memory": beam_ep,
+                "triples": {"total": triple_total},
             }
         }
 

--- a/tests/test_cli_stats.py
+++ b/tests/test_cli_stats.py
@@ -1,0 +1,123 @@
+"""Regression tests for [C23]: `mnemosyne stats` printed zeros and N/A
+because cli.cmd_stats read flat keys (working_count, episodic_count,
+triple_count, db_path) that Mnemosyne.get_stats() never returned.
+
+Tests verify:
+1. cmd_stats prints real counts, not zeros, when data exists.
+2. cmd_stats prints the actual DB path, not "N/A".
+3. get_stats() exposes triples and banks in shapes the CLI expects.
+"""
+
+import argparse
+
+import pytest
+
+from mnemosyne.core.memory import Mnemosyne
+
+
+def _seed(db_path):
+    """Populate an isolated DB with one working + one episodic + one triple."""
+    from mnemosyne.core.triples import TripleStore
+    mem = Mnemosyne(session_id="c23", db_path=db_path)
+    wm_id = mem.remember("Working memory item", source="user", importance=0.5)
+    mem.beam.consolidate_to_episodic(
+        summary="Episodic summary",
+        source_wm_ids=[wm_id],
+        source="consolidation",
+        importance=0.6,
+    )
+    triples = TripleStore(db_path=db_path)
+    triples.add(subject="alice", predicate="likes", object="python", source="test")
+    return mem
+
+
+def _run_cmd_stats(monkeypatch, db_path, capsys):
+    """Invoke cmd_stats with cli.DATA_DIR pointing at the isolated DB's parent."""
+    from mnemosyne import cli
+    monkeypatch.setattr(cli, "DATA_DIR", str(db_path.parent))
+    cli.cmd_stats(argparse.Namespace())
+    return capsys.readouterr().out
+
+
+class TestCliStatsRegression:
+    def test_stats_does_not_print_zeros_when_data_exists(self, tmp_path, monkeypatch, capsys):
+        db_path = tmp_path / "mnemosyne.db"
+        _seed(db_path)
+        out = _run_cmd_stats(monkeypatch, db_path, capsys)
+        # Working memory line must show >= 1 (we seeded one)
+        for line in out.splitlines():
+            if line.strip().startswith("Working memory:"):
+                assert "0" not in line.split(":", 1)[1].strip(), \
+                    f"Working memory printed as 0 with seeded data: {line!r}"
+                break
+        else:
+            pytest.fail("'Working memory:' line missing from stats output")
+
+    def test_stats_prints_episodic_count(self, tmp_path, monkeypatch, capsys):
+        db_path = tmp_path / "mnemosyne.db"
+        _seed(db_path)
+        out = _run_cmd_stats(monkeypatch, db_path, capsys)
+        for line in out.splitlines():
+            if line.strip().startswith("Episodic memory:"):
+                value = line.split(":", 1)[1].strip()
+                assert int(value) >= 1, \
+                    f"Episodic count was {value!r}, expected >= 1"
+                return
+        pytest.fail("'Episodic memory:' line missing from stats output")
+
+    def test_stats_prints_triple_count(self, tmp_path, monkeypatch, capsys):
+        db_path = tmp_path / "mnemosyne.db"
+        _seed(db_path)
+        out = _run_cmd_stats(monkeypatch, db_path, capsys)
+        # The triple line is conditional on truthy value — with data seeded,
+        # it must appear and show >= 1.
+        triple_lines = [
+            line for line in out.splitlines()
+            if "triple" in line.lower() or "Knowledge" in line
+        ]
+        assert triple_lines, "Triple/Knowledge line missing from stats output"
+        # At least one of those lines should reflect a real count.
+        assert any(
+            ch.isdigit() and ch != "0" for line in triple_lines for ch in line
+        ), f"Triple line(s) show no nonzero count: {triple_lines}"
+
+    def test_stats_prints_real_db_path_not_na(self, tmp_path, monkeypatch, capsys):
+        db_path = tmp_path / "mnemosyne.db"
+        _seed(db_path)
+        out = _run_cmd_stats(monkeypatch, db_path, capsys)
+        for line in out.splitlines():
+            if line.strip().startswith("DB path:"):
+                value = line.split(":", 1)[1].strip()
+                assert value != "N/A", "DB path printed as 'N/A' instead of real path"
+                assert "mnemosyne.db" in value, \
+                    f"DB path missing expected db filename: {value!r}"
+                return
+        pytest.fail("'DB path:' line missing from stats output")
+
+
+class TestGetStatsShape:
+    """Direct tests on get_stats() shape — independent of CLI rendering."""
+
+    def test_get_stats_includes_triples_in_beam(self, tmp_path):
+        """get_stats() should expose a triple count, not silently omit it."""
+        from mnemosyne.core.triples import TripleStore
+        db_path = tmp_path / "mnemosyne.db"
+        mem = Mnemosyne(session_id="c23", db_path=db_path)
+        triples = TripleStore(db_path=db_path)
+        triples.add(subject="a", predicate="b", object="c", source="test")
+        triples.add(subject="d", predicate="e", object="f", source="test")
+        stats = mem.get_stats()
+        # Canonical shape: nested under "beam" matching working_memory/episodic_memory.
+        assert "triples" in stats["beam"], \
+            "get_stats() must expose triples under stats['beam']"
+        assert stats["beam"]["triples"]["total"] >= 2
+
+    def test_get_stats_includes_banks_at_top(self, tmp_path):
+        """get_stats() should expose bank list so CLI can render it."""
+        db_path = tmp_path / "mnemosyne.db"
+        mem = Mnemosyne(session_id="c23", db_path=db_path)
+        stats = mem.get_stats()
+        assert "banks" in stats, "get_stats() must expose top-level 'banks' list"
+        assert isinstance(stats["banks"], list)
+        # 'default' is always present per BankManager.list_banks() contract.
+        assert "default" in stats["banks"]

--- a/tests/test_cli_stats.py
+++ b/tests/test_cli_stats.py
@@ -39,47 +39,45 @@ def _run_cmd_stats(monkeypatch, db_path, capsys):
     return capsys.readouterr().out
 
 
+def _line_value(out, prefix):
+    """Return the integer value after `<prefix>:` in cmd_stats output.
+    Fails the test loudly if the line is missing or non-numeric."""
+    for line in out.splitlines():
+        if line.strip().startswith(prefix):
+            value = line.split(":", 1)[1].strip()
+            try:
+                return int(value)
+            except ValueError:
+                pytest.fail(f"{prefix} value not an int: {value!r}")
+    pytest.fail(f"{prefix!r} line missing from stats output:\n{out}")
+
+
 class TestCliStatsRegression:
-    def test_stats_does_not_print_zeros_when_data_exists(self, tmp_path, monkeypatch, capsys):
+    def test_stats_prints_working_count_not_zero(self, tmp_path, monkeypatch, capsys):
         db_path = tmp_path / "mnemosyne.db"
         _seed(db_path)
         out = _run_cmd_stats(monkeypatch, db_path, capsys)
-        # Working memory line must show >= 1 (we seeded one)
-        for line in out.splitlines():
-            if line.strip().startswith("Working memory:"):
-                assert "0" not in line.split(":", 1)[1].strip(), \
-                    f"Working memory printed as 0 with seeded data: {line!r}"
-                break
-        else:
-            pytest.fail("'Working memory:' line missing from stats output")
+        assert _line_value(out, "Working memory") >= 1
 
     def test_stats_prints_episodic_count(self, tmp_path, monkeypatch, capsys):
         db_path = tmp_path / "mnemosyne.db"
         _seed(db_path)
         out = _run_cmd_stats(monkeypatch, db_path, capsys)
-        for line in out.splitlines():
-            if line.strip().startswith("Episodic memory:"):
-                value = line.split(":", 1)[1].strip()
-                assert int(value) >= 1, \
-                    f"Episodic count was {value!r}, expected >= 1"
-                return
-        pytest.fail("'Episodic memory:' line missing from stats output")
+        assert _line_value(out, "Episodic memory") >= 1
 
     def test_stats_prints_triple_count(self, tmp_path, monkeypatch, capsys):
         db_path = tmp_path / "mnemosyne.db"
         _seed(db_path)
         out = _run_cmd_stats(monkeypatch, db_path, capsys)
-        # The triple line is conditional on truthy value — with data seeded,
-        # it must appear and show >= 1.
-        triple_lines = [
-            line for line in out.splitlines()
-            if "triple" in line.lower() or "Knowledge" in line
-        ]
-        assert triple_lines, "Triple/Knowledge line missing from stats output"
-        # At least one of those lines should reflect a real count.
-        assert any(
-            ch.isdigit() and ch != "0" for line in triple_lines for ch in line
-        ), f"Triple line(s) show no nonzero count: {triple_lines}"
+        assert _line_value(out, "Knowledge triples") >= 1
+
+    def test_stats_prints_zero_triples_on_fresh_db(self, tmp_path, monkeypatch, capsys):
+        """Fresh DB with no triples must still show 'Knowledge triples: 0',
+        consistent with how Working / Episodic always render 0."""
+        db_path = tmp_path / "mnemosyne.db"
+        Mnemosyne(session_id="c23-fresh", db_path=db_path)
+        out = _run_cmd_stats(monkeypatch, db_path, capsys)
+        assert _line_value(out, "Knowledge triples") == 0
 
     def test_stats_prints_real_db_path_not_na(self, tmp_path, monkeypatch, capsys):
         db_path = tmp_path / "mnemosyne.db"


### PR DESCRIPTION
## Summary

- `mnemosyne stats` was printing `0` for working/episodic/triple counts and `N/A` for the DB path because `cli.cmd_stats` read 5 dict keys (`working_count`, `episodic_count`, `triple_count`, `db_path`, `banks`) that `Mnemosyne.get_stats()` never returned.
- Fix wires `cmd_stats` to the canonical nested shape that 5 other readers in the codebase already use, and additively extends `get_stats()` with `beam.triples` + top-level `banks` (the two fields that previously had no source data).
- 7 regression tests (new `tests/test_cli_stats.py`) covering both surfaces, including the previously-uncovered zero-triple case.

## The bug

`mnemosyne/cli.py:124-136` (cmd_stats) read flat keys from `get_stats()`:

```python
stats.get('working_count', 0)   # not present → 0
stats.get('episodic_count', 0)  # not present → 0
stats.get('triple_count')       # not present → conditional skipped
stats.get('banks')              # not present → conditional skipped
stats.get('db_path', 'N/A')     # real key is "database" → "N/A"
```

`Mnemosyne.get_stats()` returned a nested shape with none of those names. Five of six fields silently fell back to `0` / `N/A`. A user running `mnemosyne stats` against a populated DB would see "Working memory: 0 Episodic memory: 0 DB path: N/A" and assume storage was broken.

## Why it slipped through

Five other readers of `get_stats()` already use the canonical nested shape (`stats["beam"]["working_memory"]["total"]` etc.):

| Caller | Shape |
|---|---|
| `mnemosyne/diagnose.py:110` | nested |
| `hermes_memory_provider/cli.py:285` | nested |
| `tests/test_beam.py:259` | nested |
| `tests/test_memory_banks.py:262` | nested |
| `mnemosyne/mcp_tools.py:386` | passthrough (shape-agnostic JSON) |
| `hermes_plugin/tools.py:411` | passthrough |
| `mnemosyne/cli.py:127` | **flat (broken)** |

The CLI was the lone outlier. `tests/test_mnemosyne_stats.py` exists but covers a different script (`scripts/mnemosyne-stats.py`, the dashboard tool), not the bare `mnemosyne stats` command. `cmd_stats` had zero direct test coverage.

## Options considered

**A.** Update CLI to read the nested shape (minimal, in-line with codebase convention).
**B.** Same as A, plus wire up triples and banks properly (chosen).
**C.** Make `get_stats()` also return flat top-level keys for backward compat. Pollutes the return shape with duplicates.
**D.** Drop the broken CLI lines, only display what works. Hides the bug.

Picked B because:
- A would print fewer fields than today's broken-but-aspirational output.
- B fixes the whole feature so users see triple counts and bank lists.
- Diff stays small (~10 lines in get_stats, ~6 in cli.py, plus tests).

## The fix (commit 1: 3b970f6)

**`get_stats()` — additive, no existing reader breaks:**
- Adds `beam.triples.{total}` via `SELECT COUNT(*) FROM triples` (table is created lazily by TripleStore; missing-table case falls back to 0).
- Adds top-level `banks` list via `BankManager().list_banks()`.

**`cmd_stats()` — read the canonical nested shape:**
- Working memory: `stats["beam"]["working_memory"]["total"]`
- Episodic memory: `stats["beam"]["episodic_memory"]["total"]`
- Knowledge triples: `stats["beam"]["triples"]["total"]`
- DB path: `stats["database"]` (was reading the non-existent `"db_path"` key)

## Pre-landing review (commit 2: b5d8093)

This branch was reviewed pre-merge by both Claude (adversarial subagent) and Codex CLI. Both flagged the same primary issue:

> `BankManager()` was constructed with no args, so the bank list came from the module-level `DEFAULT_DATA_DIR` resolved at import time. A per-bank or custom-`db_path` Mnemosyne instance would get bank names from the wrong directory — same family of bug as the runtime data-dir issue PR #52 fixed for the recall path.

Fixes applied in commit 2:

1. **Bank scope (CRITICAL):** `BankManager(data_dir=Path(self.db_path).parent).list_banks()` so the bank list reflects the active data dir.
2. **Narrow OperationalError handling:** previously suppressed all OperationalErrors; now only suppresses the missing-table case so DB locks / I/O errors / corruption are visible to the user.
3. **Always print "Knowledge triples: 0":** previously hidden by `if triples.get("total"):`; now matches the always-show behavior of working / episodic counts.
4. **Robust test assertions:** replaced brittle `assert "0" not in line` (which silently goes false-negative for counts ≥ 10) with int-parse helpers that match the sibling `test_stats_prints_episodic_count` pattern.
5. **Added `test_stats_prints_zero_triples_on_fresh_db`** to lock in change #3.

## Behavior change worth flagging

**Pre-fix:** `BankManager()` always used the module-load default data dir. Anyone constructing `Mnemosyne(db_path=custom)` and calling `get_stats()` got bank names from `~/.hermes/...` regardless of `db_path`.

**Post-fix:** Bank list scopes to `Path(self.db_path).parent`. This is the intended behavior per the runtime data-dir contract, but consumers that previously relied on the leak will see different bank names. If any caller depends on the old behavior (none found in this repo), it would need to construct `BankManager()` directly.

## Deferred

- "Banks: default" line still always prints in the single-bank case. Taste call kept as-is to give the user explicit context about the active bank.
- No follow-up tracked.

## Test plan

- [ ] `uv run pytest tests/test_cli_stats.py -q` (7 passed locally)
- [ ] `uv run pytest -q --ignore=tests/test_local_llm.py --ignore=tests/test_llm_backends.py` (449 passed locally)
- [ ] Manual: `mnemosyne stats` against a populated DB shows real counts and a real DB path.
- [ ] Manual: `mnemosyne stats` against a freshly initialized DB shows `Knowledge triples: 0`, not a missing line.
- [ ] Manual: with a custom `MNEMOSYNE_DATA_DIR`, the bank list reflects that directory, not the default `~/.hermes/...` tree.

## Verification

\`\`\`
tests/test_cli_stats.py: 7 passed (new file, all RED before fix)
broader sweep (test_beam + test_memory_banks + test_mnemosyne_stats): 119 passed
full suite excluding LLM-dependent tests: 449 passed
\`\`\`