### PR TITLE
fix(C12.a): wrapper-extracted facts now populate the facts table + dedup runs extraction

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2157,14 +2157,21 @@ class BeamMemory:
         except Exception:
             return []
 
-        for row in fact_rows:
+        for raw_row in fact_rows:
+            # sqlite3.Row supports bracket access but not .get(); convert to
+            # dict so the column-with-default reads below work. Without this
+            # conversion fact_recall crashes the moment the facts table
+            # contains rows — a latent bug that was masked while the
+            # Mnemosyne.remember(extract=True) wrapper never populated the
+            # table (see C12.a).
+            row = dict(raw_row)
             fact_text = row["object"] if row["object"] else f"{row['subject']} {row['predicate']} {row['object']}"
             results.append({
                 "content": fact_text,
-                "score": row.get("confidence", 0.5),
+                "score": row.get("confidence") if row.get("confidence") is not None else 0.5,
                 "fact_id": row["fact_id"],
-                "subject": row.get("subject", ""),
-                "predicate": row.get("predicate", ""),
+                "subject": row.get("subject") or "",
+                "predicate": row.get("predicate") or "",
             })
 
         return results

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -958,6 +958,16 @@ class BeamMemory:
                   memory_type,
                   existing_id, self.session_id))
             self.conn.commit()
+            # Run the same entity/fact extraction the new-row path runs, so
+            # backfill calls — `mem.remember(same_content, extract=True)` on
+            # an already-existing row — actually populate the triples and
+            # facts tables. Without this the dedup early-return silently
+            # skips everything `extract=True` advertises, breaking the
+            # contract on duplicate-content writes (see C12.a /review note).
+            if extract_entities:
+                _extract_and_store_entities(self, existing_id, content)
+            if extract:
+                _extract_and_store_facts(self, existing_id, content, source)
             # Phase 3-4: Extract graph and consolidate veracity for dedup update
             self._ingest_graph_and_veracity(existing_id, content, source, veracity)
             return existing_id
@@ -2165,13 +2175,17 @@ class BeamMemory:
             # Mnemosyne.remember(extract=True) wrapper never populated the
             # table (see C12.a).
             row = dict(raw_row)
-            fact_text = row["object"] if row["object"] else f"{row['subject']} {row['predicate']} {row['object']}"
+            confidence = row.get("confidence")
+            subject = row.get("subject")
+            predicate = row.get("predicate")
+            obj = row.get("object")
+            fact_text = obj if obj else f"{subject} {predicate} {obj}"
             results.append({
                 "content": fact_text,
-                "score": row.get("confidence") if row.get("confidence") is not None else 0.5,
+                "score": confidence if confidence is not None else 0.5,
                 "fact_id": row["fact_id"],
-                "subject": row.get("subject") or "",
-                "predicate": row.get("predicate") or "",
+                "subject": subject if subject is not None else "",
+                "predicate": predicate if predicate is not None else "",
             })
 
         return results

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -246,9 +246,17 @@ class Mnemosyne:
             extract: If True, extract structured facts from content using LLM
                 and store as triples. Default False.
         """
-        # BEAM write first (generates its own ID)
-        memory_id = self.beam.remember(content, source=source, importance=importance, metadata=metadata,
-                           valid_until=valid_until, scope=scope)
+        # BEAM write first (generates its own ID). Extract flags are passed
+        # through so BeamMemory's canonical _extract_and_store_entities and
+        # _extract_and_store_facts helpers run — these populate the `facts`
+        # table that fact_recall() queries (the wrapper used to reimplement
+        # only the triples half of extraction inline, leaving facts table
+        # writes silently skipped — see C12.a).
+        memory_id = self.beam.remember(
+            content, source=source, importance=importance, metadata=metadata,
+            valid_until=valid_until, scope=scope,
+            extract_entities=extract_entities, extract=extract,
+        )
         timestamp = datetime.now().isoformat()
 
         # Legacy dual-write with same ID (INSERT OR REPLACE for dedup safety)
@@ -272,40 +280,14 @@ class Mnemosyne:
 
         self.conn.commit()
 
-        # BEAM write (reuse the same ID so legacy and working-memory rows stay in sync)
-        self.beam.remember(content, source=source, importance=importance, metadata=metadata,
-                           valid_until=valid_until, scope=scope, memory_id=memory_id)
-
-        # Entity extraction (best-effort, never fails the memory write)
-        if extract_entities:
-            try:
-                from mnemosyne.core.entities import extract_entities_regex
-                from mnemosyne.core.triples import TripleStore
-                entities = extract_entities_regex(content)
-                if entities:
-                    triples = TripleStore(db_path=self.db_path)
-                    for entity in entities:
-                        triples.add(
-                            subject=memory_id,
-                            predicate="mentions",
-                            object=entity,
-                            source=source,
-                            confidence=0.8
-                        )
-            except Exception:
-                pass  # Entity extraction is best-effort
-
-        # Structured fact extraction (best-effort, never fails the memory write)
-        if extract:
-            try:
-                from mnemosyne.core.extraction import extract_facts_safe
-                from mnemosyne.core.triples import TripleStore
-                facts = extract_facts_safe(content)
-                if facts:
-                    triples = TripleStore(db_path=self.db_path)
-                    triples.add_facts(memory_id, facts, source=source, confidence=0.7)
-            except Exception:
-                pass  # Fact extraction is best-effort
+        # BEAM write (reuse the same ID so legacy and working-memory rows
+        # stay in sync). Extract flags are intentionally NOT passed here —
+        # extraction already ran on the first call. The second call exists
+        # solely to dedup-update working_memory.
+        self.beam.remember(
+            content, source=source, importance=importance, metadata=metadata,
+            valid_until=valid_until, scope=scope, memory_id=memory_id,
+        )
 
         return memory_id
 

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -280,15 +280,12 @@ class Mnemosyne:
 
         self.conn.commit()
 
-        # BEAM write (reuse the same ID so legacy and working-memory rows
-        # stay in sync). Extract flags are intentionally NOT passed here —
-        # extraction already ran on the first call. The second call exists
-        # solely to dedup-update working_memory.
-        self.beam.remember(
-            content, source=source, importance=importance, metadata=metadata,
-            valid_until=valid_until, scope=scope, memory_id=memory_id,
-        )
-
+        # The first BEAM write already inserted the working_memory row with
+        # the correct memory_id (we used it for the legacy dual-write above).
+        # A second beam.remember call would only re-run the dedup branch and
+        # _ingest_graph_and_veracity — duplicating gist/fact graph edges and
+        # bumping mention_count for what is a single user-level remember. So
+        # this function returns directly after the legacy write.
         return memory_id
 
     def recall(self, query: str, top_k: int = 5, *,

--- a/tests/test_extract_parity.py
+++ b/tests/test_extract_parity.py
@@ -1,0 +1,172 @@
+"""Regression tests for [C12.a]: Mnemosyne.remember(extract=True) writes
+fact triples but skips the `facts` table. The canonical helper
+_extract_and_store_facts in beam.py writes BOTH tables; the wrapper's
+inline extract block only wrote triples. As a result, wrapper-extracted
+facts were visible through recall() (which scores fact triples) but
+invisible through fact_recall() (which queries the facts table directly).
+
+Bug: mnemosyne/core/memory.py — wrapper's `if extract:` block only called
+triples.add_facts(), never _store_facts_in_table().
+
+These tests assert wrapper / direct parity across all four observable
+effects of extract=True:
+  1. triples table populated
+  2. facts table populated
+  3. recall() can find the memory
+  4. fact_recall() can find the fact
+
+Plus a parity check for extract_entities=True.
+"""
+
+import pytest
+
+from mnemosyne.core.memory import Mnemosyne
+
+
+@pytest.fixture
+def fake_extract_facts(monkeypatch):
+    """Patch extract_facts_safe to return deterministic facts.
+    Both Mnemosyne.remember and BeamMemory's _extract_and_store_facts
+    import via `from mnemosyne.core.extraction import extract_facts_safe`,
+    so a module-level patch covers both paths.
+    """
+    facts = [
+        "alice was born in boston",
+        "alice studied mathematics at MIT",
+    ]
+    monkeypatch.setattr(
+        "mnemosyne.core.extraction.extract_facts_safe",
+        lambda content, **kwargs: list(facts),
+    )
+    return facts
+
+
+def _facts_table_count(db_path) -> int:
+    """Count rows in the facts table directly. Returns 0 if table missing
+    (the bug surface — table never gets written when wrapper fails to
+    populate it for the first time)."""
+    import sqlite3
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cur = conn.execute("SELECT COUNT(*) FROM facts")
+        return cur.fetchone()[0]
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        conn.close()
+
+
+def _triples_table_count(db_path) -> int:
+    import sqlite3
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cur = conn.execute("SELECT COUNT(*) FROM triples")
+        return cur.fetchone()[0]
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        conn.close()
+
+
+class TestWrapperExtractFactsTableParity:
+    """C12.a: Mnemosyne.remember(extract=True) must populate the facts
+    table the same way BeamMemory.remember(extract=True) does."""
+
+    def test_wrapper_extract_writes_facts_table(self, tmp_path, fake_extract_facts):
+        db_path = tmp_path / "c12a.db"
+        mem = Mnemosyne(session_id="c12a", db_path=db_path)
+        mem.remember(
+            "Alice was born in Boston in 1990 and studied math at MIT.",
+            source="user",
+            extract=True,
+        )
+        assert _facts_table_count(db_path) >= 1, (
+            "facts table empty after Mnemosyne.remember(extract=True); "
+            "wrapper path should populate it like BeamMemory does"
+        )
+
+    def test_wrapper_extract_still_writes_triples_table(self, tmp_path, fake_extract_facts):
+        """Regression guard: the facts-table fix must NOT remove the
+        existing triples write."""
+        db_path = tmp_path / "c12a.db"
+        mem = Mnemosyne(session_id="c12a", db_path=db_path)
+        mem.remember(
+            "Alice was born in Boston in 1990 and studied math at MIT.",
+            source="user",
+            extract=True,
+        )
+        assert _triples_table_count(db_path) >= 1, (
+            "triples table empty after extract=True; the wrapper's existing "
+            "behavior must not regress"
+        )
+
+    def test_wrapper_extracted_fact_is_visible_via_fact_recall(self, tmp_path, fake_extract_facts):
+        """The contract: extract=True through the wrapper must produce
+        facts retrievable through the public fact_recall surface."""
+        db_path = tmp_path / "c12a.db"
+        mem = Mnemosyne(session_id="c12a", db_path=db_path)
+        mem.remember(
+            "Alice was born in Boston in 1990 and studied math at MIT.",
+            source="user",
+            extract=True,
+        )
+        results = mem.beam.fact_recall("alice")
+        assert results, "fact_recall returned no results for wrapper-extracted facts"
+        contents = " ".join(str(r.get("content", "")).lower() for r in results)
+        assert "alice" in contents
+
+    def test_wrapper_and_direct_paths_produce_same_table_state(self, tmp_path, fake_extract_facts):
+        """Wrapper path and direct-Beam path must produce equivalent
+        fact-table state for the same input. Eliminates the asymmetry
+        that v2 plan §C12.a calls out."""
+        wrapper_db = tmp_path / "wrapper.db"
+        direct_db = tmp_path / "direct.db"
+        content = "Alice was born in Boston in 1990 and studied math at MIT."
+
+        wrapper_mem = Mnemosyne(session_id="parity", db_path=wrapper_db)
+        wrapper_mem.remember(content, source="user", extract=True)
+
+        # Direct path: BeamMemory.remember(extract=True) is the canonical
+        # one that already populates both tables.
+        from mnemosyne.core.beam import BeamMemory
+        direct_beam = BeamMemory(session_id="parity", db_path=direct_db)
+        direct_beam.remember(content, source="user", extract=True)
+
+        wrapper_facts = _facts_table_count(wrapper_db)
+        direct_facts = _facts_table_count(direct_db)
+        assert wrapper_facts == direct_facts, (
+            f"Wrapper wrote {wrapper_facts} facts rows; direct wrote {direct_facts}. "
+            f"Paths should produce identical fact-table state for identical input."
+        )
+
+
+class TestWrapperExtractEntitiesParity:
+    """Adjacent parity check: extract_entities=True path. Option A delegates
+    this to BeamMemory's _extract_and_store_entities helper; this test
+    locks in equivalent observable behavior."""
+
+    def test_wrapper_extract_entities_writes_mention_triples(self, tmp_path):
+        db_path = tmp_path / "c12a.db"
+        mem = Mnemosyne(session_id="c12a", db_path=db_path)
+        # A content string that the regex extractor will pick entities from.
+        # extract_entities_regex matches things like CapitalizedWords and
+        # quoted strings depending on the regex. Use a simple sentence with
+        # capitalized proper nouns.
+        mem.remember(
+            "Alice met Bob in Paris last Tuesday.",
+            source="user",
+            extract_entities=True,
+        )
+        # At least one triple with predicate='mentions' should exist.
+        import sqlite3
+        conn = sqlite3.connect(str(db_path))
+        try:
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM triples WHERE predicate = 'mentions'"
+            )
+            count = cur.fetchone()[0]
+        finally:
+            conn.close()
+        assert count >= 1, (
+            "extract_entities=True did not produce 'mentions' triples"
+        )

--- a/tests/test_extract_parity.py
+++ b/tests/test_extract_parity.py
@@ -115,6 +115,45 @@ class TestWrapperExtractFactsTableParity:
         contents = " ".join(str(r.get("content", "")).lower() for r in results)
         assert "alice" in contents
 
+    def test_extract_runs_on_dedup_for_backfill(self, tmp_path, fake_extract_facts):
+        """Backfill contract: a user with pre-existing working_memory rows
+        (written before extract=True was supported) calls
+        `mem.remember(same_content, extract=True)` to populate the facts
+        table after-the-fact. Even though the dedup path fires (content
+        already exists), extraction must still run.
+
+        Pre-fix this regression scenario was silently broken: my initial
+        delegation moved extraction inside BeamMemory.remember, which has
+        an early-return on dedup that skipped both extract blocks. Locks
+        in the fix that makes the dedup branch also call
+        _extract_and_store_facts / _extract_and_store_entities.
+        """
+        from mnemosyne.core.beam import BeamMemory
+        db_path = tmp_path / "c12a.db"
+        # Pre-existing row, no extraction (simulating an old DB)
+        beam = BeamMemory(session_id="c12a", db_path=db_path)
+        first_id = beam.remember(
+            "Alice was born in Boston in 1990 and studied math at MIT.",
+            source="user",
+            extract=False,
+        )
+        # Backfill: same content, now with extract=True
+        mem = Mnemosyne(session_id="c12a", db_path=db_path)
+        second_id = mem.remember(
+            "Alice was born in Boston in 1990 and studied math at MIT.",
+            source="user",
+            extract=True,
+        )
+        assert first_id == second_id, (
+            "Dedup did not fire: backfill expectation requires the "
+            "second call to recognize the existing row"
+        )
+        assert _facts_table_count(db_path) >= 1, (
+            "Backfill failed: facts table empty after extract=True on "
+            "duplicate content. Dedup branch in BeamMemory.remember must "
+            "run extraction so the C12.a contract holds for backfill scenarios."
+        )
+
     def test_wrapper_and_direct_paths_produce_same_table_state(self, tmp_path, fake_extract_facts):
         """Wrapper path and direct-Beam path must produce equivalent
         fact-table state for the same input. Eliminates the asymmetry


### PR DESCRIPTION
## Summary

- `Mnemosyne.remember(extract=True)` now writes to the `facts` table the same way `BeamMemory.remember(extract=True)` already did. Previously the wrapper reimplemented half of beam's canonical `_extract_and_store_facts` helper inline, calling `triples.add_facts(...)` but never `_store_facts_in_table(...)`. Wrapper-extracted facts were visible through `recall()` (which scores fact triples) but invisible through `fact_recall()` (which queries the facts table).
- Three bundled fixes:
  1. Wrapper delegates extraction to `BeamMemory.remember` (drops ~25 lines of duplicated logic).
  2. `BeamMemory.remember`'s dedup early-return now also runs extraction so backfill calls work (`mem.remember(same_content, extract=True)` on an already-existing row populates the facts table).
  3. `fact_recall` was crashing on `sqlite3.Row.get(...)` once rows existed — latent bug, masked while the wrapper kept the table empty. Converted to dict at the top of the per-row loop. Also normalized the None-handling for confidence/subject/predicate.
- 6 regression tests in `tests/test_extract_parity.py`: 3 RED before the wrapper fix, 1 RED before the `fact_recall` fix, 1 RED before the dedup-extract fix.

## The bug

Mnemosyne stores knowledge graph facts in two places:

| Storage | Used by |
|---|---|
| `triples` table | `recall()` — scores fact triples as part of NAI-5's "fact voice" |
| `facts` table | `fact_recall()` — public API for structured fact retrieval |

The canonical helper `_extract_and_store_facts` in `mnemosyne/core/beam.py:597` writes to BOTH:

```python
def _extract_and_store_facts(beam, memory_id, content, source=""):
    facts = extract_facts_safe(content)
    if not facts:
        return
    triples = TripleStore(db_path=beam.db_path)
    triples.add_facts(memory_id, facts, source=source, confidence=0.7)
    _store_facts_in_table(beam, memory_id, content, source, facts)
```

`Mnemosyne.remember(extract=True)` reimplemented half of this inline at `memory.py:299-309`:

```python
if extract:
    try:
        from mnemosyne.core.extraction import extract_facts_safe
        from mnemosyne.core.triples import TripleStore
        facts = extract_facts_safe(content)
        if facts:
            triples = TripleStore(db_path=self.db_path)
            triples.add_facts(memory_id, facts, source=source, confidence=0.7)
                                 # ← never called _store_facts_in_table
    except Exception:
        pass
```

Result: a memory remembered through the wrapper showed up in `recall()` (because triples are populated and NAI-5 scores them) but `fact_recall()` returned nothing for the same memory.

## Why it slipped through

Same anti-pattern as C26 / C23 / C20: tests called `BeamMemory.remember(extract=True)` directly with `db_path=tmp` and never went through `Mnemosyne.remember(extract=True)`. The wrapper's parallel extract path had zero coverage. `tests/test_extraction_integration.py` exists but it manually injects facts via `TripleStore.add_facts(...)` rather than exercising `extract=True` end-to-end through the wrapper.

## The fix (commit 1: ab4a81b)

**`Mnemosyne.remember` (memory.py)** — pass `extract=extract, extract_entities=extract_entities` to the first `self.beam.remember(...)` call. Drop the wrapper's two inline extract blocks (~25 lines). All extraction now routes through BeamMemory's canonical helpers (`_extract_and_store_entities`, `_extract_and_store_facts`) plus NAI-5's `_ingest_graph_and_veracity`. The wrapper becomes a thin shim — its only remaining job is the legacy `memories` dual-write.

**`fact_recall` row access (beam.py:2160-2174)** — `sqlite3.Row` supports bracket access but NOT `.get()`. The existing code called `row.get("confidence", 0.5)` etc. and crashed `AttributeError` the moment the facts table contained rows. The bug was unreachable while the wrapper bug above kept the table empty. Once C12.a was fixed and rows existed, `fact_recall` would crash on the first iteration. Convert to dict at the top of the loop so `.get(...)` works as the author intended.

## Pre-landing review (commit 2: 85db0dd)

Cross-model adversarial review (Claude subagent + Codex CLI). Both flagged the same primary regression introduced by commit 1:

> `BeamMemory.remember` has an early-return on duplicate content (beam.py:942-963). The early-return runs UPDATE + `_ingest_graph_and_veracity` and returns BEFORE the extract blocks at lines 985-988. So `mem.remember(same_content, extract=True)` after a duplicate silently skipped extraction entirely — breaking backfill on pre-existing databases.

Both also flagged a related issue: the wrapper made TWO `beam.remember` calls per `Mnemosyne.remember`, both of which run `_ingest_graph_and_veracity`. The second call duplicated graph_edges (autoincrement PK) and bumped `mention_count` for what was a single user-level write.

Fixes applied in commit 2:

1. **Dedup branch runs extraction** (CRITICAL — addresses Codex's primary finding). `mnemosyne/core/beam.py` — when `_find_duplicate` fires, the dedup branch now also calls `_extract_and_store_entities` and `_extract_and_store_facts` before returning. `extract=True` now means "extraction always runs" regardless of insert vs dedup, matching the wrapper's pre-fix inline behavior.

2. **Drop redundant second `beam.remember` call**. The wrapper used to call `beam.remember` twice per remember (once for ID generation, once for "ID-sync dedup"). Now that the first call accepts extract flags and produces the working_memory row with the right ID, the second call only ran the dedup branch redundantly + double-fired `_ingest_graph_and_veracity`. Removed entirely.

3. **Normalize `fact_recall` row access**. Replaced inconsistent `or ""` collapse with the same `is not None` pattern used for confidence. Extracted intermediate locals so each `row.get` is computed once.

## New backfill regression test

`tests/test_extract_parity.py::test_extract_runs_on_dedup_for_backfill` locks in the dedup-extraction contract by exactly the regression scenario the adversarial review found: pre-existing working_memory row (from `BeamMemory.remember(extract=False)`), then `mem.remember(same_content, extract=True)` — asserts dedup fires AND facts table populates. Without commit 2's fix this would fail silently; with the fix it's GREEN.

## Behavior change worth flagging

**Pre-fix:** `Mnemosyne.remember(extract=True)` with already-existing working_memory content → wrapper's inline extract block ran AFTER both beam.remember calls regardless of dedup. Triples populated; facts table never.

**Post-fix:** `Mnemosyne.remember(extract=True)` with already-existing content → first beam.remember hits dedup, runs extraction (including facts table). Single user-level call → single set of extraction effects.

This is the intended behavior for backfill scenarios. Anyone who depended on "extract=True is a no-op on duplicate content" (no callers found) would see facts/triples now actually appear.

## Deferred (filed separately)

- **C12.a.cognee** (added to `.hermes/ledger/memory-contract.md` locally): `mnemosyne/core/importers/cognee.py:106-109` has the same latent `sqlite3.Row.get()` pattern as `fact_recall`. Currently masked by `except Exception: pass`. Both adversarial reviewers flagged it independently. Small follow-up PR.
- NaN confidence handling — edge case noted by Claude, not exercised by current writers.
- Per-row `dict.get` perf nit — bounded by `top_k`, not a real concern.

## Test plan

- [ ] `uv run pytest tests/test_extract_parity.py -q` (6 passed locally)
- [ ] `uv run pytest -q --ignore=tests/test_local_llm.py --ignore=tests/test_llm_backends.py` (470 passed locally)
- [ ] Manual: `mem.remember("Alice was born in Boston.", extract=True)` then `mem.beam.fact_recall("alice")` returns the fact (was empty pre-fix).
- [ ] Manual backfill: write a memory with `extract=False`, then re-remember the same content with `extract=True`. Verify the facts table populates after the second call.
- [ ] Manual fact_recall under load: with several extract=True memories, `fact_recall` returns sensibly without `AttributeError`.

## Verification

\`\`\`
tests/test_extract_parity.py: 6 passed (new file)
broader sweep (extraction + entities + beam): 119 passed
full suite excluding LLM-dependent tests: 470 passed
\`\`\`