### PR TITLE
E5: wire PolyphonicRecallEngine under MNEMOSYNE_POLYPHONIC_RECALL flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,18 @@ and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemos
 ### Notes for callers
 
 - Defaults are unchanged. If you don't set `MNEMOSYNE_POLYPHONIC_RECALL=1`, you get the same recall behavior as before.
-- The engine's RRF combined_score replaces the linear scorer's weighted score in the result `score` field. Score MAGNITUDES will differ between the two paths (RRF produces small positive floats from `1/(60+rank)` summed across voices; the linear scorer produces values in [0, ~1]). Rankings are the comparable signal, not absolute scores.
-- The engine doesn't currently apply the post-E4 veracity multiplier or the tier degradation multiplier. Those are linear-scorer-only modulators. Flag=ON callers wanting that scoring composition should request it as a follow-up (E5.a).
-- Fact-voice synthetic memory ids (`cf_subject_predicate_object`) are dropped from the final list — they don't correspond to actual rows. The fact voice's score signal still flows through RRF onto real memory_ids surfaced by other voices.
+- The engine's RRF combined_score replaces the linear scorer's weighted score in the result `score` field. Score MAGNITUDES will differ between the two paths (RRF produces small positive floats from `1/(60+rank)` summed across voices; the linear scorer produces values in [0, ~1]). Rankings are the comparable signal, not absolute scores. Downstream context-formatting code that uses absolute-score buckets (e.g., `>0.3` / `>0.7` thresholds in `format_context`) may need re-tuning for the engine path.
+- **Veracity and tier multipliers DO apply on the engine path** (added in the review-pass fixes). Post-RRF the `combined_score` is multiplied by the row's `VERACITY_WEIGHTS` factor and (for episodic rows) the tier degradation factor — same composition as the linear path post-E4. Initial implementation skipped this; `/review` caught it as a regression in arm signal quality.
+- **Filter enforcement matches the linear path** (review fix). Session scope, `valid_until`, `superseded_by`, and caller-supplied `from_date` / `to_date` / `source` / `topic` / `author_id` / `author_type` / `channel_id` / `veracity` / `memory_type` filters all apply post-RRF, before returning. Initial implementation bypassed these (data-isolation regression, Codex P1).
+- **`recall_count` and `last_recalled` are updated on the engine path** (review fix). Decay scheduling, importance reinforcement, and usage telemetry signals continue to work under flag=ON.
+- **The engine is lazily cached on the BeamMemory instance.** Subsystem constructors (BinaryVectorStore / EpisodicGraph / VeracityConsolidator) fire once per BeamMemory lifecycle, not per recall call. Avoids the schema-ensure + commit storm the initial implementation produced.
+- Fact-voice synthetic memory ids (`cf_subject_predicate_object`) are skipped from the final list — the engine returns the fact key, not the producing memory_id, so we can't map them back to source rows. The fact voice's score signal still flows through RRF onto real memory_ids surfaced by other voices. Mapping `cf_*` back to source memory_ids requires the engine to track sources alongside facts — filed as a follow-up.
+
+### Known limitations (E5.a follow-ups)
+
+- **Vector voice queries the wrong table.** `BinaryVectorStore.search()` reads from a standalone `binary_vectors` table. Production binary vectors live in `episodic_memory.binary_vector` (column, added by NAI-4 commit `49f2d2a`). Under flag=ON the vector voice silently returns empty — the engine effectively runs 3 voices, not 4. To fix: either route `BinaryVectorStore.search` to the episodic column, or backfill the standalone table at consolidation time. Discovered by Codex adversarial + Claude adversarial on PR #76.
+- **Fact-voice evidence mapping.** Fact-voice ids are synthetic; mapping them back to producing memory rows requires the `ConsolidatedFact.sources` list to be threaded through the engine. Currently those scores fuse via RRF onto real memory_ids only when other voices also surface them.
+- **Long-query DOS bound.** `_fact_voice` iterates over every word in the query, issuing one `get_consolidated_facts` call per word. Adversarial 10K-char queries can amplify DOS. Cap recommended (e.g., `words[:50]`).
 
 ## [2.5] — 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemosyne) (MAJOR.MINOR).
 
+## [Unreleased]
+
+### Added
+
+**E5 — PolyphonicRecallEngine wired under feature flag**
+- `MNEMOSYNE_POLYPHONIC_RECALL=1` activates the engine inside `BeamMemory.recall()`. Default (unset or `0`): existing linear scorer runs unchanged. Production behavior preserved.
+- When the flag is ON, recall runs 4 voices in parallel via `PolyphonicRecallEngine`:
+  - **vector** — binary-vector similarity through `BinaryVectorStore`
+  - **graph** — entity-driven traversal through `EpisodicGraph`
+  - **fact** — consolidated-fact matching through `VeracityConsolidator`
+  - **temporal** — recency decay (only fires when the query carries a temporal keyword)
+  - Voices are fused via Reciprocal Rank Fusion (RRF, k=60), diversity-reranked, and assembled within a context budget.
+- Each result dict gains a `voice_scores` field carrying per-voice provenance — operators can see WHICH voices contributed to a given ranking.
+- The inline `graph_bonus` / `fact_bonus` terms in the linear scorer (added by commit `9f96ded`) are bypassed when the engine path runs; the engine handles those signals natively via RRF rather than as additive bonuses.
+- Flag is read per `recall()` call, not at `__init__` time — operators can toggle the engine without rebuilding `BeamMemory` (critical for in-process A/B experiments).
+
+### Changed
+
+**E5 — Engine reuses BeamMemory's shared connection**
+- `PolyphonicRecallEngine.__init__(db_path, conn=None)` now accepts an optional shared SQLite connection. When `conn` is passed, the engine and its subsystems (`BinaryVectorStore`, `EpisodicGraph`, `VeracityConsolidator`, `_temporal_voice`) reuse it instead of spawning new connections per recall call. Pre-E5 every recall call would open 4+ new connections — wasteful and inconsistent with the post-`9f96ded` pattern for the subsystems.
+- Standalone usage (no shared conn) still works — `_temporal_voice` opens a short-lived connection when `self.conn is None`.
+
+### Notes for callers
+
+- Defaults are unchanged. If you don't set `MNEMOSYNE_POLYPHONIC_RECALL=1`, you get the same recall behavior as before.
+- The engine's RRF combined_score replaces the linear scorer's weighted score in the result `score` field. Score MAGNITUDES will differ between the two paths (RRF produces small positive floats from `1/(60+rank)` summed across voices; the linear scorer produces values in [0, ~1]). Rankings are the comparable signal, not absolute scores.
+- The engine doesn't currently apply the post-E4 veracity multiplier or the tier degradation multiplier. Those are linear-scorer-only modulators. Flag=ON callers wanting that scoring composition should request it as a follow-up (E5.a).
+- Fact-voice synthetic memory ids (`cf_subject_predicate_object`) are dropped from the final list — they don't correspond to actual rows. The fact voice's score signal still flows through RRF onto real memory_ids surfaced by other voices.
+
 ## [2.5] — 2026-05-10
 
 ### Added

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -15,11 +15,14 @@ Hybrid ranking: 50% vector + 30% FTS rank + 20% importance.
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 import json
 import hashlib
 import threading
 import math
+
+logger = logging.getLogger(__name__)
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional, Any, Set, Union
 from pathlib import Path
@@ -1525,9 +1528,19 @@ class BeamMemory:
         """
         # E5 feature flag — read per call so operators can toggle
         # without rebuilding BeamMemory (critical for A/B experiments
-        # in the same process).
+        # in the same process). All recall filter kwargs flow through
+        # so the engine path enforces the same isolation/validity
+        # contract as the linear path. /review found that omitting
+        # them under flag=ON was a data-isolation regression (P1).
         if os.environ.get("MNEMOSYNE_POLYPHONIC_RECALL", "0") == "1":
-            return self._recall_polyphonic(query, top_k)
+            return self._recall_polyphonic(
+                query, top_k,
+                from_date=from_date, to_date=to_date,
+                source=source, topic=topic,
+                author_id=author_id, author_type=author_type,
+                channel_id=channel_id,
+                veracity=veracity, memory_type=memory_type,
+            )
 
         results = []
         query_lower = query.lower()
@@ -2358,30 +2371,44 @@ class BeamMemory:
         lines.append(f"\n_({total} memories retrieved)_")
         return "\n".join(lines)
 
-    def _recall_polyphonic(self, query: str, top_k: int) -> List[Dict]:
+    def _recall_polyphonic(self, query: str, top_k: int,
+                           *,
+                           from_date: Optional[str] = None,
+                           to_date: Optional[str] = None,
+                           source: Optional[str] = None,
+                           topic: Optional[str] = None,
+                           author_id: Optional[str] = None,
+                           author_type: Optional[str] = None,
+                           channel_id: Optional[str] = None,
+                           veracity: Optional[str] = None,
+                           memory_type: Optional[str] = None) -> List[Dict]:
         """[E5] Polyphonic recall path.
 
         Delegates to PolyphonicRecallEngine when MNEMOSYNE_POLYPHONIC_RECALL=1.
-        The engine runs vector + graph + fact + temporal voices, fuses
-        them via RRF, diversity-reranks, and assembles within a
-        context budget. Maps PolyphonicResult objects back to the
-        dict shape that BeamMemory.recall normally returns.
+        Engine runs vector + graph + fact + temporal voices, fuses via RRF,
+        diversity-reranks, assembles within a context budget. Maps
+        PolyphonicResult objects back to recall()'s dict shape.
 
-        Each result dict carries `voice_scores` for per-signal
-        provenance — the OpenViking observability principle ("show me
-        which voice contributed to this ranking"). Downstream
-        consumers that depend on the existing `score` key see the
-        engine's RRF combined_score in that field.
+        Each result carries `voice_scores` for per-signal provenance.
+        Engine's RRF combined_score lands in the `score` field; the
+        post-E4 veracity multiplier and tier-degradation multiplier
+        are then composed on top so flag=ON callers don't lose the
+        recent ranking work.
 
-        Synthetic memory ids from the fact voice (`cf_subject_...`)
-        don't correspond to actual rows; they're dropped from the
-        final list. The fact voice's contribution still flows through
-        RRF onto real memory_ids surfaced by other voices.
+        Filters from the caller (session/scope/valid_until/superseded/
+        author/channel/source/veracity/memory_type/from_date/to_date)
+        are applied during row fetch — same isolation contract as the
+        linear path. /review caught the original implementation
+        bypassing these (data-isolation regression, P1).
+
+        Synthetic fact-voice ids (`cf_...`) currently can't be mapped
+        back to source rows (the engine returns the fact key, not the
+        producing memory_id). They're skipped; the fact voice still
+        contributes ranking signal via RRF onto real memory_ids
+        surfaced by other voices. Known limitation, documented in
+        CHANGELOG.
         """
-        # Lazy import to avoid circular dependency at module load.
-        from mnemosyne.core.polyphonic_recall import PolyphonicRecallEngine
-
-        engine = PolyphonicRecallEngine(db_path=self.db_path, conn=self.conn)
+        engine = self._get_polyphonic_engine()
 
         query_embedding = None
         if _embeddings.available():
@@ -2390,47 +2417,183 @@ class BeamMemory:
                 if vecs is not None and len(vecs) > 0:
                     query_embedding = vecs[0]
             except Exception:
-                # Vector voice will return empty; other voices still
-                # contribute.
                 query_embedding = None
 
         try:
             polyphonic_results = engine.recall(
                 query=query,
                 query_embedding=query_embedding,
-                top_k=top_k,
+                top_k=top_k * 2,  # over-fetch for filter dropouts
             )
-        except Exception:
-            # If the engine path fails for any reason, return [] rather
-            # than crashing the caller. Operators can debug via the
-            # standard logging path; recall callers shouldn't
-            # propagate engine internals.
+        except Exception as exc:
+            logger.exception("polyphonic recall engine failed: %s", exc)
             return []
 
-        # Map PolyphonicResult → recall's dict shape. Skip synthetic
-        # fact-voice ids that don't have a backing row.
+        # Map → recall's dict shape with filters + multipliers applied.
+        weight_map = {"stated": STATED_WEIGHT, "inferred": INFERRED_WEIGHT,
+                      "tool": TOOL_WEIGHT, "imported": IMPORTED_WEIGHT,
+                      "unknown": UNKNOWN_WEIGHT}
+        tier_weight_map = {1: TIER1_WEIGHT, 2: TIER2_WEIGHT, 3: TIER3_WEIGHT}
+
         final = []
+        recalled_episodic_ids = []
+        recalled_working_ids = []
         cursor = self.conn.cursor()
+        now_iso = datetime.now().isoformat()
+
         for r in polyphonic_results:
             memory_id = r.memory_id
             if memory_id.startswith("cf_"):
-                # Consolidated-fact synthetic id; no row to fetch.
                 continue
             row_dict = self._fetch_polyphonic_row(cursor, memory_id)
             if row_dict is None:
                 continue
-            row_dict["score"] = r.combined_score
+
+            # Apply caller-supplied filters and the always-on
+            # isolation/validity contract.
+            if not self._polyphonic_row_passes_filters(
+                row_dict, from_date=from_date, to_date=to_date,
+                source=source, topic=topic, author_id=author_id,
+                author_type=author_type, channel_id=channel_id,
+                veracity=veracity, memory_type=memory_type, now_iso=now_iso,
+            ):
+                continue
+
+            # Compose RRF combined_score with post-E4 multipliers so
+            # flag=ON callers don't silently lose the veracity rank
+            # signal or tier degradation. Veracity multiplier applies
+            # to both tiers (matching the post-E4 linear behavior).
+            score = r.combined_score
+            row_veracity = row_dict.get("veracity") or "unknown"
+            score *= weight_map.get(row_veracity, UNKNOWN_WEIGHT)
+            if row_dict.get("tier") == "episodic":
+                ep_tier = row_dict.get("degradation_tier") or 1
+                score *= tier_weight_map.get(ep_tier, 1.0)
+                recalled_episodic_ids.append(memory_id)
+            else:
+                recalled_working_ids.append(memory_id)
+
+            row_dict["score"] = score
             row_dict["voice_scores"] = dict(r.voice_scores)
             final.append(row_dict)
+            if len(final) >= top_k:
+                break
+
+        # Re-sort post-multiplier composition so the final order reflects
+        # both RRF and the veracity/tier weights.
+        final.sort(key=lambda x: x["score"], reverse=True)
+
+        # Update recall_count / last_recalled for engine results too —
+        # the linear path updates them and downstream features (decay
+        # scheduling, importance reinforcement) depend on the signal.
+        # /review caught the missing update as a silent telemetry loss.
+        if recalled_episodic_ids:
+            placeholders = ",".join("?" * len(recalled_episodic_ids))
+            self.conn.execute(
+                f"UPDATE episodic_memory SET recall_count = recall_count + 1, "
+                f"last_recalled = ? WHERE id IN ({placeholders})",
+                (now_iso, *recalled_episodic_ids),
+            )
+        if recalled_working_ids:
+            placeholders = ",".join("?" * len(recalled_working_ids))
+            self.conn.execute(
+                f"UPDATE working_memory SET recall_count = recall_count + 1, "
+                f"last_recalled = ? WHERE id IN ({placeholders})",
+                (now_iso, *recalled_working_ids),
+            )
+        if recalled_episodic_ids or recalled_working_ids:
+            self.conn.commit()
+
         return final
+
+    def _get_polyphonic_engine(self):
+        """Lazy-cached engine instance per BeamMemory.
+
+        Pre-fix: a fresh engine was constructed on every recall call,
+        which re-ran BinaryVectorStore + EpisodicGraph + VeracityConsolidator
+        constructors and their schema-ensure SQL (`CREATE TABLE IF NOT
+        EXISTS` + `CREATE INDEX IF NOT EXISTS` + commit) on every call.
+        Under prefetch/A/B-flag workloads that's a wasteful commit
+        storm. /review caught the per-call instantiation.
+
+        Engine state is read-only between calls; the shared
+        `self.conn` is the only mutable dependency and it's pinned at
+        BeamMemory init.
+        """
+        if getattr(self, "_polyphonic_engine", None) is None:
+            from mnemosyne.core.polyphonic_recall import PolyphonicRecallEngine
+            self._polyphonic_engine = PolyphonicRecallEngine(
+                db_path=self.db_path, conn=self.conn,
+            )
+        return self._polyphonic_engine
+
+    def _polyphonic_row_passes_filters(self, row_dict: Dict, *,
+                                       from_date: Optional[str],
+                                       to_date: Optional[str],
+                                       source: Optional[str],
+                                       topic: Optional[str],
+                                       author_id: Optional[str],
+                                       author_type: Optional[str],
+                                       channel_id: Optional[str],
+                                       veracity: Optional[str],
+                                       memory_type: Optional[str],
+                                       now_iso: str) -> bool:
+        """Mirror the linear path's filter set for the engine path.
+        Always-on filters: session scope, valid_until, superseded_by.
+        Conditional filters: caller-supplied kwargs.
+        """
+        # Always-on session/scope isolation: only return rows visible
+        # to this session. Matches the linear path's WHERE clauses for
+        # both working_memory (session_id = self.session_id OR scope =
+        # 'global') and episodic_memory (same shape).
+        row_session = row_dict.get("session_id") if "session_id" in row_dict else None
+        # Some rows don't carry session_id in the engine row dict — re-fetch
+        # via the cursor to enforce. For now, treat global scope as
+        # always-visible and same-session as visible.
+        row_scope = row_dict.get("scope") or "session"
+        if row_scope != "global" and row_session is not None and row_session != self.session_id:
+            return False
+
+        # Validity filters.
+        valid_until = row_dict.get("valid_until")
+        if valid_until and valid_until <= now_iso:
+            return False
+        if row_dict.get("superseded_by"):
+            return False
+
+        # Caller-supplied filters.
+        if from_date and (row_dict.get("timestamp") or "") < from_date:
+            return False
+        if to_date and (row_dict.get("timestamp") or "") > to_date:
+            return False
+        if source and row_dict.get("source") != source:
+            return False
+        if topic and topic not in (row_dict.get("source") or ""):
+            return False
+        if author_id and row_dict.get("author_id") != author_id:
+            return False
+        if author_type and row_dict.get("author_type") != author_type:
+            return False
+        if channel_id and row_dict.get("channel_id") != channel_id:
+            return False
+        if veracity and row_dict.get("veracity") != veracity:
+            return False
+        if memory_type and row_dict.get("memory_type") != memory_type:
+            return False
+
+        return True
 
     def _fetch_polyphonic_row(self, cursor, memory_id: str) -> Optional[Dict]:
         """Resolve a memory_id from the polyphonic engine to a row
         dict matching recall()'s existing return shape. Tries episodic
         first, then working_memory; returns None if neither table
-        has the row (engine returned a stale or synthetic id)."""
+        has the row (engine returned a stale or synthetic id).
+
+        Includes session_id in the SELECT so the filter pass can
+        enforce session-scope isolation post-fetch.
+        """
         cursor.execute("""
-            SELECT id, content, source, timestamp, importance,
+            SELECT id, content, source, timestamp, session_id, importance,
                    recall_count, last_recalled, valid_until,
                    superseded_by, scope, author_id, author_type,
                    channel_id, veracity, memory_type, tier
@@ -2438,27 +2601,9 @@ class BeamMemory:
         """, (memory_id,))
         row = cursor.fetchone()
         if row is not None:
-            return {
-                "id": row["id"],
-                "content": row["content"],
-                "source": row["source"],
-                "timestamp": row["timestamp"],
-                "importance": row["importance"],
-                "recall_count": row["recall_count"] or 0,
-                "last_recalled": row["last_recalled"],
-                "scope": row["scope"] if "scope" in row.keys() else "session",
-                "author_id": row["author_id"] if "author_id" in row.keys() else None,
-                "author_type": row["author_type"] if "author_type" in row.keys() else None,
-                "channel_id": row["channel_id"] if "channel_id" in row.keys() else None,
-                "veracity": row["veracity"] if "veracity" in row.keys() else "unknown",
-                "memory_type": row["memory_type"] if "memory_type" in row.keys() else "unknown",
-                "valid_until": row["valid_until"] if "valid_until" in row.keys() else None,
-                "superseded_by": row["superseded_by"] if "superseded_by" in row.keys() else None,
-                "tier": "episodic",
-                "degradation_tier": row["tier"] if "tier" in row.keys() else 1,
-            }
+            return self._polyphonic_row_to_dict(row, tier_label="episodic")
         cursor.execute("""
-            SELECT id, content, source, timestamp, importance,
+            SELECT id, content, source, timestamp, session_id, importance,
                    recall_count, last_recalled, valid_until,
                    superseded_by, scope, author_id, author_type,
                    channel_id, veracity, memory_type
@@ -2467,11 +2612,18 @@ class BeamMemory:
         row = cursor.fetchone()
         if row is None:
             return None
-        return {
+        return self._polyphonic_row_to_dict(row, tier_label="working")
+
+    def _polyphonic_row_to_dict(self, row, *, tier_label: str) -> Dict:
+        """Shared row → recall-dict mapper. /review caught the
+        near-duplicate column mapping across episodic/working
+        branches — single helper now."""
+        d = {
             "id": row["id"],
             "content": row["content"],
             "source": row["source"],
             "timestamp": row["timestamp"],
+            "session_id": row["session_id"] if "session_id" in row.keys() else None,
             "importance": row["importance"],
             "recall_count": row["recall_count"] or 0,
             "last_recalled": row["last_recalled"],
@@ -2483,8 +2635,11 @@ class BeamMemory:
             "memory_type": row["memory_type"] if "memory_type" in row.keys() else "unknown",
             "valid_until": row["valid_until"] if "valid_until" in row.keys() else None,
             "superseded_by": row["superseded_by"] if "superseded_by" in row.keys() else None,
-            "tier": "working",
+            "tier": tier_label,
         }
+        if tier_label == "episodic":
+            d["degradation_tier"] = row["tier"] if "tier" in row.keys() else 1
+        return d
 
     def fact_recall(self, query: str, top_k: int = 30) -> List[Dict]:
         """Search the facts table (LLM-extracted structured knowledge).

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1510,7 +1510,25 @@ class BeamMemory:
             The three episodic weights are automatically normalized to sum to 1.0.
             Working memory uses a derived split: keyword gets (1 - importance_weight) * 0.6,
             recency gets (1 - importance_weight) * 0.4.
+
+        Polyphonic recall (E5, gated by MNEMOSYNE_POLYPHONIC_RECALL=1):
+            When the env flag is set to "1", recall delegates to
+            PolyphonicRecallEngine (mnemosyne/core/polyphonic_recall.py).
+            The engine runs 4 voices in parallel — vector / graph /
+            fact / temporal — fuses them via RRF (k=60), diversity-
+            reranks the combined results, and assembles within a
+            context budget. Each result dict carries `voice_scores`
+            for per-signal provenance.
+
+            Flag unset or "0" (default): the existing linear scorer
+            below runs unchanged. Zero behavior change for production.
         """
+        # E5 feature flag — read per call so operators can toggle
+        # without rebuilding BeamMemory (critical for A/B experiments
+        # in the same process).
+        if os.environ.get("MNEMOSYNE_POLYPHONIC_RECALL", "0") == "1":
+            return self._recall_polyphonic(query, top_k)
+
         results = []
         query_lower = query.lower()
         query_words = query_lower.split()
@@ -2339,6 +2357,134 @@ class BeamMemory:
         total = sum(len(v) for v in sandwich.values())
         lines.append(f"\n_({total} memories retrieved)_")
         return "\n".join(lines)
+
+    def _recall_polyphonic(self, query: str, top_k: int) -> List[Dict]:
+        """[E5] Polyphonic recall path.
+
+        Delegates to PolyphonicRecallEngine when MNEMOSYNE_POLYPHONIC_RECALL=1.
+        The engine runs vector + graph + fact + temporal voices, fuses
+        them via RRF, diversity-reranks, and assembles within a
+        context budget. Maps PolyphonicResult objects back to the
+        dict shape that BeamMemory.recall normally returns.
+
+        Each result dict carries `voice_scores` for per-signal
+        provenance — the OpenViking observability principle ("show me
+        which voice contributed to this ranking"). Downstream
+        consumers that depend on the existing `score` key see the
+        engine's RRF combined_score in that field.
+
+        Synthetic memory ids from the fact voice (`cf_subject_...`)
+        don't correspond to actual rows; they're dropped from the
+        final list. The fact voice's contribution still flows through
+        RRF onto real memory_ids surfaced by other voices.
+        """
+        # Lazy import to avoid circular dependency at module load.
+        from mnemosyne.core.polyphonic_recall import PolyphonicRecallEngine
+
+        engine = PolyphonicRecallEngine(db_path=self.db_path, conn=self.conn)
+
+        query_embedding = None
+        if _embeddings.available():
+            try:
+                vecs = _embeddings.embed([query])
+                if vecs is not None and len(vecs) > 0:
+                    query_embedding = vecs[0]
+            except Exception:
+                # Vector voice will return empty; other voices still
+                # contribute.
+                query_embedding = None
+
+        try:
+            polyphonic_results = engine.recall(
+                query=query,
+                query_embedding=query_embedding,
+                top_k=top_k,
+            )
+        except Exception:
+            # If the engine path fails for any reason, return [] rather
+            # than crashing the caller. Operators can debug via the
+            # standard logging path; recall callers shouldn't
+            # propagate engine internals.
+            return []
+
+        # Map PolyphonicResult → recall's dict shape. Skip synthetic
+        # fact-voice ids that don't have a backing row.
+        final = []
+        cursor = self.conn.cursor()
+        for r in polyphonic_results:
+            memory_id = r.memory_id
+            if memory_id.startswith("cf_"):
+                # Consolidated-fact synthetic id; no row to fetch.
+                continue
+            row_dict = self._fetch_polyphonic_row(cursor, memory_id)
+            if row_dict is None:
+                continue
+            row_dict["score"] = r.combined_score
+            row_dict["voice_scores"] = dict(r.voice_scores)
+            final.append(row_dict)
+        return final
+
+    def _fetch_polyphonic_row(self, cursor, memory_id: str) -> Optional[Dict]:
+        """Resolve a memory_id from the polyphonic engine to a row
+        dict matching recall()'s existing return shape. Tries episodic
+        first, then working_memory; returns None if neither table
+        has the row (engine returned a stale or synthetic id)."""
+        cursor.execute("""
+            SELECT id, content, source, timestamp, importance,
+                   recall_count, last_recalled, valid_until,
+                   superseded_by, scope, author_id, author_type,
+                   channel_id, veracity, memory_type, tier
+            FROM episodic_memory WHERE id = ?
+        """, (memory_id,))
+        row = cursor.fetchone()
+        if row is not None:
+            return {
+                "id": row["id"],
+                "content": row["content"],
+                "source": row["source"],
+                "timestamp": row["timestamp"],
+                "importance": row["importance"],
+                "recall_count": row["recall_count"] or 0,
+                "last_recalled": row["last_recalled"],
+                "scope": row["scope"] if "scope" in row.keys() else "session",
+                "author_id": row["author_id"] if "author_id" in row.keys() else None,
+                "author_type": row["author_type"] if "author_type" in row.keys() else None,
+                "channel_id": row["channel_id"] if "channel_id" in row.keys() else None,
+                "veracity": row["veracity"] if "veracity" in row.keys() else "unknown",
+                "memory_type": row["memory_type"] if "memory_type" in row.keys() else "unknown",
+                "valid_until": row["valid_until"] if "valid_until" in row.keys() else None,
+                "superseded_by": row["superseded_by"] if "superseded_by" in row.keys() else None,
+                "tier": "episodic",
+                "degradation_tier": row["tier"] if "tier" in row.keys() else 1,
+            }
+        cursor.execute("""
+            SELECT id, content, source, timestamp, importance,
+                   recall_count, last_recalled, valid_until,
+                   superseded_by, scope, author_id, author_type,
+                   channel_id, veracity, memory_type
+            FROM working_memory WHERE id = ?
+        """, (memory_id,))
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "content": row["content"],
+            "source": row["source"],
+            "timestamp": row["timestamp"],
+            "importance": row["importance"],
+            "recall_count": row["recall_count"] or 0,
+            "last_recalled": row["last_recalled"],
+            "scope": row["scope"] if "scope" in row.keys() else "session",
+            "author_id": row["author_id"] if "author_id" in row.keys() else None,
+            "author_type": row["author_type"] if "author_type" in row.keys() else None,
+            "channel_id": row["channel_id"] if "channel_id" in row.keys() else None,
+            "veracity": row["veracity"] if "veracity" in row.keys() else "unknown",
+            "memory_type": row["memory_type"] if "memory_type" in row.keys() else "unknown",
+            "valid_until": row["valid_until"] if "valid_until" in row.keys() else None,
+            "superseded_by": row["superseded_by"] if "superseded_by" in row.keys() else None,
+            "tier": "working",
+        }
 
     def fact_recall(self, query: str, top_k: int = 30) -> List[Dict]:
         """Search the facts table (LLM-extracted structured knowledge).

--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -63,14 +63,30 @@ class PolyphonicRecallEngine:
     - temporal: Time-aware scoring
     """
     
-    def __init__(self, db_path: Path = None):
+    def __init__(self, db_path: Path = None, conn: sqlite3.Connection = None):
+        """Initialize the engine.
+
+        db_path: filesystem path to the SQLite DB. Used by voices that
+            spawn their own connection (only when conn is None).
+        conn: optional shared sqlite3 connection. When provided, the
+            engine and its subsystems (vector_store / graph /
+            consolidator / temporal_voice) reuse this connection
+            instead of spawning their own. Required for safe use under
+            BeamMemory's thread-local connection model — without this,
+            each polyphonic recall call would open 4+ new connections
+            (one per voice + one per subsystem) which both wastes
+            resources and risks WAL-readback inconsistency under
+            concurrent writers.
+        """
         self.db_path = db_path or Path.home() / ".hermes" / "mnemosyne" / "data" / "mnemosyne.db"
-        
-        # Initialize subsystems
-        self.vector_store = BinaryVectorStore(db_path=self.db_path)
-        self.graph = EpisodicGraph(db_path=self.db_path)
-        self.consolidator = VeracityConsolidator(db_path=self.db_path)
-        
+        self.conn = conn  # may be None — voices fall back to per-call open
+
+        # Initialize subsystems. Each accepts an optional conn= since
+        # 9f96ded; pass through so they share our handle.
+        self.vector_store = BinaryVectorStore(db_path=self.db_path, conn=conn)
+        self.graph = EpisodicGraph(db_path=self.db_path, conn=conn)
+        self.consolidator = VeracityConsolidator(db_path=self.db_path, conn=conn)
+
         # Voice weights (deterministic, learned from validation)
         self.voice_weights = {
             "vector": 0.35,
@@ -205,7 +221,7 @@ class PolyphonicRecallEngine:
     def _temporal_voice(self, query: str) -> List[RecallResult]:
         """
         Voice 4: Time-aware scoring.
-        
+
         Boosts recent memories, penalizes old ones.
         Uses exponential decay based on age.
         """
@@ -214,51 +230,60 @@ class PolyphonicRecallEngine:
             "yesterday", "today", "recent", "last", "latest",
             "this week", "this month", "ago", "before"
         ]
-        
+
         has_temporal = any(kw in query.lower() for kw in temporal_keywords)
-        
+
         if not has_temporal:
             return []
-        
-        # Query recent memories from working_memory (if table exists)
-        conn = sqlite3.connect(str(self.db_path))
-        conn.row_factory = sqlite3.Row
+
+        # Use the shared connection when available; otherwise open a
+        # short-lived one (path used by the engine's standalone tests
+        # and `python -m polyphonic_recall` self-test).
+        if self.conn is not None:
+            conn = self.conn
+            own_conn = False
+        else:
+            conn = sqlite3.connect(str(self.db_path))
+            conn.row_factory = sqlite3.Row
+            own_conn = True
         cursor = conn.cursor()
-        
-        # Check if working_memory table exists
-        cursor.execute("""
-            SELECT name FROM sqlite_master WHERE type='table' AND name='working_memory'
-        """)
-        if not cursor.fetchone():
-            conn.close()
-            return []
-        
-        # Get memories from last 7 days
-        week_ago = (datetime.now() - timedelta(days=7)).isoformat()
-        cursor.execute("""
-            SELECT id, content, timestamp, importance
-            FROM working_memory
-            WHERE timestamp > ?
-            ORDER BY timestamp DESC
-            LIMIT 20
-        """, (week_ago,))
-        
-        results = []
-        for row in cursor.fetchall():
-            # Calculate temporal score
-            age = datetime.now() - datetime.fromisoformat(row["timestamp"])
-            age_days = age.total_seconds() / 86400
-            temporal_score = np.exp(-age_days / 7)  # 7-day half-life
-            
-            results.append(RecallResult(
-                memory_id=row["id"],
-                score=temporal_score * row["importance"],
-                voice="temporal",
-                metadata={"age_days": age_days, "importance": row["importance"]}
-            ))
-        
-        conn.close()
-        return results
+
+        try:
+            # Check if working_memory table exists
+            cursor.execute("""
+                SELECT name FROM sqlite_master WHERE type='table' AND name='working_memory'
+            """)
+            if not cursor.fetchone():
+                return []
+
+            # Get memories from last 7 days
+            week_ago = (datetime.now() - timedelta(days=7)).isoformat()
+            cursor.execute("""
+                SELECT id, content, timestamp, importance
+                FROM working_memory
+                WHERE timestamp > ?
+                ORDER BY timestamp DESC
+                LIMIT 20
+            """, (week_ago,))
+
+            results = []
+            for row in cursor.fetchall():
+                # Calculate temporal score
+                age = datetime.now() - datetime.fromisoformat(row["timestamp"])
+                age_days = age.total_seconds() / 86400
+                temporal_score = np.exp(-age_days / 7)  # 7-day half-life
+
+                results.append(RecallResult(
+                    memory_id=row["id"],
+                    score=temporal_score * row["importance"],
+                    voice="temporal",
+                    metadata={"age_days": age_days, "importance": row["importance"]}
+                ))
+
+            return results
+        finally:
+            if own_conn:
+                conn.close()
     
     def _extract_entities(self, text: str) -> List[str]:
         """Extract potential entity names from text."""

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -1,0 +1,271 @@
+"""Regression tests for E5 — wire PolyphonicRecallEngine under feature flag.
+
+Pre-E5: `PolyphonicRecallEngine` (mnemosyne/core/polyphonic_recall.py)
+existed as a complete 4-voice + RRF + diversity-rerank + budget-aware
+context-assembly implementation, but it was dead code — no production
+caller imported it. Commit 9f96ded's "polyphonic recall" was actually
+inline graph_bonus + fact_bonus added to BeamMemory's linear scorer
+(beam.py:2101-2156), not the engine.
+
+Post-E5:
+  - `MNEMOSYNE_POLYPHONIC_RECALL=1` activates the polyphonic engine
+    inside `BeamMemory.recall()`
+  - Default (flag unset or "0"): existing linear scorer runs unchanged —
+    production behavior preserved
+  - Flag ON: engine produces ranked candidates via RRF fusion across 4
+    voices (vector + graph + fact + temporal), diversity-reranks them,
+    and assembles context within budget. The inline graph_bonus and
+    fact_bonus terms in the linear scorer are bypassed (engine handles
+    those itself).
+  - Per-result `voice_scores` field carries provenance — operators can
+    see WHICH voices contributed to a given ranking.
+  - Engine reuses BeamMemory's shared sqlite connection rather than
+    spawning 4+ new connections per recall call.
+
+This unblocks the experiment's "strongest available recall layer" —
+all arms run with flag=ON to test against the polyphonic engine
+instead of the inline bonus shortcut.
+"""
+
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+@pytest.fixture
+def disable_llm(monkeypatch):
+    """Force deterministic non-LLM paths."""
+    monkeypatch.setattr(
+        "mnemosyne.core.local_llm.llm_available", lambda: False
+    )
+
+
+def _seed_recallable_content(beam, items):
+    """Seed working_memory + episodic_memory with content that recall
+    can find. items is a list of (content, source, importance) tuples."""
+    for content, source, importance in items:
+        beam.remember(content, source=source, importance=importance)
+
+
+class TestE5FeatureFlag:
+
+    def test_flag_off_uses_linear_scorer(self, temp_db, monkeypatch, disable_llm):
+        """[E5] When MNEMOSYNE_POLYPHONIC_RECALL is unset or '0', recall
+        runs the existing linear scorer. Production behavior unchanged.
+
+        The signal that we're on the linear path: result dicts do NOT
+        carry a `voice_scores` field (that's only populated by the
+        polyphonic engine)."""
+        monkeypatch.delenv("MNEMOSYNE_POLYPHONIC_RECALL", raising=False)
+
+        beam = BeamMemory(session_id="e5-off", db_path=temp_db)
+        _seed_recallable_content(beam, [
+            ("Alice mentioned the deploy timeline", "conversation", 0.7),
+            ("Bob owns the auth refactor", "fact", 0.8),
+        ])
+
+        results = beam.recall("deploy", top_k=10)
+        assert results, "recall returned 0 — sanity check"
+        for r in results:
+            assert "voice_scores" not in r, (
+                f"linear scorer leaked voice_scores into result: {r}"
+            )
+
+    def test_flag_off_explicit_zero(self, temp_db, monkeypatch, disable_llm):
+        """Setting the env var to '0' is the explicit way to opt out;
+        must behave identically to unset."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+
+        beam = BeamMemory(session_id="e5-off-zero", db_path=temp_db)
+        _seed_recallable_content(beam, [
+            ("explicit-zero content here", "test", 0.5),
+        ])
+
+        results = beam.recall("explicit-zero", top_k=10)
+        for r in results:
+            assert "voice_scores" not in r
+
+    def test_flag_on_uses_polyphonic_engine(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """[E5] Flag ON: results carry voice_scores provenance — the
+        signal that the engine ran instead of the linear scorer.
+        Per-signal observability is a hard requirement (the
+        OpenViking-style 'show me which voice contributed').
+        """
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+
+        beam = BeamMemory(session_id="e5-on", db_path=temp_db)
+        _seed_recallable_content(beam, [
+            ("Alice deployed the auth service last Tuesday", "convo", 0.7),
+            ("Bob filed a bug about the auth refactor", "convo", 0.7),
+            ("Carol approved Alice's deploy plan", "convo", 0.8),
+        ])
+
+        results = beam.recall("Alice deploy auth", top_k=10)
+        assert results, "polyphonic recall returned 0 — engine wired wrong"
+        # At least one result must carry voice_scores; an empty dict is
+        # not enough (would mean RRF combined nothing). The engine's
+        # RRF accumulates contributions from each contributing voice.
+        any_with_voices = any(
+            r.get("voice_scores") for r in results
+        )
+        assert any_with_voices, (
+            f"no result carries voice_scores; engine didn't run or its "
+            f"output wasn't mapped back. Got: {results}"
+        )
+
+    def test_flag_on_then_off_swaps_paths(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """The flag is read PER CALL, not at __init__ time — operators
+        can toggle the engine without rebuilding BeamMemory. Critical
+        for A/B experiments inside the same process.
+
+        Uses a query with a capitalized entity ('Alice') so the graph
+        voice has something to bite on without requiring embeddings."""
+        beam = BeamMemory(session_id="e5-toggle", db_path=temp_db)
+        _seed_recallable_content(beam, [
+            ("Alice asked about the toggle behavior", "convo", 0.6),
+            ("Alice followed up with another comment", "convo", 0.6),
+        ])
+
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        on_results = beam.recall("Alice toggle", top_k=10)
+
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+        off_results = beam.recall("Alice toggle", top_k=10)
+
+        # ON path produces voice_scores; OFF path doesn't.
+        on_has_voices = any(r.get("voice_scores") for r in on_results)
+        off_has_voices = any("voice_scores" in r for r in off_results)
+        assert on_has_voices, (
+            f"flag=ON didn't engage the engine. on_results={on_results}"
+        )
+        assert not off_has_voices, "flag=OFF still ran the engine"
+
+
+class TestE5EnginePlumbing:
+
+    def test_engine_accepts_shared_connection(self, temp_db):
+        """[E5 connection reuse] PolyphonicRecallEngine.__init__ must
+        accept conn= so BeamMemory can share its thread-local
+        connection. Without this each recall call would spawn 4+ new
+        SQLite connections (one per voice + one for the engine itself)
+        — wasteful under load and inconsistent with the post-9f96ded
+        EpisodicGraph / VeracityConsolidator / BinaryVectorStore
+        pattern."""
+        from mnemosyne.core.polyphonic_recall import PolyphonicRecallEngine
+
+        # Bring up the schema via BeamMemory so the engine has tables to query.
+        beam = BeamMemory(session_id="e5-conn", db_path=temp_db)
+        shared_conn = beam.conn
+
+        # The constructor must accept conn= without raising.
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=shared_conn)
+
+        # Verify the engine's subsystems also use the shared connection
+        # (this is the whole point of accepting it).
+        assert engine.vector_store.conn is shared_conn, (
+            "vector_store is not using the shared connection"
+        )
+        assert engine.graph.conn is shared_conn, (
+            "graph is not using the shared connection"
+        )
+        assert engine.consolidator.conn is shared_conn, (
+            "consolidator is not using the shared connection"
+        )
+
+    def test_engine_recall_handles_empty_corpus(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Flag ON against an empty DB: graceful empty return, no crash."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="e5-empty", db_path=temp_db)
+
+        results = beam.recall("anything", top_k=10)
+        # Empty list is acceptable; the contract is "doesn't crash" not
+        # "returns hits when there are no rows."
+        assert isinstance(results, list)
+
+    def test_engine_recall_handles_no_embeddings(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Flag ON when embeddings are unavailable: vector voice
+        returns empty, but graph/fact/temporal voices can still
+        contribute. No crash."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        # Disable embeddings by monkeypatching available() to False.
+        monkeypatch.setattr(
+            "mnemosyne.core.embeddings.available", lambda: False
+        )
+
+        beam = BeamMemory(session_id="e5-noemb", db_path=temp_db)
+        _seed_recallable_content(beam, [
+            ("Alice did things yesterday", "convo", 0.6),
+        ])
+
+        # Use a temporal-keyword query so the temporal voice can
+        # contribute even without entities matching the graph voice.
+        results = beam.recall("yesterday Alice", top_k=10)
+        # No crash. Results may or may not be non-empty depending on
+        # which voices found matches.
+        assert isinstance(results, list)
+
+
+class TestE5ResultShape:
+
+    def test_polyphonic_results_have_combined_score(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Flag ON: every result dict carries the RRF combined_score
+        in the `score` field (existing shape) so downstream
+        consumers don't need a special case."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="e5-shape", db_path=temp_db)
+        _seed_recallable_content(beam, [
+            ("Carol approved the launch", "convo", 0.8),
+            ("Carol pushed back on the date", "convo", 0.7),
+        ])
+
+        results = beam.recall("Carol", top_k=10)
+        for r in results:
+            assert "score" in r, f"missing score field: {r}"
+            assert isinstance(r["score"], (int, float))
+            assert r["score"] > 0, f"non-positive score: {r}"
+
+    def test_polyphonic_results_have_content(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Flag ON: result dicts include the actual memory content,
+        not just an id. Downstream consumers compose prompts from
+        `content`, so the engine path must fetch and map it back from
+        working_memory / episodic_memory."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="e5-content", db_path=temp_db)
+        unique_token = "e5contentmarkerxyz"
+        _seed_recallable_content(beam, [
+            (f"row carrying {unique_token} content", "convo", 0.7),
+        ])
+
+        results = beam.recall(unique_token, top_k=10)
+        # The engine may or may not surface the row depending on
+        # whether any of its voices match (FTS isn't part of the
+        # engine; entity extraction is the graph voice's only input).
+        # If we get hits, they MUST have content.
+        for r in results:
+            assert r.get("content"), (
+                f"result has no content; engine didn't map row back: {r}"
+            )

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -225,6 +225,202 @@ class TestE5EnginePlumbing:
         assert isinstance(results, list)
 
 
+class TestE5FilterEnforcement:
+    """[/review P1] Under flag=ON the engine path must enforce the
+    same isolation/validity filters as the linear path. Pre-fix it
+    returned rows globally, leaking cross-session and expired
+    content."""
+
+    def test_engine_path_isolates_by_session(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Two sessions, same DB. Recall from session A must NOT
+        return session B's session-scoped rows."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam_a = BeamMemory(session_id="A", db_path=temp_db)
+        beam_b = BeamMemory(session_id="B", db_path=temp_db)
+        beam_a.remember("Alice talked about session A secret", source="conv", importance=0.7, scope="session")
+        beam_b.remember("Bob talked about session B secret", source="conv", importance=0.7, scope="session")
+
+        # Recall from A must not surface B's content.
+        results = beam_a.recall("Bob", top_k=20)
+        for r in results:
+            assert "session B secret" not in (r.get("content") or ""), (
+                f"engine path leaked session B content into session A "
+                f"recall: {r}"
+            )
+
+    def test_engine_path_returns_global_scope_cross_session(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Global-scope rows MUST surface across sessions — that's
+        the design of `scope='global'`."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam_a = BeamMemory(session_id="A", db_path=temp_db)
+        beam_b = BeamMemory(session_id="B", db_path=temp_db)
+        beam_a.remember("Alice global preference for dark mode", source="pref", importance=0.9, scope="global")
+
+        results = beam_b.recall("Alice", top_k=20)
+        contents = [r.get("content", "") for r in results]
+        assert any("dark mode" in c for c in contents), (
+            f"global-scope row didn't surface in cross-session recall: "
+            f"{contents}"
+        )
+
+    def test_engine_path_filters_superseded(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Rows with superseded_by set are tombstoned — they must
+        NOT surface in recall regardless of flag state."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        old_id = beam.remember("Alice prefers Vim", source="pref", importance=0.7)
+        beam.conn.execute(
+            "UPDATE working_memory SET superseded_by = ? WHERE id = ?",
+            ("new-id", old_id),
+        )
+        beam.conn.commit()
+
+        results = beam.recall("Alice Vim", top_k=20)
+        for r in results:
+            assert r["id"] != old_id, (
+                f"engine path returned a superseded row: {r}"
+            )
+
+    def test_engine_path_filters_expired(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Rows whose valid_until has passed must not surface."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        past = (datetime.now() - timedelta(days=1)).isoformat()
+        mid = beam.remember("Alice expired content", source="conv", importance=0.7)
+        beam.conn.execute(
+            "UPDATE working_memory SET valid_until = ? WHERE id = ?",
+            (past, mid),
+        )
+        beam.conn.commit()
+
+        results = beam.recall("Alice", top_k=20)
+        for r in results:
+            assert r["id"] != mid, (
+                f"engine path returned an expired row: {r}"
+            )
+
+    def test_engine_path_honors_author_filter(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Caller-supplied author_id filter must apply on engine path."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(
+            session_id="s1", db_path=temp_db, author_id="alice"
+        )
+        beam.remember("Alice said hi", source="conv", importance=0.7)
+
+        beam2 = BeamMemory(
+            session_id="s1", db_path=temp_db, author_id="bob"
+        )
+        beam2.remember("Alice nodded", source="conv", importance=0.7)
+
+        # Filter by author_id=alice: should not see bob's row.
+        results = beam.recall("Alice", author_id="alice", top_k=20)
+        for r in results:
+            assert r.get("author_id") == "alice", (
+                f"engine path ignored author_id filter: {r}"
+            )
+
+
+class TestE5MultiplierComposition:
+    """[/review HIGH] E4 veracity multiplier + tier degradation
+    multiplier must compose with the engine's RRF combined_score.
+    Otherwise flag=ON erases the E4 work."""
+
+    def test_veracity_multiplier_applies_on_engine_path(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """'stated' content should rank higher than 'unknown'
+        content on the engine path, just as it does on the linear
+        path post-E4."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        stated_id = beam.remember(
+            "Alice prefers Vim editor", source="pref",
+            importance=0.7, veracity="stated",
+        )
+        unknown_id = beam.remember(
+            "Alice probably uses Vim editor", source="conv",
+            importance=0.7, veracity="unknown",
+        )
+
+        results = beam.recall("Alice", top_k=20)
+        scores = {r["id"]: r["score"] for r in results}
+        if stated_id in scores and unknown_id in scores:
+            assert scores[stated_id] > scores[unknown_id], (
+                f"engine path didn't apply veracity multiplier; "
+                f"stated={scores[stated_id]}, unknown={scores[unknown_id]}"
+            )
+
+
+class TestE5TelemetryUpdates:
+    """[/review HIGH] recall_count / last_recalled must update on
+    the engine path. Linear path updates them; not doing so under
+    flag=ON silently breaks decay/usage signals."""
+
+    def test_engine_path_increments_recall_count(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        mid = beam.remember("Alice unique recall content", source="conv", importance=0.7)
+
+        # Before recall: recall_count = 0.
+        pre = sqlite3.connect(str(temp_db)).execute(
+            "SELECT recall_count FROM working_memory WHERE id = ?",
+            (mid,),
+        ).fetchone()[0]
+        assert (pre or 0) == 0
+
+        results = beam.recall("Alice", top_k=10)
+        # The row should be in results (with the unique Alice entity).
+        ids = [r["id"] for r in results]
+        assert mid in ids, f"row not in results: ids={ids}"
+
+        # After: recall_count incremented, last_recalled set.
+        post_row = sqlite3.connect(str(temp_db)).execute(
+            "SELECT recall_count, last_recalled FROM working_memory "
+            "WHERE id = ?", (mid,),
+        ).fetchone()
+        assert post_row[0] >= 1, (
+            f"engine path did NOT increment recall_count; got {post_row[0]}"
+        )
+        assert post_row[1] is not None, (
+            f"engine path did NOT set last_recalled; got {post_row[1]}"
+        )
+
+
+class TestE5EngineCache:
+    """[/review maintainability] The engine should be lazily cached
+    on the BeamMemory instance so subsystem constructors don't
+    re-fire on every recall."""
+
+    def test_engine_is_cached_between_calls(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        beam.remember("Alice cached test", source="conv", importance=0.7)
+
+        beam.recall("Alice", top_k=10)
+        engine_first = beam._polyphonic_engine
+        assert engine_first is not None, "engine wasn't cached after first call"
+
+        beam.recall("Alice", top_k=10)
+        engine_second = beam._polyphonic_engine
+        assert engine_second is engine_first, (
+            "engine instance changed between calls — cache isn't holding"
+        )
+
+
 class TestE5ResultShape:
 
     def test_polyphonic_results_have_combined_score(


### PR DESCRIPTION
## Summary

E5 from the BEAM-recovery experiment prerequisites. Wires `PolyphonicRecallEngine` (which was dead code) into `BeamMemory.recall()` under the `MNEMOSYNE_POLYPHONIC_RECALL=1` env flag.

- **Default (unset or `0`)**: existing linear scorer runs unchanged. Zero behavior change for production.
- **Flag ON**: engine runs vector + graph + fact + temporal voices in parallel, fuses via RRF (k=60), diversity-reranks, and assembles within a context budget. Results carry `voice_scores` for per-signal provenance.

Commit `9f96ded` (titled "polyphonic recall — graph + fact voices wired into recall") was actually inline `graph_bonus` + `fact_bonus` added to the linear scorer. The proper engine with RRF + diversity rerank + budget-aware context assembly was untouched and unused.

## What changed

**`mnemosyne/core/polyphonic_recall.py`**
- `PolyphonicRecallEngine.__init__` accepts optional `conn=` for shared connection (aligns with the post-9f96ded pattern for EpisodicGraph / VeracityConsolidator / BinaryVectorStore).
- `_temporal_voice` reuses the shared connection when available; falls back to short-lived per-call connection for standalone use.

**`mnemosyne/core/beam.py`**
- `BeamMemory.recall()` reads `MNEMOSYNE_POLYPHONIC_RECALL` per call (operators can toggle in-process for A/B experiments).
- New `_recall_polyphonic` orchestrates the engine path: builds query embedding, calls `engine.recall()`, maps `PolyphonicResult` → recall dict shape, applies caller filters, composes veracity + tier multipliers on top of RRF, updates `recall_count`/`last_recalled`.
- Lazy `_get_polyphonic_engine()` caches the engine instance on BeamMemory so subsystem constructors don't re-fire on every recall.

## Review process

`/review` ran 3 specialists (testing, maintainability, security) in parallel + Claude adversarial + **Codex adversarial** + **Codex structured review**. Codex structured review came back with **GATE: FAIL** (P1 + 2 P2s). All cross-model-confirmed blockers addressed in commit 2:

| Severity | Finding | Status |
|---|---|---|
| P1 | Filter enforcement bypassed (data-isolation regression) | Fixed: all filter kwargs flow through; session/scope/validity enforced post-fetch |
| HIGH | Veracity + tier multipliers bypassed (E4 work erased) | Fixed: multipliers compose with RRF combined_score post-fusion |
| HIGH | `recall_count` / `last_recalled` never updated | Fixed: batched UPDATEs after composition |
| HIGH | Vector voice queries empty `binary_vectors` table | Documented as known limitation (E5.a follow-up — needs `BinaryVectorStore` → `episodic_memory.binary_vector` rewire) |
| MED | Per-call subsystem instantiation (schema-ensure storm) | Fixed: lazy engine cache on BeamMemory |
| MED | Exception swallow blinded operators | Fixed: `logger.exception(...)` on failure |
| MED | Fact-voice synthetic ids dropped | Documented (engine can't surface them without schema-side change) |

## Test plan

- [x] **17 tests** in `tests/test_beam_e5_polyphonic_recall.py`:
  - `TestE5FeatureFlag` (4): unset/0 → linear scorer; 1 → engine; per-call toggle works
  - `TestE5EnginePlumbing` (3): engine accepts shared conn; empty corpus; no embeddings
  - `TestE5FilterEnforcement` (5): session isolation; global cross-session visibility; superseded skip; expired skip; author_id filter
  - `TestE5MultiplierComposition` (1): stated > unknown on engine path
  - `TestE5TelemetryUpdates` (1): recall_count + last_recalled update
  - `TestE5EngineCache` (1): engine instance cached between calls
  - `TestE5ResultShape` (2): combined_score + content fields present
- [x] Full suite: **553 passed**, 1 skipped, 0 failures (+17 new tests). No regressions on the linear-scorer path.

## Known limitations (E5.a follow-ups)

- **Vector voice = no-op.** `BinaryVectorStore` queries a standalone `binary_vectors` table that production never writes to (binary vectors live in `episodic_memory.binary_vector` column, added by NAI-4). Under flag=ON the engine effectively runs 3 voices, not 4. Fix: either rewire `BinaryVectorStore.search` to read the episodic column, or backfill the standalone table at consolidation time.
- **Fact-voice evidence mapping.** Engine emits synthetic `cf_*` ids for fact hits; we can't currently map them back to source memory rows without threading `ConsolidatedFact.sources` through. Fact scores still flow through RRF onto real memory_ids surfaced by other voices.
- **Long-query DOS bound.** `_fact_voice` iterates over every word in the query. Cap recommended for adversarial long inputs.
- **Score-magnitude shift.** RRF combined_score values are small floats (~0.01-0.05) vs the linear scorer's [0, ~1]. Rankings are comparable; downstream consumers that depend on absolute score values (e.g., `format_context` buckets >0.3/>0.7) may need re-tuning under flag=ON.

## Why now

E5 is the experiment plan's "strongest available recall layer." All experiment arms run with flag=ON to test against the polyphonic engine instead of the inline `graph_bonus`/`fact_bonus` shortcut. Without E5, the experiment can't actually compare against the polyphonic ranking layer it's designed to evaluate. Closes the last non-E6-dependent E-series prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)