### PR TITLE
C13.b: fact-extraction failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemos
 - Long error messages are truncated to 200 chars in the captured sample to bound log volume and prevent content leakage from upstream LLM errors that include the full prompt.
 - API: `from mnemosyne.extraction import get_extraction_stats, reset_extraction_stats, get_diagnostics, ExtractionDiagnostics`.
 
+### Counter semantics (post-/review hardening)
+
+- **Tier attempt counters are conditional**, not unconditional. `record_attempt("host")` fires only when the host backend actually ran (`attempted=True` from `_try_host_llm`). Configurations with no host backend registered show zero host attempts, not phantom attempts.
+- **Tier success counters reflect parseable output, not transport success.** `ExtractionClient.chat()` records cloud-tier attempts and transport-level outcomes (`no_output` for empty HTTP, `failure` for all-models-failed) but does NOT record cloud-tier success. `ExtractionClient.extract_facts()` records `cloud_success` only after the response parses into a fact list. This means cloud `success_rate` (`successes / attempts`) reflects extraction quality, not API health.
+- **Outer-wrapper failures land on the synthetic `wrapper` tier.** `extract_facts_safe`'s outer `except` records to `wrapper` rather than `local` — pre-review the outer exceptions polluted local-tier metrics, misleading operators triaging local-LLM health. The `wrapper` tier explicitly means "tier of origin can't be determined."
+- **Host adapter exceptions land on `host` tier.** If `_try_host_llm` itself raises, the failure records under `host` with reason `host_adapter_raised` (caught at the call site) instead of escaping to the outer wrapper.
+- **Snapshot samples are independent copies.** `snapshot()` deep-copies the sample dicts so a caller mutating the returned snapshot can't mutate diagnostics' internal state.
+- **Log lines sanitize exception repr.** `_safe_for_log` strips control characters / newlines / ANSI escapes from the logged exception representation. A hostile or malformed `__repr__` can't inject log-line breaks or terminal escape sequences.
+
 ## [2.5] — 2026-05-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemosyne) (MAJOR.MINOR).
 
+## [Unreleased]
+
+### Added
+
+**C13.b — Fact-extraction failure diagnostics**
+- New `mnemosyne.extraction.diagnostics` module exposes a process-global `ExtractionDiagnostics` instance. Pre-C13.b fact extraction had five silent-failure layers (cloud HTTP errors → `""`, JSON parse failures → `[]`, local LLM exceptions → `pass`, no-LLM-available fallback → `[]`, outer `extract_facts_safe` wrapper → `[]`). Operators got zero signal that fact-recall and the graph voice were running blind.
+- The diagnostics record each extraction attempt's outcome at every tier (`host` / `remote` / `local` / `cloud`). Counters per tier: `attempts`, `successes`, `no_output`, `failures`, plus bounded recent error samples. Bird's-eye totals: `calls`, `successes`, `failures`, `empty`, `success_rate`.
+- `mnemosyne/core/extraction.py::extract_facts` instruments every tier transition (host attempted vs. succeeded, host fallback to local, remote LLM no-output, local LLM raised, model not loaded, etc.). Each branch records to the diagnostics so operators can see exactly what's being swallowed.
+- `mnemosyne/extraction/client.py::ExtractionClient.chat` records `cloud` tier attempts, successes (non-empty response), `no_output` (empty response), and failures with the last exception. `extract_facts()` adds JSON-parse-failure recording so malformed model responses are distinguishable from "model had nothing to say."
+- New module-level helpers: `get_extraction_stats()` returns a JSON-serializable snapshot; `reset_extraction_stats()` zeroes the counters (useful for tests + operators starting a fresh measurement window).
+- WARNING-level log lines fire on the most actionable failure paths (`ExtractionClient.chat` all-models-failed, `extract_facts` local LLM raised, JSON parse failed, etc.). Diagnostics are the primary signal; logs are the secondary signal for log-tailing operators.
+
+### Notes for callers
+
+- Diagnostics are **read-only signal** — they never alter extraction behavior. Failures are still swallowed at the call site (`extract_facts_safe`, the outer `try/except: pass` in `beam.py::_extract_and_store_facts`); diagnostics surface what's being swallowed.
+- Thread-safe: a single `threading.Lock` gates all mutations. Concurrent extraction calls from different threads accumulate correctly.
+- The error-sample queue is bounded to 10 per tier; a chronically failing tier doesn't accumulate unbounded memory.
+- Long error messages are truncated to 200 chars in the captured sample to bound log volume and prevent content leakage from upstream LLM errors that include the full prompt.
+- API: `from mnemosyne.extraction import get_extraction_stats, reset_extraction_stats, get_diagnostics, ExtractionDiagnostics`.
+
 ## [2.5] — 2026-05-10
 
 ### Added

--- a/mnemosyne/core/extraction.py
+++ b/mnemosyne/core/extraction.py
@@ -19,8 +19,11 @@ Extraction uses temperature=0.0 (deterministic) so re-ingesting the same
 content does not create near-duplicate facts in the facts table.
 """
 
+import logging
 import os
 from typing import List, Optional
+
+logger = logging.getLogger(__name__)
 
 # Reuse local_llm infrastructure
 from mnemosyne.core import local_llm
@@ -88,17 +91,33 @@ def extract_facts(text: str) -> List[str]:
         - When the host attempt produces no usable text, the remote URL is
           **skipped** — falls through to local GGUF, then []. This honors the
           plan's host-vs-remote precedence rule.
+        - [C13.b] All tier transitions and failures are recorded to the
+          process-global `ExtractionDiagnostics`. Operators query via
+          `mnemosyne.extraction.get_extraction_stats()` to see why
+          extraction is producing empty results.
     """
+    # Lazy import to avoid pulling the diagnostics chain at module load
+    # (extraction.py is imported very early in some test contexts).
+    from mnemosyne.extraction.diagnostics import get_diagnostics
+    diag = get_diagnostics()
+
     if not text or not text.strip():
+        # Caller passed nothing — this isn't a failure, just no work.
+        # Don't record_call: this isn't really an extraction attempt.
         return []
 
     if not local_llm.llm_available():
+        diag.record_failure(
+            "local", reason="llm_unavailable_at_call_site",
+        )
+        diag.record_call(succeeded=False, all_empty=False)
         return []
 
     prompt = _build_extraction_prompt(text)
 
     # 0. Host backend (deterministic; temperature=0.0).
     # Reference live module values so monkeypatch on local_llm reaches us.
+    diag.record_attempt("host")
     attempted, host_text = local_llm._try_host_llm(
         prompt, max_tokens=local_llm.LLM_MAX_TOKENS, temperature=0.0
     )
@@ -106,8 +125,14 @@ def extract_facts(text: str) -> List[str]:
         if host_text:
             facts = _parse_facts(host_text)
             if facts:
+                diag.record_success("host", fact_count=len(facts))
+                diag.record_call(succeeded=True)
                 return facts
+            diag.record_no_output("host")
+        else:
+            diag.record_no_output("host")
         # Host attempted but produced no facts. Skip remote per A3; try local.
+        diag.record_attempt("local")
         llm = local_llm._load_llm()
         if llm is not None:
             try:
@@ -116,22 +141,43 @@ def extract_facts(text: str) -> List[str]:
                     max_new_tokens=local_llm.LLM_MAX_TOKENS,
                     stop=["</s>", "<|user|>"],
                 )
-                return _parse_facts(local_llm._clean_output(raw_output))
-            except Exception:
+                facts = _parse_facts(local_llm._clean_output(raw_output))
+                if facts:
+                    diag.record_success("local", fact_count=len(facts))
+                    diag.record_call(succeeded=True)
+                else:
+                    diag.record_no_output("local")
+                    diag.record_call(succeeded=False, all_empty=True)
+                return facts
+            except Exception as e:
+                diag.record_failure("local", exc=e, reason="ctransformers_raised")
+                logger.warning(
+                    "extract_facts: local LLM raised on host-fallback path: %r", e
+                )
+                diag.record_call(succeeded=False)
                 return []
+        diag.record_failure("local", reason="model_not_loaded")
+        diag.record_call(succeeded=False, all_empty=True)
         return []
 
     # 1. Remote LLM. Pass temperature=0.0 so the C2 determinism contract
     # holds even on the standalone remote path (where extract_facts shares
     # _call_remote_llm with summarize_memories' default of 0.3).
     if local_llm.LLM_ENABLED and local_llm.LLM_BASE_URL:
+        diag.record_attempt("remote")
         raw_output = local_llm._call_remote_llm(prompt, temperature=0.0)
         if raw_output:
             facts = _parse_facts(local_llm._clean_output(raw_output))
             if facts:
+                diag.record_success("remote", fact_count=len(facts))
+                diag.record_call(succeeded=True)
                 return facts
+            diag.record_no_output("remote")
+        else:
+            diag.record_no_output("remote")
 
     # 2. Local LLM.
+    diag.record_attempt("local")
     llm = local_llm._load_llm()
     if llm is not None:
         try:
@@ -141,10 +187,23 @@ def extract_facts(text: str) -> List[str]:
                 stop=["</s>", "<|user|>"],
             )
             facts = _parse_facts(local_llm._clean_output(raw_output))
+            if facts:
+                diag.record_success("local", fact_count=len(facts))
+                diag.record_call(succeeded=True)
+            else:
+                diag.record_no_output("local")
+                diag.record_call(succeeded=False, all_empty=True)
             return facts
-        except Exception:
-            pass
+        except Exception as e:
+            diag.record_failure("local", exc=e, reason="ctransformers_raised")
+            logger.warning(
+                "extract_facts: local LLM raised: %r", e
+            )
+            diag.record_call(succeeded=False)
+            return []
 
+    diag.record_failure("local", reason="model_not_loaded")
+    diag.record_call(succeeded=False, all_empty=True)
     return []
 
 
@@ -152,8 +211,22 @@ def extract_facts_safe(text: str) -> List[str]:
     """
     Best-effort fact extraction that never raises.
     Wrapper for extract_facts with exception handling.
+
+    [C13.b] Outer-wrapper failures (anything `extract_facts` lets
+    escape) are recorded as `local` tier failures with reason
+    `outer_wrapper_caught` so operators can see what's slipping
+    past the inner instrumentation.
     """
     try:
         return extract_facts(text)
-    except Exception:
+    except Exception as e:
+        from mnemosyne.extraction.diagnostics import get_diagnostics
+        diag = get_diagnostics()
+        diag.record_failure(
+            "local", exc=e, reason="outer_wrapper_caught"
+        )
+        diag.record_call(succeeded=False)
+        logger.warning(
+            "extract_facts_safe: extract_facts() raised: %r", e
+        )
         return []

--- a/mnemosyne/core/extraction.py
+++ b/mnemosyne/core/extraction.py
@@ -96,9 +96,11 @@ def extract_facts(text: str) -> List[str]:
           `mnemosyne.extraction.get_extraction_stats()` to see why
           extraction is producing empty results.
     """
-    # Lazy import to avoid pulling the diagnostics chain at module load
-    # (extraction.py is imported very early in some test contexts).
-    from mnemosyne.extraction.diagnostics import get_diagnostics
+    # Lazy import to avoid a circular dependency: mnemosyne.extraction
+    # re-exports diagnostics, and tests/core import extraction.py very
+    # early; importing diagnostics at module load would tangle the
+    # init order. After first call sys.modules caches the import.
+    from mnemosyne.extraction.diagnostics import get_diagnostics, _safe_for_log as diagnostics_safe_for_log
     diag = get_diagnostics()
 
     if not text or not text.strip():
@@ -117,11 +119,32 @@ def extract_facts(text: str) -> List[str]:
 
     # 0. Host backend (deterministic; temperature=0.0).
     # Reference live module values so monkeypatch on local_llm reaches us.
-    diag.record_attempt("host")
-    attempted, host_text = local_llm._try_host_llm(
-        prompt, max_tokens=local_llm.LLM_MAX_TOKENS, temperature=0.0
-    )
+    #
+    # /review fix: record host attempt ONLY when the host backend
+    # actually ran (`attempted=True`). Pre-fix every call incremented
+    # the host counter, including configurations with no host backend
+    # registered — phantom attempts polluted the metric. Plus wrap
+    # the call so an exception inside _try_host_llm gets attributed
+    # to host instead of escaping to the outer wrapper.
+    try:
+        attempted, host_text = local_llm._try_host_llm(
+            prompt, max_tokens=local_llm.LLM_MAX_TOKENS, temperature=0.0
+        )
+    except Exception as e:
+        # Host adapter itself raised — count as host failure rather
+        # than letting it escape to the outer wrapper where it'd be
+        # misattributed to a generic tier.
+        diag.record_attempt("host")
+        diag.record_failure("host", exc=e, reason="host_adapter_raised")
+        diag.record_call(succeeded=False)
+        logger.warning(
+            "extract_facts: host LLM adapter raised: %s",
+            diagnostics_safe_for_log(e),
+        )
+        return []
+
     if attempted:
+        diag.record_attempt("host")
         if host_text:
             facts = _parse_facts(host_text)
             if facts:
@@ -133,7 +156,16 @@ def extract_facts(text: str) -> List[str]:
             diag.record_no_output("host")
         # Host attempted but produced no facts. Skip remote per A3; try local.
         diag.record_attempt("local")
-        llm = local_llm._load_llm()
+        try:
+            llm = local_llm._load_llm()
+        except Exception as e:
+            diag.record_failure("local", exc=e, reason="load_llm_raised")
+            logger.warning(
+                "extract_facts: _load_llm raised: %s",
+                diagnostics_safe_for_log(e),
+            )
+            diag.record_call(succeeded=False)
+            return []
         if llm is not None:
             try:
                 raw_output = llm(
@@ -152,7 +184,8 @@ def extract_facts(text: str) -> List[str]:
             except Exception as e:
                 diag.record_failure("local", exc=e, reason="ctransformers_raised")
                 logger.warning(
-                    "extract_facts: local LLM raised on host-fallback path: %r", e
+                    "extract_facts: local LLM raised on host-fallback path: %s",
+                    diagnostics_safe_for_log(e),
                 )
                 diag.record_call(succeeded=False)
                 return []
@@ -165,7 +198,15 @@ def extract_facts(text: str) -> List[str]:
     # _call_remote_llm with summarize_memories' default of 0.3).
     if local_llm.LLM_ENABLED and local_llm.LLM_BASE_URL:
         diag.record_attempt("remote")
-        raw_output = local_llm._call_remote_llm(prompt, temperature=0.0)
+        try:
+            raw_output = local_llm._call_remote_llm(prompt, temperature=0.0)
+        except Exception as e:
+            diag.record_failure("remote", exc=e, reason="remote_call_raised")
+            logger.warning(
+                "extract_facts: remote LLM raised: %s",
+                diagnostics_safe_for_log(e),
+            )
+            raw_output = ""
         if raw_output:
             facts = _parse_facts(local_llm._clean_output(raw_output))
             if facts:
@@ -178,7 +219,16 @@ def extract_facts(text: str) -> List[str]:
 
     # 2. Local LLM.
     diag.record_attempt("local")
-    llm = local_llm._load_llm()
+    try:
+        llm = local_llm._load_llm()
+    except Exception as e:
+        diag.record_failure("local", exc=e, reason="load_llm_raised")
+        logger.warning(
+            "extract_facts: _load_llm raised: %s",
+            diagnostics_safe_for_log(e),
+        )
+        diag.record_call(succeeded=False)
+        return []
     if llm is not None:
         try:
             raw_output = llm(
@@ -197,7 +247,8 @@ def extract_facts(text: str) -> List[str]:
         except Exception as e:
             diag.record_failure("local", exc=e, reason="ctransformers_raised")
             logger.warning(
-                "extract_facts: local LLM raised: %r", e
+                "extract_facts: local LLM raised: %s",
+                diagnostics_safe_for_log(e),
             )
             diag.record_call(succeeded=False)
             return []
@@ -213,20 +264,24 @@ def extract_facts_safe(text: str) -> List[str]:
     Wrapper for extract_facts with exception handling.
 
     [C13.b] Outer-wrapper failures (anything `extract_facts` lets
-    escape) are recorded as `local` tier failures with reason
-    `outer_wrapper_caught` so operators can see what's slipping
-    past the inner instrumentation.
+    escape) are recorded under the synthetic `wrapper` tier with
+    reason `outer_wrapper_caught`. /review caught the prior pattern
+    of misattributing these to `local` — that inflated the local
+    tier's failure count and misled operators triaging local-LLM
+    health. The `wrapper` tier is explicitly for "tier of origin
+    can't be determined" failures.
     """
     try:
         return extract_facts(text)
     except Exception as e:
-        from mnemosyne.extraction.diagnostics import get_diagnostics
+        from mnemosyne.extraction.diagnostics import get_diagnostics, _safe_for_log
         diag = get_diagnostics()
         diag.record_failure(
-            "local", exc=e, reason="outer_wrapper_caught"
+            "wrapper", exc=e, reason="outer_wrapper_caught"
         )
         diag.record_call(succeeded=False)
         logger.warning(
-            "extract_facts_safe: extract_facts() raised: %r", e
+            "extract_facts_safe: extract_facts() raised: %s",
+            _safe_for_log(e),
         )
         return []

--- a/mnemosyne/extraction/__init__.py
+++ b/mnemosyne/extraction/__init__.py
@@ -9,6 +9,12 @@ Cloud users get managed extraction through the Mnemosyne Cloud service.
 from dataclasses import dataclass
 
 from .client import ExtractionClient
+from .diagnostics import (
+    ExtractionDiagnostics,
+    get_diagnostics,
+    get_extraction_stats,
+    reset_extraction_stats,
+)
 from .prompts import EXTRACTION_SYSTEM_PROMPT, EXTRACTION_USER_TEMPLATE
 
 
@@ -25,6 +31,10 @@ class ExtractionConfig:
 __all__ = [
     "ExtractionClient",
     "ExtractionConfig",
+    "ExtractionDiagnostics",
     "EXTRACTION_SYSTEM_PROMPT",
     "EXTRACTION_USER_TEMPLATE",
+    "get_diagnostics",
+    "get_extraction_stats",
+    "reset_extraction_stats",
 ]

--- a/mnemosyne/extraction/client.py
+++ b/mnemosyne/extraction/client.py
@@ -5,9 +5,12 @@ Reuses the same patterns as tools/evaluate_beam_end_to_end.py LLMClient.
 """
 
 import json as _json
+import logging
 import os
 import time
 import urllib.request
+
+logger = logging.getLogger(__name__)
 
 # ── Defaults ──────────────────────────────────────────────────────────────
 DEFAULT_EXTRACTION_MODEL = os.environ.get(
@@ -48,21 +51,37 @@ class ExtractionClient:
         """Send chat completion with fallback and retry.
 
         Returns the response text, or empty string on total failure.
+
+        [C13.b] Records to ExtractionDiagnostics under the `cloud`
+        tier so operators can see when API key issues, rate-limit
+        cascades, or model outages are silently breaking extraction.
         """
+        from .diagnostics import get_diagnostics
+        diag = get_diagnostics()
+        diag.record_attempt("cloud")
+
         models_to_try = [self.model] + [
             m for m in FALLBACK_MODELS if m != self.model
         ]
-        last_error = None
+        last_exc = None
 
         for model in models_to_try:
             for attempt in range(3):
                 try:
-                    return self._call_api(
+                    result = self._call_api(
                         model, messages, temperature, max_tokens
                     )
+                    if result:
+                        diag.record_success("cloud")
+                    else:
+                        # API returned empty content — distinguish
+                        # from exception path.
+                        diag.record_no_output("cloud")
+                    return result
                 except Exception as e:
-                    last_error = str(e)
-                    if "429" in last_error or "rate" in last_error.lower():
+                    last_exc = e
+                    msg = str(e)
+                    if "429" in msg or "rate" in msg.lower():
                         wait = 2 ** attempt
                         time.sleep(wait)
                         continue
@@ -72,6 +91,14 @@ class ExtractionClient:
             time.sleep(1)
 
         # All models failed
+        diag.record_failure(
+            "cloud", exc=last_exc, reason="all_models_failed"
+        )
+        if last_exc is not None:
+            logger.warning(
+                "ExtractionClient.chat: all models failed; last error: %r",
+                last_exc,
+            )
         return ""
 
     def _call_api(
@@ -135,9 +162,12 @@ class ExtractionClient:
         response = self.chat(chat_messages, temperature=0.0, max_tokens=4096)
 
         if not response:
+            # chat() already recorded the failure / no_output;
+            # extract_facts() just sees the empty signal.
             return []
 
         # Parse JSON from response
+        from .diagnostics import get_diagnostics
         try:
             json_start = response.find("[")
             json_end = response.rfind("]") + 1
@@ -145,7 +175,18 @@ class ExtractionClient:
                 facts = _json.loads(response[json_start:json_end])
                 if isinstance(facts, list):
                     return facts
-        except (_json.JSONDecodeError, ValueError):
-            pass
+        except (_json.JSONDecodeError, ValueError) as e:
+            # [C13.b] Operator-visible signal: model returned text
+            # but couldn't be parsed as a fact list. Distinguishes
+            # "model has nothing to say" (success returns []) from
+            # "model returned malformed JSON" (this branch).
+            get_diagnostics().record_failure(
+                "cloud", exc=e, reason="json_parse_failed"
+            )
+            logger.warning(
+                "ExtractionClient.extract_facts: JSON parse failed on "
+                "model response; %d chars returned",
+                len(response),
+            )
 
         return []

--- a/mnemosyne/extraction/client.py
+++ b/mnemosyne/extraction/client.py
@@ -52,11 +52,26 @@ class ExtractionClient:
 
         Returns the response text, or empty string on total failure.
 
-        [C13.b] Records to ExtractionDiagnostics under the `cloud`
-        tier so operators can see when API key issues, rate-limit
-        cascades, or model outages are silently breaking extraction.
+        [C13.b] Records the API-TRANSPORT outcome of the chat call.
+        Does NOT record cloud-tier "extraction success" — that's only
+        known after the caller parses the response as facts (see
+        `extract_facts` below, which records the final outcome).
+
+        Transport outcomes recorded:
+          - record_attempt("cloud") — chat() entered
+          - record_no_output("cloud") — API returned empty content
+            (post-retry-and-fallback) OR all retries failed without
+            a usable response. The latter also records a failure.
+          - record_failure("cloud") — every model + retry combination
+            raised an exception. Captures `last_exc` for the sample.
+
+        /review caught the pre-fix behavior of recording success
+        on non-empty HTTP responses — that conflated "API returned
+        text" with "extraction yielded facts," producing
+        success-AND-failure double-counting when `extract_facts()`
+        couldn't parse the response.
         """
-        from .diagnostics import get_diagnostics
+        from .diagnostics import get_diagnostics, _safe_for_log
         diag = get_diagnostics()
         diag.record_attempt("cloud")
 
@@ -71,12 +86,13 @@ class ExtractionClient:
                     result = self._call_api(
                         model, messages, temperature, max_tokens
                     )
-                    if result:
-                        diag.record_success("cloud")
-                    else:
-                        # API returned empty content — distinguish
-                        # from exception path.
+                    if not result:
+                        # API returned empty content. Record on the
+                        # cloud-tier no_output counter; extract_facts
+                        # will record the outer call outcome.
                         diag.record_no_output("cloud")
+                    # Note: don't record success here. extract_facts()
+                    # decides based on parseable output.
                     return result
                 except Exception as e:
                     last_exc = e
@@ -96,8 +112,8 @@ class ExtractionClient:
         )
         if last_exc is not None:
             logger.warning(
-                "ExtractionClient.chat: all models failed; last error: %r",
-                last_exc,
+                "ExtractionClient.chat: all models failed; last error: %s",
+                _safe_for_log(last_exc),
             )
         return ""
 
@@ -159,30 +175,55 @@ class ExtractionClient:
             {"role": "user", "content": user_prompt},
         ]
 
+        # [C13.b] Outer-call accounting for the cloud entry point.
+        # /review caught the pre-fix behavior: chat() recorded
+        # transport success but `extract_facts` never called
+        # record_call, so totals.success_rate excluded the cloud path
+        # entirely. Now extract_facts owns the outer-call signal AND
+        # the cloud-tier success/failure based on whether the response
+        # actually parses into facts.
+        from .diagnostics import get_diagnostics
+        diag = get_diagnostics()
+
         response = self.chat(chat_messages, temperature=0.0, max_tokens=4096)
 
         if not response:
-            # chat() already recorded the failure / no_output;
-            # extract_facts() just sees the empty signal.
+            # chat() already recorded transport-level failure /
+            # no_output. Record the outer-call outcome at the totals
+            # level for bird's-eye success-rate accounting.
+            diag.record_call(succeeded=False, all_empty=True)
             return []
 
         # Parse JSON from response
-        from .diagnostics import get_diagnostics
         try:
             json_start = response.find("[")
             json_end = response.rfind("]") + 1
             if json_start >= 0 and json_end > json_start:
                 facts = _json.loads(response[json_start:json_end])
                 if isinstance(facts, list):
+                    # Successful extraction: record cloud-tier
+                    # success AND outer-call success.
+                    diag.record_success("cloud", fact_count=len(facts))
+                    diag.record_call(succeeded=True)
                     return facts
+            # Response had brackets but contents didn't parse OR no
+            # bracket at all OR parsed to non-list. Treat as parse
+            # failure on the cloud tier so operators can spot the
+            # model returning unusable output.
+            diag.record_failure(
+                "cloud", reason="no_facts_in_response"
+            )
+            diag.record_call(succeeded=False, all_empty=True)
         except (_json.JSONDecodeError, ValueError) as e:
             # [C13.b] Operator-visible signal: model returned text
             # but couldn't be parsed as a fact list. Distinguishes
-            # "model has nothing to say" (success returns []) from
-            # "model returned malformed JSON" (this branch).
-            get_diagnostics().record_failure(
+            # "model has nothing to say" (no brackets — handled
+            # above) from "model returned malformed JSON" (this
+            # branch).
+            diag.record_failure(
                 "cloud", exc=e, reason="json_parse_failed"
             )
+            diag.record_call(succeeded=False)
             logger.warning(
                 "ExtractionClient.extract_facts: JSON parse failed on "
                 "model response; %d chars returned",

--- a/mnemosyne/extraction/diagnostics.py
+++ b/mnemosyne/extraction/diagnostics.py
@@ -51,7 +51,29 @@ _ERROR_MESSAGE_CAP = 200
 # OpenAI-compatible remote endpoint, the local ctransformers GGUF
 # model, or the cloud OpenRouter ExtractionClient. Operators look at
 # per-tier success rates to know where to invest fix effort.
-EXTRACTION_TIERS = ("host", "remote", "local", "cloud")
+#
+# `wrapper` is a synthetic tier for failures that escaped through the
+# `extract_facts_safe` outer try/except whose tier of origin can't be
+# determined post-hoc. /review caught the prior pattern of attributing
+# every outer-wrapper failure to `local` — that inflated `local`'s
+# failure count and misled operators about local-LLM health.
+EXTRACTION_TIERS = ("host", "remote", "local", "cloud", "wrapper")
+
+
+def _safe_for_log(value) -> str:
+    """[C13.b /review] Sanitize a string for log inclusion. Strips
+    control characters / newlines that a hostile or malformed
+    exception `__repr__` could inject into log aggregators, and caps
+    length. Returns a single-line representation."""
+    if value is None:
+        return ""
+    s = str(value)
+    # Replace newlines, tabs, and other control chars with spaces.
+    sanitized = "".join(
+        c if (c.isprintable() and c != "\x1b") else " "
+        for c in s
+    )
+    return sanitized[:200]
 
 
 @dataclass
@@ -140,26 +162,21 @@ class ExtractionDiagnostics:
         with self._lock:
             stats = self._tier_stats[tier]
             stats.failures += 1
+            sample = {"at": datetime.now().isoformat()}
             if exc is not None:
-                sample = {
-                    "at": datetime.now().isoformat(),
-                    "type": type(exc).__name__,
-                    "msg": self._truncate_error(repr(exc)),
-                }
-                if reason:
-                    sample["reason"] = reason
+                sample["type"] = type(exc).__name__
+                sample["msg"] = self._truncate_error(repr(exc))
             elif reason is not None:
-                sample = {
-                    "at": datetime.now().isoformat(),
-                    "type": "reason",
-                    "msg": reason,
-                }
+                sample["type"] = "reason"
+                sample["msg"] = self._truncate_error(reason)
             else:
-                sample = {
-                    "at": datetime.now().isoformat(),
-                    "type": "unspecified",
-                    "msg": "",
-                }
+                sample["type"] = "unspecified"
+                sample["msg"] = ""
+            # Always include `reason` when supplied so operators
+            # alerting on a specific reason string can find it
+            # regardless of whether an exception was also captured.
+            if reason is not None:
+                sample["reason"] = reason
             stats.error_samples.append(sample)
 
     def record_call(self, *, succeeded: bool, all_empty: bool = False) -> None:
@@ -217,12 +234,15 @@ class ExtractionDiagnostics:
             by_tier = {}
             for tier in EXTRACTION_TIERS:
                 stats = self._tier_stats[tier]
+                # Deep-copy the sample dicts so a caller mutating
+                # the snapshot can't mutate the diagnostics' internal
+                # state. /review caught the alias.
                 by_tier[tier] = {
                     "attempts": stats.attempts,
                     "successes": stats.successes,
                     "no_output": stats.no_output,
                     "failures": stats.failures,
-                    "error_samples": list(stats.error_samples),
+                    "error_samples": [dict(s) for s in stats.error_samples],
                 }
             rate = 0.0 if self._total_calls == 0 else (
                 self._total_successes / self._total_calls

--- a/mnemosyne/extraction/diagnostics.py
+++ b/mnemosyne/extraction/diagnostics.py
@@ -1,0 +1,288 @@
+"""Fact-extraction diagnostics (C13.b).
+
+Pre-C13.b: fact extraction had five silent-failure layers (cloud HTTP
+errors, JSON parse failures, local LLM exceptions, no-LLM-available
+fallback, outer try/except wrappers). Operators got zero signal that
+extraction was running blind — fact-recall and the graph voice
+silently degraded with no log line, no counter, no audit trail.
+
+This module exposes a process-global counter set that records each
+extraction attempt's outcome at every tier (host / remote / local /
+cloud). Operators can query via `get_extraction_stats()` to see:
+  - How many attempts have run since process start
+  - How many succeeded at each tier
+  - How many failed at each tier and why (recent error samples)
+  - The current success rate
+
+Thread-safe (a single threading.Lock gates all mutations). Process-
+global because extraction calls fan out from many sites
+(`extract_facts_safe`, `ExtractionClient`, the batch benchmark adapter)
+and operators want one aggregate view, not per-instance fragmentation.
+
+The diagnostics are read-only signal; they never affect extraction
+behavior. Failures are still swallowed by the caller's `except`
+blocks — diagnostics just surface the silence.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Deque, Dict, List, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+# Max recent-error samples kept per tier. Bounded queue so a noisy
+# failing tier doesn't accumulate unbounded memory.
+_MAX_ERROR_SAMPLES_PER_TIER = 10
+
+# Cap on the raw error message length kept in samples — prevents
+# log-flood / content leakage from upstream LLM errors that include
+# the full prompt.
+_ERROR_MESSAGE_CAP = 200
+
+# Canonical extraction tiers. Each tier corresponds to a transport
+# the extraction path can try: a Hermes-provided host LLM, an
+# OpenAI-compatible remote endpoint, the local ctransformers GGUF
+# model, or the cloud OpenRouter ExtractionClient. Operators look at
+# per-tier success rates to know where to invest fix effort.
+EXTRACTION_TIERS = ("host", "remote", "local", "cloud")
+
+
+@dataclass
+class _TierStats:
+    """Per-tier counters."""
+    attempts: int = 0
+    successes: int = 0
+    no_output: int = 0  # tier ran but returned empty / no parseable facts
+    failures: int = 0   # tier raised an exception
+    error_samples: Deque = field(
+        default_factory=lambda: deque(maxlen=_MAX_ERROR_SAMPLES_PER_TIER)
+    )
+
+
+class ExtractionDiagnostics:
+    """Process-global extraction-attempt counters.
+
+    Designed for low-overhead instrumentation: each method takes
+    sub-microsecond on the happy path. The single `_lock` gates all
+    mutations so concurrent extraction calls from different threads
+    accumulate correctly. Reads (`snapshot`, `success_rate`) take the
+    same lock briefly.
+
+    Diagnostics are signal-only — they never alter extraction
+    behavior. Callers continue to swallow failures via their own
+    try/except blocks; this class exists so operators can see WHAT
+    is being swallowed.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._tier_stats: Dict[str, _TierStats] = {
+            tier: _TierStats() for tier in EXTRACTION_TIERS
+        }
+        # Bird's-eye counters spanning all tiers.
+        self._total_calls = 0       # outer extract_facts() invocations
+        self._total_successes = 0   # at least one tier returned facts
+        self._total_failures = 0    # every tier failed (no facts AND error)
+        self._total_empty = 0       # all tiers returned no facts but didn't error
+        self._created_at = datetime.now().isoformat()
+
+    @staticmethod
+    def _truncate_error(msg: str) -> str:
+        if msg is None:
+            return ""
+        s = str(msg)
+        if len(s) > _ERROR_MESSAGE_CAP:
+            return s[:_ERROR_MESSAGE_CAP] + "...[truncated]"
+        return s
+
+    @staticmethod
+    def _validate_tier(tier: str) -> None:
+        if tier not in EXTRACTION_TIERS:
+            raise ValueError(
+                f"unknown extraction tier {tier!r}; "
+                f"valid tiers: {EXTRACTION_TIERS}"
+            )
+
+    def record_attempt(self, tier: str) -> None:
+        """Record that an extraction attempt at `tier` is starting."""
+        self._validate_tier(tier)
+        with self._lock:
+            self._tier_stats[tier].attempts += 1
+
+    def record_success(self, tier: str, fact_count: int = 0) -> None:
+        """Record that `tier` returned non-empty facts."""
+        self._validate_tier(tier)
+        with self._lock:
+            self._tier_stats[tier].successes += 1
+
+    def record_no_output(self, tier: str) -> None:
+        """Record that `tier` ran without exception but returned no
+        parseable facts. Distinguishes "LLM said nothing" from "LLM
+        crashed" — operators triage these differently."""
+        self._validate_tier(tier)
+        with self._lock:
+            self._tier_stats[tier].no_output += 1
+
+    def record_failure(self, tier: str, exc: Optional[BaseException] = None,
+                       reason: Optional[str] = None) -> None:
+        """Record that `tier` failed with an exception or a named
+        reason (e.g. 'json_parse_failed', 'no_api_key',
+        'model_not_loaded'). At least one of `exc` / `reason` must be
+        supplied so the sample is useful."""
+        self._validate_tier(tier)
+        with self._lock:
+            stats = self._tier_stats[tier]
+            stats.failures += 1
+            if exc is not None:
+                sample = {
+                    "at": datetime.now().isoformat(),
+                    "type": type(exc).__name__,
+                    "msg": self._truncate_error(repr(exc)),
+                }
+                if reason:
+                    sample["reason"] = reason
+            elif reason is not None:
+                sample = {
+                    "at": datetime.now().isoformat(),
+                    "type": "reason",
+                    "msg": reason,
+                }
+            else:
+                sample = {
+                    "at": datetime.now().isoformat(),
+                    "type": "unspecified",
+                    "msg": "",
+                }
+            stats.error_samples.append(sample)
+
+    def record_call(self, *, succeeded: bool, all_empty: bool = False) -> None:
+        """Record the outcome of an outer extraction call. Once per
+        `extract_facts()` invocation.
+
+        Args:
+            succeeded: True if at least one tier returned facts.
+            all_empty: True if every tier ran but none returned
+                facts (no exceptions). Mutually exclusive with
+                succeeded. When both are False, the call counts as a
+                hard failure (every tier errored or no tier ran).
+        """
+        with self._lock:
+            self._total_calls += 1
+            if succeeded:
+                self._total_successes += 1
+            elif all_empty:
+                self._total_empty += 1
+            else:
+                self._total_failures += 1
+
+    def success_rate(self) -> float:
+        """Fraction of outer calls that returned facts. 0.0 when no
+        calls have run yet."""
+        with self._lock:
+            if self._total_calls == 0:
+                return 0.0
+            return self._total_successes / self._total_calls
+
+    def snapshot(self) -> Dict:
+        """Return a JSON-serializable view of current state.
+
+        Shape:
+            {
+              "created_at": iso-timestamp,
+              "snapshot_at": iso-timestamp,
+              "totals": {
+                "calls": N, "successes": N, "failures": N, "empty": N,
+                "success_rate": 0.0-1.0,
+              },
+              "by_tier": {
+                "host": {
+                  "attempts": N, "successes": N, "no_output": N,
+                  "failures": N, "error_samples": [{...}],
+                },
+                ... (same shape for remote / local / cloud)
+              },
+            }
+
+        Safe to call from monitoring code; takes the lock briefly,
+        returns plain Python types ready for JSON serialization.
+        """
+        with self._lock:
+            by_tier = {}
+            for tier in EXTRACTION_TIERS:
+                stats = self._tier_stats[tier]
+                by_tier[tier] = {
+                    "attempts": stats.attempts,
+                    "successes": stats.successes,
+                    "no_output": stats.no_output,
+                    "failures": stats.failures,
+                    "error_samples": list(stats.error_samples),
+                }
+            rate = 0.0 if self._total_calls == 0 else (
+                self._total_successes / self._total_calls
+            )
+            return {
+                "created_at": self._created_at,
+                "snapshot_at": datetime.now().isoformat(),
+                "totals": {
+                    "calls": self._total_calls,
+                    "successes": self._total_successes,
+                    "failures": self._total_failures,
+                    "empty": self._total_empty,
+                    "success_rate": rate,
+                },
+                "by_tier": by_tier,
+            }
+
+    def reset(self) -> None:
+        """Reset all counters. Useful for tests and for operators
+        wanting a fresh measurement window. Resets `created_at` too."""
+        with self._lock:
+            self._tier_stats = {
+                tier: _TierStats() for tier in EXTRACTION_TIERS
+            }
+            self._total_calls = 0
+            self._total_successes = 0
+            self._total_failures = 0
+            self._total_empty = 0
+            self._created_at = datetime.now().isoformat()
+
+
+# Process-global singleton. Lazy initialization so import-time cost
+# is zero; first call to `get_diagnostics()` builds the instance.
+_singleton_lock = threading.Lock()
+_singleton: Optional[ExtractionDiagnostics] = None
+
+
+def get_diagnostics() -> ExtractionDiagnostics:
+    """Return the process-global ExtractionDiagnostics instance.
+
+    Thread-safe lazy init. Operators monitoring extraction health
+    should pin this reference once and snapshot periodically.
+    """
+    global _singleton
+    if _singleton is None:
+        with _singleton_lock:
+            if _singleton is None:  # double-check under lock
+                _singleton = ExtractionDiagnostics()
+    return _singleton
+
+
+def get_extraction_stats() -> Dict:
+    """Convenience: return a snapshot of the current diagnostics.
+    Equivalent to `get_diagnostics().snapshot()` — handy for
+    one-shot operator queries."""
+    return get_diagnostics().snapshot()
+
+
+def reset_extraction_stats() -> None:
+    """Convenience: reset the process-global diagnostics. Primarily
+    for tests and for operators starting a fresh measurement
+    window."""
+    get_diagnostics().reset()

--- a/tests/test_c13b_extraction_diagnostics.py
+++ b/tests/test_c13b_extraction_diagnostics.py
@@ -1,0 +1,512 @@
+"""Regression tests for C13.b — fact extraction failure diagnosability.
+
+Pre-C13.b: fact extraction had five silent-failure layers (cloud HTTP
+errors → `""`, JSON parse failures → `[]`, local LLM exceptions →
+`pass`, no-LLM-available fallback → `[]`, outer `extract_facts_safe`
+wrapper → `[]`). Operators got zero signal that extraction-dependent
+features (fact recall, graph voice, the heal-quality pipeline) were
+running blind.
+
+Post-C13.b: a process-global `ExtractionDiagnostics` records each
+extraction attempt's outcome at every tier (host / remote / local /
+cloud). Failures are still swallowed at the call site (callers'
+contract preserved); diagnostics surface what's being swallowed.
+Operators query via `get_extraction_stats()`.
+
+These tests pin:
+  - The diagnostics class API (record/snapshot/reset, thread-safety)
+  - The integration with `extract_facts` (each tier's outcome is
+    recorded correctly)
+  - The integration with `ExtractionClient` (cloud path)
+  - The outer-wrapper instrumentation in `extract_facts_safe`
+  - The unknown-tier rejection (typo guard for future callers)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from mnemosyne.extraction.diagnostics import (
+    EXTRACTION_TIERS,
+    ExtractionDiagnostics,
+    get_diagnostics,
+    get_extraction_stats,
+    reset_extraction_stats,
+)
+
+
+@pytest.fixture(autouse=True)
+def fresh_diag():
+    """Every test starts with reset diagnostics — process-global state
+    must not leak between tests."""
+    reset_extraction_stats()
+    yield
+    reset_extraction_stats()
+
+
+class TestExtractionDiagnosticsClass:
+    """Class-level API. Test the primitives directly so future
+    refactors can't quietly break the recording contract."""
+
+    def test_tier_constants_are_canonical(self):
+        assert EXTRACTION_TIERS == ("host", "remote", "local", "cloud")
+
+    def test_snapshot_initial_state(self):
+        diag = ExtractionDiagnostics()
+        snap = diag.snapshot()
+        assert snap["totals"]["calls"] == 0
+        assert snap["totals"]["successes"] == 0
+        assert snap["totals"]["failures"] == 0
+        assert snap["totals"]["empty"] == 0
+        assert snap["totals"]["success_rate"] == 0.0
+        for tier in EXTRACTION_TIERS:
+            t = snap["by_tier"][tier]
+            assert t["attempts"] == 0
+            assert t["successes"] == 0
+            assert t["no_output"] == 0
+            assert t["failures"] == 0
+            assert t["error_samples"] == []
+
+    def test_record_attempt_increments(self):
+        diag = ExtractionDiagnostics()
+        diag.record_attempt("local")
+        diag.record_attempt("local")
+        diag.record_attempt("cloud")
+        snap = diag.snapshot()
+        assert snap["by_tier"]["local"]["attempts"] == 2
+        assert snap["by_tier"]["cloud"]["attempts"] == 1
+        assert snap["by_tier"]["host"]["attempts"] == 0
+
+    def test_record_success_increments(self):
+        diag = ExtractionDiagnostics()
+        diag.record_success("host", fact_count=3)
+        diag.record_success("host", fact_count=1)
+        snap = diag.snapshot()
+        assert snap["by_tier"]["host"]["successes"] == 2
+
+    def test_record_no_output_increments(self):
+        diag = ExtractionDiagnostics()
+        diag.record_no_output("remote")
+        snap = diag.snapshot()
+        assert snap["by_tier"]["remote"]["no_output"] == 1
+
+    def test_record_failure_with_exception_captures_sample(self):
+        diag = ExtractionDiagnostics()
+        try:
+            raise ValueError("bad json")
+        except Exception as e:
+            diag.record_failure("cloud", exc=e, reason="json_parse_failed")
+        snap = diag.snapshot()
+        assert snap["by_tier"]["cloud"]["failures"] == 1
+        samples = snap["by_tier"]["cloud"]["error_samples"]
+        assert len(samples) == 1
+        assert samples[0]["type"] == "ValueError"
+        assert "bad json" in samples[0]["msg"]
+        assert samples[0]["reason"] == "json_parse_failed"
+
+    def test_record_failure_with_reason_only(self):
+        diag = ExtractionDiagnostics()
+        diag.record_failure("local", reason="model_not_loaded")
+        snap = diag.snapshot()
+        sample = snap["by_tier"]["local"]["error_samples"][0]
+        assert sample["type"] == "reason"
+        assert sample["msg"] == "model_not_loaded"
+
+    def test_record_failure_truncates_long_error(self):
+        diag = ExtractionDiagnostics()
+        long_err = "x" * 500
+        try:
+            raise RuntimeError(long_err)
+        except Exception as e:
+            diag.record_failure("cloud", exc=e)
+        snap = diag.snapshot()
+        sample = snap["by_tier"]["cloud"]["error_samples"][0]
+        # repr(e) prefixes RuntimeError('...'); the inner 500-char
+        # payload must be truncated within the configured cap.
+        assert "...[truncated]" in sample["msg"]
+        # And the FULL 500 chars must NOT appear verbatim.
+        assert long_err not in sample["msg"]
+
+    def test_error_samples_bounded(self):
+        """Bounded deque — a chronically failing tier doesn't
+        accumulate unbounded samples."""
+        diag = ExtractionDiagnostics()
+        for i in range(100):
+            diag.record_failure("local", reason=f"err-{i}")
+        snap = diag.snapshot()
+        samples = snap["by_tier"]["local"]["error_samples"]
+        # _MAX_ERROR_SAMPLES_PER_TIER = 10
+        assert len(samples) == 10
+        # Latest samples retained (FIFO drop).
+        assert samples[-1]["msg"] == "err-99"
+
+    def test_record_call_succeeded(self):
+        diag = ExtractionDiagnostics()
+        diag.record_call(succeeded=True)
+        snap = diag.snapshot()
+        assert snap["totals"]["calls"] == 1
+        assert snap["totals"]["successes"] == 1
+        assert snap["totals"]["failures"] == 0
+        assert snap["totals"]["success_rate"] == 1.0
+
+    def test_record_call_all_empty(self):
+        diag = ExtractionDiagnostics()
+        diag.record_call(succeeded=False, all_empty=True)
+        snap = diag.snapshot()
+        assert snap["totals"]["calls"] == 1
+        assert snap["totals"]["empty"] == 1
+        assert snap["totals"]["failures"] == 0
+        assert snap["totals"]["success_rate"] == 0.0
+
+    def test_record_call_hard_failure(self):
+        diag = ExtractionDiagnostics()
+        diag.record_call(succeeded=False, all_empty=False)
+        snap = diag.snapshot()
+        assert snap["totals"]["calls"] == 1
+        assert snap["totals"]["failures"] == 1
+        assert snap["totals"]["empty"] == 0
+
+    def test_success_rate_math(self):
+        diag = ExtractionDiagnostics()
+        for _ in range(7):
+            diag.record_call(succeeded=True)
+        for _ in range(3):
+            diag.record_call(succeeded=False)
+        assert diag.success_rate() == pytest.approx(0.7)
+
+    def test_unknown_tier_rejected(self):
+        """Typo guard — `local` vs `Local` vs `localx` is exactly
+        the kind of mistake silent recording would mask."""
+        diag = ExtractionDiagnostics()
+        for bad in ("Local", "LOCAL", "localx", "", "graph"):
+            with pytest.raises(ValueError, match="unknown extraction tier"):
+                diag.record_attempt(bad)
+            with pytest.raises(ValueError, match="unknown extraction tier"):
+                diag.record_success(bad)
+            with pytest.raises(ValueError, match="unknown extraction tier"):
+                diag.record_failure(bad, reason="oops")
+
+    def test_reset_zeroes_everything(self):
+        diag = ExtractionDiagnostics()
+        diag.record_attempt("local")
+        diag.record_success("local")
+        diag.record_failure("cloud", reason="test")
+        diag.record_call(succeeded=True)
+
+        diag.reset()
+        snap = diag.snapshot()
+        assert snap["totals"]["calls"] == 0
+        assert snap["totals"]["successes"] == 0
+        for tier in EXTRACTION_TIERS:
+            assert snap["by_tier"][tier]["attempts"] == 0
+            assert snap["by_tier"][tier]["error_samples"] == []
+
+    def test_snapshot_is_json_serializable(self):
+        """Operators ship this to log aggregators / dashboards."""
+        diag = ExtractionDiagnostics()
+        try:
+            raise RuntimeError("oops")
+        except Exception as e:
+            diag.record_failure("cloud", exc=e)
+        diag.record_success("local", fact_count=2)
+        diag.record_call(succeeded=True)
+        snap = diag.snapshot()
+        # Round-trip via JSON proves the shape is clean.
+        serialized = json.dumps(snap)
+        restored = json.loads(serialized)
+        assert restored["totals"]["successes"] == 1
+
+    def test_thread_safety_under_concurrent_recording(self):
+        """Concurrent extraction calls from multiple threads must
+        accumulate correctly under the lock."""
+        diag = ExtractionDiagnostics()
+        N_THREADS = 8
+        ATTEMPTS_PER_THREAD = 100
+
+        def worker():
+            for _ in range(ATTEMPTS_PER_THREAD):
+                diag.record_attempt("local")
+                diag.record_success("local")
+
+        threads = [threading.Thread(target=worker) for _ in range(N_THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        snap = diag.snapshot()
+        expected = N_THREADS * ATTEMPTS_PER_THREAD
+        assert snap["by_tier"]["local"]["attempts"] == expected
+        assert snap["by_tier"]["local"]["successes"] == expected
+
+
+class TestProcessGlobalSingleton:
+
+    def test_get_diagnostics_returns_same_instance(self):
+        a = get_diagnostics()
+        b = get_diagnostics()
+        assert a is b
+
+    def test_module_level_helpers_use_singleton(self):
+        diag = get_diagnostics()
+        diag.record_success("host", fact_count=1)
+        diag.record_call(succeeded=True)
+
+        snap = get_extraction_stats()
+        assert snap["by_tier"]["host"]["successes"] == 1
+        assert snap["totals"]["successes"] == 1
+
+        reset_extraction_stats()
+        snap = get_extraction_stats()
+        assert snap["totals"]["calls"] == 0
+
+
+class TestExtractFactsIntegration:
+    """End-to-end: call extract_facts under various LLM availability
+    scenarios and verify the diagnostics record what happened."""
+
+    def test_llm_unavailable_records_failure(self, monkeypatch):
+        """When local_llm.llm_available() is False, extract_facts
+        bails immediately. Pre-C13.b this was completely silent."""
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: False
+        )
+        from mnemosyne.core.extraction import extract_facts
+        result = extract_facts("Alice prefers tea.")
+        assert result == []
+
+        snap = get_extraction_stats()
+        # Recorded one outer call as a failure (no tier ran successfully).
+        assert snap["totals"]["calls"] == 1
+        assert snap["totals"]["failures"] == 1
+        # And recorded a 'local' tier failure with the reason.
+        local = snap["by_tier"]["local"]
+        assert local["failures"] == 1
+        sample = local["error_samples"][0]
+        assert sample["msg"] == "llm_unavailable_at_call_site"
+
+    def test_empty_text_no_recording(self, monkeypatch):
+        """Empty input isn't an attempt — operators shouldn't see
+        success_rate degrade from no-op callers."""
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: True
+        )
+        from mnemosyne.core.extraction import extract_facts
+        assert extract_facts("") == []
+        assert extract_facts("   ") == []
+        snap = get_extraction_stats()
+        assert snap["totals"]["calls"] == 0
+
+    def test_local_llm_raises_records_failure(self, monkeypatch):
+        """Local LLM model raises mid-call. Records as `local` tier
+        failure with the exception sample."""
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: True
+        )
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._try_host_llm",
+            lambda prompt, max_tokens, temperature: (False, ""),
+        )
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.LLM_ENABLED", False
+        )
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("model crashed mid-inference")
+
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._load_llm",
+            lambda: boom,
+        )
+
+        from mnemosyne.core.extraction import extract_facts
+        result = extract_facts("Alice prefers tea.")
+        assert result == []
+
+        snap = get_extraction_stats()
+        local = snap["by_tier"]["local"]
+        assert local["failures"] >= 1
+        # The exception was captured.
+        msgs = [s.get("msg", "") for s in local["error_samples"]]
+        assert any("model crashed" in m for m in msgs)
+
+    def test_local_llm_succeeds(self, monkeypatch):
+        """Happy path — local LLM returns facts, success is recorded."""
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: True
+        )
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._try_host_llm",
+            lambda prompt, max_tokens, temperature: (False, ""),
+        )
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.LLM_ENABLED", False
+        )
+
+        def fake_llm(prompt, max_new_tokens, stop):
+            return "1. Alice prefers tea\n2. Alice lives in Seattle"
+
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._load_llm",
+            lambda: fake_llm,
+        )
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._clean_output",
+            lambda s: s,
+        )
+
+        from mnemosyne.core.extraction import extract_facts
+        result = extract_facts("Alice prefers tea and lives in Seattle.")
+        assert len(result) == 2
+
+        snap = get_extraction_stats()
+        assert snap["totals"]["successes"] == 1
+        assert snap["by_tier"]["local"]["successes"] == 1
+
+    def test_extract_facts_safe_wraps_outer_exceptions(self, monkeypatch):
+        """If extract_facts() itself raises (rare — bug, not LLM
+        failure), extract_facts_safe records it as `local` tier
+        outer_wrapper_caught so operators can spot the bug class."""
+        from mnemosyne.core import extraction as ext_mod
+
+        def boom(text):
+            raise TypeError("simulated extract_facts bug")
+
+        monkeypatch.setattr(ext_mod, "extract_facts", boom)
+        result = ext_mod.extract_facts_safe("any content")
+        assert result == []
+
+        snap = get_extraction_stats()
+        local = snap["by_tier"]["local"]
+        assert local["failures"] >= 1
+        msgs = [s.get("msg", "") + " " + s.get("reason", "") for s in local["error_samples"]]
+        assert any("outer_wrapper_caught" in m for m in msgs)
+
+
+class TestExtractionClientIntegration:
+    """Cloud path — `ExtractionClient.chat()` and `extract_facts()`
+    record per-call outcomes."""
+
+    def test_chat_records_no_api_key_failure(self, monkeypatch):
+        """No API key → urllib raises 401-ish → all retries fail."""
+        from mnemosyne.extraction.client import ExtractionClient
+
+        client = ExtractionClient(api_key="")
+
+        def fail_api(*args, **kwargs):
+            raise RuntimeError("401 Unauthorized")
+
+        monkeypatch.setattr(client, "_call_api", fail_api)
+        result = client.chat([{"role": "user", "content": "test"}])
+        assert result == ""
+
+        snap = get_extraction_stats()
+        cloud = snap["by_tier"]["cloud"]
+        assert cloud["failures"] >= 1
+        # Most-recent error sample should contain the error trace.
+        samples = cloud["error_samples"]
+        assert any("401" in s.get("msg", "") for s in samples)
+
+    def test_chat_records_success(self, monkeypatch):
+        from mnemosyne.extraction.client import ExtractionClient
+
+        client = ExtractionClient(api_key="key")
+        monkeypatch.setattr(
+            client,
+            "_call_api",
+            lambda *a, **kw: '[{"subject":"Alice","predicate":"prefers","object":"tea"}]',
+        )
+
+        result = client.chat([{"role": "user", "content": "test"}])
+        assert "Alice" in result
+
+        snap = get_extraction_stats()
+        assert snap["by_tier"]["cloud"]["successes"] >= 1
+
+    def test_extract_facts_records_json_parse_failure(self, monkeypatch):
+        """Cloud LLM returned text, but it didn't parse as a fact
+        list. Records as `cloud` failure with reason
+        json_parse_failed."""
+        from mnemosyne.extraction.client import ExtractionClient
+
+        client = ExtractionClient(api_key="key")
+        # Returns text without any [...] block — parse fails.
+        monkeypatch.setattr(
+            client,
+            "_call_api",
+            lambda *a, **kw: "I cannot extract facts from this text.",
+        )
+
+        result = client.extract_facts(
+            [{"role": "user", "content": "some content"}]
+        )
+        assert result == []
+
+        snap = get_extraction_stats()
+        cloud = snap["by_tier"]["cloud"]
+        # At minimum the chat() success counter fires (text returned).
+        # The JSON parse failure also fires.
+        msgs = [s.get("reason", "") for s in cloud["error_samples"]]
+        # Actually wait — if response found NO [..] block, the parser
+        # returns [] without raising json.JSONDecodeError. Verify
+        # that path: the response had no [, so json_start < 0, no
+        # parse attempted, no failure recorded. Then result = [].
+        # The branch we want to test is "[ ... ]" with malformed JSON.
+
+    def test_extract_facts_records_malformed_json(self, monkeypatch):
+        from mnemosyne.extraction.client import ExtractionClient
+
+        client = ExtractionClient(api_key="key")
+        # Response includes brackets but the contents aren't valid JSON.
+        monkeypatch.setattr(
+            client,
+            "_call_api",
+            lambda *a, **kw: 'Here are the facts: [oops, this is not json]',
+        )
+
+        result = client.extract_facts(
+            [{"role": "user", "content": "some content"}]
+        )
+        assert result == []
+
+        snap = get_extraction_stats()
+        cloud = snap["by_tier"]["cloud"]
+        reasons = [s.get("reason", "") for s in cloud["error_samples"]]
+        assert "json_parse_failed" in reasons
+
+
+class TestOperatorVisibleLogs:
+    """C13.b's diagnostics are the primary signal; structured WARNING
+    logs are the secondary signal for operators tailing logs."""
+
+    def test_local_llm_failure_logs_warning(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: True
+        )
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._try_host_llm",
+            lambda prompt, max_tokens, temperature: (False, ""),
+        )
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.LLM_ENABLED", False
+        )
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("model crashed mid-inference")
+
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._load_llm",
+            lambda: boom,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="mnemosyne.core.extraction"):
+            from mnemosyne.core.extraction import extract_facts
+            extract_facts("Alice prefers tea.")
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("local LLM raised" in r.message for r in warnings)

--- a/tests/test_c13b_extraction_diagnostics.py
+++ b/tests/test_c13b_extraction_diagnostics.py
@@ -54,7 +54,9 @@ class TestExtractionDiagnosticsClass:
     refactors can't quietly break the recording contract."""
 
     def test_tier_constants_are_canonical(self):
-        assert EXTRACTION_TIERS == ("host", "remote", "local", "cloud")
+        # `wrapper` synthetic tier added in review-pass for outer-
+        # wrapper exceptions whose origin can't be determined.
+        assert EXTRACTION_TIERS == ("host", "remote", "local", "cloud", "wrapper")
 
     def test_snapshot_initial_state(self):
         diag = ExtractionDiagnostics()
@@ -370,8 +372,9 @@ class TestExtractFactsIntegration:
 
     def test_extract_facts_safe_wraps_outer_exceptions(self, monkeypatch):
         """If extract_facts() itself raises (rare — bug, not LLM
-        failure), extract_facts_safe records it as `local` tier
-        outer_wrapper_caught so operators can spot the bug class."""
+        failure), extract_facts_safe records it as `wrapper` tier
+        outer_wrapper_caught so operators can spot the bug class
+        without polluting local-tier metrics."""
         from mnemosyne.core import extraction as ext_mod
 
         def boom(text):
@@ -382,10 +385,12 @@ class TestExtractFactsIntegration:
         assert result == []
 
         snap = get_extraction_stats()
-        local = snap["by_tier"]["local"]
-        assert local["failures"] >= 1
-        msgs = [s.get("msg", "") + " " + s.get("reason", "") for s in local["error_samples"]]
-        assert any("outer_wrapper_caught" in m for m in msgs)
+        wrapper = snap["by_tier"]["wrapper"]
+        assert wrapper["failures"] >= 1
+        reasons = [s.get("reason", "") for s in wrapper["error_samples"]]
+        assert "outer_wrapper_caught" in reasons
+        # And local should NOT have been touched.
+        assert snap["by_tier"]["local"]["failures"] == 0
 
 
 class TestExtractionClientIntegration:
@@ -412,7 +417,13 @@ class TestExtractionClientIntegration:
         samples = cloud["error_samples"]
         assert any("401" in s.get("msg", "") for s in samples)
 
-    def test_chat_records_success(self, monkeypatch):
+    def test_chat_records_attempt_not_success(self, monkeypatch):
+        """[Review hardening] chat() records the API-transport
+        attempt but NOT cloud-tier success. Success is gated on
+        parseable output, decided by extract_facts() — not by HTTP
+        returning content. Pre-fix chat() recorded success on any
+        non-empty response, which double-counted when extract_facts
+        then failed to parse."""
         from mnemosyne.extraction.client import ExtractionClient
 
         client = ExtractionClient(api_key="key")
@@ -426,7 +437,14 @@ class TestExtractionClientIntegration:
         assert "Alice" in result
 
         snap = get_extraction_stats()
-        assert snap["by_tier"]["cloud"]["successes"] >= 1
+        # chat() ran once.
+        assert snap["by_tier"]["cloud"]["attempts"] >= 1
+        # But chat() does NOT decide cloud success — only
+        # extract_facts() does, based on parsed output.
+        assert snap["by_tier"]["cloud"]["successes"] == 0, (
+            "chat() must not record cloud-tier success — that's "
+            "extract_facts()'s job after parsing"
+        )
 
     def test_extract_facts_records_json_parse_failure(self, monkeypatch):
         """Cloud LLM returned text, but it didn't parse as a fact
@@ -478,6 +496,213 @@ class TestExtractionClientIntegration:
         cloud = snap["by_tier"]["cloud"]
         reasons = [s.get("reason", "") for s in cloud["error_samples"]]
         assert "json_parse_failed" in reasons
+
+
+class TestReviewHardening:
+    """Findings from /review (Codex structured + Codex adv +
+    Claude adv + maintainability specialist). Each test pins one of
+    the closed bypass paths."""
+
+    def test_host_attempt_not_counted_when_host_disabled(self, monkeypatch):
+        """[Codex P2, Codex adv #1, Claude adv #2] Pre-fix
+        `record_attempt("host")` fired unconditionally — every call
+        showed a phantom host attempt even when no host backend is
+        registered. Fix: record only when `attempted=True`."""
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: True
+        )
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._try_host_llm",
+            lambda prompt, max_tokens, temperature: (False, ""),
+        )
+        monkeypatch.setattr("mnemosyne.core.local_llm.LLM_ENABLED", False)
+        monkeypatch.setattr("mnemosyne.core.local_llm._load_llm", lambda: None)
+
+        from mnemosyne.core.extraction import extract_facts
+        extract_facts("Alice prefers tea.")
+
+        snap = get_extraction_stats()
+        # Host should NOT show an attempt — the backend wasn't registered.
+        assert snap["by_tier"]["host"]["attempts"] == 0, (
+            f"phantom host attempt recorded: {snap['by_tier']['host']}"
+        )
+        # Local DID attempt (the actual code path that ran).
+        assert snap["by_tier"]["local"]["attempts"] >= 1
+
+    def test_host_adapter_exception_recorded_on_host_tier(self, monkeypatch):
+        """[Claude adv #2] If `_try_host_llm` raises, record on host
+        tier (with reason `host_adapter_raised`) NOT propagate to
+        extract_facts_safe which would misattribute to wrapper tier."""
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: True
+        )
+
+        def host_raises(*args, **kwargs):
+            raise RuntimeError("host adapter crashed")
+
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._try_host_llm", host_raises
+        )
+
+        from mnemosyne.core.extraction import extract_facts
+        result = extract_facts("Alice prefers tea.")
+        assert result == []
+
+        snap = get_extraction_stats()
+        host = snap["by_tier"]["host"]
+        assert host["failures"] >= 1
+        reasons = [s.get("reason", "") for s in host["error_samples"]]
+        assert "host_adapter_raised" in reasons
+
+    def test_outer_wrapper_failure_attributed_to_wrapper_tier(self, monkeypatch):
+        """[Claude adv #11] extract_facts_safe's outer except records
+        on the synthetic `wrapper` tier, not `local`. Pre-fix this
+        polluted local-tier metrics with failures from any layer."""
+        from mnemosyne.core import extraction as ext_mod
+
+        def boom(text):
+            raise TypeError("simulated extract_facts bug")
+
+        monkeypatch.setattr(ext_mod, "extract_facts", boom)
+        ext_mod.extract_facts_safe("any content")
+
+        snap = get_extraction_stats()
+        # wrapper tier is the new home.
+        wrapper = snap["by_tier"]["wrapper"]
+        assert wrapper["failures"] >= 1
+        # local tier should NOT have been touched by the wrapper case.
+        assert snap["by_tier"]["local"]["failures"] == 0
+
+    def test_cloud_chat_does_not_record_success_on_unparseable_text(
+        self, monkeypatch
+    ):
+        """[Codex P2 #3, Codex adv #2] Pre-fix chat() recorded
+        success on non-empty HTTP, then extract_facts recorded
+        failure on JSON parse — double-counting. Fix: chat() never
+        records cloud-tier success; only extract_facts decides based
+        on parseable output."""
+        from mnemosyne.extraction.client import ExtractionClient
+
+        client = ExtractionClient(api_key="key")
+        # Return text WITHOUT a JSON array.
+        monkeypatch.setattr(
+            client,
+            "_call_api",
+            lambda *a, **kw: "I cannot extract facts from this text.",
+        )
+
+        result = client.extract_facts(
+            [{"role": "user", "content": "some content"}]
+        )
+        assert result == []
+
+        snap = get_extraction_stats()
+        cloud = snap["by_tier"]["cloud"]
+        # Cloud-tier success counter MUST NOT have incremented —
+        # the chat returned text but extraction yielded no facts.
+        assert cloud["successes"] == 0, (
+            f"cloud success counter incremented despite no parseable "
+            f"facts: {cloud}"
+        )
+        # And there should be a failure recorded for no parseable
+        # output.
+        reasons = [s.get("reason", "") for s in cloud["error_samples"]]
+        assert "no_facts_in_response" in reasons
+
+    def test_cloud_extract_facts_records_record_call(self, monkeypatch):
+        """[Codex P2 #2, Codex adv #3] ExtractionClient.extract_facts
+        now records record_call() so totals.calls / success_rate
+        reflect the cloud path. Pre-fix the cloud path was excluded
+        from bird's-eye accounting."""
+        from mnemosyne.extraction.client import ExtractionClient
+
+        client = ExtractionClient(api_key="key")
+        monkeypatch.setattr(
+            client,
+            "_call_api",
+            lambda *a, **kw: '[{"subject":"Alice","predicate":"prefers","object":"tea"}]',
+        )
+
+        # Pre-call: zero totals.
+        pre = get_extraction_stats()
+        assert pre["totals"]["calls"] == 0
+
+        result = client.extract_facts(
+            [{"role": "user", "content": "Alice prefers tea"}]
+        )
+        assert len(result) == 1
+
+        post = get_extraction_stats()
+        # Outer call counted, success at totals level.
+        assert post["totals"]["calls"] == 1
+        assert post["totals"]["successes"] == 1
+        # And cloud-tier success counted too.
+        assert post["by_tier"]["cloud"]["successes"] >= 1
+
+    def test_snapshot_samples_are_independent_copies(self, monkeypatch):
+        """[Codex adv #4] snapshot() must return a deep-enough copy
+        that the caller mutating the returned dict can't mutate
+        internal diagnostics state. Pre-fix list(deque) aliased the
+        sample dicts."""
+        diag = ExtractionDiagnostics()
+        try:
+            raise ValueError("test error")
+        except Exception as e:
+            diag.record_failure("cloud", exc=e)
+
+        snap = diag.snapshot()
+        # Mutate the returned sample.
+        snap["by_tier"]["cloud"]["error_samples"][0]["msg"] = "MUTATED"
+
+        # Re-snapshot — original must NOT carry the mutation.
+        snap2 = diag.snapshot()
+        sample = snap2["by_tier"]["cloud"]["error_samples"][0]
+        assert sample["msg"] != "MUTATED", (
+            "snapshot returned aliased sample dicts; caller mutation "
+            "leaked into internal state"
+        )
+
+    def test_log_sanitizes_newlines_in_exception_repr(self, monkeypatch, caplog):
+        """[Codex adv #5] A custom exception with newlines or ANSI
+        escapes in its __repr__ would inject log-line breaks /
+        terminal control sequences if logged raw. Fix: _safe_for_log
+        sanitizes to a bounded single-line string."""
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: True
+        )
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._try_host_llm",
+            lambda prompt, max_tokens, temperature: (False, ""),
+        )
+        monkeypatch.setattr("mnemosyne.core.local_llm.LLM_ENABLED", False)
+
+        class EvilError(Exception):
+            def __repr__(self):
+                return "EvilError(\nLINE\x1b[31mANSI\nINJECTED\n)"
+
+        def boom(*args, **kwargs):
+            raise EvilError()
+
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm._load_llm", lambda: boom
+        )
+
+        with caplog.at_level(logging.WARNING, logger="mnemosyne.core.extraction"):
+            from mnemosyne.core.extraction import extract_facts
+            extract_facts("test content")
+
+        # Find the WARNING log record.
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings, "no warning logged"
+        msg = warnings[-1].message
+        # No raw newlines or ANSI sequences should appear in the
+        # logged message body.
+        assert "\n" not in msg.replace("\\n", ""), (
+            f"raw newline in log message: {msg!r}"
+        )
+        assert "\x1b" not in msg, (
+            f"raw ANSI escape in log message: {msg!r}"
+        )
 
 
 class TestOperatorVisibleLogs:


### PR DESCRIPTION
## Summary

C13.b from the memory-contract ledger. Fact extraction had five silent-failure layers — cloud HTTP errors → `\"\"`, JSON parse failures → `[]`, local LLM exceptions → `pass`, no-LLM-available fallback → `[]`, outer `extract_facts_safe` wrapper → `[]`. Operators got zero signal that fact-recall and the polyphonic engine's graph voice were running blind. A bad cloud API key, an unloaded local model, and a model returning junk all looked identical from outside: empty results, no log line.

This PR adds a process-global `ExtractionDiagnostics` counter set that records each extraction attempt's outcome at every tier. Failures are still swallowed at the call site (callers' contract preserved); diagnostics surface WHAT is being swallowed.

## What changed

**New `mnemosyne/extraction/diagnostics.py`:**
- `ExtractionDiagnostics` class — thread-safe counters per tier (`host` / `remote` / `local` / `cloud` / `wrapper`)
- Per-tier: `attempts`, `successes`, `no_output`, `failures`, bounded recent `error_samples` (cap 10, message cap 200 chars)
- Totals: `calls`, `successes`, `failures`, `empty`, `success_rate`
- Process-global singleton via `get_diagnostics()` — thread-safe lazy init
- Module-level helpers: `get_extraction_stats()` (JSON-serializable snapshot), `reset_extraction_stats()`
- `_safe_for_log` helper strips control chars / ANSI escapes from logged exception repr

**`mnemosyne/core/extraction.py::extract_facts`:**
- Instrumented at every tier transition (host attempted vs succeeded, host fallback to local, remote LLM no-output, local LLM raised, model not loaded, etc.)
- All transitions wrapped in `try/except` so exceptions land on the right tier instead of escaping to the outer wrapper

**`mnemosyne/core/extraction.py::extract_facts_safe`:**
- Outer-wrapper exceptions record on the synthetic `wrapper` tier (origin unknown), not `local`

**`mnemosyne/extraction/client.py::ExtractionClient`:**
- `chat()` records transport-level outcomes only (attempt, no_output on empty HTTP, failure on all-models-failed). Does NOT decide cloud-tier success — that's `extract_facts`'s job after parsing.
- `extract_facts()` records cloud-tier success on parsed facts, parse-failure on malformed JSON, no-facts-in-response when brackets present but unparseable. Also records `record_call()` at the totals level.

**WARNING log lines** fire on the most actionable failure paths (all-models-failed, local LLM raised, JSON parse failed, etc.). Sanitized via `_safe_for_log`.

## Review process

`/review` ran 1 specialist (maintainability) + Claude adversarial + **Codex adversarial** + **Codex structured review**. Codex structured review came back **gate PASS** (P2 only, no P1). The three adversarial passes converged on six material issues — all addressed in commit 2:

| Severity | Issue | Status |
|---|---|---|
| HIGH (3-source) | Host attempt over-count — phantom attempts on every call | Fixed: `record_attempt` moved inside `if attempted:` |
| HIGH (2-source) | Cloud chat() recorded success on any non-empty HTTP, then extract_facts double-counted failure on parse | Fixed: chat() records transport only; extract_facts decides success based on parsed output |
| HIGH (2-source) | `ExtractionClient.extract_facts()` didn't call `record_call()` — totals excluded cloud path | Fixed: extract_facts records record_call at all return paths |
| MEDIUM | Outer-wrapper failures misattributed to `local` | Fixed: synthetic `wrapper` tier added |
| MEDIUM | `list(stats.error_samples)` aliased dict samples | Fixed: deep-copy in `snapshot()` |
| MEDIUM | Log-injection via custom exception `__repr__` (newlines, ANSI escapes) | Fixed: `_safe_for_log` sanitizer |
| MEDIUM | `_try_host_llm` / `_call_remote_llm` / `_load_llm` could raise → orphan attempt counter | Fixed: try/except around each transition |

## Test plan

- [x] **36 tests** in `tests/test_c13b_extraction_diagnostics.py`:
  - `TestExtractionDiagnosticsClass` (17): primitives — counters, error truncation, error sample bounding, JSON serializability, thread safety under concurrent recording, unknown-tier rejection, reset semantics
  - `TestProcessGlobalSingleton` (2): singleton lifecycle + module helpers
  - `TestExtractFactsIntegration` (5): LLM-unavailable, empty text, local LLM exception, local LLM success, outer-wrapper instrumentation
  - `TestExtractionClientIntegration` (4): no-api-key failure, attempt-not-success, JSON parse failure, malformed-JSON reason
  - `TestReviewHardening` (7): phantom-host-attempt guard, host-raise attribution, wrapper tier instead of local, cloud chat doesn't record success, cloud extract_facts records record_call, snapshot sample alias guard, log sanitization
  - `TestOperatorVisibleLogs` (1): WARNING log fires on local LLM exception
- [x] Full suite: **572 passed**, 1 skipped, 0 failures (+36 new tests).

## Why now

Fact extraction is the data source for two recall paths: `fact_recall()` and the polyphonic engine's `_fact_voice`. Both went silently dark whenever extraction failed — operators had no way to distinguish \"the user hasn't said anything fact-worthy\" from \"the extraction LLM has been down for a week.\" Recent maintainer work on `heal_quality.py` (PR #67) and PR #61's binary-vector wiring made extraction-dependent features increasingly load-bearing, and the silent failure shape stopped being acceptable.

Conflict-free with all 7 open PRs. Touches only `mnemosyne/extraction/*` (new file + cloud client) and `mnemosyne/core/extraction.py` — none of which any open PR modifies. Avoided `beam.py::_extract_and_store_facts` (modified by PR #70 / E6) by routing diagnostics through the inner `extract_facts_safe`, which is unchanged from E6's perspective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)