### PR TITLE
fix(#45 followup): expose scoring weights in hermes_plugin RECALL_SCHEMA + forward through handler

### DIFF
--- a/hermes_plugin/tools.py
+++ b/hermes_plugin/tools.py
@@ -65,7 +65,7 @@ REMEMBER_SCHEMA = {
 
 RECALL_SCHEMA = {
     "name": "mnemosyne_recall",
-    "description": "Search memories in Mnemosyne. Uses hybrid vector + full-text search across working and episodic memory. Supports temporal weighting to boost recent memories.",
+    "description": "Search memories in Mnemosyne. Uses hybrid vector + full-text search across working and episodic memory. Supports temporal weighting to boost recent memories and per-query scoring weight overrides.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -92,6 +92,18 @@ RECALL_SCHEMA = {
                 "type": "number",
                 "description": "Hours until temporal boost decays by half. Default 24. Lower = faster decay.",
                 "default": 24,
+            },
+            "vec_weight": {
+                "type": "number",
+                "description": "Vector similarity weight in hybrid scoring. Omit (or pass null) to use MNEMOSYNE_VEC_WEIGHT env var or built-in default 0.5."
+            },
+            "fts_weight": {
+                "type": "number",
+                "description": "Full-text search weight in hybrid scoring. Omit (or pass null) to use MNEMOSYNE_FTS_WEIGHT env var or built-in default 0.3."
+            },
+            "importance_weight": {
+                "type": "number",
+                "description": "Importance score weight in hybrid scoring. Omit (or pass null) to use MNEMOSYNE_IMPORTANCE_WEIGHT env var or built-in default 0.2."
             },
             "author_id": {
                 "type": "string",
@@ -384,13 +396,23 @@ def mnemosyne_recall(args: dict, **kwargs) -> str:
         if not query:
             return json.dumps({"error": "Query is required"})
 
+        # Forward configurable scoring weights ONLY when caller supplied them.
+        # mem.recall treats None as "fall back to env var or default" via
+        # _normalize_weights; passing 0.0 / 0.5 / etc. when the caller didn't
+        # ask for tuning would override that resolution and break
+        # MNEMOSYNE_*_WEIGHT env-var deployments. See issue #45.
+        recall_kwargs = {
+            "top_k": top_k,
+            "temporal_weight": temporal_weight,
+            "query_time": query_time,
+            "temporal_halflife": temporal_halflife_hours,
+        }
+        for weight_key in ("vec_weight", "fts_weight", "importance_weight"):
+            if weight_key in args:
+                recall_kwargs[weight_key] = args[weight_key]
+
         mem = _get_memory()
-        results = mem.recall(
-            query, top_k=top_k,
-            temporal_weight=temporal_weight,
-            query_time=query_time,
-            temporal_halflife=temporal_halflife_hours
-        )
+        results = mem.recall(query, **recall_kwargs)
 
         return json.dumps({
             "query": query,

--- a/tests/test_hermes_plugin_tools.py
+++ b/tests/test_hermes_plugin_tools.py
@@ -1,0 +1,100 @@
+"""[issue #45 followup] Tests for hermes_plugin.tools.mnemosyne_recall.
+
+Adversarial review of issue #45's PR caught that the Hermes plugin's recall
+handler ALSO drops vec_weight / fts_weight / importance_weight. The
+RECALL_SCHEMA at hermes_plugin/tools.py:66-110 doesn't advertise the
+scoring weights, and the handler at lines 375-393 doesn't forward them
+to mem.recall.
+
+Same bug class as the MCP-side fix in PR #46 and the
+hermes_memory_provider fix on the C12.b branch — schema/handler mismatch
+with what BeamMemory.recall actually accepts.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_recall_schema_advertises_scoring_weights():
+    """Hermes plugin's RECALL_SCHEMA must advertise vec_weight / fts_weight /
+    importance_weight as type=number properties so Hermes' tool-arg validator
+    accepts them instead of stripping as unknown fields."""
+    from hermes_plugin.tools import RECALL_SCHEMA
+
+    props = RECALL_SCHEMA["parameters"]["properties"]
+    for key in ("vec_weight", "fts_weight", "importance_weight"):
+        assert key in props, (
+            f"hermes_plugin RECALL_SCHEMA missing {key!r} — schema "
+            f"advertises 'hybrid vector + full-text search' but doesn't "
+            f"let clients tune the weights"
+        )
+        assert props[key]["type"] == "number", (
+            f"{key} should be type=number, got {props[key].get('type')!r}"
+        )
+
+
+def test_mnemosyne_recall_forwards_scoring_weights_to_mem(monkeypatch):
+    """hermes_plugin.tools.mnemosyne_recall handler must forward vec_weight /
+    fts_weight / importance_weight to mem.recall when caller supplies them."""
+    from hermes_plugin import tools as plugin_tools
+
+    captured = {}
+
+    class _StubMem:
+        def recall(self, query, **kwargs):
+            captured["query"] = query
+            captured.update(kwargs)
+            return []
+
+    monkeypatch.setattr(plugin_tools, "_get_memory", lambda: _StubMem())
+
+    response = plugin_tools.mnemosyne_recall({
+        "query": "anything",
+        "top_k": 3,
+        "vec_weight": 0.55,
+        "fts_weight": 0.25,
+        "importance_weight": 0.20,
+    })
+
+    parsed = json.loads(response)
+    assert "error" not in parsed, parsed
+    assert captured.get("vec_weight") == 0.55, (
+        f"mnemosyne_recall did not forward vec_weight; captured={captured!r}"
+    )
+    assert captured.get("fts_weight") == 0.25
+    assert captured.get("importance_weight") == 0.20
+
+
+def test_mnemosyne_recall_omits_weights_when_caller_does_not_supply(monkeypatch):
+    """When caller omits the scoring weights, the handler must NOT pass
+    spurious values to mem.recall — beam treats None as 'fall back to env
+    var or default' via _normalize_weights, and forcing 0.0 / 0.5 / etc.
+    would override that resolution and break MNEMOSYNE_*_WEIGHT env-var
+    deployments."""
+    from hermes_plugin import tools as plugin_tools
+
+    captured = {}
+
+    class _StubMem:
+        def recall(self, query, **kwargs):
+            captured["query"] = query
+            captured.update(kwargs)
+            return []
+
+    monkeypatch.setattr(plugin_tools, "_get_memory", lambda: _StubMem())
+
+    plugin_tools.mnemosyne_recall({"query": "anything", "top_k": 3})
+
+    # Acceptable: kwarg not in mem.recall's call OR explicitly None.
+    # Failing path: a numeric default (0.5 / 0.0) leaked through.
+    for key in ("vec_weight", "fts_weight", "importance_weight"):
+        val = captured.get(key, "OMITTED")
+        assert val in (None, "OMITTED"), (
+            f"mnemosyne_recall forwarded {key}={val!r} when caller "
+            f"omitted it; this overrides beam's env/default resolution. "
+            f"Either pass None or omit the kwarg entirely."
+        )


### PR DESCRIPTION
Followup to #45 / [PR #46](https://github.com/AxDSan/mnemosyne/pull/46).

## Summary

- Issue #45's PR #46 covered \`Mnemosyne.recall\`, module-level \`mnemosyne.recall\`, and \`mcp_tools._handle_recall\`. Adversarial review on a parallel investigation caught two more recall surfaces with the same bug class.
- \`hermes_memory_provider/__init__.py\` is the second surface — covered in [PR #62](https://github.com/AxDSan/mnemosyne/pull/62) (the C12.b branch already touches that file).
- \`hermes_plugin/tools.py\` is the third surface — covered in **this PR**.
- 3 regression tests, full suite 467 passed.

## What the user actually sees go wrong

Pre-fix:

\`\`\`python
# Via the Hermes plugin tool surface:
hermes_call("mnemosyne_recall", {
    "query": "deploy plan",
    "vec_weight": 0.7,
    "fts_weight": 0.2,
    "importance_weight": 0.1,
})
\`\`\`

Behavior:
- Hermes' tool-arg validator either rejects the call (unknown fields per the schema) or strips the unknown fields before they reach the handler.
- Handler runs \`mem.recall(...)\` without any of the scoring kwargs.
- Ranking uses the default 50% / 30% / 20% split (or whatever \`MNEMOSYNE_*_WEIGHT\` env vars say), unaffected by the caller's request.
- The docs/comparison page claim that scoring weights are configurable per query is silently violated on this surface.

## The fix

Mirrors the conditional-forward pattern from PR #46 and the matching commit on PR #62.

### Schema — \`hermes_plugin/tools.py:66-110\`

Adds \`vec_weight\`, \`fts_weight\`, \`importance_weight\` as \`type=number\` properties. **No \`default\` value** — beam.recall handles \`None\` as \"fall back to env var or built-in default\" via \`_normalize_weights\`. Description explains the env-var resolution:

> \"Vector similarity weight in hybrid scoring. Omit (or pass null) to use \`MNEMOSYNE_VEC_WEIGHT\` env var or built-in default 0.5.\"

### Handler — \`hermes_plugin/tools.py:375-410\`

Conditionally forwards each weight only when the caller supplied it in \`args\`:

\`\`\`python
recall_kwargs = {
    \"top_k\": top_k,
    \"temporal_weight\": temporal_weight,
    \"query_time\": query_time,
    \"temporal_halflife\": temporal_halflife_hours,
}
for weight_key in (\"vec_weight\", \"fts_weight\", \"importance_weight\"):
    if weight_key in args:
        recall_kwargs[weight_key] = args[weight_key]

results = mem.recall(query, **recall_kwargs)
\`\`\`

Passing \`0.0\` / \`0.5\` / etc. when the caller didn't ask would override beam's env/default resolution and break \`MNEMOSYNE_*_WEIGHT\` env-var deployments. The conditional pattern preserves both per-call tuning AND env-var deployments.

## Tests

New file \`tests/test_hermes_plugin_tools.py\`:

- \`test_recall_schema_advertises_scoring_weights\` — locks the schema exposes all three weight properties as \`type=number\`.
- \`test_mnemosyne_recall_forwards_scoring_weights_to_mem\` — locks the handler-to-mem wiring when caller supplies values (RED-without-fix verified).
- \`test_mnemosyne_recall_omits_weights_when_caller_does_not_supply\` — locks the backward-compat contract that env/default resolution survives when caller omits the kwargs.

## Why three separate PRs for the same bug class

Each surface lives in a different file with different deployment dynamics:
- PR #46 covers the public Python API + MCP server surface
- PR #62 covers the Hermes plugin's MemoryProvider surface (this same file is also being modified for C12.b's REMEMBER_SCHEMA expansion)
- This PR covers the Hermes plugin's tool-call surface (\`hermes_plugin/tools.py\` — separate file from #62, no overlap)

Splitting was the right call because PR #62 has additional REMEMBER_SCHEMA + veracity-clamp work bundled with it; folding the recall fix into PR #62 makes sense (same file). But \`hermes_plugin/tools.py\` is a clean separate concern, and bundling it into PR #62 would have made that PR's scope confusing.

## Test plan

- [ ] \`uv run pytest tests/test_hermes_plugin_tools.py -v\` (3 passed locally)
- [ ] \`uv run pytest -q --ignore=tests/test_local_llm.py --ignore=tests/test_llm_backends.py\` (467 passed locally)
- [ ] Manual: deploy plugin, call \`mnemosyne_recall\` from an agent with \`vec_weight=0.7, fts_weight=0.2, importance_weight=0.1\` and verify the resulting ranking shifts toward vector similarity vs the default 50/30/20 split.
- [ ] Manual with \`MNEMOSYNE_VEC_WEIGHT=0.7\` set in env: call \`mnemosyne_recall\` WITHOUT supplying the kwarg; verify the env value is what gets used (no override to default 0.5).