### PR TITLE
fix(C12.a.cognee): convert sqlite3.Row to dict in cognee direct importer

### DIFF
--- a/mnemosyne/core/importers/cognee.py
+++ b/mnemosyne/core/importers/cognee.py
@@ -98,13 +98,21 @@ class CogneeImporter(BaseImporter):
                 rows = conn.execute(
                     "SELECT * FROM data_chunks ORDER BY created_at"
                 ).fetchall()
-                for row in rows:
+                for raw_row in rows:
+                    # sqlite3.Row supports bracket access but not .get();
+                    # convert to dict so the column-with-default reads
+                    # below work. Pre-fix the .get() calls raised
+                    # AttributeError and the broad `except` below swallowed
+                    # it silently, returning [] for every direct cognee
+                    # import even when data_chunks was populated. Same
+                    # pattern as the fact_recall fix in C12.a.
+                    row = dict(raw_row)
                     items.append({
-                        "content": row["text"] or row["content"] or "",
+                        "content": row.get("text") or row.get("content") or "",
                         "source": "cognee_direct",
                         "metadata": {
-                            "chunk_id": row.get("id", ""),
-                            "document_id": row.get("document_id", ""),
+                            "chunk_id": row.get("id") or "",
+                            "document_id": row.get("document_id") or "",
                         },
                         "timestamp": row.get("created_at"),
                     })

--- a/tests/test_importers/test_cognee.py
+++ b/tests/test_importers/test_cognee.py
@@ -1,0 +1,126 @@
+"""Regression tests for [C12.a.cognee]: CogneeImporter._extract_direct
+read rows out of Cognee's SQLite metadata using `conn.row_factory =
+sqlite3.Row` and then called `row.get("id", "")` etc. sqlite3.Row does
+not support `.get()` — bracket access only — so each row raised
+AttributeError. The surrounding `except Exception: pass` swallowed it,
+so direct cognee imports silently returned zero rows even when the
+data was present.
+
+Same pattern as the latent fact_recall bug surfaced by C12.a; this is
+the adjacent occurrence in the importer surface.
+"""
+
+import sqlite3
+
+import pytest
+
+from mnemosyne.core.importers.cognee import CogneeImporter
+
+
+def _make_cognee_db(tmp_path):
+    """Build a minimal Cognee-shaped SQLite DB with one data_chunks row."""
+    data_dir = tmp_path / "cognee-data"
+    data_dir.mkdir()
+    db_path = data_dir / "cognee_db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("""
+            CREATE TABLE data_chunks (
+                id TEXT PRIMARY KEY,
+                document_id TEXT,
+                text TEXT,
+                content TEXT,
+                created_at TEXT
+            )
+        """)
+        conn.execute("""
+            INSERT INTO data_chunks (id, document_id, text, content, created_at)
+            VALUES (?, ?, ?, ?, ?)
+        """, (
+            "chunk-1",
+            "doc-1",
+            "Alice was born in Boston.",
+            None,
+            "2026-05-09T00:00:00",
+        ))
+        conn.commit()
+    finally:
+        conn.close()
+    return data_dir
+
+
+class TestCogneeDirectImport:
+
+    def test_extract_direct_returns_rows_from_data_chunks(self, tmp_path):
+        """The bug surface: pre-fix, this returned [] silently because
+        row.get on sqlite3.Row raised AttributeError and the broad
+        except swallowed it."""
+        data_dir = _make_cognee_db(tmp_path)
+        importer = CogneeImporter(
+            data_dir=str(data_dir),
+            direct_db=True,
+        )
+        items = importer._extract_direct()
+        assert items, (
+            "_extract_direct returned empty despite seeded data_chunks "
+            "row — the row.get on sqlite3.Row crash is masked by the "
+            "broad except"
+        )
+        assert len(items) == 1
+        item = items[0]
+        assert item["content"] == "Alice was born in Boston."
+        assert item["source"] == "cognee_direct"
+        assert item["metadata"]["chunk_id"] == "chunk-1"
+        assert item["metadata"]["document_id"] == "doc-1"
+        assert item["timestamp"] == "2026-05-09T00:00:00"
+
+    def test_extract_direct_handles_null_text_falls_back_to_content(self, tmp_path):
+        """Existing fallback: row['text'] or row['content'] or ''. Make
+        sure it survives the dict conversion."""
+        data_dir = tmp_path / "cognee-data"
+        data_dir.mkdir()
+        db_path = data_dir / "cognee_db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("""
+                CREATE TABLE data_chunks (
+                    id TEXT PRIMARY KEY,
+                    document_id TEXT,
+                    text TEXT,
+                    content TEXT,
+                    created_at TEXT
+                )
+            """)
+            conn.execute("""
+                INSERT INTO data_chunks (id, document_id, text, content, created_at)
+                VALUES (?, ?, ?, ?, ?)
+            """, (
+                "chunk-2",
+                "doc-2",
+                None,
+                "Backup content text",
+                "2026-05-09T00:00:01",
+            ))
+            conn.commit()
+        finally:
+            conn.close()
+
+        importer = CogneeImporter(
+            data_dir=str(data_dir),
+            direct_db=True,
+        )
+        items = importer._extract_direct()
+        assert items
+        assert items[0]["content"] == "Backup content text"
+
+    def test_extract_direct_returns_empty_when_db_missing(self, tmp_path):
+        """Defensive: missing cognee_db should produce [] (not raise),
+        which is the existing contract the broad except provides."""
+        data_dir = tmp_path / "no-cognee"
+        data_dir.mkdir()
+        importer = CogneeImporter(
+            data_dir=str(data_dir),
+            direct_db=True,
+        )
+        items = importer._extract_direct()
+        assert items == []


### PR DESCRIPTION
## Summary

- `mnemosyne/core/importers/cognee.py:106-109` called `row.get(...)` on a `sqlite3.Row` object. `sqlite3.Row` supports bracket access but NOT `.get()` — every iteration raised `AttributeError`, swallowed by the surrounding `except Exception: pass`. Direct cognee imports silently returned `[]` regardless of how much data was in `data_chunks`.
- Convert `raw_row` to `dict(raw_row)` at the top of the per-row loop so the existing `.get()` calls work as the author intended.
- 3 regression tests in `tests/test_importers/test_cognee.py` (2 RED before fix, 1 GREEN both before and after as a missing-DB contract guard).

## Why now

This is a bundled follow-up from the C12.a `/review` (PR #58). Both Claude and Codex adversarial reviewers spotted this same `sqlite3.Row.get()` pattern in `cognee.py` while reviewing the `fact_recall` fix. Mechanically identical fix, different file/feature — landing as its own small PR rather than expanding C12.a's scope.

## The bug, explicitly

```python
conn = sqlite3.connect(str(sqlite_path))
conn.row_factory = sqlite3.Row    # ← Row factory configured
try:
    rows = conn.execute("SELECT * FROM data_chunks ORDER BY created_at").fetchall()
    for row in rows:
        items.append({
            "content": row["text"] or row["content"] or "",  # works (bracket)
            "source": "cognee_direct",
            "metadata": {
                "chunk_id": row.get("id", ""),               # AttributeError
                "document_id": row.get("document_id", ""),   # never reached
            },
            "timestamp": row.get("created_at"),              # never reached
        })
except Exception:
    pass                                                     # swallows the crash
```

The first `.get()` call raised, the `except` caught it, and `items` ended up empty for every call. Anyone using `CogneeImporter(direct_db=True)` got zero rows imported, with no error or warning, regardless of how much was in `data_chunks`.

## The fix

```python
for raw_row in rows:
    row = dict(raw_row)   # sqlite3.Row → dict so .get() works
    items.append({
        "content": row.get("text") or row.get("content") or "",
        "source": "cognee_direct",
        "metadata": {
            "chunk_id": row.get("id") or "",
            "document_id": row.get("document_id") or "",
        },
        "timestamp": row.get("created_at"),
    })
```

Three lines added, no behavior change for the missing-DB / empty-table paths.

## Tests

`tests/test_importers/test_cognee.py` — 3 tests, all using a tmp `cognee_db` SQLite file with seeded `data_chunks` rows:

1. **`test_extract_direct_returns_rows_from_data_chunks`** — seeds one row, asserts `_extract_direct()` returns it with the expected `content` / `source` / `metadata` / `timestamp` shape. RED before fix (returned `[]`).
2. **`test_extract_direct_handles_null_text_falls_back_to_content`** — seeds a row with NULL `text` and a populated `content` column; asserts the fallback works. RED before fix.
3. **`test_extract_direct_returns_empty_when_db_missing`** — defensive contract guard. GREEN both before and after; locks in the missing-DB → `[]` behavior so future refactors don't accidentally raise.

## Test plan

- [ ] `uv run pytest tests/test_importers/test_cognee.py -q` (3 passed locally)
- [ ] `uv run pytest -q --ignore=tests/test_local_llm.py --ignore=tests/test_llm_backends.py` (467 passed locally)
- [ ] Manual: configure a `CogneeImporter(direct_db=True, data_dir=...)` against a real Cognee install with populated `data_chunks`. Verify rows now flow through (was returning `[]`).

## Verification

\`\`\`
tests/test_importers/test_cognee.py: 3 passed (new file, 2 RED before fix)
full suite excluding LLM-dependent tests: 467 passed
\`\`\`