### PR TITLE
E4: remember_batch veracity threading + working-memory recall multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,31 @@ and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemos
 ### Changed
 
 **E4 — Veracity threading in `remember_batch` + working-memory recall multiplier**
-- `BeamMemory.remember_batch(items, *, veracity=None)` accepts a method-level `veracity` kwarg as the per-batch default, and each item dict may carry its own `veracity` key as a per-item override. Both are clamped at the trust boundary to the canonical allowlist (`stated`, `inferred`, `tool`, `imported`, `unknown`). Non-canonical labels (case variants, typos, LLM hallucinations) fall back to `unknown` with a WARNING log. Mirrors the C12.b clamp pattern at the `hermes_memory_provider` boundary.
-- `BeamMemory.recall()` applies the veracity multiplier to **working-memory** results too, not just episodic. Pre-E4 the multiplier only fired on episodic rows, so per-row veracity on working_memory rows (now populated by `remember_batch` with per-row labels) had no scoring effect. This unblocks experiment Arms A and C of the BEAM-recovery experiment: without per-row veracity differentiation, the recall scorer cannot rank confident facts above unconfident ones.
+- `BeamMemory.remember_batch(items, *, veracity=None, force_veracity=False)` — new kwargs. `veracity` is the per-batch default; `force_veracity` is a security knob that forces the method default and ignores per-item `item["veracity"]`. Default `force_veracity=False` preserves the legitimate mixed-trust batch use case (user messages = `stated`, tool observations = `tool`). Set `force_veracity=True` when ingesting untrusted content (LLM-generated, external imports) so items cannot self-elevate their own trust label. Both layers clamp at the trust boundary; non-canonical labels (case variants, typos, LLM hallucinations) fall back to `unknown` with a WARNING log.
+- `BeamMemory.remember()` now clamps `veracity` at entry (same allowlist, same helper). Mirrors `remember_batch` and the C12.b pattern at `hermes_memory_provider` — every public ingest path under BeamMemory is now trust-boundary-uniform.
+- `BeamMemory.recall()` applies the veracity multiplier to **working-memory** results too, not just episodic. Pre-E4 the multiplier only fired on episodic rows, so per-row veracity on working_memory rows had no scoring effect. This unblocks experiment Arms A and C of the BEAM-recovery experiment: without per-row veracity differentiation, the recall scorer cannot rank confident facts above unconfident ones.
 
 ### Added
 
 **E4 — Shared veracity-allowlist primitive**
 - New `mnemosyne.core.veracity_consolidation.VERACITY_ALLOWED` (frozenset of `VERACITY_WEIGHTS` keys) — single source of truth for the canonical labels.
-- New `mnemosyne.core.veracity_consolidation.clamp_veracity(raw, *, context)` helper — normalizes case/whitespace, matches against `VERACITY_ALLOWED`, falls back to `unknown` with a WARNING log when no match. Single primitive for every future trust boundary (importers, batch ingest, MCP tools).
+- New `mnemosyne.core.veracity_consolidation.clamp_veracity(raw, *, context)` helper — normalizes case/whitespace, matches against `VERACITY_ALLOWED`, falls back to `unknown` with a WARNING log (raw value truncated to 80 chars to bound log volume and prevent content leakage from upstream typos). Single primitive for every future trust boundary (importers, batch ingest, MCP tools).
+- `consolidated_at`-style export/import preservation: `working_memory.veracity` is now part of `export_to_dict` / `import_from_dict` so backups round-trip the per-row trust signal. Pre-E4 1.0 exports (no key in dict) default to NULL; the recall scorer's fallback handles NULL via the `unknown` weight, and new writes always carry a canonical label thanks to the clamp.
+
+### Fixed
+
+- `hermes_memory_provider._handle_remember` now uses the central `clamp_veracity` helper instead of an inline duplicate of the allowlist. Eliminates the triple-definition drift risk between the provider, the central frozenset, and the beam.py ImportError fallback.
+
+### Behavior change for legacy callers
+
+- **Score magnitudes shift for working_memory rows.** Pre-E4 working-memory hits got no veracity multiplier; post-E4 the default `unknown` label applies a 0.8x multiplier. If you have downstream tuning against specific score magnitudes (e.g., `MIN_SCORE_THRESHOLD` in the provider's prefetch path), you may want to re-tune. Ranking within the same veracity tier is unchanged. The fix is in service of the experiment goal — making veracity an actual rank signal rather than a global scale.
+- The `MNEMOSYNE_*_WEIGHT` env vars (`STATED_WEIGHT`, `INFERRED_WEIGHT`, etc.) now affect working-memory scoring too. Pre-E4 they only applied to episodic.
 
 ### Notes for callers
 
-- Existing `remember_batch(items)` calls without the new `veracity` kwarg keep their current behavior: rows default to `unknown` via the column DEFAULT, and the new working-memory veracity multiplier (0.8 for `unknown`) applies uniformly across the batch. No code changes required at call sites — but if you want batch-ingested content to score higher than the `unknown` floor, supply `veracity="stated"` (or per-item) at write time.
-- `hermes_memory_provider/__init__.py:504` still defines its own `_VERACITY_ALLOWED` inline. It now duplicates `VERACITY_ALLOWED` from `veracity_consolidation.py`; folding the two together is a clean follow-up for whichever PR next touches the provider's trust boundary.
+- Existing `remember_batch(items)` calls without the new kwargs keep their behavior: rows default to `unknown`. To enable per-row trust differentiation at write time, supply `veracity="stated"` (per-batch default) or per-item `{"veracity": ...}`.
+- For untrusted ingest paths (LLM output, external imports), use `force_veracity=True` to defend against per-item label escalation.
+- If `mnemosyne.core.veracity_consolidation` is unavailable for any reason (stripped install, broken import), `beam.py` falls back to an inline clamp that logs ONE warning at import time so the degraded mode is visible in startup logs.
 
 ## [2.5] — 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemosyne) (MAJOR.MINOR).
 
+## [Unreleased]
+
+### Changed
+
+**E4 — Veracity threading in `remember_batch` + working-memory recall multiplier**
+- `BeamMemory.remember_batch(items, *, veracity=None)` accepts a method-level `veracity` kwarg as the per-batch default, and each item dict may carry its own `veracity` key as a per-item override. Both are clamped at the trust boundary to the canonical allowlist (`stated`, `inferred`, `tool`, `imported`, `unknown`). Non-canonical labels (case variants, typos, LLM hallucinations) fall back to `unknown` with a WARNING log. Mirrors the C12.b clamp pattern at the `hermes_memory_provider` boundary.
+- `BeamMemory.recall()` applies the veracity multiplier to **working-memory** results too, not just episodic. Pre-E4 the multiplier only fired on episodic rows, so per-row veracity on working_memory rows (now populated by `remember_batch` with per-row labels) had no scoring effect. This unblocks experiment Arms A and C of the BEAM-recovery experiment: without per-row veracity differentiation, the recall scorer cannot rank confident facts above unconfident ones.
+
+### Added
+
+**E4 — Shared veracity-allowlist primitive**
+- New `mnemosyne.core.veracity_consolidation.VERACITY_ALLOWED` (frozenset of `VERACITY_WEIGHTS` keys) — single source of truth for the canonical labels.
+- New `mnemosyne.core.veracity_consolidation.clamp_veracity(raw, *, context)` helper — normalizes case/whitespace, matches against `VERACITY_ALLOWED`, falls back to `unknown` with a WARNING log when no match. Single primitive for every future trust boundary (importers, batch ingest, MCP tools).
+
+### Notes for callers
+
+- Existing `remember_batch(items)` calls without the new `veracity` kwarg keep their current behavior: rows default to `unknown` via the column DEFAULT, and the new working-memory veracity multiplier (0.8 for `unknown`) applies uniformly across the batch. No code changes required at call sites — but if you want batch-ingested content to score higher than the `unknown` floor, supply `veracity="stated"` (or per-item) at write time.
+- `hermes_memory_provider/__init__.py:504` still defines its own `_VERACITY_ALLOWED` inline. It now duplicates `VERACITY_ALLOWED` from `veracity_consolidation.py`; folding the two together is a clean follow-up for whichever PR next touches the provider's trust boundary.
+
 ## [2.5] — 2026-05-10
 
 ### Added

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -496,14 +496,13 @@ class MnemosyneMemoryProvider(MemoryProvider):
             logger.error("Mnemosyne tool %s failed: %s", tool_name, e)
             return json.dumps({"error": f"Mnemosyne tool '{tool_name}' failed: {e}"})
 
-    # Canonical veracity allowlist mirrors VERACITY_WEIGHTS in
-    # mnemosyne/core/veracity_consolidation.py. Anything outside this set
-    # bypasses the recall weighting AND pollutes the contamination filter
-    # (which compares `veracity != 'stated'`), so unknown labels persist as
-    # garbage in the row. Clamp at the trust boundary.
-    _VERACITY_ALLOWED = {"stated", "inferred", "tool", "imported", "unknown"}
-
     def _handle_remember(self, args: Dict[str, Any]) -> str:
+        # Import at call-site so the provider module loads even when
+        # the optional veracity_consolidation chain isn't on path
+        # (BeamMemory ships a fallback). At call-time the import is
+        # always satisfied because BeamMemory is already constructed.
+        from mnemosyne.core.veracity_consolidation import clamp_veracity
+
         content = args.get("content", "")
         importance = float(args.get("importance", 0.5))
         source = args.get("source", "user")
@@ -512,16 +511,11 @@ class MnemosyneMemoryProvider(MemoryProvider):
         extract_entities = bool(args.get("extract_entities", False))
         extract = bool(args.get("extract", False))
         metadata = args.get("metadata") or None
-        raw_veracity = args.get("veracity", "unknown") or "unknown"
-        veracity_norm = str(raw_veracity).strip().lower()
-        if veracity_norm in self._VERACITY_ALLOWED:
-            veracity = veracity_norm
-        else:
-            logger.warning(
-                "mnemosyne_remember received unknown veracity %r; clamping to 'unknown'",
-                raw_veracity,
-            )
-            veracity = "unknown"
+        # Trust-boundary clamp — see VERACITY_ALLOWED in
+        # mnemosyne/core/veracity_consolidation.py for the canonical set.
+        veracity = clamp_veracity(
+            args.get("veracity"), context="mnemosyne_remember"
+        )
         if not content:
             return json.dumps({"error": "content is required"})
         memory_id = self._beam.remember(

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -15,6 +15,7 @@ Hybrid ranking: 50% vector + 30% FTS rank + 20% importance.
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 import json
 import hashlib
@@ -23,6 +24,9 @@ import math
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional, Any, Set, Union
 from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
 
 # Typed memory classification (Phase 1 — zero overhead, pattern-based)
 try:
@@ -60,17 +64,33 @@ except ImportError:
     VeracityConsolidator = None
     VERACITY_WEIGHTS = {}
 
+    # Surface degraded mode at import time so operators see ONE signal
+    # in startup logs that the canonical helper isn't available. Without
+    # this, the fallback silently clamps every bad label with no audit
+    # trail across the run.
+    logger.warning(
+        "mnemosyne.core.veracity_consolidation unavailable; using fallback "
+        "clamp_veracity. Non-canonical veracity labels will be clamped "
+        "silently (no per-call WARNING). Operators should resolve the "
+        "import to restore full audit logging."
+    )
+
     def clamp_veracity(raw, *, context: str = "veracity") -> str:
         """Fallback when veracity_consolidation is unavailable.
-        Mirrors the canonical helper's API and clamps everything to
-        'unknown' silently — the column DEFAULT.
+        Mirrors the canonical helper's API and clamps non-canonical
+        labels to 'unknown'. Does NOT log per-call warnings — the
+        import-time warning above is the audit signal. Operators
+        should fix the import to restore full observability.
         """
-        if raw is None or not str(raw).strip():
+        if raw is None:
             return "unknown"
         norm = str(raw).strip().lower()
+        if not norm:
+            return "unknown"
         # Without the canonical allowlist available, fall back to the
-        # known-safe set inline. Keeps the runtime contract intact
-        # even in stripped-down installs.
+        # known-safe set inline. Drift between this literal and the
+        # canonical set is bounded by the fact that this branch
+        # only fires when the import is broken.
         if norm in {"stated", "inferred", "tool", "imported", "unknown"}:
             return norm
         return "unknown"
@@ -1088,8 +1108,18 @@ class BeamMemory:
             extract_entities: If True, extract and store entity mentions as triples
             extract: If True, extract structured facts from content using LLM
                 and store as triples. Default False.
-            veracity: Confidence level — 'stated', 'inferred', 'tool', 'imported', 'unknown'
+            veracity: Confidence level — 'stated', 'inferred', 'tool', 'imported', 'unknown'.
+                Non-canonical labels are clamped to 'unknown' with a WARNING
+                (mirrors the C12.b clamp at the hermes_memory_provider boundary).
         """
+        # Clamp veracity at the BeamMemory.remember entry too — the
+        # method is the lowest-level public ingest path under BeamMemory,
+        # so consistency with remember_batch and the provider
+        # boundary requires clamping here. Pre-E4 the column was raw;
+        # the new recall multiplier means non-canonical labels would
+        # silently fall through to UNKNOWN_WEIGHT at scoring time.
+        veracity = clamp_veracity(veracity, context="remember")
+
         # --- Typed memory classification (Phase 1 — zero overhead) ---
         memory_type = None
         if classify_memory is not None:
@@ -1168,27 +1198,49 @@ class BeamMemory:
         return memory_id
 
     def remember_batch(self, items: List[Dict],
-                       *, veracity: Optional[str] = None) -> List[str]:
+                       *,
+                       veracity: Optional[str] = None,
+                       force_veracity: bool = False) -> List[str]:
         """
         Batch insert into working_memory for high-throughput ingestion.
         Each item dict should have keys: content, source, importance,
         metadata (optional), veracity (optional).
 
-        veracity (method-level kwarg): default applied to items that
-            don't supply their own `veracity` key. None → 'unknown'.
-            Per-item `veracity` in the item dict overrides this default.
-            All values are clamped to the canonical allowlist
-            (VERACITY_ALLOWED in mnemosyne.core.veracity_consolidation)
-            via clamp_veracity — non-canonical labels emit a WARNING
-            and fall back to 'unknown'. Mirrors the C12.b clamp pattern
-            at the hermes_memory_provider trust boundary; remember_batch
-            is the high-throughput path used by importers, BEAM
-            benchmark adapter, and batch ingest CLIs where label
-            quality varies.
+        Legal veracity values: 'stated', 'inferred', 'tool', 'imported',
+        'unknown'. None / empty / whitespace silently → 'unknown'.
+        Non-canonical non-empty labels emit a WARNING and clamp to
+        'unknown'.
 
-            Pre-E4 the column defaulted to 'unknown' for every batch
-            row; recall's veracity multiplier collapsed to a constant
-            0.8 (global scale factor instead of rank signal).
+        veracity (method-level kwarg): default applied to items that
+            don't supply their own `veracity` key.
+
+        force_veracity (default False): security knob. When True, the
+            method-level `veracity` is applied to EVERY row uniformly
+            and per-item `item["veracity"]` is IGNORED (warning logged
+            per item if present so the operator sees the override).
+            Use this when the caller is the authority on trust —
+            e.g., an importer ingesting LLM-generated content that
+            shouldn't be able to self-elevate its label. Pre-E4 the
+            per-item override was harmless because veracity didn't
+            affect ranking; post-E4 it gates a real ranking signal
+            so callers consuming untrusted content need this knob.
+            When False (default), per-item `veracity` keys override
+            the method default — preserves the legitimate use case
+            of mixed-trust batches (e.g., user messages='stated',
+            tool observations='tool').
+
+        All values are clamped to the canonical allowlist via
+        `clamp_veracity` (mirrors C12.b at the hermes_memory_provider
+        trust boundary). remember_batch is the high-throughput path
+        used by importers, the BEAM benchmark adapter, and batch
+        ingest CLIs where label quality varies.
+
+        Pre-E4 the column defaulted to 'unknown' for every batch row;
+        recall's veracity multiplier collapsed to a constant 0.8
+        (global scale factor instead of rank signal). The recall
+        scorer at beam.py::recall now applies the multiplier to
+        working_memory hits too, so per-row veracity differentiates
+        scores at the experiment level.
         """
         cursor = self.conn.cursor()
         ids = []
@@ -1196,7 +1248,7 @@ class BeamMemory:
         # Clamp the method-level default once, not per row — operators
         # who pass a bad default should see one warning, not N.
         default_veracity = clamp_veracity(
-            veracity, context="remember_batch (default)"
+            veracity, context="remember_batch.default"
         )
         for item in items:
             memory_id = _generate_id(item["content"])
@@ -1209,12 +1261,24 @@ class BeamMemory:
                     item_type = result.memory_type.value
                 except Exception:
                     pass
-            # Per-item override clamped at the trust boundary. If the
-            # item omits `veracity`, fall through to the method-level
-            # default (already clamped above).
-            if "veracity" in item:
+            # Per-item override semantics gated by force_veracity. In
+            # strict mode (force_veracity=True) per-item keys are
+            # ignored — the caller is the trust authority. Otherwise
+            # per-item overrides the method-level default. Either way
+            # the final value passes through clamp_veracity at the
+            # trust boundary.
+            if force_veracity:
+                if "veracity" in item:
+                    logger.warning(
+                        "remember_batch.force_veracity=True; "
+                        "ignoring per-item veracity %r in favor of "
+                        "method-level default %r",
+                        item["veracity"], default_veracity,
+                    )
+                item_veracity = default_veracity
+            elif "veracity" in item:
                 item_veracity = clamp_veracity(
-                    item["veracity"], context="remember_batch (per-item)"
+                    item["veracity"], context="remember_batch.per_item"
                 )
             else:
                 item_veracity = default_veracity
@@ -3064,11 +3128,19 @@ class BeamMemory:
             }
         }
 
-        # Working memory (all sessions)
+        # Working memory (all sessions). veracity is now part of the
+        # row's recall-scoring identity (post-E4 — the multiplier
+        # applies to working_memory hits), so it must survive
+        # backup/restore. Without it, restored rows collapse to
+        # 'unknown' and lose their per-row trust signal.
+        # NOTE: the recall multiplier at beam.py::recall (the
+        # `if r.get("tier") == "working":` block) depends on this
+        # column being in the row dict; do not drop it from this
+        # SELECT without updating the multiplier path.
         cursor.execute("""
             SELECT id, content, source, timestamp, session_id, importance,
                    metadata_json, valid_until, superseded_by, scope,
-                   recall_count, last_recalled, created_at
+                   recall_count, last_recalled, created_at, veracity
             FROM working_memory
             ORDER BY session_id, timestamp
         """)
@@ -3151,17 +3223,24 @@ class BeamMemory:
                 stats["working_memory"]["overwritten"] += 1
             else:
                 stats["working_memory"]["inserted"] += 1
+            # veracity preserves the per-row trust signal across
+            # backup/restore. Pre-E4 1.0 exports (no key in dict) get
+            # NULL, which the recall multiplier handles via the
+            # 'unknown' fallback. The clamp at write time means new
+            # rows always carry a canonical label.
             cursor.execute("""
                 INSERT INTO working_memory
                 (id, content, source, timestamp, session_id, importance, metadata_json,
-                 valid_until, superseded_by, scope, recall_count, last_recalled, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 valid_until, superseded_by, scope, recall_count, last_recalled, created_at,
+                 veracity)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 mid, item.get("content"), item.get("source"), item.get("timestamp"),
                 item.get("session_id", "default"), item.get("importance", 0.5),
                 item.get("metadata_json", "{}"), item.get("valid_until"),
                 item.get("superseded_by"), item.get("scope", "session"),
-                item.get("recall_count", 0), item.get("last_recalled"), item.get("created_at")
+                item.get("recall_count", 0), item.get("last_recalled"), item.get("created_at"),
+                item.get("veracity"),
             ))
         self.conn.commit()
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -51,10 +51,29 @@ except ImportError:
     EpisodicGraph = None
     GraphEdge = None
 try:
-    from mnemosyne.core.veracity_consolidation import VeracityConsolidator, VERACITY_WEIGHTS
+    from mnemosyne.core.veracity_consolidation import (
+        VeracityConsolidator,
+        VERACITY_WEIGHTS,
+        clamp_veracity,
+    )
 except ImportError:
     VeracityConsolidator = None
     VERACITY_WEIGHTS = {}
+
+    def clamp_veracity(raw, *, context: str = "veracity") -> str:
+        """Fallback when veracity_consolidation is unavailable.
+        Mirrors the canonical helper's API and clamps everything to
+        'unknown' silently — the column DEFAULT.
+        """
+        if raw is None or not str(raw).strip():
+            return "unknown"
+        norm = str(raw).strip().lower()
+        # Without the canonical allowlist available, fall back to the
+        # known-safe set inline. Keeps the runtime contract intact
+        # even in stripped-down installs.
+        if norm in {"stated", "inferred", "tool", "imported", "unknown"}:
+            return norm
+        return "unknown"
 
 try:
     import numpy as np
@@ -1148,14 +1167,37 @@ class BeamMemory:
                          source=source, importance=importance, metadata=metadata)
         return memory_id
 
-    def remember_batch(self, items: List[Dict]) -> List[str]:
+    def remember_batch(self, items: List[Dict],
+                       *, veracity: Optional[str] = None) -> List[str]:
         """
         Batch insert into working_memory for high-throughput ingestion.
-        Each item dict should have keys: content, source, importance, metadata (optional).
+        Each item dict should have keys: content, source, importance,
+        metadata (optional), veracity (optional).
+
+        veracity (method-level kwarg): default applied to items that
+            don't supply their own `veracity` key. None → 'unknown'.
+            Per-item `veracity` in the item dict overrides this default.
+            All values are clamped to the canonical allowlist
+            (VERACITY_ALLOWED in mnemosyne.core.veracity_consolidation)
+            via clamp_veracity — non-canonical labels emit a WARNING
+            and fall back to 'unknown'. Mirrors the C12.b clamp pattern
+            at the hermes_memory_provider trust boundary; remember_batch
+            is the high-throughput path used by importers, BEAM
+            benchmark adapter, and batch ingest CLIs where label
+            quality varies.
+
+            Pre-E4 the column defaulted to 'unknown' for every batch
+            row; recall's veracity multiplier collapsed to a constant
+            0.8 (global scale factor instead of rank signal).
         """
         cursor = self.conn.cursor()
         ids = []
         timestamp = datetime.now().isoformat()
+        # Clamp the method-level default once, not per row — operators
+        # who pass a bad default should see one warning, not N.
+        default_veracity = clamp_veracity(
+            veracity, context="remember_batch (default)"
+        )
         for item in items:
             memory_id = _generate_id(item["content"])
             ids.append(memory_id)
@@ -1167,10 +1209,19 @@ class BeamMemory:
                     item_type = result.memory_type.value
                 except Exception:
                     pass
+            # Per-item override clamped at the trust boundary. If the
+            # item omits `veracity`, fall through to the method-level
+            # default (already clamped above).
+            if "veracity" in item:
+                item_veracity = clamp_veracity(
+                    item["veracity"], context="remember_batch (per-item)"
+                )
+            else:
+                item_veracity = default_veracity
             cursor.execute("""
                 INSERT INTO working_memory (id, content, source, timestamp, session_id, importance, metadata_json,
-                author_id, author_type, channel_id, memory_type)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                author_id, author_type, channel_id, memory_type, veracity)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 memory_id,
                 item["content"],
@@ -1182,7 +1233,8 @@ class BeamMemory:
                 item.get("author_id", self.author_id),
                 item.get("author_type", self.author_type),
                 item.get("channel_id", self.channel_id),
-                item_type
+                item_type,
+                item_veracity,
             ))
         self.conn.commit()
         
@@ -2222,6 +2274,18 @@ class BeamMemory:
                     r["veracity"] = ep_veracity
                     r["score"] *= weight_map.get(ep_tier, 1.0)
                     r["score"] *= veracity_map.get(ep_veracity, UNKNOWN_WEIGHT)
+
+        # [E4] Apply the veracity multiplier to working_memory results
+        # too. Pre-E4 the multiplier was episodic-only, so per-row
+        # veracity on working_memory rows (now populated by
+        # remember_batch with per-row labels) had no scoring effect —
+        # batch-ingested 'stated' content didn't rank above 'unknown'.
+        # The row dicts already carry "veracity" from the SELECT
+        # populated earlier in this function, so no second query needed.
+        for r in results:
+            if r.get("tier") == "working":
+                wm_veracity = r.get("veracity") or "unknown"
+                r["score"] *= veracity_map.get(wm_veracity, UNKNOWN_WEIGHT)
 
         results.sort(key=lambda x: x["score"], reverse=True)
         final_results = results[:top_k]

--- a/mnemosyne/core/veracity_consolidation.py
+++ b/mnemosyne/core/veracity_consolidation.py
@@ -53,17 +53,27 @@ VERACITY_WEIGHTS = {
 VERACITY_ALLOWED = frozenset(VERACITY_WEIGHTS.keys())
 
 
+# Cap on the raw value included in the WARNING log. Without this, an
+# importer pushing 100k items with embedded long strings as veracity
+# values can flood log aggregators (cost) AND leak user content into
+# operator logs (privacy). 80 chars is enough to debug typos / case
+# issues without being a privacy or storage hazard.
+_VERACITY_WARN_VALUE_CAP = 80
+
+
 def clamp_veracity(raw, *, context: str = "veracity") -> str:
     """Normalize and clamp a veracity label to the canonical allowlist.
 
     Behavior:
         - None / empty / whitespace → 'unknown' silently
         - Case-and-whitespace normalize then match against VERACITY_ALLOWED
-        - Anything else → 'unknown' with a WARNING log
+        - Anything else → 'unknown' with a WARNING log (raw value
+          truncated to %d chars to bound log volume)
 
     `context` appears in the warning so the operator can see where
-    the bad label came from (e.g. 'remember_batch', 'mnemosyne_remember').
-    """
+    the bad label came from (e.g. 'remember_batch.default',
+    'remember_batch.per_item', 'mnemosyne_remember').
+    """ % _VERACITY_WARN_VALUE_CAP
     if raw is None:
         return "unknown"
     norm = str(raw).strip().lower()
@@ -71,9 +81,17 @@ def clamp_veracity(raw, *, context: str = "veracity") -> str:
         return "unknown"
     if norm in VERACITY_ALLOWED:
         return norm
+    # Truncate the raw value for the log line. %r quoting prevents
+    # control-character injection into log aggregators; the cap
+    # prevents log-flood and content leakage from upstream typos.
+    raw_str = str(raw)
+    if len(raw_str) > _VERACITY_WARN_VALUE_CAP:
+        raw_for_log = raw_str[:_VERACITY_WARN_VALUE_CAP] + "...[truncated]"
+    else:
+        raw_for_log = raw_str
     logger.warning(
         "%s received unknown veracity %r; clamping to 'unknown'",
-        context, raw,
+        context, raw_for_log,
     )
     return "unknown"
 

--- a/mnemosyne/core/veracity_consolidation.py
+++ b/mnemosyne/core/veracity_consolidation.py
@@ -22,12 +22,16 @@ Conflict resolution:
 - Consolidation: periodic synthesis of high-confidence facts
 """
 
+import logging
 import sqlite3
 import json
 from datetime import datetime, timedelta
 from typing import Dict, List, Tuple, Optional
 from dataclasses import dataclass
 from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
 
 
 # Veracity weights
@@ -38,6 +42,40 @@ VERACITY_WEIGHTS = {
     "imported": 0.6,
     "unknown": 0.8,
 }
+
+# Canonical allowlist for trust-boundary clamping. Anything outside this
+# set bypasses the recall weighting (VERACITY_WEIGHTS.get(..., 0.8) falls
+# back to the 'unknown' weight) AND pollutes the contamination filter
+# downstream (which compares `veracity != 'stated'`). Callers at the
+# trust boundary (LLM output, importers, MCP tool args, batch ingest)
+# should clamp via clamp_veracity() so non-canonical labels don't
+# persist as garbage in the row.
+VERACITY_ALLOWED = frozenset(VERACITY_WEIGHTS.keys())
+
+
+def clamp_veracity(raw, *, context: str = "veracity") -> str:
+    """Normalize and clamp a veracity label to the canonical allowlist.
+
+    Behavior:
+        - None / empty / whitespace → 'unknown' silently
+        - Case-and-whitespace normalize then match against VERACITY_ALLOWED
+        - Anything else → 'unknown' with a WARNING log
+
+    `context` appears in the warning so the operator can see where
+    the bad label came from (e.g. 'remember_batch', 'mnemosyne_remember').
+    """
+    if raw is None:
+        return "unknown"
+    norm = str(raw).strip().lower()
+    if not norm:
+        return "unknown"
+    if norm in VERACITY_ALLOWED:
+        return norm
+    logger.warning(
+        "%s received unknown veracity %r; clamping to 'unknown'",
+        context, raw,
+    )
+    return "unknown"
 
 
 @dataclass

--- a/tests/test_beam_e4_remember_batch_veracity.py
+++ b/tests/test_beam_e4_remember_batch_veracity.py
@@ -1,0 +1,238 @@
+"""Regression tests for E4 — remember_batch veracity threading.
+
+Pre-E4: BeamMemory.remember_batch() didn't accept a veracity param. The
+INSERT omitted the column, so every batch-ingested row defaulted to
+'unknown'. The recall scorer's veracity multiplier (VERACITY_WEIGHTS in
+veracity_consolidation.py) then collapsed to a constant 0.8 across the
+entire batch corpus — globally scale-factored rather than rank-signal.
+
+Post-E4:
+  - remember_batch accepts a method-level `veracity` kwarg as the
+    per-batch default
+  - each item dict may carry its own `veracity` key to override
+  - non-canonical labels are clamped to 'unknown' with a warning,
+    matching the C12.b trust-boundary pattern in hermes_memory_provider
+  - the column value is what recall reads, so scoring varies measurably
+    between 'stated' and 'unknown' rows in the same DB
+
+This blocks experiment Arms A and C of the BEAM-recovery experiment —
+without per-row veracity, the recall scorer cannot differentiate
+confident from unconfident facts.
+"""
+
+import logging
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+from mnemosyne.core.veracity_consolidation import (
+    VERACITY_ALLOWED,
+    VERACITY_WEIGHTS,
+    clamp_veracity,
+)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+def _veracity_for(db_path, memory_id):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT veracity FROM working_memory WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+class TestClampVeracity:
+    """The clamp helper is the trust-boundary primitive. Test it
+    directly so future call sites can use it confidently."""
+
+    def test_clamp_accepts_canonical_values(self):
+        for label in VERACITY_ALLOWED:
+            assert clamp_veracity(label) == label
+
+    def test_clamp_normalizes_case_and_whitespace(self):
+        assert clamp_veracity("STATED") == "stated"
+        assert clamp_veracity("  Inferred ") == "inferred"
+        assert clamp_veracity("Tool\n") == "tool"
+
+    def test_clamp_unknown_label_returns_unknown(self):
+        assert clamp_veracity("random_garbage") == "unknown"
+        assert clamp_veracity("certain") == "unknown"  # not in the set
+        assert clamp_veracity("state") == "unknown"    # truncated typo
+
+    def test_clamp_none_returns_unknown(self):
+        assert clamp_veracity(None) == "unknown"
+
+    def test_clamp_empty_string_returns_unknown(self):
+        assert clamp_veracity("") == "unknown"
+        assert clamp_veracity("   ") == "unknown"
+
+    def test_clamp_warns_on_unknown_label(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            clamp_veracity("random_garbage")
+        assert any(
+            "veracity" in record.message.lower()
+            and "random_garbage" in record.message
+            for record in caplog.records
+        ), f"no warning logged for unknown label: {caplog.records}"
+
+    def test_clamp_does_not_warn_on_canonical_label(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            for label in VERACITY_ALLOWED:
+                clamp_veracity(label)
+        assert not caplog.records, (
+            f"clamp warned on canonical labels: {caplog.records}"
+        )
+
+    def test_veracity_allowed_matches_weights(self):
+        """The allowlist and the weights table must stay in sync —
+        a label without a weight collapses scoring to the .get default."""
+        assert VERACITY_ALLOWED == set(VERACITY_WEIGHTS.keys())
+
+
+class TestRememberBatchVeracity:
+
+    def test_remember_batch_default_unknown(self, temp_db):
+        """No veracity supplied anywhere → row's column is 'unknown'."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ids = beam.remember_batch([
+            {"content": "no-veracity item", "source": "test"},
+        ])
+        assert _veracity_for(temp_db, ids[0]) == "unknown"
+
+    def test_remember_batch_method_default(self, temp_db):
+        """Method-level veracity kwarg applies to every item that
+        doesn't supply its own."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ids = beam.remember_batch(
+            [
+                {"content": "item a", "source": "test"},
+                {"content": "item b", "source": "test"},
+            ],
+            veracity="stated",
+        )
+        for mid in ids:
+            assert _veracity_for(temp_db, mid) == "stated"
+
+    def test_remember_batch_per_item_override(self, temp_db):
+        """Per-item veracity overrides the method-level default."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ids = beam.remember_batch(
+            [
+                {"content": "user said it", "source": "user", "veracity": "stated"},
+                {"content": "llm inferred it", "source": "llm", "veracity": "inferred"},
+                {"content": "tool reported it", "source": "tool", "veracity": "tool"},
+                {"content": "no override here", "source": "test"},
+            ],
+            veracity="imported",  # method-level default for the no-override item
+        )
+        assert _veracity_for(temp_db, ids[0]) == "stated"
+        assert _veracity_for(temp_db, ids[1]) == "inferred"
+        assert _veracity_for(temp_db, ids[2]) == "tool"
+        assert _veracity_for(temp_db, ids[3]) == "imported"
+
+    def test_remember_batch_clamps_unknown_labels(self, temp_db, caplog):
+        """Non-canonical labels get clamped to 'unknown' with a warning,
+        mirroring C12.b at the provider trust boundary."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        with caplog.at_level(logging.WARNING):
+            ids = beam.remember_batch([
+                {"content": "STATED caps", "source": "test", "veracity": "STATED"},
+                {"content": "junk label", "source": "test", "veracity": "random_garbage"},
+                {"content": "typo", "source": "test", "veracity": "state"},
+            ])
+
+        # STATED normalizes to 'stated' (case-insensitive match).
+        assert _veracity_for(temp_db, ids[0]) == "stated"
+        # The other two clamp to 'unknown' and emit a warning.
+        assert _veracity_for(temp_db, ids[1]) == "unknown"
+        assert _veracity_for(temp_db, ids[2]) == "unknown"
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        # Two clamped labels → at least two warnings; one per non-canonical.
+        clamp_warns = [
+            w for w in warnings
+            if "veracity" in w.message.lower()
+            and ("random_garbage" in w.message or "state" in w.message.lower())
+        ]
+        assert len(clamp_warns) >= 2, (
+            f"expected ≥2 clamp warnings, got {len(clamp_warns)}: {warnings}"
+        )
+
+    def test_remember_batch_clamps_method_default_too(self, temp_db, caplog):
+        """The method-level veracity kwarg is also clamped — protects
+        callers that pass an unvalidated string from the LLM layer."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        with caplog.at_level(logging.WARNING):
+            ids = beam.remember_batch(
+                [{"content": "uses bad default", "source": "test"}],
+                veracity="totally_invalid_label",
+            )
+        assert _veracity_for(temp_db, ids[0]) == "unknown"
+        assert any(
+            "veracity" in r.message.lower() and "totally_invalid_label" in r.message
+            for r in caplog.records
+        )
+
+    def test_remember_batch_recall_scoring_varies(self, temp_db):
+        """[E4 experiment unblock] After per-row veracity is populated,
+        recall scoring varies measurably between 'stated' and 'unknown'
+        rows on the same content match. Pre-E4 this multiplier collapsed
+        to a constant 0.8 because every batch row defaulted to 'unknown'.
+
+        Uses two batches with shared rare token so FTS surfaces both
+        rows; veracity is the only difference, so any score delta is
+        attributable to the multiplier."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        rare_token = "quetzzzlcoatl"  # unlikely to collide with FTS noise
+        beam.remember_batch(
+            [{"content": f"{rare_token} stated-content", "source": "test"}],
+            veracity="stated",
+        )
+        beam.remember_batch(
+            [{"content": f"{rare_token} unknown-content", "source": "test"}],
+            veracity="unknown",
+        )
+
+        results = beam.recall(rare_token, top_k=10)
+        by_veracity = {r.get("veracity"): r.get("score", 0.0) for r in results}
+        # Both rows should surface.
+        assert "stated" in by_veracity, f"stated row not in results: {results}"
+        assert "unknown" in by_veracity, f"unknown row not in results: {results}"
+        # And the stated row should score strictly higher — stated=1.0
+        # vs unknown=0.8 in VERACITY_WEIGHTS. Any equality means the
+        # multiplier was bypassed (the pre-E4 bug shape).
+        assert by_veracity["stated"] > by_veracity["unknown"], (
+            f"veracity multiplier did not differentiate scores: "
+            f"stated={by_veracity['stated']:.4f}, unknown={by_veracity['unknown']:.4f}. "
+            f"Pre-E4 the column collapsed to 'unknown' for both rows."
+        )
+
+    def test_remember_batch_empty_list_no_op(self, temp_db):
+        """Empty items list shouldn't crash or warn."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ids = beam.remember_batch([])
+        assert ids == []
+
+    def test_remember_batch_signature_back_compat(self, temp_db):
+        """Calling without the new veracity kwarg must still work —
+        existing callers (BEAM benchmark adapter, importers) shouldn't
+        need to update their call sites just because E4 added a kwarg."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ids = beam.remember_batch([
+            {"content": "legacy call shape", "source": "test"},
+        ])
+        assert len(ids) == 1
+        # Default behavior: unknown, no warning.
+        assert _veracity_for(temp_db, ids[0]) == "unknown"

--- a/tests/test_beam_e4_remember_batch_veracity.py
+++ b/tests/test_beam_e4_remember_batch_veracity.py
@@ -236,3 +236,216 @@ class TestRememberBatchVeracity:
         assert len(ids) == 1
         # Default behavior: unknown, no warning.
         assert _veracity_for(temp_db, ids[0]) == "unknown"
+
+    def test_remember_batch_force_veracity_ignores_per_item(self, temp_db, caplog):
+        """[Codex adversarial] force_veracity=True locks the method
+        default and IGNORES per-item veracity. Defends against the
+        retrieval-poisoning path where an importer calls
+        remember_batch(items, veracity='imported') but an item self-
+        elevates with veracity='stated'."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        with caplog.at_level(logging.WARNING):
+            ids = beam.remember_batch(
+                [
+                    {"content": "trusted content", "source": "test"},
+                    {"content": "tries to elevate", "source": "test", "veracity": "stated"},
+                    {"content": "tries to lie low", "source": "test", "veracity": "unknown"},
+                ],
+                veracity="imported",
+                force_veracity=True,
+            )
+        # All three rows must carry the method-level 'imported' label,
+        # NOT the per-item override.
+        for mid in ids:
+            assert _veracity_for(temp_db, mid) == "imported", (
+                f"force_veracity=True did not enforce method default; "
+                f"row {mid} got {_veracity_for(temp_db, mid)!r}"
+            )
+        # Each ignored per-item override should produce a WARNING so
+        # the operator can audit attempts.
+        ignored_warns = [
+            r for r in caplog.records
+            if "force_veracity" in r.message and "ignoring per-item" in r.message
+        ]
+        assert len(ignored_warns) == 2, (
+            f"expected 2 ignored-override warnings (for stated + unknown), "
+            f"got {len(ignored_warns)}: {[w.message for w in ignored_warns]}"
+        )
+
+    def test_remember_batch_force_veracity_default_false(self, temp_db):
+        """Sanity: force_veracity defaults to False, preserving per-item
+        override behavior. No silent flip in defaults."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ids = beam.remember_batch(
+            [
+                {"content": "uses method default", "source": "test"},
+                {"content": "overrides", "source": "test", "veracity": "stated"},
+            ],
+            veracity="imported",
+        )
+        assert _veracity_for(temp_db, ids[0]) == "imported"
+        assert _veracity_for(temp_db, ids[1]) == "stated"
+
+    def test_recall_full_veracity_ordering(self, temp_db):
+        """[testing specialist] Pin the full canonical multiplier order.
+        Pre-E4 only the stated > unknown pair was implicitly tested;
+        a regression that swapped weights between inferred / tool /
+        imported would slip through. E4 is the rank-signal unlocker
+        for the experiment, so the full ordering deserves a guard."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        rare_token = "veraxxxordtest"
+        # One row per canonical label, distinct content but same rare token.
+        for label in ("stated", "inferred", "imported", "unknown", "tool"):
+            beam.remember_batch(
+                [{"content": f"{rare_token} {label}-tagged content", "source": "t"}],
+                veracity=label,
+            )
+
+        results = beam.recall(rare_token, top_k=20)
+        by_label = {r.get("veracity"): r.get("score", 0.0) for r in results}
+        # All five canonical labels should appear.
+        missing = {"stated", "inferred", "imported", "unknown", "tool"} - set(by_label.keys())
+        assert not missing, f"recall missed labels: {missing}; got {by_label}"
+
+        # Expected descending order per VERACITY_WEIGHTS:
+        # stated=1.0 > unknown=0.8 > inferred=0.7 > imported=0.6 > tool=0.5
+        ordered = sorted(by_label.items(), key=lambda kv: -kv[1])
+        descending_labels = [label for label, _ in ordered]
+        expected = ["stated", "unknown", "inferred", "imported", "tool"]
+        assert descending_labels == expected, (
+            f"veracity multiplier order regression: got {descending_labels} "
+            f"expected {expected}. Raw scores: {by_label}"
+        )
+
+    def test_recall_handles_null_veracity_in_legacy_row(self, temp_db):
+        """[testing specialist] Legacy rows (pre-veracity-column or
+        hand-edited) may have NULL veracity. The recall multiplier's
+        veracity_map.get(..., UNKNOWN_WEIGHT) fallback must handle it
+        without crashing, applying the UNKNOWN_WEIGHT multiplier."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Insert a row directly via cursor with NULL veracity.
+        conn = sqlite3.connect(str(temp_db))
+        from datetime import datetime
+        conn.execute(
+            "INSERT INTO working_memory "
+            "(id, content, source, timestamp, session_id, importance, veracity) "
+            "VALUES (?, ?, ?, ?, ?, ?, NULL)",
+            ("null-ver-1", "legacy null-veracity nullycontent", "test",
+             datetime.now().isoformat(), "s1", 0.5),
+        )
+        conn.commit()
+        conn.close()
+
+        results = beam.recall("nullycontent", top_k=10)
+        assert results, "row with NULL veracity not surfaced"
+        # The defensive fallback should treat NULL as 'unknown' and
+        # apply UNKNOWN_WEIGHT — score must be finite and > 0.
+        for r in results:
+            assert r.get("score", 0.0) > 0, (
+                f"NULL-veracity row scored 0/non-finite: {r}"
+            )
+
+    def test_recall_handles_junk_veracity_in_row(self, temp_db):
+        """[testing specialist] Defense-in-depth at recall: even if a
+        non-canonical label landed in the DB via a non-clamping path
+        (raw INSERT, schema migration, hand-edit), the recall scorer
+        must fall back to UNKNOWN_WEIGHT and not crash."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        conn = sqlite3.connect(str(temp_db))
+        from datetime import datetime
+        conn.execute(
+            "INSERT INTO working_memory "
+            "(id, content, source, timestamp, session_id, importance, veracity) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("junk-ver-1", "junkverlabel contains rare token zzzqqqx", "test",
+             datetime.now().isoformat(), "s1", 0.5, "totally_made_up_label"),
+        )
+        conn.commit()
+        conn.close()
+
+        results = beam.recall("zzzqqqx", top_k=10)
+        assert results, "row with junk veracity not surfaced"
+        for r in results:
+            if r.get("id") == "junk-ver-1":
+                # Junk veracity should fall through to UNKNOWN_WEIGHT;
+                # score must be positive and finite.
+                assert r.get("score", 0.0) > 0
+                break
+        else:
+            pytest.fail(f"junk-ver-1 not in results: {results}")
+
+    def test_export_import_preserves_veracity(self, temp_db):
+        """[Codex adversarial] Backup round-trip must preserve
+        per-row veracity. Pre-E4 fix, export omitted the column —
+        restored rows collapsed to 'unknown' and lost their rank
+        signal. Same shape as the E3 consolidated_at gap."""
+        import tempfile as _tempfile
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ids = beam.remember_batch(
+            [
+                {"content": "stated content", "source": "t"},
+                {"content": "tool observation", "source": "t"},
+            ],
+            veracity="stated",
+        )
+        # Differentiate the second row.
+        beam.conn.execute(
+            "UPDATE working_memory SET veracity = 'tool' WHERE id = ?",
+            (ids[1],),
+        )
+        beam.conn.commit()
+
+        # Read originals.
+        original = {mid: _veracity_for(temp_db, mid) for mid in ids}
+
+        # Export → fresh DB → import.
+        export = beam.export_to_dict()
+        with _tempfile.TemporaryDirectory() as td:
+            dest_path = Path(td) / "restored.db"
+            beam_dest = BeamMemory(session_id="s1", db_path=dest_path)
+            beam_dest.import_from_dict(export)
+
+            for mid in ids:
+                restored = _veracity_for(dest_path, mid)
+                assert restored == original[mid], (
+                    f"export/import lost veracity for {mid}: "
+                    f"original={original[mid]!r}, restored={restored!r}"
+                )
+
+    def test_remember_method_also_clamps(self, temp_db, caplog):
+        """[security specialist + Codex] BeamMemory.remember() now
+        clamps veracity too — consistency with remember_batch and
+        the C12.b pattern at the provider boundary."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        with caplog.at_level(logging.WARNING):
+            beam.remember("content one", source="t", veracity="STATED")
+            beam.remember("content two", source="t", veracity="random_garbage")
+
+        # Case-folded canonical landed.
+        rows = sqlite3.connect(str(temp_db)).execute(
+            "SELECT content, veracity FROM working_memory ORDER BY content"
+        ).fetchall()
+        by_content = {c: v for c, v in rows}
+        assert by_content["content one"] == "stated"
+        # Non-canonical clamped.
+        assert by_content["content two"] == "unknown"
+        # Warning fired for the clamp.
+        assert any(
+            "random_garbage" in r.message for r in caplog.records
+        ), f"no clamp warning for remember(): {caplog.records}"
+
+    def test_clamp_truncates_long_raw_value_in_log(self, caplog):
+        """[Codex / Claude adv] Bad veracity strings can be arbitrarily
+        long (e.g. an LLM dumping the full prompt into the slot). The
+        WARNING log must truncate to avoid log flood / content leak."""
+        long_garbage = "x" * 500
+        with caplog.at_level(logging.WARNING):
+            result = clamp_veracity(long_garbage, context="test")
+        assert result == "unknown"
+        warn = next((r for r in caplog.records if r.levelname == "WARNING"), None)
+        assert warn is not None
+        # 80-char cap + truncation marker should appear, but full
+        # 500-char value must NOT.
+        assert long_garbage not in warn.message
+        assert "[truncated]" in warn.message


### PR DESCRIPTION
## Summary

E4 from the BEAM-recovery experiment prerequisites. Two coupled changes:

1. **`BeamMemory.remember_batch(items, *, veracity=None, force_veracity=False)`** — new kwargs for per-batch default + trust-authority enforcement. Per-item `item[\"veracity\"]` is clamped to the canonical allowlist via the new `clamp_veracity()` helper at the trust boundary. `force_veracity=True` defends against item-level label escalation when ingesting untrusted content.
2. **Recall scorer extension** — `BeamMemory.recall()` now applies the veracity multiplier to working-memory results too, not just episodic. Per-row veracity becomes an actual rank signal instead of a global scale.

Unblocks experiment Arms A and C: without per-row veracity differentiation, the recall scorer cannot rank confident facts above unconfident ones.

## What changed

**New shared primitive in `mnemosyne/core/veracity_consolidation.py`:**
- `VERACITY_ALLOWED` frozenset derived from `VERACITY_WEIGHTS.keys()`
- `clamp_veracity(raw, *, context)` helper — normalize, validate, warn-and-clamp on miss. Single source of truth for every future trust boundary. Logs truncated to 80 chars to bound log volume + prevent content leakage.

**`BeamMemory` updates:**
- `remember_batch(items, *, veracity=None, force_veracity=False)` — method-level default + per-item override (gated by `force_veracity`)
- `remember()` also clamps at entry for consistency
- `recall()` applies the multiplier to working-memory results
- `export_to_dict` / `import_from_dict` carry the `veracity` column so backups round-trip the per-row trust signal

**Provider fold:**
- `hermes_memory_provider._handle_remember` now imports and uses `clamp_veracity` directly. The inline `_VERACITY_ALLOWED` constant is removed — one source of truth, no drift risk.

## Review process

Specialist subagents in parallel (testing, maintainability, security) + Claude adversarial + Codex adversarial. Codex structured review came back clean on the original diff; the adversarial passes found:
- **HIGH** — per-item veracity escalation path (Codex). Fixed via `force_veracity` knob.
- **HIGH** — `remember()` not clamped (Codex + security specialist). Fixed via central clamp.
- **MEDIUM** — export/import drops veracity (Codex). Same shape as the E3 `consolidated_at` gap. Fixed.
- **MEDIUM** — provider `_VERACITY_ALLOWED` duplicate (maintainability + security). Folded.
- **MEDIUM** — log-flood / content-leak risk from long raw values (Codex + Claude adv). Truncated.

All addressed in commit 2 on the branch.

## Behavior change for legacy callers

**Score magnitudes shift for working_memory rows.** Pre-E4 working-memory hits got no veracity multiplier; post-E4 the default `unknown` label applies a 0.8x multiplier. If you tune `MIN_SCORE_THRESHOLD` or similar against absolute score values, you may want to re-tune. **Ranking within the same veracity tier is unchanged.** The shift is in service of the experiment goal — making veracity an actual rank signal rather than a global scale.

## Test plan

- [x] 24 tests in `tests/test_beam_e4_remember_batch_veracity.py`:
  - `TestClampVeracity` (8 tests) pinning the helper contract — canonical accepted, case-insensitive, junk clamped, None/empty silently `unknown`, warns on non-canonical, no warn on canonical, allowlist↔weights consistency
  - `TestRememberBatchVeracity` (16 tests) covering default/method-level/per-item layers, clamp at both layers, empty-list no-op, signature back-compat, `force_veracity` ignores per-item (security), full veracity ordering (stated > unknown > inferred > imported > tool), NULL veracity in legacy rows, junk veracity in DB, export/import roundtrip, `remember()` consistency clamp, log truncation
- [x] Full suite: 560 passed, 1 skipped, 0 failures (+24 new tests).

## Deferred (filed as known)

- `_generate_id` microsecond-level collisions in `remember_batch` — pre-existing, not E4-introduced
- `MNEMOSYNE_*_WEIGHT` env vars vs central `VERACITY_WEIGHTS` duplication — pre-existing, out of scope
- Per-call clamp warning rate-limit — operational concern, no good in-PR fix

Closes E4 in the local memory-contract ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)