### PR TITLE
fix(#53): `hermes mnemosyne version` ImportError — re-export __version__ from outer package stub

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,10 +11,25 @@ _repo_root = Path(__file__).resolve().parent
 if str(_repo_root) not in sys.path:
     sys.path.insert(0, str(_repo_root))
 
+# Re-export __version__ / __author__ from the inner mnemosyne subpackage so
+# `from mnemosyne import __version__` works in either install layout:
+#   - Hermes plugin tree: outer `mnemosyne/` is the resolved package, inner
+#     `mnemosyne/mnemosyne/` is the subpackage `mnemosyne.mnemosyne`.
+#   - pip / repo-direct install: inner `mnemosyne/` is the resolved package
+#     directly and this stub is never loaded.
+# Without this re-export, `hermes mnemosyne version` (and any other caller
+# doing `from mnemosyne import __version__`) crashed with ImportError under
+# the Hermes plugin layout. See issue #53.
+try:
+    from .mnemosyne import __version__, __author__
+except ImportError:
+    __version__ = "unknown"
+    __author__ = "Abdias J"
+
 # Graceful fallback when Hermes framework is not present
 # (e.g. pip-only / standalone installs without hermes_plugin)
 try:
     from hermes_plugin import register
-    __all__ = ["register"]
+    __all__ = ["register", "__version__", "__author__"]
 except ImportError:
-    __all__ = []
+    __all__ = ["__version__", "__author__"]

--- a/tests/test_outer_package_version.py
+++ b/tests/test_outer_package_version.py
@@ -1,0 +1,84 @@
+"""[issue #53] Regression test for `hermes mnemosyne version` ImportError.
+
+The repo has a nested-package layout:
+    mnemosyne/                  ← outer: repo root + Hermes plugin entry stub
+        __init__.py             ← used to NOT define __version__/__author__
+        mnemosyne/              ← inner: actual library
+            __init__.py         ← defines __version__ / __author__
+
+When Hermes installs the plugin via repo-tree symlink, the OUTER package
+becomes the resolved `mnemosyne` module on `sys.path`. Pre-fix,
+`from mnemosyne import __version__, __author__` raised ImportError because
+the outer stub didn't re-export those names. Post-fix, the outer stub
+re-exports from `.mnemosyne` (the inner subpackage).
+
+This test simulates the Hermes plugin-loader sys.path layout via subprocess
+so it doesn't pollute the test process's already-loaded `mnemosyne` module
+(pytest runs from the repo with the inner package directly on path, which
+bypasses the failure mode).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_outer_package_reexports_version_and_author():
+    """Simulate Hermes plugin-loader layout: parent of repo root on sys.path,
+    so `import mnemosyne` resolves to the OUTER stub package. The outer must
+    re-export __version__ and __author__ from the inner subpackage."""
+    # Run a subprocess with sys.path manipulated so the outer mnemosyne stub
+    # is the resolved `mnemosyne` module — exactly the layout Hermes' plugin
+    # loader produces when symlinking the repo root into ~/.hermes/plugins.
+    script = textwrap.dedent(f"""
+        import sys
+        # Put the parent of the repo first so `mnemosyne` resolves to the
+        # outer __init__.py at the repo root, mirroring the plugin layout.
+        sys.path.insert(0, {str(REPO_ROOT.parent)!r})
+        # Drop the inner-package path (if present) so we don't accidentally
+        # resolve to the inner __init__.py instead.
+        sys.path = [p for p in sys.path if p != {str(REPO_ROOT)!r}]
+
+        import mnemosyne
+        # Sanity check: we loaded the OUTER stub, not the inner library.
+        assert mnemosyne.__file__.endswith({str(REPO_ROOT / "__init__.py")!r}), (
+            "test setup failed: did not load outer package, got " + mnemosyne.__file__
+        )
+
+        # The actual contract:
+        from mnemosyne import __version__, __author__
+        print("VERSION=" + __version__)
+        print("AUTHOR=" + __author__)
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT.parent),  # avoid CWD on path leaking inner package
+    )
+
+    assert result.returncode == 0, (
+        f"subprocess failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "VERSION=" in result.stdout, result.stdout
+    assert "AUTHOR=" in result.stdout, result.stdout
+
+    # Don't pin a specific version (it bumps); just assert non-empty and not
+    # the fallback "unknown" that the except-branch would emit if the inner
+    # subpackage somehow couldn't be imported.
+    version_line = next(
+        ln for ln in result.stdout.splitlines() if ln.startswith("VERSION=")
+    )
+    version = version_line.split("=", 1)[1].strip()
+    assert version and version != "unknown", (
+        f"outer __init__.py exported VERSION={version!r}; expected a real "
+        f"version string from the inner subpackage. Likely cause: the "
+        f"`from .mnemosyne import __version__` re-export failed and we "
+        f"fell through to the except-branch fallback."
+    )


### PR DESCRIPTION
Closes #53.

## Summary

- Outer \`mnemosyne/__init__.py\` (Hermes plugin entry stub) didn't re-export \`__version__\` / \`__author__\` from the inner \`mnemosyne/mnemosyne/\` subpackage.
- Under the Hermes plugin-tree symlink layout, the outer stub becomes the resolved \`mnemosyne\` module, so \`from mnemosyne import __version__, __author__\` (in \`hermes_memory_provider/cli.py:82\`) raised ImportError.
- Fix re-exports both names; \`hermes mnemosyne version\` works again.
- 1 regression test using subprocess + sys.path manipulation to simulate the Hermes plugin-loader layout.

## What the user actually sees go wrong

Pre-fix:

\`\`\`
$ hermes mnemosyne version
Traceback (most recent call last):
  File \".../hermes\", line 10, in <module>
    sys.exit(main())
  File \".../hermes_cli/main.py\", line ..., in main
    args.func(args)
  File \".../plugins/mnemosyne/cli.py\", line 82, in mnemosyne_command
    from mnemosyne import __version__, __author__
ImportError: cannot import name '__version__' from 'mnemosyne'
       (.../mnemosyne/__init__.py)
\`\`\`

Post-fix:

\`\`\`
$ hermes mnemosyne version
Mnemosyne 2.5.0 by Abdias J
\`\`\`

## Root cause

The repo has a nested-package layout where the outer directory is BOTH the repo root AND a Python package, and the inner directory is the real library:

\`\`\`
mnemosyne/                    ← outer: repo root + Hermes plugin entry stub
    __init__.py               ← USED to NOT define __version__ / __author__
    pyproject.toml
    mnemosyne/                ← inner: actual library
        __init__.py           ← defines __version__ = \"2.5.0\", __author__ = \"Abdias J\"
        core/
        ...
\`\`\`

Two install layouts produce different \`mnemosyne\` resolutions:

| Layout | Resolved \`mnemosyne\` is | \`__version__\` works? |
|---|---|---|
| pip install / repo-direct | inner package | ✅ yes |
| Hermes plugin tree (symlink repo root into ~/.hermes/plugins/mnemosyne) | outer stub | ❌ no (pre-fix) |

In the Hermes layout, the parent of the repo root ends up on \`sys.path\` first, so \`import mnemosyne\` resolves to the outer stub — which never defined \`__version__\` or \`__author__\`. The fix makes the outer stub re-export from the inner subpackage so the public API is consistent across layouts.

## The fix

Outer \`__init__.py\` now does:

\`\`\`python
try:
    from .mnemosyne import __version__, __author__
except ImportError:
    __version__ = \"unknown\"
    __author__ = \"Abdias J\"
\`\`\`

Adopted Option B from the issue (re-export at the public surface) over Option A (change the cli.py import to \`from mnemosyne.mnemosyne import ...\`). Option B is more robust — any other code doing \`from mnemosyne import __version__\` works without each caller needing to know about the nested-package detail. The fallback values match the inner package's current author and use \"unknown\" for version (the explicit fallback signal that the inner subpackage couldn't be resolved at all).

\`__all__\` is updated to include the re-exported names so \`from mnemosyne import *\` exposes them.

## Regression test

\`tests/test_outer_package_version.py\` uses \`subprocess\` to spawn a fresh Python interpreter with \`sys.path\` manipulated to mirror the Hermes plugin-loader layout (parent of repo on path, inner package path removed). It asserts the outer stub is what loads, then asserts \`from mnemosyne import __version__, __author__\` succeeds and the version is NOT the \"unknown\" fallback string (which would indicate the re-export silently failed and we fell through to the except-branch).

The subprocess approach is deliberate: pytest runs from inside the repo with the inner package directly on \`sys.path\`, which short-circuits the failure mode entirely. Without subprocess isolation, the test couldn't reproduce the bug.

**RED-without-fix verified**: stashing the fix and re-running the test produced the exact pre-fix \`ImportError: cannot import name '__version__' from 'mnemosyne'\` output. GREEN with the re-export.

## Test plan

- [ ] \`uv run pytest tests/test_outer_package_version.py -v\` (1 passed locally)
- [ ] \`uv run pytest -q --ignore=tests/test_local_llm.py --ignore=tests/test_llm_backends.py\` (full suite green)
- [ ] Manual: deploy the plugin via Hermes plugin-tree layout, run \`hermes mnemosyne version\`, verify \"Mnemosyne 2.5.0 by Abdias J\" prints.
- [ ] Manual: run \`python -c \"from mnemosyne import __version__; print(__version__)\"\` from outside the repo (pip-install layout) — should still print the version, no regression.