### PR TITLE
fix(C18.b): refresh dense-recall embeddings on episodic degradation

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2294,12 +2294,81 @@ class BeamMemory:
             compressed += " [...]"
         return compressed
 
+    def _refresh_episodic_embedding(self, memory_id: str, rowid: int, new_content: str):
+        """Refresh dense-recall embedding stores for an episodic row whose
+        content has been mutated (degraded). Without this the
+        vec_episodes / memory_embeddings / binary_vector entries continue
+        representing the pre-mutation content, so dense recall scores
+        rows by semantics that no longer match what the row displays.
+        See C18.b in the memory-contract ledger.
+
+        - If embeddings provider is available: regenerate using the new
+          content and overwrite the existing vector store entries.
+        - If unavailable: invalidate (DELETE / NULL) the stale entries so
+          dense recall stops returning semantically misleading hits. The
+          row remains discoverable via FTS.
+        """
+        cursor = self.conn.cursor()
+
+        vec_available_now = _vec_available(self.conn)
+
+        if _embeddings.available():
+            try:
+                vec = _embeddings.embed([new_content])
+            except Exception:
+                vec = None
+            if vec is not None:
+                # vec_episodes is a sqlite-vec virtual table; vec0 doesn't
+                # support UPDATE on the embedding column reliably, so we
+                # DELETE+INSERT to refresh.
+                if vec_available_now:
+                    cursor.execute("DELETE FROM vec_episodes WHERE rowid = ?", (rowid,))
+                    _vec_insert(self.conn, rowid, vec[0].tolist())
+                else:
+                    cursor.execute("""
+                        INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model)
+                        VALUES (?, ?, ?)
+                    """, (memory_id, _embeddings.serialize(vec[0]), _embeddings._DEFAULT_MODEL))
+
+                if _mib is not None:
+                    try:
+                        bv = _mib(vec[0])
+                        cursor.execute(
+                            "UPDATE episodic_memory SET binary_vector = ? WHERE id = ?",
+                            (bv, memory_id),
+                        )
+                    except Exception:
+                        pass
+                return
+
+        # Provider unavailable (or embed() returned None). Invalidate the
+        # stale entries so dense recall doesn't lie. The row keeps its
+        # FTS-searchable content and remains otherwise intact. Each DELETE
+        # is gated on the matching store's availability — vec_episodes is
+        # a sqlite-vec virtual table that doesn't exist when the extension
+        # isn't loaded, so an unconditional DELETE there raises
+        # OperationalError and the caller's broad except would silently
+        # skip the memory_embeddings cleanup too.
+        if vec_available_now:
+            cursor.execute("DELETE FROM vec_episodes WHERE rowid = ?", (rowid,))
+        cursor.execute("DELETE FROM memory_embeddings WHERE memory_id = ?", (memory_id,))
+        if _mib is not None:
+            cursor.execute(
+                "UPDATE episodic_memory SET binary_vector = NULL WHERE id = ?",
+                (memory_id,),
+            )
+
     def degrade_episodic(self, dry_run: bool = False) -> Dict:
         """Degrade old episodic memories through tier 1→2→3 compression.
 
         Tier 1 (0-TIER2_DAYS): Full detail, 1.0x recall weight
         Tier 2 (TIER2_DAYS-TIER3_DAYS): LLM-summarized, 0.5x weight
         Tier 3 (TIER3_DAYS+): Text extraction compressed, 0.25x weight
+
+        Each tier transition that mutates content also refreshes the
+        row's dense-recall embedding (or invalidates it if the embeddings
+        provider is unavailable) so vec_episodes / memory_embeddings /
+        binary_vector stay aligned with the displayed text. See C18.b.
 
         Returns summary of tier transitions performed.
         """
@@ -2312,9 +2381,10 @@ class BeamMemory:
         tier2_cutoff = (now - timedelta(days=TIER2_DAYS)).isoformat()
         tier3_cutoff = (now - timedelta(days=TIER3_DAYS)).isoformat()
 
-        # Tier 1 → Tier 2: old enough, still at tier 1
+        # Tier 1 → Tier 2: old enough, still at tier 1.
+        # rowid is selected so the embedding refresh can address vec_episodes.
         cursor.execute("""
-            SELECT id, content, importance FROM episodic_memory
+            SELECT id, rowid, content, importance FROM episodic_memory
             WHERE tier = 1 AND created_at < ?
             ORDER BY created_at ASC LIMIT ?
         """, (tier2_cutoff, DEGRADE_BATCH_SIZE))
@@ -2322,7 +2392,7 @@ class BeamMemory:
 
         # Tier 2 → Tier 3: very old, at tier 2
         cursor.execute("""
-            SELECT id, content FROM episodic_memory
+            SELECT id, rowid, content FROM episodic_memory
             WHERE tier = 2 AND created_at < ?
             ORDER BY created_at ASC LIMIT ?
         """, (tier3_cutoff, DEGRADE_BATCH_SIZE // 2))
@@ -2342,10 +2412,17 @@ class BeamMemory:
                     summary = local_llm.summarize_memories([row["content"]])
                     if summary:
                         compressed = summary[:400]
+                final_content = compressed[:800]
                 cursor.execute(
                     "UPDATE episodic_memory SET content = ?, tier = 2, degraded_at = ? WHERE id = ?",
-                    (compressed[:800], now.isoformat(), row["id"])
+                    (final_content, now.isoformat(), row["id"])
                 )
+                # Only refresh the embedding when content actually changed.
+                # If LLM was unavailable and content is unchanged the
+                # existing embedding is already correct and an embed()
+                # call would be wasted.
+                if final_content != row["content"]:
+                    self._refresh_episodic_embedding(row["id"], row["rowid"], final_content)
                 results["tier1_to_tier2"] += 1
             except Exception:
                 pass
@@ -2364,6 +2441,8 @@ class BeamMemory:
                     "UPDATE episodic_memory SET content = ?, tier = 3, degraded_at = ? WHERE id = ?",
                     (compressed, now.isoformat(), row["id"])
                 )
+                if compressed != row["content"]:
+                    self._refresh_episodic_embedding(row["id"], row["rowid"], compressed)
                 results["tier2_to_tier3"] += 1
             except Exception:
                 pass

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2404,8 +2404,16 @@ class BeamMemory:
             return results
 
         # --- Degrade tier 1 → tier 2: LLM summarization ---
+        # Each row's UPDATE + embedding refresh runs inside a SAVEPOINT so
+        # a refresh failure rolls back the content mutation too. Without
+        # this the broad except below would swallow the refresh exception
+        # while leaving the UPDATE staged in the implicit transaction,
+        # which then commits at the end of degrade_episodic — producing
+        # the very content/embedding drift this fix exists to prevent
+        # (caught by /review for C18.b).
         from mnemosyne.core import local_llm
         for row in tier1_rows:
+            cursor.execute("SAVEPOINT degrade_row")
             try:
                 compressed = row["content"]
                 if local_llm.llm_available() and len(row["content"]) > 300:
@@ -2423,12 +2431,18 @@ class BeamMemory:
                 # call would be wasted.
                 if final_content != row["content"]:
                     self._refresh_episodic_embedding(row["id"], row["rowid"], final_content)
+                cursor.execute("RELEASE degrade_row")
                 results["tier1_to_tier2"] += 1
             except Exception:
-                pass
+                try:
+                    cursor.execute("ROLLBACK TO degrade_row")
+                    cursor.execute("RELEASE degrade_row")
+                except Exception:
+                    pass
 
         # --- Degrade tier 2 → tier 3: smart extraction (keep key entities) ---
         for row in tier2_rows:
+            cursor.execute("SAVEPOINT degrade_row")
             try:
                 content = row["content"]
                 if SMART_COMPRESS and len(content) > TIER3_MAX_CHARS:
@@ -2443,9 +2457,14 @@ class BeamMemory:
                 )
                 if compressed != row["content"]:
                     self._refresh_episodic_embedding(row["id"], row["rowid"], compressed)
+                cursor.execute("RELEASE degrade_row")
                 results["tier2_to_tier3"] += 1
             except Exception:
-                pass
+                try:
+                    cursor.execute("ROLLBACK TO degrade_row")
+                    cursor.execute("RELEASE degrade_row")
+                except Exception:
+                    pass
 
         self.conn.commit()
         return results

--- a/tests/test_degrade_vector.py
+++ b/tests/test_degrade_vector.py
@@ -1,0 +1,242 @@
+"""Regression tests for [C18.b]: degrade_episodic updates content text but
+leaves stale dense embeddings. Pre-fix the embedding stored in vec_episodes
+or memory_embeddings still represented the ORIGINAL content even after the
+content was compressed/truncated, causing dense recall to score against
+content that no longer exists in the row.
+
+Two tests:
+1. With embeddings provider available, degrade regenerates the embedding
+   to match the new compressed content.
+2. With embeddings provider unavailable, degrade invalidates (deletes)
+   the stale embedding so dense recall doesn't return semantically
+   misleading results.
+"""
+
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mnemosyne.core import beam as beam_module
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+def _content_to_vec(text: str, dim: int = 384) -> np.ndarray:
+    """Deterministic content-encoding 'embedding'. Different content
+    produces different vectors. Two scalars at the front carry length
+    and first-char info so an assertion can detect change."""
+    v = np.zeros(dim, dtype=np.float32)
+    if not text:
+        return v
+    v[0] = float(len(text))
+    v[1] = float(ord(text[0]))
+    # Light hash spread so identical-length, identical-first-char strings
+    # still produce different vectors (covers truncation that preserves
+    # both signals).
+    h = hash(text) & 0xFFFF
+    v[2] = float(h % 256)
+    v[3] = float((h >> 8) % 256)
+    return v
+
+
+@pytest.fixture
+def fake_embeddings(monkeypatch):
+    """Patch the embeddings module: available() returns True, embed()
+    returns content-deterministic vectors, and force the in-memory
+    fallback path so we don't need sqlite-vec loaded."""
+    from mnemosyne.core import embeddings as emb
+
+    monkeypatch.setattr(emb, "available", lambda: True)
+    monkeypatch.setattr(
+        emb, "embed",
+        lambda texts: np.stack([_content_to_vec(t) for t in texts]),
+    )
+    # Force the memory_embeddings fallback path; sqlite-vec presence
+    # varies across test environments and the bug is identical for
+    # both stores.
+    monkeypatch.setattr(beam_module, "_vec_available", lambda conn: False)
+    return emb
+
+
+def _read_fallback_embedding(db_path, memory_id):
+    """Return the serialized embedding stored in memory_embeddings for
+    the given memory_id, or None if missing."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT embedding_json FROM memory_embeddings WHERE memory_id = ?",
+            (memory_id,),
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def _read_binary_vector(db_path, memory_id):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT binary_vector FROM episodic_memory WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+class TestDegradeEpisodicVectorRefresh:
+
+    def test_tier_2_to_tier_3_regenerates_embedding(self, temp_db, fake_embeddings):
+        """When tier 2→3 truncation changes content, the embedding stored
+        in memory_embeddings must update to match the new content."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+
+        # Long original content that will be truncated by tier 2→3 (TIER3_MAX_CHARS=300)
+        original = ("ORIGINAL_DETAILED_CONTEXT " * 30).strip()
+        assert len(original) > beam_module.TIER3_MAX_CHARS
+
+        memory_id = beam.consolidate_to_episodic(
+            summary=original,
+            source_wm_ids=["fake-wm"],
+            importance=0.6,
+        )
+
+        original_embedding = _read_fallback_embedding(temp_db, memory_id)
+        assert original_embedding is not None, (
+            "memory_embeddings should contain a row after consolidate_to_episodic"
+        )
+
+        # Backdate to make the row eligible for tier 2→3 and set tier=2 so it
+        # hits the truncation path (skips the LLM-summarization tier 1→2 path
+        # which is a no-op when local_llm is unavailable).
+        old_ts = (datetime.now() - timedelta(days=beam_module.TIER3_DAYS + 1)).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute(
+            "UPDATE episodic_memory SET tier = 2, created_at = ? WHERE id = ?",
+            (old_ts, memory_id),
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.degrade_episodic(dry_run=False)
+        assert result["tier2_to_tier3"] == 1, (
+            f"Expected one tier 2→3 transition, got {result}"
+        )
+
+        conn = sqlite3.connect(str(temp_db))
+        new_content = conn.execute(
+            "SELECT content FROM episodic_memory WHERE id = ?", (memory_id,)
+        ).fetchone()[0]
+        conn.close()
+        assert new_content != original, "tier 2→3 should have truncated the content"
+
+        post_embedding = _read_fallback_embedding(temp_db, memory_id)
+        assert post_embedding is not None, (
+            "memory_embeddings row missing after degrade; expected regenerated, "
+            "not deleted, when the embeddings provider is available"
+        )
+        assert post_embedding != original_embedding, (
+            "memory_embeddings still holds the pre-degradation embedding — "
+            "dense recall would score against original content while displaying "
+            "truncated content. C18.b regeneration did not run."
+        )
+
+    def test_tier_2_to_tier_3_regenerates_binary_vector(self, temp_db, fake_embeddings):
+        """The binary_vector column on episodic_memory must also update
+        to match the new content."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+
+        original = ("ORIGINAL_DETAILED_CONTEXT " * 30).strip()
+        memory_id = beam.consolidate_to_episodic(
+            summary=original,
+            source_wm_ids=["fake-wm"],
+            importance=0.6,
+        )
+
+        if beam_module._mib is None:
+            pytest.skip("binary vectorization not available in this build")
+
+        original_bv = _read_binary_vector(temp_db, memory_id)
+        assert original_bv is not None
+
+        old_ts = (datetime.now() - timedelta(days=beam_module.TIER3_DAYS + 1)).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute(
+            "UPDATE episodic_memory SET tier = 2, created_at = ? WHERE id = ?",
+            (old_ts, memory_id),
+        )
+        conn.commit()
+        conn.close()
+
+        beam.degrade_episodic(dry_run=False)
+
+        post_bv = _read_binary_vector(temp_db, memory_id)
+        assert post_bv is not None, (
+            "binary_vector should be present (regenerated, not nulled) when "
+            "the embedding provider is available"
+        )
+        assert post_bv != original_bv, (
+            "binary_vector still holds pre-degradation bytes — same C18.b drift"
+        )
+
+    def test_tier_2_to_tier_3_invalidates_when_provider_unavailable(
+        self, temp_db, monkeypatch
+    ):
+        """If embeddings provider is unavailable at degrade time, the stale
+        embedding rows must be invalidated so dense recall can't return
+        semantically misleading hits."""
+        from mnemosyne.core import embeddings as emb
+
+        # Phase 1: provider available — seed.
+        monkeypatch.setattr(emb, "available", lambda: True)
+        monkeypatch.setattr(
+            emb, "embed",
+            lambda texts: np.stack([_content_to_vec(t) for t in texts]),
+        )
+        monkeypatch.setattr(beam_module, "_vec_available", lambda conn: False)
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        original = ("ORIGINAL_DETAILED_CONTEXT " * 30).strip()
+        memory_id = beam.consolidate_to_episodic(
+            summary=original,
+            source_wm_ids=["fake-wm"],
+            importance=0.6,
+        )
+        assert _read_fallback_embedding(temp_db, memory_id) is not None
+
+        # Phase 2: provider goes unavailable BEFORE degrade.
+        monkeypatch.setattr(emb, "available", lambda: False)
+
+        old_ts = (datetime.now() - timedelta(days=beam_module.TIER3_DAYS + 1)).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute(
+            "UPDATE episodic_memory SET tier = 2, created_at = ? WHERE id = ?",
+            (old_ts, memory_id),
+        )
+        conn.commit()
+        conn.close()
+
+        beam.degrade_episodic(dry_run=False)
+
+        post_embedding = _read_fallback_embedding(temp_db, memory_id)
+        assert post_embedding is None, (
+            "Stale memory_embeddings row remained after degrade with no embeddings "
+            "provider. Should have been deleted to avoid ranking against content "
+            "that no longer matches the row's text."
+        )
+
+        post_bv = _read_binary_vector(temp_db, memory_id)
+        if beam_module._mib is not None:
+            assert post_bv is None, (
+                "binary_vector should be NULLed when the embedding provider is "
+                "unavailable at degrade time"
+            )

--- a/tests/test_degrade_vector.py
+++ b/tests/test_degrade_vector.py
@@ -188,6 +188,129 @@ class TestDegradeEpisodicVectorRefresh:
             "binary_vector still holds pre-degradation bytes — same C18.b drift"
         )
 
+    def test_tier_1_to_tier_2_llm_path_regenerates_embedding(
+        self, temp_db, fake_embeddings, monkeypatch
+    ):
+        """Tier 1→2 with the LLM-summarization path active: monkeypatched
+        local_llm replaces content with a stub summary. The embedding
+        must regenerate to match. Closes the test gap from /review —
+        same _refresh_episodic_embedding path is exercised but a
+        regression specific to the tier 1→2 hookup (e.g., wrong arg)
+        wouldn't slip through."""
+        from mnemosyne.core import local_llm
+
+        monkeypatch.setattr(local_llm, "llm_available", lambda: True)
+        monkeypatch.setattr(
+            local_llm, "summarize_memories",
+            lambda lines, source="": "STUB SUMMARY produced by LLM (deterministic)",
+        )
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Long content (>300 chars) so the tier 1→2 path hits the LLM branch
+        long_original = ("OriginalLongFactPrefix " + "padding " * 100).strip()
+        assert len(long_original) > 300
+
+        memory_id = beam.consolidate_to_episodic(
+            summary=long_original,
+            source_wm_ids=["wm-1"],
+            importance=0.6,
+        )
+        original_embedding = _read_fallback_embedding(temp_db, memory_id)
+        assert original_embedding is not None
+
+        # Backdate so the row is eligible for tier 1→2 (tier defaults to 1
+        # in the schema, so we just need the timestamp).
+        old_ts = (datetime.now() - timedelta(days=beam_module.TIER2_DAYS + 1)).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute(
+            "UPDATE episodic_memory SET created_at = ? WHERE id = ?",
+            (old_ts, memory_id),
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.degrade_episodic(dry_run=False)
+        assert result["tier1_to_tier2"] == 1, (
+            f"Expected one tier 1→2 transition, got {result}"
+        )
+
+        # Content should now be the stub summary
+        conn = sqlite3.connect(str(temp_db))
+        new_content = conn.execute(
+            "SELECT content FROM episodic_memory WHERE id = ?", (memory_id,)
+        ).fetchone()[0]
+        conn.close()
+        assert new_content.startswith("STUB SUMMARY"), (
+            f"tier 1→2 LLM path didn't replace content: {new_content[:60]!r}"
+        )
+
+        # Embedding must match new (summary) content, not original
+        post_embedding = _read_fallback_embedding(temp_db, memory_id)
+        assert post_embedding is not None
+        assert post_embedding != original_embedding, (
+            "Embedding still reflects pre-LLM content; tier 1→2 path "
+            "did not call _refresh_episodic_embedding"
+        )
+
+    def test_refresh_failure_rolls_back_content_update(
+        self, temp_db, fake_embeddings, monkeypatch
+    ):
+        """[C18.b /review finding #1] If _refresh_episodic_embedding raises
+        after the UPDATE statement runs, the SAVEPOINT must roll back the
+        content mutation so we don't commit content=NEW with embedding=OLD
+        (the very drift this PR fixes). Pre-fix, the broad except in the
+        loop body swallowed the refresh exception and the UPDATE stayed
+        staged in the implicit transaction."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+
+        original = ("ORIGINAL_DETAILED_CONTEXT " * 30).strip()
+        memory_id = beam.consolidate_to_episodic(
+            summary=original,
+            source_wm_ids=["fake-wm"],
+            importance=0.6,
+        )
+
+        # Backdate + mark tier 2 so degrade hits the tier 2→3 path.
+        old_ts = (datetime.now() - timedelta(days=beam_module.TIER3_DAYS + 1)).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute(
+            "UPDATE episodic_memory SET tier = 2, created_at = ? WHERE id = ?",
+            (old_ts, memory_id),
+        )
+        conn.commit()
+        conn.close()
+
+        # Force the refresh to raise mid-call so we exercise the SAVEPOINT
+        # rollback path. We patch on the instance so other beam instances
+        # in the same test session aren't affected.
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated refresh failure")
+        monkeypatch.setattr(beam, "_refresh_episodic_embedding", boom)
+
+        result = beam.degrade_episodic(dry_run=False)
+        # The row should NOT count as consolidated since the savepoint
+        # rolled back.
+        assert result["tier2_to_tier3"] == 0, (
+            f"Refresh raised but row still counted as degraded: {result}"
+        )
+
+        # Critically: content must remain at the original (rollback worked),
+        # NOT the truncated form. If the SAVEPOINT didn't roll back, the
+        # UPDATE would have committed and we'd see truncated content + stale
+        # embedding — exactly the C18.b drift.
+        conn = sqlite3.connect(str(temp_db))
+        post_content = conn.execute(
+            "SELECT content, tier FROM episodic_memory WHERE id = ?", (memory_id,)
+        ).fetchone()
+        conn.close()
+        assert post_content[0] == original, (
+            f"SAVEPOINT did not roll back: content was mutated despite refresh "
+            f"failure. Got {post_content[0][:60]!r}, expected original."
+        )
+        assert post_content[1] == 2, (
+            f"SAVEPOINT did not roll back tier change: got tier={post_content[1]}"
+        )
+
     def test_tier_2_to_tier_3_invalidates_when_provider_unavailable(
         self, temp_db, monkeypatch
     ):


### PR DESCRIPTION
## Summary

- `BeamMemory.degrade_episodic()` UPDATEd `episodic_memory.content / tier / degraded_at` but never touched the dense-recall stores (`vec_episodes`, `memory_embeddings`, `binary_vector`). Dense recall scored rows by their pre-degradation embedding while showing the compressed text — silent semantic drift between ranking and content.
- Fix adds `_refresh_episodic_embedding(memory_id, rowid, new_content)` that either regenerates (provider available) or invalidates (provider unavailable) the dense-recall stores after each tier transition. Each per-row UPDATE+refresh runs inside a SAVEPOINT so partial failures roll back cleanly.
- 4 regression tests in `tests/test_degrade_vector.py` (1 skips when binary vectorization isn't in the build): tier 2→3 regenerate, tier 2→3 invalidate-when-unavailable, tier 1→2 LLM path regenerate, and SAVEPOINT-rollback-on-refresh-failure.

## What the user actually sees go wrong

```
Original episodic row at Tier 1:
  content     = "Last week I deployed mnemosyne v2.4 to prod, including
                 the sqlite-vec extension and a fix for the cross-session
                 recall bug found in beta testing."
  vec         = embedding(full_text)
  binary      = bin_embedding(full_text)

Time passes. degrade_episodic runs the Tier 1→2 transition.

After degrade (PRE-FIX):
  content     = "Deployed mnemosyne v2.4 with sqlite-vec."   ← updated
  tier        = 2                                              ← updated
  degraded_at = now()                                          ← updated
  vec         = embedding(full_text)                           ← STALE
  binary      = bin_embedding(full_text)                       ← STALE
```

Query `recall("beta testing bug fix")`:
- FTS hits the new content text → no match (got "Deployed mnemosyne v2.4")
- Vector hits embedding(original) → strong match (original mentioned "beta testing")
- Ranking treats the row as semantically about "beta testing"
- User sees `"Deployed mnemosyne v2.4 with sqlite-vec."` returned for a beta-testing query

Silent drift between what's ranked and what's shown.

## Why it slipped through

`consolidate_to_episodic` writes content and embedding paired. `degrade_episodic` was added later to compress old content but the author never extended it to the embedding stores. No test exercised dense recall post-degradation. Same anti-pattern as the rest of the C-series: feature added, paired-state contract not maintained, no test for the contract.

## The fix (commit 1: a0faf2e)

New private helper `_refresh_episodic_embedding` mirrors the embedding write logic from `consolidate_to_episodic`:

```python
def _refresh_episodic_embedding(self, memory_id, rowid, new_content):
    vec_available_now = _vec_available(self.conn)

    if _embeddings.available():
        try:
            vec = _embeddings.embed([new_content])
        except Exception:
            vec = None
        if vec is not None:
            # vec_episodes is a sqlite-vec virtual table; vec0 doesn't
            # support UPDATE on the embedding column reliably, so
            # DELETE+INSERT to refresh.
            if vec_available_now:
                cursor.execute("DELETE FROM vec_episodes WHERE rowid = ?", (rowid,))
                _vec_insert(self.conn, rowid, vec[0].tolist())
            else:
                cursor.execute("INSERT OR REPLACE INTO memory_embeddings ...")
            if _mib is not None:
                cursor.execute("UPDATE episodic_memory SET binary_vector = ? WHERE id = ?", ...)
            return

    # Provider unavailable. Invalidate so dense recall doesn't lie.
    if vec_available_now:
        cursor.execute("DELETE FROM vec_episodes WHERE rowid = ?", (rowid,))
    cursor.execute("DELETE FROM memory_embeddings WHERE memory_id = ?", (memory_id,))
    if _mib is not None:
        cursor.execute("UPDATE episodic_memory SET binary_vector = NULL WHERE id = ?", ...)
```

`degrade_episodic` calls it after each tier UPDATE — but only when the content actually changed (a no-op tier 1→2 with no LLM available leaves content identical, so the existing embedding is already correct).

Both DELETE paths in the invalidate branch are gated on `_vec_available(conn)` because `vec_episodes` is a virtual table that doesn't exist when sqlite-vec isn't loaded. Without the gate, the DELETE raises `OperationalError` and the broad except in the loop body would silently skip the `memory_embeddings` cleanup too.

## Pre-landing review (commit 2: e614756)

Cross-model adversarial review (Claude subagent + Codex CLI) caught a critical correctness regression my initial fix introduced and a test gap:

### Critical: partial refresh failure leaves UPDATE staged → C18.b drift returns

The per-row try wraps both `UPDATE episodic_memory ...` and `_refresh_episodic_embedding(...)`. If the refresh raises after the UPDATE statement runs (e.g., `_vec_insert` raises `OperationalError`, `embed()` raises something not caught inside the helper's inner try), the broad except swallows it but the UPDATE stays staged in the implicit transaction. The next successful row OR the final `self.conn.commit()` at the end of `degrade_episodic` commits the content mutation **without** the matching embedding refresh.

Result: for the affected row, the C18.b drift this PR is supposed to fix returns — content is the degraded version, embedding still represents the original.

**Fix:** wrap each row's UPDATE+refresh in a `SAVEPOINT degrade_row`. On success, `RELEASE`. On exception, `ROLLBACK TO degrade_row` inside the broad except so the content mutation is un-staged too. Either both succeed and commit, or both rollback.

### Test gap: tier 1→2 LLM path was unexercised

Existing tests dodge the tier 1→2 branch by setting `tier = 2` directly so the row hits the truncation path. Same `_refresh_episodic_embedding` code path is exercised, but a regression specific to the tier 1→2 wiring (e.g., wrong arg passed) wouldn't be caught.

**Fix:** added `test_tier_1_to_tier_2_llm_path_regenerates_embedding` that monkeypatches `local_llm.llm_available → True` and `summarize_memories → "STUB SUMMARY ..."`, leaves the row at tier 1, and asserts the embedding regenerates to match the new summary content.

### Plus: SAVEPOINT-rollback regression test

`test_refresh_failure_rolls_back_content_update` monkeypatches `_refresh_episodic_embedding` to raise unconditionally, runs degrade, asserts:
- `tier2_to_tier3 == 0` (the row was NOT counted as degraded — the SAVEPOINT rolled back)
- `content == original` (content was NOT mutated — the SAVEPOINT rolled back the UPDATE)

Without commit 2's SAVEPOINT this test fails: content gets truncated, embedding stays stale.

## Deferred (per /review notes)

- **`vec_episodes` DELETE+INSERT race window on shared connection.** Claude rated CRITICAL but it's a pre-existing concurrency concern — `consolidate_to_episodic` has the same pattern with INSERT into `episodic_memory` followed by INSERT into `vec_episodes`. Tractable via `BEGIN IMMEDIATE` wrapping but expands scope. Separate concurrency-hardening PR is the right place to address it across all sites.
- **Backfill semantics.** If consolidate ran with provider unavailable (no embedding written), degrade later with provider available now creates a new vec_episodes row indexing the COMPRESSED content. Both reviewers flagged it could go either way. Deferred as a design call.
- **Per-row embed-fail mid-batch.** If `embed()` returns None for one row mid-batch, that row gets invalidated while siblings get refreshed. Heterogeneous final state but the "no row has stale embedding" invariant holds.
- **Concurrent degrade re-processing same row.** Pre-existing — no tier guard on the UPDATE WHERE clause. Idempotent in practice (same compressed text, same regenerated embedding).

## Design choices not taken

- **Drop dense recall for tier 2/3 entirely (Option B).** Cheaper but loses semantic search on old data — the tier 2 LLM summary is still useful semantically.
- **Document the behavior, no code change (Option C).** Leaves the silent-drift bug in place.
- **Tier-aware mix: regenerate on T1→T2, invalidate on T2→T3.** More nuanced but more code; the uniform regenerate-or-invalidate is simpler and the perf cost is bounded by `DEGRADE_BATCH_SIZE` per maintenance cycle.

## Test plan

- [ ] `uv run pytest tests/test_degrade_vector.py -q` (4 passed + 1 skipped locally; skip is when `_mib` binary vectorizer isn't installed)
- [ ] `uv run pytest -q --ignore=tests/test_local_llm.py --ignore=tests/test_llm_backends.py` (468 passed locally)
- [ ] Manual: store a memory containing two distinct semantic phrases. Wait/backdate so it degrades. After degrade, query for the phrase that was truncated away — should NOT surface this row via dense recall.
- [ ] Manual without embeddings provider: same setup, run degrade, verify `memory_embeddings` row is gone (DELETED) so dense recall can't lie.

## Verification

\`\`\`
tests/test_degrade_vector.py: 4 passed, 1 skipped
full suite excluding LLM-dependent tests: 468 passed
\`\`\`