### PR TITLE
E3: additive sleep — kill summarize-and-delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,33 @@ and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemos
 - `BeamMemory.sleep()` no longer DELETEs source `working_memory` rows after writing the consolidated summary to `episodic_memory`. Originals are marked with a new `consolidated_at` timestamp and remain queryable through recall.
 - Maintainer decision (2026-05-10): "Originals stay. Summaries become enrichment on top. Storage cost is fine — it's the lowest-cost tradeoff." Unblocks experiment Arm B (ADD-only ingest) of the BEAM-recovery experiment.
 - No feature flag — additive is the only mode going forward.
+- `BeamMemory._trim_working_memory` exempts rows with `consolidated_at IS NOT NULL`. The TTL/MAX_ITEMS sliding window only bounds NOT-YET-consolidated content; consolidated originals live until explicit `forget()`. Strict reading of the "originals stay" contract.
+- `BeamMemory.remember`'s dedup-update path clears `consolidated_at = NULL` when re-asserting an already-consolidated row, so the refreshed occurrence becomes eligible for sleep again.
+- `sleep()` now uses an atomic claim: marks `consolidated_at` BEFORE writing the episodic summary, gated on `consolidated_at IS STILL NULL`. Concurrent sleep callers see `rowcount=0` and bail; crash-after-claim leaves an orphan marker but no phantom summary.
+- The `wm_au` FTS trigger now fires `AFTER UPDATE OF content`, not on every UPDATE. Sleep's marker writes don't churn the FTS index — important now that sleep is high-volume.
 
 ### Added
 
 **E3 schema migration**
 - `working_memory.consolidated_at TEXT` column (nullable). Added idempotently in `init_beam()` for existing databases. NULL means "not yet processed by sleep"; sleep filters on `consolidated_at IS NULL` so each row is consolidated at most once.
+- Partial index `idx_wm_unconsolidated ON working_memory(session_id, timestamp) WHERE consolidated_at IS NULL` to keep sleep's eligibility scan in O(eligible).
+- `consolidated_at` is now part of `export_to_dict` / `import_from_dict` (working_memory section) so backup round-trips don't lose the marker. Imports from pre-E3 exports default `consolidated_at` to NULL — handled normally by next sleep.
+
+### Fixed
+
+- Migration error handling: the `ALTER TABLE` for `consolidated_at` now narrows its `except` to "duplicate column" only. Disk-locked, readonly-DB, and other transient `OperationalError`s surface instead of silently leaving the schema broken.
 
 ### Migration notes
 
 - Existing databases pick up the new column automatically on the next `BeamMemory` construction. No manual step required.
-- Pre-E3 databases have empty `working_memory` for any session that has been through sleep (because pre-E3 sleep deleted those rows). That's the expected pre-migration state — nothing to backfill; future sleep cycles populate `consolidated_at` going forward.
+- **Pre-E3 backfill:** all existing `working_memory` rows are marked `consolidated_at = NOW` at upgrade time. This preserves the pre-E3 expectation that "old rows are gone" — the first post-upgrade sleep does not blast a huge batch over the pre-existing backlog. If you want a specific row to be re-eligible for sleep, set its `consolidated_at` back to NULL by hand.
 - The new column name `consolidated_at` is intentionally aligned with the existing `metadata_json["consolidated_at"]` key on `episodic_memory` (introduced in 2.5 by the heal-quality pipeline). Same concept, different angle — episodic's key records when a summary row was finalized; working_memory's column records when the source row was marked done by sleep.
+- **Rollback:** the column persists after downgrade (SQLite < 3.35 doesn't support `DROP COLUMN` cleanly). Pre-E3 code ignores the column. If you upgrade, run sleep, then downgrade, the pre-E3 sleep will DELETE rows the post-E3 code had marked as consolidated — leaving orphan episodic summaries pointing at non-existent originals. Recommend backing up the DB before upgrading.
+
+### Known limitations
+
+- `consolidated_at` marker writes do not bump `rowid` or `timestamp`, so `DeltaSync` (`streaming.py`) won't propagate the marker to peers. In a multi-replica setup each peer will independently consolidate the same rows. Filed as a follow-up; affects multi-replica deployments only.
+- `episodic_memory.summary_of` (comma-separated source `working_memory` ids) can still go dangling if the source row is later `forget()`ed. Pre-existing pattern, no fresh regression from E3, but the additive design surfaces the issue more often.
 
 ## [2.5] — 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemosyne) (MAJOR.MINOR).
 
+## [Unreleased]
+
+### Changed
+
+**E3 — Additive sleep (kill summarize-and-delete)**
+- `BeamMemory.sleep()` no longer DELETEs source `working_memory` rows after writing the consolidated summary to `episodic_memory`. Originals are marked with a new `consolidated_at` timestamp and remain queryable through recall.
+- Maintainer decision (2026-05-10): "Originals stay. Summaries become enrichment on top. Storage cost is fine — it's the lowest-cost tradeoff." Unblocks experiment Arm B (ADD-only ingest) of the BEAM-recovery experiment.
+- No feature flag — additive is the only mode going forward.
+
+### Added
+
+**E3 schema migration**
+- `working_memory.consolidated_at TEXT` column (nullable). Added idempotently in `init_beam()` for existing databases. NULL means "not yet processed by sleep"; sleep filters on `consolidated_at IS NULL` so each row is consolidated at most once.
+
+### Migration notes
+
+- Existing databases pick up the new column automatically on the next `BeamMemory` construction. No manual step required.
+- Pre-E3 databases have empty `working_memory` for any session that has been through sleep (because pre-E3 sleep deleted those rows). That's the expected pre-migration state — nothing to backfill; future sleep cycles populate `consolidated_at` going forward.
+- The new column name `consolidated_at` is intentionally aligned with the existing `metadata_json["consolidated_at"]` key on `episodic_memory` (introduced in 2.5 by the heal-quality pipeline). Same concept, different angle — episodic's key records when a summary row was finalized; working_memory's column records when the source row was marked done by sleep.
+
 ## [2.5] — 2026-05-10
 
 ### Added

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -269,10 +269,47 @@ def init_beam(db_path: Path = None):
     # post-E3 the originals remain so they're still recallable, and
     # consolidated_at IS NULL is the predicate sleep uses to find
     # not-yet-consolidated rows.
+    #
+    # Naming note: episodic_memory.metadata_json["consolidated_at"]
+    # (introduced in 2.5 by the heal-quality pipeline) records when a
+    # summary row was finalized; this column records when a SOURCE row
+    # was marked done by sleep. Same concept, different angle.
+    _e3_column_added = False
     try:
         cursor.execute("ALTER TABLE working_memory ADD COLUMN consolidated_at TEXT")
-    except sqlite3.OperationalError:
-        pass
+        _e3_column_added = True
+    except sqlite3.OperationalError as exc:
+        # Only swallow "duplicate column" — every other OperationalError
+        # (database locked, disk I/O, readonly, missing table) must
+        # surface so callers don't proceed with a broken schema.
+        if "duplicate column" not in str(exc).lower():
+            raise
+
+    if _e3_column_added:
+        # Pre-E3 backfill: existing rows are treated as already-consolidated.
+        # Without this, the first post-upgrade sleep would treat the entire
+        # pre-existing backlog as "not yet consolidated" and try to summarize
+        # everything at once — including rows pre-E3 sleep would have already
+        # DELETEd. The backfill preserves the pre-E3 expectation that "old
+        # rows are gone." Cost: a single UPDATE on existing rows at upgrade
+        # time. Idempotent: this branch only fires when the column was just
+        # added, so re-running init_beam is a no-op.
+        cursor.execute(
+            "UPDATE working_memory SET consolidated_at = ? "
+            "WHERE consolidated_at IS NULL",
+            (datetime.now().isoformat(),),
+        )
+
+    # Partial index for the sleep eligibility predicate. Sleep scans
+    # WHERE session_id = ? AND timestamp < ? AND consolidated_at IS NULL
+    # on every cycle; once consolidated rows accumulate the predicate
+    # becomes the dominant filter. The partial index lets the planner
+    # skip already-consolidated rows in O(eligible) instead of O(session).
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_wm_unconsolidated "
+        "ON working_memory(session_id, timestamp) "
+        "WHERE consolidated_at IS NULL"
+    )
 
     # --- SCRATCHPAD ---
     cursor.execute("""
@@ -346,8 +383,15 @@ def init_beam(db_path: Path = None):
             DELETE FROM fts_working WHERE id = old.id;
         END
     """)
+    # The wm_au trigger restricts to UPDATE OF content so sleep's
+    # consolidated_at marker writes don't churn the FTS index. Pre-E3
+    # this trigger fired on every UPDATE — fine when UPDATEs were rare;
+    # post-E3 sleep marks SLEEP_BATCH_SIZE rows per cycle and would
+    # otherwise generate 2*N FTS round-trips per sleep with no content
+    # delta. SQLite column-list triggers handle the perf concern.
+    cursor.execute("DROP TRIGGER IF EXISTS wm_au")
     cursor.execute("""
-        CREATE TRIGGER IF NOT EXISTS wm_au AFTER UPDATE ON working_memory BEGIN
+        CREATE TRIGGER IF NOT EXISTS wm_au AFTER UPDATE OF content ON working_memory BEGIN
             DELETE FROM fts_working WHERE id = old.id;
             INSERT INTO fts_working(id, content) VALUES (new.id, new.content);
         END
@@ -1095,6 +1139,13 @@ class BeamMemory:
         existing_id = self._find_duplicate(content)
         if existing_id:
             cursor = self.conn.cursor()
+            # Dedup-update clears consolidated_at so a re-remembered row
+            # becomes eligible for sleep again. Without this, an already-
+            # consolidated row that the user reasserts is permanently
+            # skipped — its fresher timestamp/source/scope never produces
+            # a fresh summary. Pre-E3 this scenario didn't exist because
+            # consolidated rows were deleted; the additive design has to
+            # opt back in.
             cursor.execute("""
                 UPDATE working_memory
                 SET importance = MAX(importance, ?), timestamp = ?, source = ?,
@@ -1103,7 +1154,8 @@ class BeamMemory:
                     author_id = COALESCE(?, author_id),
                     author_type = COALESCE(?, author_type),
                     channel_id = COALESCE(?, channel_id),
-                    memory_type = COALESCE(?, memory_type)
+                    memory_type = COALESCE(?, memory_type),
+                    consolidated_at = NULL
                 WHERE id = ? AND session_id = ?
             """, (importance, datetime.now().isoformat(), source,
                   valid_until, scope,
@@ -1288,19 +1340,29 @@ class BeamMemory:
             pass
 
     def _trim_working_memory(self):
-        """Keep working_memory within size/time limits."""
+        """Keep working_memory within size/time limits.
+
+        Post-E3: consolidated rows (consolidated_at IS NOT NULL) are
+        exempt from trim. The "originals stay" contract means they
+        remain queryable until explicit forget(); the TTL window only
+        bounds NOT-YET-consolidated content. Without this exemption,
+        the additive promise expires at WORKING_MEMORY_TTL_HOURS and
+        the experiment Arm B's "ADD-only" guarantee collapses at 24h.
+        """
         cutoff = (datetime.now() - timedelta(hours=WORKING_MEMORY_TTL_HOURS)).isoformat()
         self.conn.execute("""
             DELETE FROM working_memory
-            WHERE session_id = ? AND (
+            WHERE session_id = ?
+              AND consolidated_at IS NULL
+              AND (
                 timestamp < ? OR
                 id NOT IN (
                     SELECT id FROM working_memory
-                    WHERE session_id = ?
+                    WHERE session_id = ? AND consolidated_at IS NULL
                     ORDER BY timestamp DESC
                     LIMIT ?
                 )
-            )
+              )
         """, (self.session_id, cutoff, self.session_id, WORKING_MEMORY_MAX_ITEMS))
         self.conn.commit()
 
@@ -2799,6 +2861,54 @@ class BeamMemory:
         if not rows:
             return {"status": "no_op", "message": "No old working memories to consolidate"}
 
+        # Atomic claim: mark rows consolidated_at BEFORE writing the
+        # episodic summary, gated on consolidated_at IS STILL NULL.
+        # This serves two roles at once:
+        # (1) concurrent sleep() callers — a second process that also
+        #     SELECTed the same rows finds rowcount=0 on its claim and
+        #     bails before producing a duplicate summary
+        # (2) crash safety — if the process dies after the claim but
+        #     before episodic INSERT, the next sleep cycle finds
+        #     consolidated_at set and skips them rather than producing
+        #     a duplicate. The flip side is a possible orphan claim
+        #     (marker set, no summary) — acceptable; the originals
+        #     remain recallable and a manual "reclaim" can clear
+        #     consolidated_at if needed.
+        # The dry_run branch skips the claim entirely so it stays
+        # side-effect-free.
+        if not dry_run:
+            now_iso = datetime.now().isoformat()
+            ids_to_claim = [row["id"] for row in rows]
+            placeholders = ",".join("?" * len(ids_to_claim))
+            cursor.execute(
+                f"UPDATE working_memory SET consolidated_at = ? "
+                f"WHERE id IN ({placeholders}) AND consolidated_at IS NULL",
+                (now_iso, *ids_to_claim),
+            )
+            claimed_ids = set()
+            if cursor.rowcount == len(ids_to_claim):
+                # Fast path: we got all of them.
+                claimed_ids = set(ids_to_claim)
+            else:
+                # Slow path: at least one row was claimed concurrently
+                # by another sleep. Re-read which ones we actually own
+                # so we only summarize those.
+                cursor.execute(
+                    f"SELECT id FROM working_memory "
+                    f"WHERE id IN ({placeholders}) AND consolidated_at = ?",
+                    (*ids_to_claim, now_iso),
+                )
+                claimed_ids = {r["id"] for r in cursor.fetchall()}
+
+            if not claimed_ids:
+                # Lost the race entirely.
+                self.conn.commit()
+                return {"status": "no_op", "message": "All eligible rows claimed by concurrent sleep"}
+
+            # Filter rows to only those we successfully claimed.
+            rows = [r for r in rows if r["id"] in claimed_ids]
+            self.conn.commit()
+
         grouped: Dict[str, List[Dict]] = {}
         for row in rows:
             grouped.setdefault(row["source"], []).append(dict(row))
@@ -2859,6 +2969,11 @@ class BeamMemory:
                 summary = f"[{source}] {compressed}"
 
             if not dry_run:
+                # Originals are already claimed (consolidated_at set above).
+                # Just write the summary. If consolidate_to_episodic raises
+                # the claim survives — the rows show as consolidated but
+                # without a summary. That's preferable to a phantom-summary-
+                # without-claim race the previous ordering allowed.
                 self.consolidate_to_episodic(
                     summary=summary,
                     source_wm_ids=ids,
@@ -2872,18 +2987,6 @@ class BeamMemory:
                         "llm_used": llm_succeeded
                     }
                 )
-                # E3: mark originals as consolidated instead of deleting
-                # them. Sleep's query filter (consolidated_at IS NULL)
-                # excludes them from the next cycle so we don't produce
-                # duplicate summaries on subsequent runs.
-                placeholders = ",".join("?" * len(ids))
-                now_iso = datetime.now().isoformat()
-                cursor.execute(
-                    f"UPDATE working_memory SET consolidated_at = ? "
-                    f"WHERE id IN ({placeholders})",
-                    (now_iso, *ids),
-                )
-                self.conn.commit()
             consolidated_ids.extend(ids)
             summaries_created += 1
 
@@ -3032,11 +3135,13 @@ class BeamMemory:
             }
         }
 
-        # Working memory (all sessions)
+        # Working memory (all sessions). consolidated_at carries the
+        # post-E3 sleep marker; without it on the export, restored DBs
+        # would re-summarize every already-slept row on next sleep.
         cursor.execute("""
             SELECT id, content, source, timestamp, session_id, importance,
                    metadata_json, valid_until, superseded_by, scope,
-                   recall_count, last_recalled, created_at
+                   recall_count, last_recalled, created_at, consolidated_at
             FROM working_memory
             ORDER BY session_id, timestamp
         """)
@@ -3122,14 +3227,19 @@ class BeamMemory:
             cursor.execute("""
                 INSERT INTO working_memory
                 (id, content, source, timestamp, session_id, importance, metadata_json,
-                 valid_until, superseded_by, scope, recall_count, last_recalled, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 valid_until, superseded_by, scope, recall_count, last_recalled, created_at,
+                 consolidated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 mid, item.get("content"), item.get("source"), item.get("timestamp"),
                 item.get("session_id", "default"), item.get("importance", 0.5),
                 item.get("metadata_json", "{}"), item.get("valid_until"),
                 item.get("superseded_by"), item.get("scope", "session"),
-                item.get("recall_count", 0), item.get("last_recalled"), item.get("created_at")
+                item.get("recall_count", 0), item.get("last_recalled"), item.get("created_at"),
+                # consolidated_at: pre-E3 exports (no key) get NULL —
+                # treated as "not yet consolidated" so the next sleep
+                # cycle on the importing DB processes them normally.
+                item.get("consolidated_at"),
             ))
         self.conn.commit()
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -263,6 +263,17 @@ def init_beam(db_path: Path = None):
     except sqlite3.OperationalError:
         pass
 
+    # --- E3 additive sleep migration ---
+    # Working memories that sleep() has consolidated into an episodic
+    # summary get this timestamp set. Pre-E3 sleep() DELETEd those rows;
+    # post-E3 the originals remain so they're still recallable, and
+    # consolidated_at IS NULL is the predicate sleep uses to find
+    # not-yet-consolidated rows.
+    try:
+        cursor.execute("ALTER TABLE working_memory ADD COLUMN consolidated_at TEXT")
+    except sqlite3.OperationalError:
+        pass
+
     # --- SCRATCHPAD ---
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS scratchpad (
@@ -2752,6 +2763,11 @@ class BeamMemory:
         compression if the model is missing or inference fails.
         Returns summary of what was done.
 
+        Post-E3 (additive): the source working_memory rows are NOT
+        deleted. Instead they're marked with consolidated_at = NOW
+        so the next sleep cycle skips them. Originals remain
+        recallable alongside the new episodic summary.
+
         Note: this method intentionally remains session-scoped. Use
         sleep_all_sessions() for maintenance that consolidates eligible old
         working memories across inactive sessions.
@@ -2768,10 +2784,14 @@ class BeamMemory:
         # collects them as a NULL group, maps to "default" for the loop,
         # then beam.sleep("default") would query session_id = 'default'
         # and miss the NULL rows. See Codex /review note for C9.
+        # consolidated_at IS NULL filters out rows already processed by
+        # a prior sleep so we don't re-summarize the same originals.
         cursor.execute(f"""
             SELECT id, content, source, timestamp, importance, metadata_json, scope, valid_until
             FROM working_memory
-            WHERE COALESCE(session_id, 'default') = ? AND timestamp < ?
+            WHERE COALESCE(session_id, 'default') = ?
+              AND timestamp < ?
+              AND consolidated_at IS NULL
             ORDER BY timestamp ASC
             LIMIT {SLEEP_BATCH_SIZE}
         """, (self.session_id, cutoff))
@@ -2852,8 +2872,17 @@ class BeamMemory:
                         "llm_used": llm_succeeded
                     }
                 )
+                # E3: mark originals as consolidated instead of deleting
+                # them. Sleep's query filter (consolidated_at IS NULL)
+                # excludes them from the next cycle so we don't produce
+                # duplicate summaries on subsequent runs.
                 placeholders = ",".join("?" * len(ids))
-                cursor.execute(f"DELETE FROM working_memory WHERE id IN ({placeholders})", ids)
+                now_iso = datetime.now().isoformat()
+                cursor.execute(
+                    f"UPDATE working_memory SET consolidated_at = ? "
+                    f"WHERE id IN ({placeholders})",
+                    (now_iso, *ids),
+                )
                 self.conn.commit()
             consolidated_ids.extend(ids)
             summaries_created += 1
@@ -2889,10 +2918,13 @@ class BeamMemory:
         """
         cursor = self.conn.cursor()
         cutoff = (datetime.now() - timedelta(hours=WORKING_MEMORY_TTL_HOURS // 2)).isoformat()
+        # Mirror sleep()'s filter: only count rows that haven't been
+        # consolidated yet, so we don't redo work on every maintenance pass.
         cursor.execute("""
             SELECT session_id, COUNT(*) AS eligible
             FROM working_memory
             WHERE timestamp < ?
+              AND consolidated_at IS NULL
             GROUP BY session_id
             ORDER BY MIN(timestamp) ASC
         """, (cutoff,))

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -156,10 +156,17 @@ class TestSleepCycle:
         assert result["status"] == "consolidated"
         assert result["items_consolidated"] == 1
 
+        # E3: source rows remain after sleep. s1's row gains
+        # consolidated_at; s2's stays untouched (different session).
         conn = sqlite3.connect(temp_db)
-        remaining = conn.execute("SELECT session_id FROM working_memory ORDER BY session_id").fetchall()
+        rows = conn.execute(
+            "SELECT session_id, consolidated_at FROM working_memory ORDER BY session_id"
+        ).fetchall()
         conn.close()
-        assert remaining == [("s2",)]
+        assert len(rows) == 2
+        by_session = dict(rows)
+        assert by_session["s1"] is not None, "s1 row should be marked consolidated"
+        assert by_session["s2"] is None, "s2 row should be untouched by s1's sleep"
 
     def test_sleep_all_sessions_consolidates_inactive_sessions(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
@@ -185,13 +192,22 @@ class TestSleepCycle:
         assert result["summaries_created"] == 2
         assert result["errors"] == 0
 
+        # E3: source rows remain. Old rows have consolidated_at set;
+        # the fresh row (timestamp > cutoff) stays NULL because sleep
+        # never picked it up.
         conn = sqlite3.connect(temp_db)
-        remaining = conn.execute("SELECT id, session_id FROM working_memory").fetchall()
+        rows = conn.execute(
+            "SELECT id, session_id, consolidated_at FROM working_memory ORDER BY id"
+        ).fetchall()
         logs = conn.execute("SELECT session_id, items_consolidated FROM consolidation_log ORDER BY session_id").fetchall()
         episodic_count = conn.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0]
         conn.close()
 
-        assert remaining == [("s2-fresh", "s2")]
+        assert len(rows) == 3
+        by_id = {r[0]: (r[1], r[2]) for r in rows}
+        assert by_id["s1-old"][1] is not None, "s1-old should be marked consolidated"
+        assert by_id["s2-old"][1] is not None, "s2-old should be marked consolidated"
+        assert by_id["s2-fresh"][1] is None, "s2-fresh wasn't eligible — must stay NULL"
         assert logs == [("s1", 1), ("s2", 1)]
         assert episodic_count == 2
 
@@ -723,13 +739,23 @@ class TestTokenAwareConsolidation:
         assert result["status"] == "consolidated"
         assert result["summaries_created"] >= 1
 
-        # Verify no working memory left for this session
+        # E3: originals remain; sleep marks them consolidated_at instead of deleting.
         conn = sqlite3.connect(temp_db)
         cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) FROM working_memory WHERE session_id = ?", ("test-chunking",))
+        cursor.execute(
+            "SELECT COUNT(*) FROM working_memory WHERE session_id = ?",
+            ("test-chunking",),
+        )
         count = cursor.fetchone()[0]
+        cursor.execute(
+            "SELECT COUNT(*) FROM working_memory "
+            "WHERE session_id = ? AND consolidated_at IS NOT NULL",
+            ("test-chunking",),
+        )
+        marked = cursor.fetchone()[0]
         conn.close()
-        assert count == 0
+        assert count == 30
+        assert marked == 30
 
     def test_chunk_memories_by_budget_single_oversized(self, monkeypatch):
         """A single memory exceeding the budget should be skipped from LLM chunking."""

--- a/tests/test_beam_e3_additive_sleep.py
+++ b/tests/test_beam_e3_additive_sleep.py
@@ -1,0 +1,275 @@
+"""Regression tests for E3 — additive sleep().
+
+Pre-E3 contract: BeamMemory.sleep() consolidated old working_memory rows
+into an episodic_memory summary and then DELETED the source rows. The
+new contract (per maintainer decision 2026-05-10: "Kill summarize-and-
+delete. Originals stay.") is additive:
+
+  - Source working_memory rows REMAIN after sleep
+  - A new `consolidated_at` TIMESTAMP column on working_memory is set on
+    the rows sleep processed
+  - sleep() doesn't pick up rows that already have consolidated_at set
+    (so calling sleep twice doesn't double-summarize the same originals)
+  - Recall surfaces both the original working_memory row AND the
+    episodic summary row when both are relevant
+
+This blocks experiment Arm B (ADD-only ingest) of the BEAM-recovery
+experiment.
+"""
+
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+def _wm_count(db_path, session_id=None):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        if session_id is None:
+            return conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0]
+        return conn.execute(
+            "SELECT COUNT(*) FROM working_memory WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _consolidated_rows(db_path, session_id):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute(
+            "SELECT id, consolidated_at FROM working_memory "
+            "WHERE session_id = ? ORDER BY id",
+            (session_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def _seed_old_wm(db_path, session_id, n, ts_offset_hours=20):
+    """Insert n old working_memory rows for the given session. Uses
+    distinct content per row so each is uniquely identifiable."""
+    conn = sqlite3.connect(str(db_path))
+    ts = (datetime.now() - timedelta(hours=ts_offset_hours)).isoformat()
+    rows = [
+        (f"e3-{session_id}-{i}", f"e3-content-{i}", "conversation", ts, session_id)
+        for i in range(n)
+    ]
+    conn.executemany(
+        "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return [r[0] for r in rows]
+
+
+class TestE3AdditiveSleep:
+
+    def test_sleep_preserves_working_memory_rows(self, temp_db):
+        """Post-E3, source working_memory rows survive sleep()."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        seeded_ids = _seed_old_wm(temp_db, "s1", n=3)
+
+        assert _wm_count(temp_db, "s1") == 3
+
+        result = beam.sleep(dry_run=False)
+        assert result["status"] == "consolidated"
+        assert result["items_consolidated"] == 3
+
+        # The whole point of E3: originals stay.
+        post_count = _wm_count(temp_db, "s1")
+        assert post_count == 3, (
+            f"sleep() deleted working_memory rows — pre-E3 behavior. "
+            f"Expected 3 originals to remain, got {post_count}."
+        )
+
+        # IDs unchanged.
+        conn = sqlite3.connect(str(temp_db))
+        post_ids = sorted(r[0] for r in conn.execute(
+            "SELECT id FROM working_memory WHERE session_id = 's1'"
+        ).fetchall())
+        conn.close()
+        assert post_ids == sorted(seeded_ids)
+
+    def test_sleep_marks_consolidated_at(self, temp_db):
+        """After sleep, every processed row has consolidated_at set."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=2)
+
+        beam.sleep(dry_run=False)
+
+        rows = _consolidated_rows(temp_db, "s1")
+        assert len(rows) == 2
+        for row_id, consolidated_at in rows:
+            assert consolidated_at is not None, (
+                f"row {row_id} survived sleep but consolidated_at is NULL "
+                f"— sleep didn't mark it, so the next sleep cycle will "
+                f"re-consolidate it and produce a duplicate summary."
+            )
+
+    def test_sleep_does_not_reconsolidate_marked_rows(self, temp_db):
+        """Calling sleep twice doesn't pick up already-marked rows."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=2)
+
+        first = beam.sleep(dry_run=False)
+        assert first["items_consolidated"] == 2
+        first_episodic = sqlite3.connect(str(temp_db)).execute(
+            "SELECT COUNT(*) FROM episodic_memory"
+        ).fetchone()[0]
+
+        # Second sleep should find no eligible rows (status no_op) and
+        # crucially not create a second summary.
+        second = beam.sleep(dry_run=False)
+        assert second["status"] == "no_op", (
+            f"sleep re-processed already-consolidated rows; got {second}"
+        )
+
+        second_episodic = sqlite3.connect(str(temp_db)).execute(
+            "SELECT COUNT(*) FROM episodic_memory"
+        ).fetchone()[0]
+        assert second_episodic == first_episodic, (
+            f"sleep produced a duplicate summary on the second call: "
+            f"first={first_episodic}, second={second_episodic}"
+        )
+
+    def test_dry_run_does_not_mark_consolidated_at(self, temp_db):
+        """Dry run must not mutate working_memory (no consolidated_at writes)."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=2)
+
+        result = beam.sleep(dry_run=True)
+        assert result["status"] == "dry_run"
+
+        rows = _consolidated_rows(temp_db, "s1")
+        for row_id, consolidated_at in rows:
+            assert consolidated_at is None, (
+                f"dry_run set consolidated_at on row {row_id} — "
+                f"dry_run must be side-effect-free."
+            )
+
+    def test_consolidated_originals_remain_recallable(self, temp_db, monkeypatch):
+        """[E3] Originals stay queryable through recall() after sleep.
+        Uses LLM-disabled path so unique tokens survive into the
+        aaak-encoded summary; the assertion is that recall returns hits
+        whose content matches the ORIGINAL working_memory row content,
+        not just the summary."""
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: False
+        )
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+
+        # Distinctive token only in the original, very unlikely to
+        # appear in an aaak-encoded summary.
+        conn = sqlite3.connect(str(temp_db))
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("orig1", "original wm marker zzzunique42", "conversation", old_ts, "s1"),
+        )
+        conn.commit()
+        conn.close()
+
+        beam.sleep(dry_run=False)
+
+        results = beam.recall("zzzunique42", top_k=10)
+        assert results, "consolidated original is unreachable through recall()"
+        # The exact-token original should be findable; the wm row carries
+        # tier=='working' in the post-recall shape.
+        assert any(
+            r.get("tier") == "working" and "zzzunique42" in (r.get("content") or "")
+            for r in results
+        ), (
+            f"recall did not surface the original working_memory row that "
+            f"carries the unique token. E3 contract requires originals "
+            f"remain recallable. Got: "
+            f"{[(r.get('tier'), (r.get('content') or '')[:40]) for r in results]}"
+        )
+
+    def test_sleep_remains_session_scoped_with_marker(self, temp_db):
+        """E3 version of the legacy test_sleep_remains_session_scoped:
+        cross-session row stays untouched (no consolidated_at marker)
+        because the caller's session is s1."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=1)
+        _seed_old_wm(temp_db, "s2", n=1)
+
+        beam.sleep(dry_run=False)
+
+        conn = sqlite3.connect(str(temp_db))
+        rows = conn.execute(
+            "SELECT session_id, consolidated_at FROM working_memory ORDER BY session_id"
+        ).fetchall()
+        conn.close()
+
+        # Both rows still exist; only s1's is marked.
+        assert len(rows) == 2
+        by_session = {r[0]: r[1] for r in rows}
+        assert by_session["s1"] is not None, "s1 row not marked consolidated"
+        assert by_session["s2"] is None, (
+            "s2 row was marked despite caller being session s1 — cross-"
+            "session leak on the consolidation marker"
+        )
+
+    def test_consolidated_at_column_added_on_legacy_db(self, temp_db):
+        """Pre-E3 databases that don't have consolidated_at must get the
+        column added by init_beam() without losing data."""
+        # Simulate a legacy DB: create the working_memory table without
+        # consolidated_at, insert a row, then re-init.
+        legacy_conn = sqlite3.connect(str(temp_db))
+        legacy_conn.execute("""
+            CREATE TABLE working_memory (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                source TEXT,
+                timestamp TEXT,
+                session_id TEXT DEFAULT 'default',
+                importance REAL DEFAULT 0.5,
+                metadata_json TEXT,
+                veracity TEXT DEFAULT 'unknown',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        legacy_conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("legacy-1", "legacy content", "conversation", old_ts, "s1"),
+        )
+        legacy_conn.commit()
+        legacy_conn.close()
+
+        # init_beam via BeamMemory construction should add the column.
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+
+        conn = sqlite3.connect(str(temp_db))
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(working_memory)").fetchall()]
+        conn.close()
+        assert "consolidated_at" in cols, (
+            "init_beam did not add consolidated_at column to legacy DB"
+        )
+
+        # Legacy row should still be there with consolidated_at = NULL.
+        rows = _consolidated_rows(temp_db, "s1")
+        assert rows == [("legacy-1", None)]
+
+        # And sleep should still process it (consolidated_at IS NULL).
+        result = beam.sleep(dry_run=False)
+        assert result["items_consolidated"] == 1
+        rows = _consolidated_rows(temp_db, "s1")
+        assert rows[0][1] is not None

--- a/tests/test_beam_e3_additive_sleep.py
+++ b/tests/test_beam_e3_additive_sleep.py
@@ -228,7 +228,9 @@ class TestE3AdditiveSleep:
 
     def test_consolidated_at_column_added_on_legacy_db(self, temp_db):
         """Pre-E3 databases that don't have consolidated_at must get the
-        column added by init_beam() without losing data."""
+        column added by init_beam() with existing rows backfilled to
+        'already consolidated' (preserving the pre-E3 expectation that
+        old rows are gone)."""
         # Simulate a legacy DB: create the working_memory table without
         # consolidated_at, insert a row, then re-init.
         legacy_conn = sqlite3.connect(str(temp_db))
@@ -264,12 +266,212 @@ class TestE3AdditiveSleep:
             "init_beam did not add consolidated_at column to legacy DB"
         )
 
-        # Legacy row should still be there with consolidated_at = NULL.
+        # Existing legacy row should be backfilled to "already consolidated"
+        # — without this, the first post-upgrade sleep would blast a huge
+        # batch over the pre-E3 backlog.
         rows = _consolidated_rows(temp_db, "s1")
-        assert rows == [("legacy-1", None)]
+        assert len(rows) == 1
+        assert rows[0][0] == "legacy-1"
+        assert rows[0][1] is not None, (
+            "pre-E3 row was not backfilled; the first sleep cycle would "
+            "incorrectly re-consolidate everything"
+        )
+        # Backfilled value must be a parseable ISO timestamp.
+        datetime.fromisoformat(rows[0][1])
 
-        # And sleep should still process it (consolidated_at IS NULL).
+        # And sleep should NOT re-process the backfilled row.
         result = beam.sleep(dry_run=False)
-        assert result["items_consolidated"] == 1
+        assert result["status"] == "no_op", (
+            f"Pre-E3 backfilled row was incorrectly re-consolidated: {result}"
+        )
+
+    def test_consolidated_at_is_iso_timestamp(self, temp_db):
+        """The marker value must be a parseable ISO-8601 timestamp.
+        Downstream consumers compute age from consolidated_at; a sentinel
+        like '1' or '' would silently break them."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=2)
+
+        beam.sleep(dry_run=False)
+
         rows = _consolidated_rows(temp_db, "s1")
-        assert rows[0][1] is not None
+        now = datetime.now()
+        for row_id, consolidated_at in rows:
+            parsed = datetime.fromisoformat(consolidated_at)
+            # Within 60s of NOW (generous for CI clock skew).
+            delta = abs((now - parsed).total_seconds())
+            assert delta < 60, (
+                f"consolidated_at for {row_id} is {consolidated_at}, "
+                f"{delta:.1f}s from NOW — outside the expected window"
+            )
+
+    def test_consolidated_at_idempotent_on_modern_db(self, temp_db):
+        """A second BeamMemory init on the same DB must not crash and
+        must NOT clobber existing consolidated_at values."""
+        beam1 = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=1)
+        beam1.sleep(dry_run=False)
+
+        rows_first = _consolidated_rows(temp_db, "s1")
+        first_marker = rows_first[0][1]
+        assert first_marker is not None
+
+        # Re-init.
+        BeamMemory(session_id="s1", db_path=temp_db)
+
+        rows_second = _consolidated_rows(temp_db, "s1")
+        assert rows_second[0][1] == first_marker, (
+            "second init clobbered the existing consolidated_at value"
+        )
+
+        # PRAGMA shows the column exactly once.
+        conn = sqlite3.connect(str(temp_db))
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(working_memory)").fetchall()]
+        conn.close()
+        assert cols.count("consolidated_at") == 1
+
+    def test_dry_run_writes_nothing(self, temp_db):
+        """Dry run must not mutate working_memory, episodic_memory, or
+        consolidation_log. Pre-E3 only DELETE was suppressed; post-E3
+        the UPDATE marker is a second mutation that must also be skipped."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=2)
+
+        result = beam.sleep(dry_run=True)
+        assert result["status"] == "dry_run"
+
+        conn = sqlite3.connect(str(temp_db))
+        wm_count = conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0]
+        ep_count = conn.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0]
+        log_count = conn.execute("SELECT COUNT(*) FROM consolidation_log").fetchone()[0]
+        marked = conn.execute(
+            "SELECT COUNT(*) FROM working_memory WHERE consolidated_at IS NOT NULL"
+        ).fetchone()[0]
+        conn.close()
+
+        assert wm_count == 2, "dry_run deleted working_memory rows"
+        assert ep_count == 0, "dry_run wrote an episodic summary"
+        assert log_count == 0, "dry_run wrote to consolidation_log"
+        assert marked == 0, "dry_run set consolidated_at"
+
+    def test_trim_exempts_consolidated_rows(self, temp_db):
+        """[E3 trim policy] _trim_working_memory must NOT delete rows
+        whose consolidated_at is set. Without this exemption, the
+        'originals stay' contract collapses at the TTL boundary."""
+        from mnemosyne.core.beam import WORKING_MEMORY_TTL_HOURS
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Seed a row, consolidate it, then move the row's timestamp
+        # past the trim TTL window. The trim runs implicitly on every
+        # remember(); explicitly invoke it to be unambiguous.
+        _seed_old_wm(temp_db, "s1", n=1)
+        beam.sleep(dry_run=False)
+        rows_after_sleep = _consolidated_rows(temp_db, "s1")
+        assert rows_after_sleep[0][1] is not None
+
+        # Backdate the row past the trim cutoff (= WORKING_MEMORY_TTL_HOURS).
+        very_old = (
+            datetime.now() - timedelta(hours=WORKING_MEMORY_TTL_HOURS + 5)
+        ).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute(
+            "UPDATE working_memory SET timestamp = ?", (very_old,)
+        )
+        conn.commit()
+        conn.close()
+
+        # Trigger trim by writing a new (fresh) row through beam.remember.
+        beam.remember("fresh content not eligible for sleep", source="conversation")
+
+        # The consolidated row must survive.
+        count = _wm_count(temp_db, "s1")
+        assert count == 2, (
+            f"trim deleted a consolidated row; the additive contract is "
+            f"broken at the TTL boundary. Expected 2 rows (1 consolidated "
+            f"+ 1 fresh), got {count}"
+        )
+
+    def test_dedup_remember_clears_consolidated_at(self, temp_db):
+        """When the same content is remembered again after sleep, the
+        dedup-update path must clear consolidated_at so the refreshed
+        occurrence becomes eligible for sleep again."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        content = "duplicate-content-for-dedup-test"
+
+        # Insert and consolidate.
+        mem_id = beam.remember(content, source="conversation")
+        conn = sqlite3.connect(str(temp_db))
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        conn.execute(
+            "UPDATE working_memory SET timestamp = ? WHERE id = ?",
+            (old_ts, mem_id),
+        )
+        conn.commit()
+        conn.close()
+
+        beam.sleep(dry_run=False)
+        rows = _consolidated_rows(temp_db, "s1")
+        assert rows[0][1] is not None, "sleep didn't mark the row"
+
+        # Re-remember the same content.
+        beam.remember(content, source="conversation")
+
+        rows = _consolidated_rows(temp_db, "s1")
+        assert rows[0][1] is None, (
+            "dedup-update path did not clear consolidated_at; the "
+            "refreshed occurrence is permanently skipped"
+        )
+
+    def test_concurrent_sleep_atomic_claim(self, temp_db):
+        """Two BeamMemory instances calling sleep() on the same DB must
+        not both summarize the same originals. The atomic claim — UPDATE
+        WHERE consolidated_at IS NULL with rowcount check — gates this."""
+        beam_a = BeamMemory(session_id="s1", db_path=temp_db)
+        beam_b = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=3)
+
+        result_a = beam_a.sleep(dry_run=False)
+        result_b = beam_b.sleep(dry_run=False)
+
+        # Exactly one summary should exist; the second sleep should be
+        # a no_op (all rows claimed) or skip-already-consolidated.
+        conn = sqlite3.connect(str(temp_db))
+        ep_count = conn.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0]
+        conn.close()
+        assert ep_count == 1, (
+            f"concurrent sleeps produced {ep_count} summaries; the atomic "
+            f"claim failed. result_a={result_a}, result_b={result_b}"
+        )
+
+    def test_export_import_preserves_consolidated_at(self, temp_db):
+        """Backup round-trip must preserve consolidated_at so the
+        importing DB doesn't re-summarize already-slept rows on next
+        sleep."""
+        import tempfile as _tempfile
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=2)
+        beam.sleep(dry_run=False)
+
+        original_rows = _consolidated_rows(temp_db, "s1")
+        original_markers = {r[0]: r[1] for r in original_rows}
+
+        # Export then re-import into a fresh DB.
+        export = beam.export_to_dict()
+        with _tempfile.TemporaryDirectory() as td:
+            dest_path = Path(td) / "restored.db"
+            beam_dest = BeamMemory(session_id="s1", db_path=dest_path)
+            beam_dest.import_from_dict(export)
+
+            restored_rows = _consolidated_rows(dest_path, "s1")
+            assert len(restored_rows) == 2
+            for row_id, consolidated_at in restored_rows:
+                assert consolidated_at == original_markers[row_id], (
+                    f"export/import lost consolidated_at for {row_id}: "
+                    f"original={original_markers[row_id]}, "
+                    f"restored={consolidated_at}"
+                )
+
+            # And sleep on the restored DB must be a no-op.
+            result = beam_dest.sleep(dry_run=False)
+            assert result["status"] == "no_op"


### PR DESCRIPTION
## Summary

E3 from the BEAM-recovery experiment prerequisites (`.review_synthesis.md`). Rewrites `BeamMemory.sleep()` to be additive: source `working_memory` rows are NOT deleted after consolidation; they're marked with a new `consolidated_at` timestamp and remain queryable through recall. Unblocks experiment Arm B (ADD-only ingest).

Per maintainer decision (2026-05-10): **"Kill summarize-and-delete. Originals stay. Summaries become enrichment on top. Storage cost is fine — it's the lowest-cost tradeoff."** No feature flag — additive is the only mode going forward.

## What changed

**Schema**
- New `working_memory.consolidated_at TEXT` column (nullable), added idempotently in `init_beam()`.
- Partial index `idx_wm_unconsolidated ON working_memory(session_id, timestamp) WHERE consolidated_at IS NULL` so sleep's eligibility scan stays O(eligible).
- `wm_au` FTS trigger restricted to `AFTER UPDATE OF content` so sleep's marker writes don't churn the FTS index.

**Behavior**
- `sleep()` filters `consolidated_at IS NULL` and uses an **atomic claim** (UPDATE BEFORE summary INSERT, rowcount-checked). Concurrent sleeps from two processes can't double-summarize; crash-after-claim leaves an orphan marker, never a phantom summary.
- `_trim_working_memory` exempts rows where `consolidated_at IS NOT NULL` — the "originals stay" contract is honored beyond the TTL window. Active users pay the storage cost (maintainer's explicit decision).
- The dedup-update path in `remember()` clears `consolidated_at = NULL` when re-asserting an already-consolidated row, so refreshed occurrences become sleep-eligible again.
- `export_to_dict` / `import_from_dict` now carry `consolidated_at` so backup round-trips don't lose the marker. Pre-E3 1.0 exports default to NULL on import.

**Migration**
- Pre-E3 databases backfill `consolidated_at = NOW` on every existing row at upgrade time. Preserves pre-E3 semantics ("rows that would have been deleted are already done") so first post-upgrade sleep doesn't blast a huge batch over the pre-existing backlog.
- `except sqlite3.OperationalError` narrowed to "duplicate column" only — every other error surfaces instead of silently masking schema breaks.

## Review process

- Specialist subagents in parallel: testing, maintainability, security, data-migration.
- Claude adversarial subagent + Codex adversarial pass.
- Cross-model agreement on 7 issues elevated them above noise:
  - export/import drops `consolidated_at` (4 sources)
  - `_trim_working_memory` deletes consolidated rows at TTL (2 sources, design call)
  - non-atomic commit ordering (2 sources)
  - concurrent sleep race (3 sources)
  - migration error swallow (1 source, but high impact)
  - `wm_au` FTS churn (2 sources)
  - dedup re-remember doesn't clear marker (1 source)
- All 7 addressed in the second commit on this branch.

## Test plan

- [x] Unit: `tests/test_beam_e3_additive_sleep.py` — 14 tests covering the contract
  - originals survive sleep
  - marker is parseable ISO timestamp
  - second sleep is no_op (idempotency)
  - dry_run is side-effect-free (working_memory, episodic_memory, consolidation_log all untouched)
  - consolidated originals remain recallable
  - session scoping (cross-session marker isolation)
  - legacy DB migration adds column AND backfills existing rows
  - migration idempotency on a modern DB
  - trim exempts consolidated rows
  - dedup remember clears the marker
  - concurrent sleep produces exactly one summary
  - export/import preserves the marker round-trip
- [x] Regression: 3 existing tests in `tests/test_beam.py` updated to assert post-E3 contract instead of pre-E3 deletion
- [x] Full suite: 550 passed, 1 skipped, 0 failures

## Known limitations (deferred)

- DeltaSync streaming (`streaming.py:274`) doesn't propagate `consolidated_at` to peers since the marker write doesn't bump `rowid`/`timestamp`. Affects multi-replica deployments only.
- `episodic_memory.summary_of` (comma-separated source ids) can dangle if a consolidated row is `forget()`ed. Pre-existing pattern, no E3-introduced regression.

## Rollback

The `consolidated_at` column persists after downgrade. Pre-E3 code ignores it. If you upgrade, run sleep, then downgrade, pre-E3 sleep will DELETE rows the post-E3 code had marked as consolidated — leaving orphan `summary_of` references. Recommend backing up the DB before upgrading.

Closes E3 in the local memory-contract ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)