### PR TITLE
fix(C12.b): expose extract/metadata/veracity in plugin REMEMBER_SCHEMA + clamp veracity

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -55,7 +55,11 @@ REMEMBER_SCHEMA = {
         "(0.0-1.0) surfaces the memory more often. Use scope='global' for user-level "
         "facts; scope='session' for conversation-specific context. Use valid_until "
         "(ISO date YYYY-MM-DD) for time-bound facts. Use extract_entities=True to "
-        "extract named entities for fuzzy recall (e.g. 'Abdias' and 'Abdias J.' will match)."
+        "extract named entities for fuzzy recall (e.g. 'Abdias' and 'Abdias J.' will match). "
+        "Use extract=True to also pull subject-predicate-object fact triples via LLM "
+        "for fact-aware recall. Use veracity to tag confidence: 'stated' for direct "
+        "user assertions, 'tool' for deterministic tool output, 'inferred' for derived "
+        "guesses; 'unknown' (default) gets no recall boost."
     ),
     "parameters": {
         "type": "object",
@@ -66,6 +70,9 @@ REMEMBER_SCHEMA = {
             "scope": {"type": "string", "description": "'session' (default) or 'global'.", "default": "session"},
             "valid_until": {"type": "string", "description": "Optional expiry date YYYY-MM-DD.", "default": ""},
             "extract_entities": {"type": "boolean", "description": "Extract named entities for fuzzy recall. Default False.", "default": False},
+            "extract": {"type": "boolean", "description": "Extract subject-predicate-object fact triples via LLM for fact-aware recall. Default False.", "default": False},
+            "metadata": {"type": "object", "description": "Optional dict of additional fields (source_doc, tags, page, etc.). Default empty.", "default": {}},
+            "veracity": {"type": "string", "description": "Confidence label: 'stated' | 'inferred' | 'tool' | 'imported' | 'unknown'. Default 'unknown'.", "default": "unknown"},
         },
         "required": ["content"],
     },
@@ -400,6 +407,9 @@ class MnemosyneMemoryProvider(MemoryProvider):
         scope = args.get("scope", "session")
         valid_until = args.get("valid_until", None) or None
         extract_entities = bool(args.get("extract_entities", False))
+        extract = bool(args.get("extract", False))
+        metadata = args.get("metadata") or None
+        veracity = args.get("veracity", "unknown") or "unknown"
         if not content:
             return json.dumps({"error": "content is required"})
         memory_id = self._beam.remember(
@@ -409,8 +419,18 @@ class MnemosyneMemoryProvider(MemoryProvider):
             scope=scope,
             valid_until=valid_until,
             extract_entities=extract_entities,
+            extract=extract,
+            metadata=metadata,
+            veracity=veracity,
         )
-        return json.dumps({"status": "stored", "memory_id": memory_id, "content_preview": content[:100], "extract_entities": extract_entities})
+        return json.dumps({
+            "status": "stored",
+            "memory_id": memory_id,
+            "content_preview": content[:100],
+            "extract_entities": extract_entities,
+            "extract": extract,
+            "veracity": veracity,
+        })
 
     def _handle_recall(self, args: Dict[str, Any]) -> str:
         query = args.get("query", "")

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -81,9 +81,10 @@ REMEMBER_SCHEMA = {
 RECALL_SCHEMA = {
     "name": "mnemosyne_recall",
     "description": (
-        "Search Mnemosyne for relevant memories. Uses hybrid ranking: 50% vector "
-        "similarity + 30% FTS5 text rank + 20% importance + optional temporal boost. "
-        "Supports temporal weighting to boost recent memories. Returns ranked results."
+        "Search Mnemosyne for relevant memories. Uses hybrid ranking: by default "
+        "50% vector similarity + 30% FTS5 text rank + 20% importance + optional "
+        "temporal boost. Tune the per-query weights via vec_weight, fts_weight, "
+        "importance_weight (omit to use environment defaults). Returns ranked results."
     ),
     "parameters": {
         "type": "object",
@@ -104,6 +105,18 @@ RECALL_SCHEMA = {
                 "type": "number",
                 "description": "Hours until temporal boost decays by half. Default 24. Lower = faster decay.",
                 "default": 24,
+            },
+            "vec_weight": {
+                "type": "number",
+                "description": "Vector similarity weight in hybrid scoring. Omit (or pass null) to use MNEMOSYNE_VEC_WEIGHT env var or built-in default 0.5.",
+            },
+            "fts_weight": {
+                "type": "number",
+                "description": "Full-text search weight in hybrid scoring. Omit (or pass null) to use MNEMOSYNE_FTS_WEIGHT env var or built-in default 0.3.",
+            },
+            "importance_weight": {
+                "type": "number",
+                "description": "Importance score weight in hybrid scoring. Omit (or pass null) to use MNEMOSYNE_IMPORTANCE_WEIGHT env var or built-in default 0.2.",
             },
         },
         "required": ["query"],
@@ -457,12 +470,23 @@ class MnemosyneMemoryProvider(MemoryProvider):
         temporal_halflife_hours = float(args.get("temporal_halflife", 24))
         if not query:
             return json.dumps({"error": "query is required"})
-        results = self._beam.recall(
-            query, top_k=top_k,
-            temporal_weight=temporal_weight,
-            query_time=query_time,
-            temporal_halflife=temporal_halflife_hours,
-        )
+
+        # Forward configurable scoring weights ONLY when the caller actually
+        # supplied them. beam.recall treats None as "fall back to env var or
+        # default" via _normalize_weights; passing 0.0 / 0.5 / etc. when the
+        # caller didn't ask for tuning would override that resolution and
+        # break MNEMOSYNE_*_WEIGHT env-var deployments. See issue #45.
+        recall_kwargs: Dict[str, Any] = {
+            "top_k": top_k,
+            "temporal_weight": temporal_weight,
+            "query_time": query_time,
+            "temporal_halflife": temporal_halflife_hours,
+        }
+        for weight_key in ("vec_weight", "fts_weight", "importance_weight"):
+            if weight_key in args:
+                recall_kwargs[weight_key] = args[weight_key]
+
+        results = self._beam.recall(query, **recall_kwargs)
         return json.dumps({"query": query, "count": len(results), "temporal_weight": temporal_weight, "results": results})
 
     def _handle_sleep(self, args: Dict[str, Any]) -> str:

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -400,6 +400,13 @@ class MnemosyneMemoryProvider(MemoryProvider):
             logger.error("Mnemosyne tool %s failed: %s", tool_name, e)
             return json.dumps({"error": f"Mnemosyne tool '{tool_name}' failed: {e}"})
 
+    # Canonical veracity allowlist mirrors VERACITY_WEIGHTS in
+    # mnemosyne/core/veracity_consolidation.py. Anything outside this set
+    # bypasses the recall weighting AND pollutes the contamination filter
+    # (which compares `veracity != 'stated'`), so unknown labels persist as
+    # garbage in the row. Clamp at the trust boundary.
+    _VERACITY_ALLOWED = {"stated", "inferred", "tool", "imported", "unknown"}
+
     def _handle_remember(self, args: Dict[str, Any]) -> str:
         content = args.get("content", "")
         importance = float(args.get("importance", 0.5))
@@ -409,7 +416,16 @@ class MnemosyneMemoryProvider(MemoryProvider):
         extract_entities = bool(args.get("extract_entities", False))
         extract = bool(args.get("extract", False))
         metadata = args.get("metadata") or None
-        veracity = args.get("veracity", "unknown") or "unknown"
+        raw_veracity = args.get("veracity", "unknown") or "unknown"
+        veracity_norm = str(raw_veracity).strip().lower()
+        if veracity_norm in self._VERACITY_ALLOWED:
+            veracity = veracity_norm
+        else:
+            logger.warning(
+                "mnemosyne_remember received unknown veracity %r; clamping to 'unknown'",
+                raw_veracity,
+            )
+            veracity = "unknown"
         if not content:
             return json.dumps({"error": "content is required"})
         memory_id = self._beam.remember(
@@ -429,6 +445,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             "content_preview": content[:100],
             "extract_entities": extract_entities,
             "extract": extract,
+            "metadata": metadata,
             "veracity": veracity,
         })
 

--- a/tests/test_hermes_memory_provider.py
+++ b/tests/test_hermes_memory_provider.py
@@ -390,3 +390,83 @@ def test_handle_remember_response_echoes_metadata(monkeypatch):
     assert parsed.get("metadata") == {"source_doc": "deck.pdf", "page": 7}, (
         f"response missing metadata echo: {parsed!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #45 followup — RECALL_SCHEMA + _handle_recall scoring weight forwarding
+# ---------------------------------------------------------------------------
+#
+# Adversarial review of issue #45's PR caught that the Hermes-side recall
+# surface here also drops vec_weight / fts_weight / importance_weight. The
+# RECALL_SCHEMA's description literally says "50% vector + 30% FTS5 + 20%
+# importance" but never lets clients tune those weights. Same shape as the
+# C12.b REMEMBER fix in this same file — schema mismatch with what
+# BeamMemory.recall actually accepts.
+
+def test_recall_schema_advertises_scoring_weights():
+    """[issue #45 followup] RECALL_SCHEMA must advertise the per-call scoring
+    weights that BeamMemory.recall accepts (beam.py:1296-1298) so Hermes'
+    tool-arg validator accepts them instead of stripping as unknown fields."""
+    from hermes_memory_provider import RECALL_SCHEMA
+
+    props = RECALL_SCHEMA["parameters"]["properties"]
+    for key in ("vec_weight", "fts_weight", "importance_weight"):
+        assert key in props, (
+            f"RECALL_SCHEMA missing {key!r} — schema description claims "
+            f"'50% vector + 30% FTS5 + 20% importance' but never lets the "
+            f"client tune those weights"
+        )
+        assert props[key]["type"] == "number"
+
+
+def test_handle_recall_forwards_scoring_weights_to_beam(monkeypatch):
+    """[issue #45 followup] _handle_recall must forward vec_weight /
+    fts_weight / importance_weight when the caller supplies them, so the
+    schema-advertised tuning actually takes effect on ranking."""
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    provider = MnemosyneMemoryProvider()
+    beam = MagicMock()
+    beam.recall.return_value = []
+    provider._beam = beam
+
+    provider._handle_recall({
+        "query": "anything",
+        "limit": 3,
+        "vec_weight": 0.55,
+        "fts_weight": 0.25,
+        "importance_weight": 0.20,
+    })
+
+    kwargs = beam.recall.call_args.kwargs
+    assert kwargs.get("vec_weight") == 0.55, (
+        f"_handle_recall did not forward vec_weight; kwargs={kwargs!r}"
+    )
+    assert kwargs.get("fts_weight") == 0.25
+    assert kwargs.get("importance_weight") == 0.20
+
+
+def test_handle_recall_omits_weights_when_caller_does_not_supply():
+    """[issue #45 followup] When caller omits the weight kwargs, the handler
+    must NOT pass spurious values to beam.recall — beam treats None as
+    "fall back to env var or default" via _normalize_weights, and forcing
+    0.0 / 0.5 / etc. would override that resolution."""
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    provider = MnemosyneMemoryProvider()
+    beam = MagicMock()
+    beam.recall.return_value = []
+    provider._beam = beam
+
+    provider._handle_recall({"query": "anything", "limit": 3})
+
+    kwargs = beam.recall.call_args.kwargs
+    # Acceptable: the kwarg is not in beam.recall's call OR is explicitly None.
+    # Failing path: a numeric default like 0.5 / 0.0 leaked through.
+    for key in ("vec_weight", "fts_weight", "importance_weight"):
+        val = kwargs.get(key, "OMITTED")
+        assert val in (None, "OMITTED"), (
+            f"_handle_recall forwarded {key}={val!r} when caller omitted it; "
+            f"this overrides beam's env/default resolution. Either pass None "
+            f"or omit the kwarg entirely."
+        )

--- a/tests/test_hermes_memory_provider.py
+++ b/tests/test_hermes_memory_provider.py
@@ -244,3 +244,96 @@ def test_shutdown_proceeds_when_drain_times_out(caplog):
 def test_shutdown_drain_default_matches_design():
     """Production drain default should remain 2s."""
     assert MnemosyneMemoryProvider.SHUTDOWN_DRAIN_TIMEOUT_SECONDS == 2
+
+
+# ---------------------------------------------------------------------------
+# C12.b — REMEMBER_SCHEMA + _handle_remember per-call kwargs parity
+# ---------------------------------------------------------------------------
+#
+# BeamMemory.remember() accepts extract, metadata, veracity per call. The
+# plugin's REMEMBER_SCHEMA used to only expose content/importance/source/
+# scope/valid_until/extract_entities, so callers passing any of the missing
+# fields had them silently stripped:
+#   - extract=True (LLM fact-triple extraction): facts never extracted
+#   - metadata={...} (source/tag tracking): provenance lost
+#   - veracity="stated"/"tool"/...: every plugin memory defaulted to "unknown",
+#     defeating the veracity boost in recall
+# These tests lock the schema → handler → beam wiring.
+
+def test_remember_schema_advertises_extract_and_metadata_and_veracity():
+    """[C12.b] REMEMBER_SCHEMA must advertise the per-call kwargs that
+    beam.remember() actually supports, so Hermes' tool-arg validator
+    accepts them instead of stripping them as unknown fields."""
+    from hermes_memory_provider import REMEMBER_SCHEMA
+
+    props = REMEMBER_SCHEMA["parameters"]["properties"]
+    assert "extract" in props, (
+        "REMEMBER_SCHEMA missing 'extract' — LLM fact-triple extraction "
+        "is unreachable through the plugin"
+    )
+    assert "metadata" in props, (
+        "REMEMBER_SCHEMA missing 'metadata' — caller-supplied tags / "
+        "source-doc IDs get silently dropped"
+    )
+    assert "veracity" in props, (
+        "REMEMBER_SCHEMA missing 'veracity' — every plugin-stored memory "
+        "defaults to 'unknown', defeating recall's veracity weighting"
+    )
+    # Sanity-check the advertised types so a typo doesn't slip in.
+    assert props["extract"]["type"] == "boolean"
+    assert props["metadata"]["type"] == "object"
+    assert props["veracity"]["type"] == "string"
+
+
+def test_handle_remember_passes_extract_metadata_veracity_to_beam(monkeypatch):
+    """[C12.b] _handle_remember must forward extract / metadata / veracity
+    to beam.remember(). Pre-fix the args were either ignored (no .get())
+    or never wired into the beam call."""
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    provider = MnemosyneMemoryProvider()
+    beam = MagicMock()
+    beam.remember.return_value = "mem-123"
+    provider._beam = beam
+
+    args = {
+        "content": "Sarah leads Project Falcon, started 2026-04-01.",
+        "extract": True,
+        "metadata": {"source_doc": "kickoff-deck.pdf", "page": 3},
+        "veracity": "stated",
+    }
+    provider._handle_remember(args)
+
+    beam.remember.assert_called_once()
+    kwargs = beam.remember.call_args.kwargs
+    assert kwargs.get("extract") is True, (
+        "extract=True was not forwarded to beam.remember — LLM fact "
+        "extraction is unreachable through the plugin tool"
+    )
+    assert kwargs.get("metadata") == {"source_doc": "kickoff-deck.pdf", "page": 3}, (
+        f"metadata not forwarded to beam.remember; got {kwargs.get('metadata')!r}"
+    )
+    assert kwargs.get("veracity") == "stated", (
+        f"veracity not forwarded to beam.remember; got {kwargs.get('veracity')!r}"
+    )
+
+
+def test_handle_remember_defaults_when_new_kwargs_omitted(monkeypatch):
+    """[C12.b] Pre-existing callers that don't pass the new kwargs must not
+    break: extract defaults False, metadata defaults None, veracity defaults
+    'unknown'. Verifies the schema bump is backward-compatible."""
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    provider = MnemosyneMemoryProvider()
+    beam = MagicMock()
+    beam.remember.return_value = "mem-456"
+    provider._beam = beam
+
+    provider._handle_remember({"content": "minimal call"})
+
+    kwargs = beam.remember.call_args.kwargs
+    assert kwargs.get("extract", False) is False
+    # metadata may be None or absent; both are acceptable as "not set"
+    assert kwargs.get("metadata") in (None, {}), kwargs.get("metadata")
+    # veracity may be "unknown" (passed through) or absent (beam default)
+    assert kwargs.get("veracity", "unknown") == "unknown"

--- a/tests/test_hermes_memory_provider.py
+++ b/tests/test_hermes_memory_provider.py
@@ -6,6 +6,7 @@ the host backend), and the registration flow added to initialize().
 
 from __future__ import annotations
 
+import json
 import time
 from unittest.mock import MagicMock, patch
 
@@ -337,3 +338,55 @@ def test_handle_remember_defaults_when_new_kwargs_omitted(monkeypatch):
     assert kwargs.get("metadata") in (None, {}), kwargs.get("metadata")
     # veracity may be "unknown" (passed through) or absent (beam default)
     assert kwargs.get("veracity", "unknown") == "unknown"
+
+
+def test_handle_remember_clamps_unknown_veracity_to_unknown(monkeypatch, caplog):
+    """[C12.b — adversarial review] An LLM typo or a caller passing a
+    non-canonical veracity label (e.g. 'STATED' capitalization, 'state'
+    truncation, 'random_garbage') must be clamped to 'unknown' at the
+    trust boundary. Beam itself does not validate; the row would persist
+    with the junk label and pollute the contamination filter
+    (`veracity != 'stated'`). Locks the handler-side allowlist."""
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    provider = MnemosyneMemoryProvider()
+    beam = MagicMock()
+    beam.remember.return_value = "mem-789"
+    provider._beam = beam
+
+    # 'STATED' (capitalization) — should normalize to 'stated', not clamp.
+    provider._handle_remember({"content": "x", "veracity": "STATED"})
+    assert beam.remember.call_args.kwargs.get("veracity") == "stated"
+
+    # 'state' (truncated) — not in allowlist, must clamp to 'unknown'.
+    beam.remember.reset_mock()
+    with caplog.at_level("WARNING", logger="hermes_memory_provider"):
+        provider._handle_remember({"content": "y", "veracity": "state"})
+    assert beam.remember.call_args.kwargs.get("veracity") == "unknown"
+    assert any("unknown veracity" in r.getMessage() for r in caplog.records), (
+        "handler should log a warning when clamping a bad veracity label"
+    )
+
+    # 'random_garbage' — not in allowlist, must clamp to 'unknown'.
+    beam.remember.reset_mock()
+    provider._handle_remember({"content": "z", "veracity": "random_garbage"})
+    assert beam.remember.call_args.kwargs.get("veracity") == "unknown"
+
+
+def test_handle_remember_response_echoes_metadata(monkeypatch):
+    """[C12.b — adversarial review] The response JSON echoes extract /
+    extract_entities / veracity already; metadata should be in the same
+    surface for symmetry so callers can confirm what got applied."""
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    provider = MnemosyneMemoryProvider()
+    beam = MagicMock()
+    beam.remember.return_value = "mem-meta"
+    provider._beam = beam
+
+    payload = {"content": "x", "metadata": {"source_doc": "deck.pdf", "page": 7}}
+    response = provider._handle_remember(payload)
+    parsed = json.loads(response)
+    assert parsed.get("metadata") == {"source_doc": "deck.pdf", "page": 7}, (
+        f"response missing metadata echo: {parsed!r}"
+    )


### PR DESCRIPTION
## Summary

- Hermes plugin's \`mnemosyne_remember\` tool advertised 6 fields; \`BeamMemory.remember()\` accepts 9. Three per-call kwargs were unreachable: \`extract\` (LLM fact-triple extraction), \`metadata\` (source-doc/tag dict), \`veracity\` (Phase 3 confidence label).
- Schema gains all 3 properties; \`_handle_remember\` forwards them to beam.
- Adversarial review found veracity was free-text with no allowlist guard — handler now clamps non-canonical values to \`unknown\` at the trust boundary.
- 5 regression tests, 20 total provider tests, full suite 469 passed.

## What the user actually sees go wrong

### Symptom 1 — \`extract=True\` silently rejected

\`\`\`
LLM via Hermes plugin calls:
  mnemosyne_remember(
    content="Sarah leads Project Falcon, started 2026-04-01.",
    extract=True              ← unknown field per schema
  )
→ Hermes' tool-arg validator either rejects the call OR strips the field
→ beam.remember() runs WITHOUT extract=True
→ The fact-triples never written:
     (sarah, leads, falcon)
     (falcon, started_at, 2026-04-01)
→ Later: recall("who leads Falcon?") returns the raw memory but no
  fact-rank boost from the missing triples
\`\`\`

### Symptom 2 — \`metadata\` dropped on the floor

\`\`\`
LLM calls: mnemosyne_remember(
  content="...",
  metadata={"source_doc": "kickoff-deck.pdf", "page": 3}
)
→ Plugin's _handle_remember had no args.get("metadata") line
→ beam.remember() called without metadata
→ Doc-trace lost; recall surfaces the memory but you can't tell where
  it came from
\`\`\`

### Symptom 3 — every plugin-stored memory has veracity=\"unknown\"

\`\`\`
Tool-extracted facts (calendar API → deterministic):  veracity=\"unknown\"
User-stated facts ("my dog's name is Bella"):          veracity=\"unknown\"
LLM-inferred guesses ("Sarah likely prefers..."):      veracity=\"unknown\"
→ Recall's veracity boost has no signal to use
→ Phase 3 contamination filter (veracity != 'stated') treats them
  all as suspect
\`\`\`

## The fix

\`\`\`python
REMEMBER_SCHEMA = {
    ...
    "properties": {
        "content": {...},
        "importance": {...},
        "source": {...},
        "scope": {...},
        "valid_until": {...},
        "extract_entities": {...},
        # NEW:
        "extract":  {"type": "boolean", ..., "default": False},
        "metadata": {"type": "object",  ..., "default": {}},
        "veracity": {"type": "string",  ..., "default": "unknown"},
    },
    ...
}

def _handle_remember(self, args):
    ...
    extract  = bool(args.get("extract", False))
    metadata = args.get("metadata") or None
    raw_veracity = args.get("veracity", "unknown") or "unknown"
    veracity_norm = str(raw_veracity).strip().lower()
    if veracity_norm in self._VERACITY_ALLOWED:
        veracity = veracity_norm
    else:
        logger.warning("mnemosyne_remember received unknown veracity %r; clamping to 'unknown'", raw_veracity)
        veracity = "unknown"
    memory_id = self._beam.remember(
        ..., extract=extract, metadata=metadata, veracity=veracity,
    )
\`\`\`

The veracity allowlist mirrors \`VERACITY_WEIGHTS\` in \`mnemosyne/core/veracity_consolidation.py:34-40\` — \`{stated, inferred, tool, imported, unknown}\`. Anything outside that set bypasses the recall weighting AND pollutes the contamination filter (which compares \`veracity != 'stated'\`), so we clamp at the trust boundary instead of trusting downstream code to handle garbage labels.

## Pre-landing adversarial review (commit 2: 98c88a0)

Cross-model adversarial review surfaced two real issues my initial fix missed:

### MAJOR — veracity has no allowlist guard

Beam stores whatever string you hand it. \`recall()\`'s \`veracity_map.get(..., UNKNOWN_WEIGHT)\` silently degrades bad labels to default weight, but the row persists with the junk label:

- \`veracity=\"STATED\"\` (caps)        → row stores \`\"STATED\"\` → contamination filter mis-classifies as contaminated (since \`\"STATED\" != 'stated'\`)
- \`veracity=\"state\"\` (truncated)    → row stores \`\"state\"\`  → silent UNKNOWN_WEIGHT
- \`veracity=\"random_garbage\"\`       → row stores garbage    → silent UNKNOWN_WEIGHT

LLM-trust-boundary issue: schema \"description\" is advisory, not enforced. Fixed: handler normalizes to lowercase + validates against the allowlist; falls back to \`'unknown'\` with a warning log.

### MINOR — response JSON omitted metadata echo

\`extract\`, \`extract_entities\`, \`veracity\` all echoed in the response so the LLM can confirm what got applied. \`metadata\` was missing. Trivial 1-line symmetry fix.

### Deferred (reviewer flagged but per user direction skipped)

- **\`metadata = args.get(\"metadata\") or None\`** collapses caller-supplied \`{}\` to \`None\`. Reviewer admitted \"harmless today\" — beam does \`json.dumps(metadata or {})\` so the stored row is identical. Cosmetic.

## Out of scope (separate PR)

The v2 plan badge for C12.b mentioned \`bank\`, \`author_id\`, \`author_type\`, \`channel_id\`, \`channel_type\`. Those are **\`BeamMemory\` instance state** (set in \`__init__\`, not per-call kwargs to \`remember()\`). Surfacing them through the schema would require either:

1. Constructing a transient \`BeamMemory\` per call — throws away dedup state and connection caching
2. Adding per-call overrides to \`remember()\` — signature change, ripples into beam internals at lines 957, 975, 1026-1028, 1252

Belongs in a separate design PR — likely intersects C0's identity-scope decision.

## Test plan

- [ ] \`uv run pytest tests/test_hermes_memory_provider.py -v\` (20 passed locally)
- [ ] \`uv run pytest -q --ignore=tests/test_local_llm.py --ignore=tests/test_llm_backends.py\` (469 passed locally)
- [ ] Manual: deploy plugin, call \`mnemosyne_remember\` with \`extract=True\` from an agent, verify fact-triples written via \`SELECT * FROM episodic_graph_facts\`.
- [ ] Manual: call with \`veracity=\"STATED\"\` (caps) and verify the row stores \`\"stated\"\`.
- [ ] Manual: call with \`veracity=\"random_garbage\"\` and verify row stores \`\"unknown\"\` + warning logged.

## Verification

\`\`\`
tests/test_hermes_memory_provider.py: 20 passed
full suite (excluding LLM-dependent tests): 469 passed
\`\`\`