### PR TITLE
test(C5): lock sleep recallability invariants — recall hit + dense store written

### DIFF
--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -281,19 +281,30 @@ class TestSleepCycle:
                 "fallback is empty — the embed→INSERT path did not run."
             )
 
-    def test_sleep_consolidated_content_is_recallable_via_fts(self, temp_db, monkeypatch):
+    def test_sleep_consolidated_content_is_recallable(self, temp_db, monkeypatch):
         """[C5] End-to-end recallability check. Existing sleep tests assert
         counts (items_consolidated, episodic_count) but never verify the
         consolidated content is actually findable through the public recall
-        API. A regression that broke the FTS5 trigger / write path during
-        sleep would slip through every existing sleep test.
+        API. A regression that took the consolidated row off-recall via ALL
+        recall paths simultaneously (FTS5 trigger broken AND dense store
+        skipped AND fallback substring match unreachable) would slip through
+        every existing sleep test.
 
         Locks: after sleep, recall(unique_token_from_seeded_wm) returns at
         least one episodic-tier hit whose content contains that token.
 
-        Uses deterministic concat path (LLM disabled) so seeded tokens
-        survive into episodic content — same precedent as test_beam.py:372
-        and the cross-session recall test."""
+        Note: this is NOT an FTS-isolated assertion. recall() unions vec
+        and FTS rowids (beam.py:1751) and falls back to substring scan
+        (beam.py:1880) when both are empty, so this test locks recallability
+        by *any* path — not the FTS path specifically. Stronger isolation
+        would require calling _fts_search directly; that lives in a follow-up
+        if the union/fallback layers shift.
+
+        Uses LLM-disabled deterministic AAAK-encoded summary path
+        (beam.py:2483 — `compressed = aaak_encode(combined)`). AAAK is
+        phrase-substitution + compaction; uncommon literal tokens like
+        the ones seeded below survive intact. Same monkeypatch pattern as
+        test_beam.py:297, :488, :691, :938, :961."""
         monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
 
         beam = BeamMemory(session_id="s1", db_path=temp_db)
@@ -323,8 +334,9 @@ class TestSleepCycle:
             assert results, (
                 f"recall({token!r}) returned 0 results — the sleep path "
                 f"consolidated working_memory but the episodic row is not "
-                f"reachable via FTS. Likely cause: FTS5 trigger missed the "
-                f"insert, or the consolidated content does not contain the "
+                f"reachable through ANY recall path (FTS, vec, fallback "
+                f"substring scan). Likely cause: FTS5 trigger missed AND "
+                f"dense store missed AND content does not contain the "
                 f"original token (LLM summarization path active despite "
                 f"monkeypatch?)."
             )

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -223,6 +223,122 @@ class TestSleepCycle:
         assert episodic_count == 0
         assert log_count == 0
 
+    def test_sleep_writes_dense_embedding_for_consolidated_row(self, temp_db, monkeypatch):
+        """[C5] State-level companion to the FTS recallability test. Verifies
+        sleep populates a dense-recall store (sqlite-vec's vec_episodes when
+        loaded, otherwise the memory_embeddings fallback) for each consolidated
+        episodic row. A regression that broke the embed→write call (e.g.
+        embed() returning None silently, or a missing INSERT into the
+        fallback table) would leave dense recall empty even though FTS keeps
+        working.
+
+        Skipped when fastembed isn't installed; the dense path is gated on
+        _embeddings.available() and a model load. CI runs with fastembed."""
+        from mnemosyne.core import embeddings as _embeddings
+
+        if not _embeddings.available():
+            pytest.skip("fastembed not available — dense-recall path inactive")
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        conn = sqlite3.connect(temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        conn.executemany(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("old0", "deploy plan for falcon kickoff", "conversation", old_ts, "s1"),
+                ("old1", "retro notes from beta release", "conversation", old_ts, "s1"),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        beam.sleep(dry_run=False)
+
+        # Post-sleep, exactly one episodic row should exist (one consolidated
+        # summary for the session). Dense store should hold a row for it.
+        from mnemosyne.core.beam import _vec_available
+
+        conn = sqlite3.connect(temp_db)
+        ep_ids = [r[0] for r in conn.execute("SELECT id FROM episodic_memory").fetchall()]
+        assert len(ep_ids) == 1, f"expected 1 consolidated episodic row, got {len(ep_ids)}"
+
+        if _vec_available(conn):
+            vec_count = conn.execute("SELECT COUNT(*) FROM vec_episodes").fetchone()[0]
+            conn.close()
+            assert vec_count >= 1, (
+                "sleep consolidated an episodic row but vec_episodes is "
+                "empty — the embed→_vec_insert path did not run. Likely "
+                "cause: _embeddings.embed() returned None silently, or "
+                "_vec_insert raised and was swallowed."
+            )
+        else:
+            mem_count = conn.execute(
+                "SELECT COUNT(*) FROM memory_embeddings WHERE memory_id = ?", (ep_ids[0],)
+            ).fetchone()[0]
+            conn.close()
+            assert mem_count >= 1, (
+                "sleep consolidated an episodic row but memory_embeddings "
+                "fallback is empty — the embed→INSERT path did not run."
+            )
+
+    def test_sleep_consolidated_content_is_recallable_via_fts(self, temp_db, monkeypatch):
+        """[C5] End-to-end recallability check. Existing sleep tests assert
+        counts (items_consolidated, episodic_count) but never verify the
+        consolidated content is actually findable through the public recall
+        API. A regression that broke the FTS5 trigger / write path during
+        sleep would slip through every existing sleep test.
+
+        Locks: after sleep, recall(unique_token_from_seeded_wm) returns at
+        least one episodic-tier hit whose content contains that token.
+
+        Uses deterministic concat path (LLM disabled) so seeded tokens
+        survive into episodic content — same precedent as test_beam.py:372
+        and the cross-session recall test."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        conn = sqlite3.connect(temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        # Three distinct unique tokens — one per seeded memory.
+        # Pick tokens that won't collide with FTS stop-words or the deterministic
+        # concat header text.
+        conn.executemany(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("old0", "wm contains marker zorblax kickoff plan", "conversation", old_ts, "s1"),
+                ("old1", "wm contains marker quetzelfin retro notes", "conversation", old_ts, "s1"),
+                ("old2", "wm contains marker xanadush deploy log", "conversation", old_ts, "s1"),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.sleep(dry_run=False)
+        assert result["status"] == "consolidated"
+        assert result["items_consolidated"] == 3
+
+        # Each unique token must surface an episodic-tier result.
+        for token in ("zorblax", "quetzelfin", "xanadush"):
+            results = beam.recall(token, top_k=10)
+            assert results, (
+                f"recall({token!r}) returned 0 results — the sleep path "
+                f"consolidated working_memory but the episodic row is not "
+                f"reachable via FTS. Likely cause: FTS5 trigger missed the "
+                f"insert, or the consolidated content does not contain the "
+                f"original token (LLM summarization path active despite "
+                f"monkeypatch?)."
+            )
+            assert any(r.get("tier") == "episodic" for r in results), (
+                f"recall({token!r}) returned {len(results)} hits but none "
+                f"are episodic-tier: {[(r.get('tier'), r.get('content', '')[:50]) for r in results]}"
+            )
+            assert any(token in (r.get("content") or "").lower() for r in results), (
+                f"recall({token!r}) returned hits but the token does not "
+                f"appear in any returned content — FTS may be matching on "
+                f"trigram noise rather than the seeded token: "
+                f"{[r.get('content') for r in results]}"
+            )
+
 
 class TestMnemosyneIntegration:
     def test_legacy_and_beam_dual_write(self, temp_db):


### PR DESCRIPTION
## Summary

- Pre-existing sleep tests asserted counts only (\`items_consolidated\`, \`episodic_count\`) but never verified the consolidated content was findable through the public recall API or that the dense-recall stores got populated.
- Adds two regression-guard tests in \`TestSleepCycle\`: end-to-end recallability + dense-store state assertion.
- C5 is RESEARCH-tagged. No real bug surfaced on current main; this is a regression guard locking the silent-failure modes that the existing count-based tests would miss.
- Suite: 52 passed + 1 skipped (was 51 + 1; the skip is the dense test when fastembed isn't installed).

## What the user actually sees go wrong (if this regression class hits)

\`\`\`
You write a memory:
  beam.remember("Plan deploy of mnemosyne v2.4 on Friday")

Time passes. Sleep runs.
  beam.sleep()  →  consolidates to episodic_memory ✓
                   writes embedding to vec_episodes ✓
                   ✗ FTS5 trigger fails silently due to schema migration /
                     charset issue / etc.
                   ✗ AND dense-store INSERT fails because embed() returned None
                   ✗ AND fallback substring scan can't find anything either
                     (e.g. content was over-compressed past readability)

You query later:
  beam.recall("deploy")  →  returns nothing
  beam.recall("v2.4")    →  returns nothing
\`\`\`

The memory is on disk but unfindable by user search. Counts pass; the consolidation log says \"3 items consolidated\". Hard to debug because there's no error — just zero results. The strengthened tests catch this class of regression on the next test run.

## The tests

### 1. \`test_sleep_consolidated_content_is_recallable\`

Seeds three working_memory rows with unique tokens (\`zorblax\`, \`quetzelfin\`, \`xanadush\`), runs \`beam.sleep(dry_run=False)\`, then asserts \`recall(token)\` returns an episodic-tier hit whose content contains the token. Disables LLM via monkeypatch so the deterministic AAAK-encoded path runs (which preserves the unique tokens intact since they don't match any AAAK phrase substitution rule).

### 2. \`test_sleep_writes_dense_embedding_for_consolidated_row\`

State-level companion. After sleep, asserts \`vec_episodes\` (when sqlite-vec is loaded) or \`memory_embeddings\` (fallback) contains a row for the consolidated episodic id. Skipped when fastembed isn't installed (gated on \`_embeddings.available()\`). CI exercises it.

## Pre-landing adversarial review (commit 2: 64a55c1)

Cross-model review caught two CRITICAL test-correctness issues and two MAJOR docstring inaccuracies in the initial commit:

### CRITICAL — original test name \"via_fts\" overstated isolation

\`recall()\` unions vec and FTS rowids at \`beam.py:1751\`:

\`\`\`python
episodic_rowids = set(vec_results.keys()) | set(fts_results.keys())
\`\`\`

So when fastembed is available (CI), a dense-store hit alone surfaces the row even with a broken FTS5 trigger. Then \`recall()\` falls back to a substring scan at \`beam.py:1880-1881\`:

\`\`\`python
if not episodic_rowids:
    # ... scan recent episodic and match via word overlap
    full_match = 1.0 if query_lower in content_lower else 0.0
\`\`\`

Since seeded tokens like \`\"zorblax\"\` appear verbatim in the AAAK-encoded summary, this fallback rescues the row even with FTS+vec both broken.

The test as written locked \"consolidated row is recallable through ANY path\" (a useful regression guard) but did NOT lock \"via FTS specifically\" (the regression class the v2 plan badge implied).

**Fix**: renamed to \`test_sleep_consolidated_content_is_recallable\` (no path claim), docstring honestly notes the union+fallback layering, assertion message updated. True FTS isolation would call \`_fts_search\` directly — deferred follow-up if the union/fallback layers shift.

### MAJOR — docstring inaccuracies

- Original docstring said \"deterministic concat path\" but the actual fallback at \`beam.py:2483\` is \`compressed = aaak_encode(combined)\`. AAAK is phrase substitution + compaction (not concat). Uncommon tokens like the seeded ones still survive intact, so the test happens to pass, but the docstring claim was misleading.
- Original cited \`test_beam.py:372\` as the monkeypatch precedent — that line is \`test_beam_stats\`, unrelated. Correct precedents: \`test_beam.py:297, :488, :691, :938, :961\`.

**Fix**: docstring updated with correct paths and precedent line numbers.

### Deferred (per user direction)

- **MAJOR #5 — lock summary_of, tier=1, importance=0.6, metadata_json.original_count**: scope creep beyond \"recallability\". C5 asked for recallability strengthening; these are separate output-shape contracts. Belongs in a separate test or its own ledger item.
- **MINOR #6 — MNEMOSYNE_REQUIRE_DENSE env flag to convert dense-test skip→fail**: over-engineering for a research item. CI's fastembed availability is stable enough.

## Test plan

- [ ] \`uv run pytest tests/test_beam.py -q\` (52 passed + 1 skipped locally)
- [ ] CI run exercises the dense-store assertion (fastembed available)
- [ ] Future regression check: drop the FTS5 trigger from the schema in a scratch branch and verify the test still passes (it will — by design now, locks recallability-by-any-path not FTS specifically)

## Verification

\`\`\`
tests/test_beam.py: 52 passed, 1 skipped (unchanged from main)
\`\`\`