### PR TITLE
E5.a: rewire polyphonic vector voice to dense memory_embeddings store

### DIFF
--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -290,15 +290,38 @@ class PolyphonicRecallEngine:
                             dist = rowid_to_dist.get(row["rowid"])
                             if dist is None:
                                 continue
-                            # 1.0 - distance yields cosine-style
-                            # similarity for int8/bit (after the
-                            # quantize). Bit-Hamming returns a count;
-                            # we don't try to normalize across types
-                            # here — ordering within a single voice
-                            # call is preserved because vec_type
-                            # doesn't change mid-call. Downstream RRF
-                            # uses rank position, not score magnitude.
-                            sim = 1.0 - float(dist)
+                            # Normalize sqlite-vec distances to a
+                            # cosine-similarity-compatible [0, 1] scale
+                            # so cross-tier dedup against the WM tier's
+                            # numpy cosine values is meaningful.
+                            #
+                            # /review (4-source: Codex structured P2,
+                            # Codex adversarial MEDIUM, Claude
+                            # CRITICAL, perf HIGH) caught the pre-fix
+                            # behavior of using `1.0 - distance`
+                            # directly: bit-type Hamming distance is
+                            # an int in [0, EMBEDDING_DIM_BITS], so
+                            # the score went heavily negative
+                            # (~-383). WM cosine is in [-1, 1].
+                            # Dedup at `sim > existing.score` then
+                            # always preferred WM hits over EM
+                            # sqlite-vec hits, silently inverting the
+                            # tier-priority semantics for bit-quantized
+                            # vectors. Normalize per vec_type:
+                            #   bit:    1 - dist/EMBEDDING_DIM_BITS
+                            #   int8:   1 - dist/2  (cosine_dist in
+                            #                       [0, 2] for unit
+                            #                       vectors)
+                            #   raw f32: 1/(1+dist) (L2 → (0, 1])
+                            raw_dist = float(dist)
+                            if vec_type == "bit":
+                                # 384 dims for MiniLM-class embeddings
+                                # (matches binary_vectors.EMBEDDING_DIM)
+                                sim = 1.0 - (raw_dist / 384.0)
+                            elif vec_type == "int8":
+                                sim = 1.0 - (raw_dist / 2.0)
+                            else:
+                                sim = 1.0 / (1.0 + raw_dist)
                             existing = by_id.get(mid)
                             if existing is None or sim > existing.score:
                                 by_id[mid] = RecallResult(
@@ -307,13 +330,30 @@ class PolyphonicRecallEngine:
                                     voice="vector",
                                     metadata={
                                         "similarity": sim,
+                                        "raw_distance": raw_dist,
+                                        "vec_type": vec_type,
                                         "embedding_tier": "episodic",
                                         "backend": "sqlite-vec",
                                     },
                                 )
-                        em_consumed_via_vec_episodes = True
-            except (ImportError, sqlite3.OperationalError, ValueError):
-                # Any failure in the fast path: fall through to numpy.
+                        # Only mark EM consumed when the fast path
+                        # actually produced results. If all top-60
+                        # ANN hits failed the superseded/valid_until
+                        # filter (or orphaned the JOIN), fall through
+                        # to the numpy path so it can scan up to
+                        # vec_limit and find valid rows beyond the
+                        # truncated ANN candidate set. /review (4-source)
+                        # caught the silent EM-starvation regression.
+                        em_consumed_via_vec_episodes = bool(em_rows_via_vec)
+            except (ImportError, AttributeError,
+                    sqlite3.Error, ValueError, TypeError) as exc:
+                # Broader catch than the original tuple — partial
+                # imports can surface as AttributeError, corrupt DB
+                # state as sqlite3.DatabaseError (other Error
+                # subclasses), and quantize edge cases as TypeError.
+                # /review (Claude MEDIUM) caught the narrow filter
+                # silently hiding unexpected failure modes. Fall
+                # through to the numpy path on any of them.
                 em_consumed_via_vec_episodes = False
 
             # --- EM tier — numpy fallback (or when sqlite-vec absent) ---
@@ -344,7 +384,13 @@ class PolyphonicRecallEngine:
                         vec_norm = float(np.linalg.norm(vec))
                         if vec_norm == 0.0:
                             continue
-                        sim = float(np.dot(query_unit, vec / vec_norm))
+                        cos_sim = float(np.dot(query_unit, vec / vec_norm))
+                        # Normalize cosine to [0, 1] so cross-path dedup
+                        # against the sqlite-vec fast path (which now
+                        # also produces [0, 1] scores) compares apples
+                        # to apples. /review (4-source) caught the
+                        # raw-cosine-vs-bit-Hamming inversion bug.
+                        sim = (cos_sim + 1.0) / 2.0
                         existing = by_id.get(memory_id)
                         if existing is None or sim > existing.score:
                             by_id[memory_id] = RecallResult(
@@ -353,6 +399,7 @@ class PolyphonicRecallEngine:
                                 voice="vector",
                                 metadata={
                                     "similarity": sim,
+                                    "cosine_similarity": cos_sim,
                                     "embedding_tier": "episodic",
                                     "backend": "memory_embeddings",
                                 },
@@ -390,7 +437,10 @@ class PolyphonicRecallEngine:
                     vec_norm = float(np.linalg.norm(vec))
                     if vec_norm == 0.0:
                         continue
-                    sim = float(np.dot(query_unit, vec / vec_norm))
+                    cos_sim = float(np.dot(query_unit, vec / vec_norm))
+                    # Normalize cosine to [0, 1] — same rationale as EM
+                    # numpy path above (cross-path dedup parity).
+                    sim = (cos_sim + 1.0) / 2.0
                     existing = by_id.get(memory_id)
                     if existing is None or sim > existing.score:
                         by_id[memory_id] = RecallResult(
@@ -399,6 +449,7 @@ class PolyphonicRecallEngine:
                             voice="vector",
                             metadata={
                                 "similarity": sim,
+                                "cosine_similarity": cos_sim,
                                 "embedding_tier": "working",
                                 "backend": "memory_embeddings",
                             },

--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -4,7 +4,7 @@ Mnemosyne Polyphonic Recall Engine
 Multi-strategy parallel retrieval with deterministic re-ranking.
 
 Strategies (4 voices):
-1. Vector voice: Binary vector similarity (Phase 2)
+1. Vector voice: Dense semantic similarity over working_memory + episodic_memory
 2. Graph voice: Episodic graph traversal (Phase 3)
 3. Fact voice: Structured fact matching (Phase 4)
 4. Temporal voice: Time-aware scoring
@@ -21,15 +21,19 @@ Building on:
 - Our novel deterministic combination
 """
 
+import json
 import sqlite3
-import numpy as np
 from datetime import datetime, timedelta
 from typing import Dict, List, Tuple, Optional
 from dataclasses import dataclass
 from pathlib import Path
 
+try:
+    import numpy as np
+except ImportError:  # numpy is required by other voices too; guard for parity
+    np = None
+
 from mnemosyne.core.typed_memory import classify_memory, MemoryType, get_type_priority
-from mnemosyne.core.binary_vectors import BinaryVectorStore
 from mnemosyne.core.episodic_graph import EpisodicGraph
 from mnemosyne.core.veracity_consolidation import VeracityConsolidator
 
@@ -83,7 +87,11 @@ class PolyphonicRecallEngine:
 
         # Initialize subsystems. Each accepts an optional conn= since
         # 9f96ded; pass through so they share our handle.
-        self.vector_store = BinaryVectorStore(db_path=self.db_path, conn=conn)
+        # NOTE: vector_store removed. The vector voice now reads dense
+        # embeddings from `memory_embeddings` (the production-canonical
+        # store also used by the linear recall path), not from the
+        # standalone `binary_vectors` table which production never wrote
+        # to. See _vector_voice for the rewired query path.
         self.graph = EpisodicGraph(db_path=self.db_path, conn=conn)
         self.consolidator = VeracityConsolidator(db_path=self.db_path, conn=conn)
 
@@ -128,27 +136,111 @@ class PolyphonicRecallEngine:
         
         return context
     
-    def _vector_voice(self, query_embedding: np.ndarray) -> List[RecallResult]:
+    def _vector_voice(self, query_embedding) -> List[RecallResult]:
         """
-        Voice 1: Binary vector similarity.
-        
-        Uses information-theoretic binary vectors for fast,
-        deterministic similarity search.
+        Voice 1: Dense semantic similarity over WM + EM.
+
+        Queries the production-canonical dense embedding store
+        (`memory_embeddings`) — the same source the linear recall path
+        uses via `_wm_vec_search` / `_in_memory_vec_search` in beam.py.
+        Pre-fix this voice queried the standalone `binary_vectors` table
+        which production never wrote to (NAI-4 wrote binary vectors as a
+        column on episodic_memory, NOT to that table); the result was a
+        silently-empty vector voice and a 3-voice polyphonic engine.
+
+        Returning to a single source of truth across the recall stack
+        matches the cross-system convergence pattern (Hindsight, mem0,
+        Zep, Cognee, Letta all use one dense store shared by every
+        retrieval path) and makes polyphonic-vs-linear comparisons
+        apples-to-apples for the BEAM-recovery experiment.
+
+        Reads both WM and EM tiers, filters out invalidated /
+        superseded rows (mirror of `_wm_vec_search` WHERE clauses), and
+        ranks by cosine similarity computed in numpy. Performance is
+        bounded by linear cosine over the joined memory_embeddings rows
+        (same shape as the existing linear fallback); on databases
+        sized for the BEAM benchmark we expect this to land in the
+        same order of magnitude as the linear path's WM/EM vec search.
         """
-        if query_embedding is None:
+        if query_embedding is None or np is None:
             return []
-        
-        results = self.vector_store.search(query_embedding, top_k=20)
-        
-        return [
-            RecallResult(
-                memory_id=r["memory_id"],
-                score=r["score"],
-                voice="vector",
-                metadata={"distance": r["distance"]}
-            )
-            for r in results
-        ]
+
+        query_embedding = np.asarray(query_embedding, dtype=np.float32)
+        if query_embedding.size == 0:
+            return []
+        query_norm = float(np.linalg.norm(query_embedding))
+        if query_norm == 0.0:
+            return []
+        query_unit = query_embedding / query_norm
+
+        if self.conn is not None:
+            conn = self.conn
+            own_conn = False
+        else:
+            conn = sqlite3.connect(str(self.db_path))
+            conn.row_factory = sqlite3.Row
+            own_conn = True
+        try:
+            results: List[RecallResult] = []
+            now_iso = datetime.now().isoformat()
+
+            # --- WM tier ---
+            # Same WHERE clause shape as beam._wm_vec_search: skip
+            # invalidated / superseded rows so vector voice never
+            # surfaces ghost rows the linear path would have hidden.
+            try:
+                wm_rows = conn.execute("""
+                    SELECT wm.id AS memory_id, me.embedding_json
+                    FROM memory_embeddings me
+                    JOIN working_memory wm ON me.memory_id = wm.id
+                    WHERE wm.superseded_by IS NULL
+                      AND (wm.valid_until IS NULL OR wm.valid_until > ?)
+                    LIMIT 50000
+                """, (now_iso,)).fetchall()
+            except sqlite3.OperationalError:
+                wm_rows = []
+
+            # --- EM tier ---
+            try:
+                em_rows = conn.execute("""
+                    SELECT em.id AS memory_id, me.embedding_json
+                    FROM memory_embeddings me
+                    JOIN episodic_memory em ON me.memory_id = em.id
+                    LIMIT 50000
+                """).fetchall()
+            except sqlite3.OperationalError:
+                em_rows = []
+
+            for tier, rows in (("working", wm_rows), ("episodic", em_rows)):
+                for row in rows:
+                    try:
+                        memory_id = row["memory_id"]
+                        embedding_json = row["embedding_json"]
+                        if not embedding_json:
+                            continue
+                        vec = np.asarray(
+                            json.loads(embedding_json), dtype=np.float32
+                        )
+                        vec_norm = float(np.linalg.norm(vec))
+                        if vec_norm == 0.0:
+                            continue
+                        sim = float(np.dot(query_unit, vec / vec_norm))
+                        results.append(RecallResult(
+                            memory_id=memory_id,
+                            score=sim,
+                            voice="vector",
+                            metadata={"similarity": sim, "tier": tier},
+                        ))
+                    except (ValueError, TypeError, json.JSONDecodeError):
+                        # Defensive: bad / unparseable embedding_json
+                        # rows shouldn't break the voice.
+                        continue
+
+            results.sort(key=lambda r: r.score, reverse=True)
+            return results[:20]
+        finally:
+            if own_conn:
+                conn.close()
     
     def _graph_voice(self, query: str) -> List[RecallResult]:
         """
@@ -405,16 +497,25 @@ class PolyphonicRecallEngine:
     
     def get_stats(self) -> Dict:
         """Get engine statistics."""
+        # vector voice now queries memory_embeddings directly; surface
+        # the count of embedded rows as the vector-voice signal-of-life.
+        vec_count = 0
+        if self.conn is not None:
+            try:
+                vec_count = self.conn.execute(
+                    "SELECT COUNT(*) FROM memory_embeddings"
+                ).fetchone()[0]
+            except sqlite3.OperationalError:
+                vec_count = 0
         return {
             "voice_weights": self.voice_weights,
-            "vector_stats": self.vector_store.get_stats(),
+            "vector_stats": {"embedded_rows": vec_count},
             "graph_stats": self.graph.get_stats(),
             "consolidation_stats": self.consolidator.get_stats(),
         }
-    
+
     def close(self):
         """Close all connections."""
-        self.vector_store.close()
         self.graph.close()
         self.consolidator.close()
 

--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -162,17 +162,18 @@ class PolyphonicRecallEngine:
         retrieval path) and makes polyphonic-vs-linear comparisons
         apples-to-apples for the BEAM-recovery experiment.
 
-        Future work (E5.a follow-up): the linear path additionally
-        uses sqlite-vec's `vec_episodes` virtual table when available
-        (`beam._vec_search`); this voice currently only uses the
-        numpy-cosine fallback layer. Wiring sqlite-vec acceleration is
-        a separate change.
+        EM tier prefers sqlite-vec's `vec_episodes` virtual table when
+        available (same fast-path the linear scorer uses via
+        `beam._vec_search`); falls through to numpy cosine over
+        `memory_embeddings` on any failure. WM tier uses numpy cosine
+        (matches the linear path — no sqlite-vec WM index exists
+        today).
 
         Reads both WM and EM tiers, filters out invalidated /
         superseded / expired rows (mirror of `_wm_vec_search` WHERE
-        clauses for both tiers), and ranks by cosine similarity
-        computed in numpy. Dedups across WM/EM by `memory_id` keeping
-        the higher-similarity occurrence — without this, a memory that
+        clauses for both tiers), and ranks by cosine similarity.
+        Dedups across WM/EM by `memory_id` keeping the
+        higher-similarity occurrence — without this, a memory that
         exists in both tiers post-E3 would be double-counted in RRF
         and silently cap unique candidates below `top_k=20`.
         """
@@ -204,62 +205,134 @@ class PolyphonicRecallEngine:
             conn.row_factory = sqlite3.Row
             own_conn = True
         try:
-            results: List[RecallResult] = []
             now_iso = datetime.now().isoformat()
-
-            # --- WM tier ---
-            # Same WHERE clause shape as beam._wm_vec_search: skip
-            # invalidated / superseded rows so vector voice never
-            # surfaces ghost rows the linear path would have hidden.
-            try:
-                wm_rows = conn.execute(
-                    """
-                    SELECT wm.id AS memory_id, me.embedding_json
-                    FROM memory_embeddings me
-                    JOIN working_memory wm ON me.memory_id = wm.id
-                    WHERE wm.superseded_by IS NULL
-                      AND (wm.valid_until IS NULL OR wm.valid_until > ?)
-                    LIMIT ?
-                    """,
-                    (now_iso, vec_limit),
-                ).fetchall()
-            except sqlite3.OperationalError:
-                wm_rows = []
-
-            # --- EM tier ---
-            # EM also has superseded_by + valid_until columns and the
-            # linear path filters them out at row-fetch time
-            # (beam.py:_polyphonic_row_passes_filters). Filtering at
-            # SQL avoids spending cosine compute on rows that will be
-            # dropped anyway, and keeps the `LIMIT` budget pointed at
-            # valid candidates instead of starving them under a dense
-            # cluster of invalidated rows.
-            try:
-                em_rows = conn.execute(
-                    """
-                    SELECT em.id AS memory_id, me.embedding_json
-                    FROM memory_embeddings me
-                    JOIN episodic_memory em ON me.memory_id = em.id
-                    WHERE em.superseded_by IS NULL
-                      AND (em.valid_until IS NULL OR em.valid_until > ?)
-                    LIMIT ?
-                    """,
-                    (now_iso, vec_limit),
-                ).fetchall()
-            except sqlite3.OperationalError:
-                em_rows = []
-
-            # Dedup keyed by memory_id, keeping the higher similarity
-            # tier. Post-E3 consolidation an id can exist in both WM
-            # (original row, consolidated_at set) and EM (summary row);
-            # without dedup, the duplicate flows into _combine_voices
-            # where the second occurrence overwrites the first's
-            # voice-rank AND the for-loop double-counts the RRF
-            # contribution. /review (Claude adversarial C1) caught the
-            # silent rank corruption + sub-20 unique-candidate cap.
             by_id: Dict[str, RecallResult] = {}
-            for tier, rows in (("working", wm_rows), ("episodic", em_rows)):
-                for row in rows:
+
+            # --- EM tier — prefer sqlite-vec ANN, fall back to numpy ---
+            #
+            # The linear path uses sqlite-vec's `vec_episodes` virtual
+            # table via beam._vec_search for fast O(log N) ANN on EM
+            # when sqlite-vec is loaded. Without mirroring that path,
+            # the polyphonic engine would do a linear O(N) JSON-decode
+            # + cosine over every embedded EM row — strictly slower
+            # than the linear scorer at benchmark scale (~250K rows).
+            # That confounds the BEAM-recovery experiment's
+            # polyphonic-vs-linear latency comparison.
+            em_consumed_via_vec_episodes = False
+            try:
+                # Lazy import: avoids any module-load circular import
+                # with beam.py (which lazily imports
+                # PolyphonicRecallEngine inside _get_polyphonic_engine).
+                # Both directions are runtime-only.
+                from mnemosyne.core.beam import (
+                    _vec_available,
+                    _effective_vec_type,
+                )
+
+                if _vec_available(conn):
+                    vec_type = _effective_vec_type(conn)
+                    emb_json = json.dumps(
+                        query_embedding.astype(np.float32).tolist()
+                    )
+                    # sqlite-vec's MATCH planner needs LIMIT to be a
+                    # literal at planning time AND enforces a hard max
+                    # of 4096 (raises OperationalError: "k value in knn
+                    # query too large" above that). The fast path is a
+                    # top-K lookup, not a full scan, so we only need
+                    # enough candidates to survive post-fetch filter
+                    # dropouts (~50 buffer above the top-20 the engine
+                    # ultimately returns). vec_limit (which controls
+                    # the numpy fallback's full-scan budget under
+                    # BEAM_MODE) is irrelevant here.
+                    k_inline = 60
+                    if vec_type == "bit":
+                        rank_sql = (
+                            "SELECT rowid, distance FROM vec_episodes "
+                            "WHERE embedding MATCH vec_quantize_binary(?) "
+                            f"ORDER BY distance LIMIT {k_inline}"
+                        )
+                    elif vec_type == "int8":
+                        rank_sql = (
+                            "SELECT rowid, distance FROM vec_episodes "
+                            "WHERE embedding MATCH vec_quantize_int8(?, 'unit') "
+                            f"ORDER BY distance LIMIT {k_inline}"
+                        )
+                    else:
+                        rank_sql = (
+                            "SELECT rowid, distance FROM vec_episodes "
+                            "WHERE embedding MATCH ? "
+                            f"ORDER BY distance LIMIT {k_inline}"
+                        )
+                    vec_rows = conn.execute(rank_sql, (emb_json,)).fetchall()
+                    if vec_rows:
+                        rowid_to_dist = {
+                            r["rowid"]: r["distance"] for r in vec_rows
+                        }
+                        # Map rowid → memory_id and apply WHERE-clause
+                        # parity with the numpy EM fallback. JOIN
+                        # ensures rows orphaned from episodic_memory
+                        # (e.g., deleted post-vec_episodes-insert) drop
+                        # out cleanly.
+                        rowid_list = list(rowid_to_dist.keys())
+                        placeholders = ",".join("?" * len(rowid_list))
+                        em_rows_via_vec = conn.execute(
+                            f"""
+                            SELECT em.rowid AS rowid, em.id AS memory_id
+                            FROM episodic_memory em
+                            WHERE em.rowid IN ({placeholders})
+                              AND em.superseded_by IS NULL
+                              AND (em.valid_until IS NULL OR em.valid_until > ?)
+                            """,
+                            (*rowid_list, now_iso),
+                        ).fetchall()
+                        for row in em_rows_via_vec:
+                            mid = row["memory_id"]
+                            dist = rowid_to_dist.get(row["rowid"])
+                            if dist is None:
+                                continue
+                            # 1.0 - distance yields cosine-style
+                            # similarity for int8/bit (after the
+                            # quantize). Bit-Hamming returns a count;
+                            # we don't try to normalize across types
+                            # here — ordering within a single voice
+                            # call is preserved because vec_type
+                            # doesn't change mid-call. Downstream RRF
+                            # uses rank position, not score magnitude.
+                            sim = 1.0 - float(dist)
+                            existing = by_id.get(mid)
+                            if existing is None or sim > existing.score:
+                                by_id[mid] = RecallResult(
+                                    memory_id=mid,
+                                    score=sim,
+                                    voice="vector",
+                                    metadata={
+                                        "similarity": sim,
+                                        "embedding_tier": "episodic",
+                                        "backend": "sqlite-vec",
+                                    },
+                                )
+                        em_consumed_via_vec_episodes = True
+            except (ImportError, sqlite3.OperationalError, ValueError):
+                # Any failure in the fast path: fall through to numpy.
+                em_consumed_via_vec_episodes = False
+
+            # --- EM tier — numpy fallback (or when sqlite-vec absent) ---
+            if not em_consumed_via_vec_episodes:
+                try:
+                    em_rows = conn.execute(
+                        """
+                        SELECT em.id AS memory_id, me.embedding_json
+                        FROM memory_embeddings me
+                        JOIN episodic_memory em ON me.memory_id = em.id
+                        WHERE em.superseded_by IS NULL
+                          AND (em.valid_until IS NULL OR em.valid_until > ?)
+                        LIMIT ?
+                        """,
+                        (now_iso, vec_limit),
+                    ).fetchall()
+                except sqlite3.OperationalError:
+                    em_rows = []
+                for row in em_rows:
                     try:
                         memory_id = row["memory_id"]
                         embedding_json = row["embedding_json"]
@@ -278,22 +351,60 @@ class PolyphonicRecallEngine:
                                 memory_id=memory_id,
                                 score=sim,
                                 voice="vector",
-                                # `embedding_tier` instead of `tier` —
-                                # avoid colliding with the `tier` key
-                                # _polyphonic_row_to_dict (beam.py)
-                                # writes meaning "working"/"episodic"
-                                # row-source label AND with
-                                # `degradation_tier` for episodic 1→2→3
-                                # content tiers.
                                 metadata={
                                     "similarity": sim,
-                                    "embedding_tier": tier,
+                                    "embedding_tier": "episodic",
+                                    "backend": "memory_embeddings",
                                 },
                             )
                     except (ValueError, TypeError, json.JSONDecodeError):
-                        # Defensive: bad / unparseable embedding_json
-                        # rows shouldn't break the voice.
                         continue
+
+            # --- WM tier — numpy cosine (no sqlite-vec WM index today) ---
+            # Same WHERE clause shape as beam._wm_vec_search: skip
+            # invalidated / superseded rows so vector voice never
+            # surfaces ghost rows the linear path would have hidden.
+            try:
+                wm_rows = conn.execute(
+                    """
+                    SELECT wm.id AS memory_id, me.embedding_json
+                    FROM memory_embeddings me
+                    JOIN working_memory wm ON me.memory_id = wm.id
+                    WHERE wm.superseded_by IS NULL
+                      AND (wm.valid_until IS NULL OR wm.valid_until > ?)
+                    LIMIT ?
+                    """,
+                    (now_iso, vec_limit),
+                ).fetchall()
+            except sqlite3.OperationalError:
+                wm_rows = []
+            for row in wm_rows:
+                try:
+                    memory_id = row["memory_id"]
+                    embedding_json = row["embedding_json"]
+                    if not embedding_json:
+                        continue
+                    vec = np.asarray(
+                        json.loads(embedding_json), dtype=np.float32
+                    )
+                    vec_norm = float(np.linalg.norm(vec))
+                    if vec_norm == 0.0:
+                        continue
+                    sim = float(np.dot(query_unit, vec / vec_norm))
+                    existing = by_id.get(memory_id)
+                    if existing is None or sim > existing.score:
+                        by_id[memory_id] = RecallResult(
+                            memory_id=memory_id,
+                            score=sim,
+                            voice="vector",
+                            metadata={
+                                "similarity": sim,
+                                "embedding_tier": "working",
+                                "backend": "memory_embeddings",
+                            },
+                        )
+                except (ValueError, TypeError, json.JSONDecodeError):
+                    continue
 
             results = sorted(
                 by_id.values(), key=lambda r: r.score, reverse=True

--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -21,7 +21,14 @@ Building on:
 - Our novel deterministic combination
 """
 
+# Postponed annotation evaluation: lets us reference np.ndarray in type
+# hints without breaking module import when numpy is unavailable.
+# /review (E5.a commit 2) caught the earlier `try: import np` guard
+# being defeated by `np.ndarray = None` evaluation at class-body load.
+from __future__ import annotations
+
 import json
+import os
 import sqlite3
 from datetime import datetime, timedelta
 from typing import Dict, List, Tuple, Optional
@@ -142,11 +149,12 @@ class PolyphonicRecallEngine:
 
         Queries the production-canonical dense embedding store
         (`memory_embeddings`) — the same source the linear recall path
-        uses via `_wm_vec_search` / `_in_memory_vec_search` in beam.py.
-        Pre-fix this voice queried the standalone `binary_vectors` table
-        which production never wrote to (NAI-4 wrote binary vectors as a
-        column on episodic_memory, NOT to that table); the result was a
-        silently-empty vector voice and a 3-voice polyphonic engine.
+        uses via `_wm_vec_search` / `_in_memory_vec_search` (the
+        numpy-cosine fallback layer in beam.py). Pre-fix this voice
+        queried the standalone `binary_vectors` table which production
+        never wrote to (NAI-4 wrote binary vectors as a column on
+        episodic_memory, NOT to that table); the result was a silently
+        empty vector voice and a 3-voice polyphonic engine.
 
         Returning to a single source of truth across the recall stack
         matches the cross-system convergence pattern (Hindsight, mem0,
@@ -154,13 +162,19 @@ class PolyphonicRecallEngine:
         retrieval path) and makes polyphonic-vs-linear comparisons
         apples-to-apples for the BEAM-recovery experiment.
 
+        Future work (E5.a follow-up): the linear path additionally
+        uses sqlite-vec's `vec_episodes` virtual table when available
+        (`beam._vec_search`); this voice currently only uses the
+        numpy-cosine fallback layer. Wiring sqlite-vec acceleration is
+        a separate change.
+
         Reads both WM and EM tiers, filters out invalidated /
-        superseded rows (mirror of `_wm_vec_search` WHERE clauses), and
-        ranks by cosine similarity computed in numpy. Performance is
-        bounded by linear cosine over the joined memory_embeddings rows
-        (same shape as the existing linear fallback); on databases
-        sized for the BEAM benchmark we expect this to land in the
-        same order of magnitude as the linear path's WM/EM vec search.
+        superseded / expired rows (mirror of `_wm_vec_search` WHERE
+        clauses for both tiers), and ranks by cosine similarity
+        computed in numpy. Dedups across WM/EM by `memory_id` keeping
+        the higher-similarity occurrence — without this, a memory that
+        exists in both tiers post-E3 would be double-counted in RRF
+        and silently cap unique candidates below `top_k=20`.
         """
         if query_embedding is None or np is None:
             return []
@@ -172,6 +186,15 @@ class PolyphonicRecallEngine:
         if query_norm == 0.0:
             return []
         query_unit = query_embedding / query_norm
+
+        # Match the linear path's BEAM-mode scan budget so this voice
+        # doesn't silently truncate against a benchmark-scale corpus
+        # that the linear scorer would have seen entirely (beam.py
+        # `_wm_vec_search` uses `_vec_limit = 500000 if _BEAM_MODE else
+        # 50000`). The env var read mirrors the existing flag without
+        # creating an import cycle on beam.py.
+        beam_mode = os.environ.get("MNEMOSYNE_BEAM_MODE", "").lower() in ("1", "true", "yes")
+        vec_limit = 500000 if beam_mode else 50000
 
         if self.conn is not None:
             conn = self.conn
@@ -189,28 +212,52 @@ class PolyphonicRecallEngine:
             # invalidated / superseded rows so vector voice never
             # surfaces ghost rows the linear path would have hidden.
             try:
-                wm_rows = conn.execute("""
+                wm_rows = conn.execute(
+                    """
                     SELECT wm.id AS memory_id, me.embedding_json
                     FROM memory_embeddings me
                     JOIN working_memory wm ON me.memory_id = wm.id
                     WHERE wm.superseded_by IS NULL
                       AND (wm.valid_until IS NULL OR wm.valid_until > ?)
-                    LIMIT 50000
-                """, (now_iso,)).fetchall()
+                    LIMIT ?
+                    """,
+                    (now_iso, vec_limit),
+                ).fetchall()
             except sqlite3.OperationalError:
                 wm_rows = []
 
             # --- EM tier ---
+            # EM also has superseded_by + valid_until columns and the
+            # linear path filters them out at row-fetch time
+            # (beam.py:_polyphonic_row_passes_filters). Filtering at
+            # SQL avoids spending cosine compute on rows that will be
+            # dropped anyway, and keeps the `LIMIT` budget pointed at
+            # valid candidates instead of starving them under a dense
+            # cluster of invalidated rows.
             try:
-                em_rows = conn.execute("""
+                em_rows = conn.execute(
+                    """
                     SELECT em.id AS memory_id, me.embedding_json
                     FROM memory_embeddings me
                     JOIN episodic_memory em ON me.memory_id = em.id
-                    LIMIT 50000
-                """).fetchall()
+                    WHERE em.superseded_by IS NULL
+                      AND (em.valid_until IS NULL OR em.valid_until > ?)
+                    LIMIT ?
+                    """,
+                    (now_iso, vec_limit),
+                ).fetchall()
             except sqlite3.OperationalError:
                 em_rows = []
 
+            # Dedup keyed by memory_id, keeping the higher similarity
+            # tier. Post-E3 consolidation an id can exist in both WM
+            # (original row, consolidated_at set) and EM (summary row);
+            # without dedup, the duplicate flows into _combine_voices
+            # where the second occurrence overwrites the first's
+            # voice-rank AND the for-loop double-counts the RRF
+            # contribution. /review (Claude adversarial C1) caught the
+            # silent rank corruption + sub-20 unique-candidate cap.
+            by_id: Dict[str, RecallResult] = {}
             for tier, rows in (("working", wm_rows), ("episodic", em_rows)):
                 for row in rows:
                     try:
@@ -225,18 +272,32 @@ class PolyphonicRecallEngine:
                         if vec_norm == 0.0:
                             continue
                         sim = float(np.dot(query_unit, vec / vec_norm))
-                        results.append(RecallResult(
-                            memory_id=memory_id,
-                            score=sim,
-                            voice="vector",
-                            metadata={"similarity": sim, "tier": tier},
-                        ))
+                        existing = by_id.get(memory_id)
+                        if existing is None or sim > existing.score:
+                            by_id[memory_id] = RecallResult(
+                                memory_id=memory_id,
+                                score=sim,
+                                voice="vector",
+                                # `embedding_tier` instead of `tier` —
+                                # avoid colliding with the `tier` key
+                                # _polyphonic_row_to_dict (beam.py)
+                                # writes meaning "working"/"episodic"
+                                # row-source label AND with
+                                # `degradation_tier` for episodic 1→2→3
+                                # content tiers.
+                                metadata={
+                                    "similarity": sim,
+                                    "embedding_tier": tier,
+                                },
+                            )
                     except (ValueError, TypeError, json.JSONDecodeError):
                         # Defensive: bad / unparseable embedding_json
                         # rows shouldn't break the voice.
                         continue
 
-            results.sort(key=lambda r: r.score, reverse=True)
+            results = sorted(
+                by_id.values(), key=lambda r: r.score, reverse=True
+            )
             return results[:20]
         finally:
             if own_conn:
@@ -499,14 +560,33 @@ class PolyphonicRecallEngine:
         """Get engine statistics."""
         # vector voice now queries memory_embeddings directly; surface
         # the count of embedded rows as the vector-voice signal-of-life.
+        # /review caught the pre-fix behavior of returning 0 whenever
+        # self.conn was None (standalone engines / CLI self-test);
+        # mirror _vector_voice's own_conn fallback so the stat is
+        # accurate regardless of construction mode.
         vec_count = 0
         if self.conn is not None:
+            conn = self.conn
+            own_conn = False
+        else:
             try:
-                vec_count = self.conn.execute(
-                    "SELECT COUNT(*) FROM memory_embeddings"
-                ).fetchone()[0]
+                conn = sqlite3.connect(str(self.db_path))
+                conn.row_factory = sqlite3.Row
+                own_conn = True
             except sqlite3.OperationalError:
-                vec_count = 0
+                conn = None
+                own_conn = False
+        try:
+            if conn is not None:
+                try:
+                    vec_count = conn.execute(
+                        "SELECT COUNT(*) FROM memory_embeddings"
+                    ).fetchone()[0]
+                except sqlite3.OperationalError:
+                    vec_count = 0
+        finally:
+            if own_conn and conn is not None:
+                conn.close()
         return {
             "voice_weights": self.voice_weights,
             "vector_stats": {"embedded_rows": vec_count},

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -162,11 +162,15 @@ class TestE5EnginePlumbing:
     def test_engine_accepts_shared_connection(self, temp_db):
         """[E5 connection reuse] PolyphonicRecallEngine.__init__ must
         accept conn= so BeamMemory can share its thread-local
-        connection. Without this each recall call would spawn 4+ new
-        SQLite connections (one per voice + one for the engine itself)
-        — wasteful under load and inconsistent with the post-9f96ded
-        EpisodicGraph / VeracityConsolidator / BinaryVectorStore
-        pattern."""
+        connection. Without this each recall call would spawn multiple
+        new SQLite connections (one per subsystem + one for the engine
+        itself) — wasteful under load and inconsistent with the
+        post-9f96ded EpisodicGraph / VeracityConsolidator pattern.
+
+        Post-E5.a: the standalone BinaryVectorStore subsystem was
+        removed (vector voice now queries memory_embeddings directly),
+        so the engine's connection plumbing surface shrank to
+        graph + consolidator + the engine's own self.conn."""
         from mnemosyne.core.polyphonic_recall import PolyphonicRecallEngine
 
         # Bring up the schema via BeamMemory so the engine has tables to query.
@@ -176,10 +180,10 @@ class TestE5EnginePlumbing:
         # The constructor must accept conn= without raising.
         engine = PolyphonicRecallEngine(db_path=temp_db, conn=shared_conn)
 
-        # Verify the engine's subsystems also use the shared connection
-        # (this is the whole point of accepting it).
-        assert engine.vector_store.conn is shared_conn, (
-            "vector_store is not using the shared connection"
+        # Verify the engine and its subsystems all use the shared
+        # connection (this is the whole point of accepting it).
+        assert engine.conn is shared_conn, (
+            "engine self.conn is not the shared connection"
         )
         assert engine.graph.conn is shared_conn, (
             "graph is not using the shared connection"

--- a/tests/test_e5a_vector_voice_dense_rewire.py
+++ b/tests/test_e5a_vector_voice_dense_rewire.py
@@ -682,6 +682,150 @@ class TestReviewHardening:
         )
         assert "em-live-vec" in ids
 
+    def test_em_starvation_falls_back_when_all_top_60_filtered(
+        self, temp_db
+    ):
+        """4-source /review convergence: when sqlite-vec returns
+        non-empty ANN hits but ALL of them fail the
+        superseded_by/valid_until filter at the rowid JOIN, the
+        fast path must NOT mark EM as consumed — the numpy fallback
+        needs to fire so it can find valid candidates beyond the
+        top-60 ANN truncation."""
+        from mnemosyne.core.beam import _vec_available, _vec_insert
+
+        beam = BeamMemory(session_id="e5a-starve", db_path=temp_db)
+        if not _vec_available(beam.conn):
+            pytest.skip("sqlite-vec not available in this environment")
+
+        target_vec = _unit_vec(seed=950)
+
+        # Seed several superseded EM rows that vec_episodes will rank
+        # at the top — the fast path will fetch them all, the rowid
+        # JOIN will filter them all out, and (post-fix) the numpy
+        # fallback should still fire.
+        for i in range(3):
+            mid = f"em-doomed-{i}"
+            beam.conn.execute(
+                "INSERT INTO episodic_memory (id, content, source, "
+                "timestamp, importance, superseded_by) "
+                f"VALUES ('{mid}', 'doomed-{i}', 'test', "
+                "datetime('now'), 0.5, 'em-valid')"
+            )
+            rowid = beam.conn.execute(
+                "SELECT rowid FROM episodic_memory WHERE id = ?", (mid,)
+            ).fetchone()[0]
+            _seed_embedding(beam.conn, mid, target_vec)
+            _vec_insert(beam.conn, rowid, target_vec.tolist())
+
+        # Seed a valid EM row that vec_episodes won't see (no
+        # vec_episodes entry) — only memory_embeddings has it. The
+        # numpy fallback should surface this.
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, "
+            "timestamp, importance) "
+            "VALUES ('em-valid', 'survivor', 'test', "
+            "datetime('now'), 0.5)"
+        )
+        _seed_embedding(beam.conn, "em-valid", target_vec)
+        beam.conn.commit()
+
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(target_vec)
+        ids = {r.memory_id for r in results}
+        # The fast path's top-60 were ALL filtered out. Numpy
+        # fallback must have fired to find em-valid.
+        assert "em-valid" in ids, (
+            "starvation regression: when ANN top-N all fail filters, "
+            "numpy fallback must still run to surface valid rows"
+        )
+        # And the doomed rows must NOT appear in the final results
+        # (filtered at both layers).
+        for i in range(3):
+            assert f"em-doomed-{i}" not in ids
+
+    def test_orphan_vec_episodes_row_doesnt_starve_em_recall(
+        self, temp_db
+    ):
+        """Defense: vec_episodes can carry rowids that have been
+        DELETEd from episodic_memory (e.g., import_session path at
+        beam.py:3991). The rowid JOIN drops them cleanly; the numpy
+        fallback should still surface valid EM rows that have
+        memory_embeddings entries but no (or orphaned) vec_episodes
+        entries."""
+        from mnemosyne.core.beam import _vec_available, _vec_insert
+
+        beam = BeamMemory(session_id="e5a-orphan", db_path=temp_db)
+        if not _vec_available(beam.conn):
+            pytest.skip("sqlite-vec not available in this environment")
+
+        target_vec = _unit_vec(seed=951)
+
+        # Insert a row, capture its rowid, then DELETE the row but
+        # leave its vec_episodes entry — simulates the orphan state
+        # that DELETE-without-cascade can produce.
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, "
+            "timestamp, importance) "
+            "VALUES ('em-ghost', 'ghost', 'test', datetime('now'), 0.5)"
+        )
+        ghost_rowid = beam.conn.execute(
+            "SELECT rowid FROM episodic_memory WHERE id = ?", ("em-ghost",)
+        ).fetchone()[0]
+        _vec_insert(beam.conn, ghost_rowid, target_vec.tolist())
+        beam.conn.execute(
+            "DELETE FROM episodic_memory WHERE id = ?", ("em-ghost",)
+        )
+        # vec_episodes still has the rowid; episodic_memory does not.
+
+        # A valid row that should still surface via numpy fallback.
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, "
+            "timestamp, importance) "
+            "VALUES ('em-alive', 'alive', 'test', datetime('now'), 0.5)"
+        )
+        _seed_embedding(beam.conn, "em-alive", target_vec)
+        beam.conn.commit()
+
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(target_vec)
+        ids = {r.memory_id for r in results}
+        assert "em-alive" in ids, (
+            "orphan-vec regression: numpy fallback skipped after "
+            "vec_episodes top-K all dropped via missing JOIN"
+        )
+        assert "em-ghost" not in ids
+
+    def test_scores_normalized_to_zero_one_across_paths(self, temp_db):
+        """All vector voice scores live in [0, 1] regardless of
+        which retrieval backend served them (sqlite-vec
+        bit/int8/float32 OR numpy cosine on memory_embeddings).
+        This is the cross-tier-dedup-parity contract that closes
+        the bit-Hamming poisoning bug."""
+        beam = BeamMemory(session_id="e5a-norm", db_path=temp_db)
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, "
+            "timestamp, importance) "
+            "VALUES ('em-norm', 'x', 'test', datetime('now'), 0.5)"
+        )
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, "
+            "timestamp, session_id, importance) "
+            "VALUES ('wm-norm', 'x', 'test', datetime('now'), "
+            "'e5a-norm', 0.5)"
+        )
+        target_vec = _unit_vec(seed=952)
+        _seed_embedding(beam.conn, "em-norm", target_vec)
+        _seed_embedding(beam.conn, "wm-norm", target_vec)
+
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(target_vec)
+        for r in results:
+            assert 0.0 <= r.score <= 1.0, (
+                f"score {r.score} from backend "
+                f"{r.metadata.get('backend')} outside [0, 1] — "
+                "cross-path dedup parity broken"
+            )
+
     def test_module_import_works_when_numpy_absent(self):
         """`from __future__ import annotations` should let
         polyphonic_recall.py import even if numpy fails to load —

--- a/tests/test_e5a_vector_voice_dense_rewire.py
+++ b/tests/test_e5a_vector_voice_dense_rewire.py
@@ -1,0 +1,340 @@
+"""
+Regression tests for E5.a — vector voice dense rewire
+=====================================================
+
+Pre-fix: ``PolyphonicRecallEngine._vector_voice`` queried the standalone
+``binary_vectors`` table that production never wrote to (NAI-4 stored
+binary vectors as a column on ``episodic_memory`` instead). The vector
+voice silently returned ``[]`` on every call, so polyphonic recall was
+effectively 3-voice (graph + fact + temporal) in production.
+
+Post-fix: the vector voice queries ``memory_embeddings`` directly —
+the same dense embedding store the linear recall path uses via
+``_wm_vec_search`` / ``_in_memory_vec_search``. Single source of
+truth, both WM and EM tiers covered, no schema migration.
+
+These tests pin:
+  - vector voice returns candidates when memory_embeddings is populated
+  - results are ranked by cosine similarity (closest first)
+  - WM and EM tiers are both covered
+  - invalidated / superseded WM rows are excluded (parity with linear)
+  - vector voice returns [] when query_embedding is None (preserves the
+    pre-fix fallback contract — fastembed-unavailable callers don't get
+    crashes)
+  - vector voice returns [] when memory_embeddings is empty (no false
+    positives from the now-removed standalone table)
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+from mnemosyne.core.polyphonic_recall import PolyphonicRecallEngine
+
+
+@pytest.fixture
+def temp_db(tmp_path: Path) -> Path:
+    return tmp_path / "mnemosyne_e5a.db"
+
+
+def _seed_embedding(conn, memory_id: str, vec: np.ndarray) -> None:
+    """Insert a row into memory_embeddings for a memory_id."""
+    conn.execute(
+        "INSERT OR REPLACE INTO memory_embeddings "
+        "(memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        (memory_id, json.dumps(vec.astype(np.float32).tolist()), "test-model"),
+    )
+    conn.commit()
+
+
+def _unit_vec(seed: int, dim: int = 384) -> np.ndarray:
+    """Deterministic unit vector for a given seed."""
+    rng = np.random.RandomState(seed)
+    v = rng.randn(dim).astype(np.float32)
+    return v / np.linalg.norm(v)
+
+
+# ---------------------------------------------------------------------------
+# Core rewire: vector voice reads memory_embeddings, not binary_vectors
+# ---------------------------------------------------------------------------
+
+
+def test_vector_voice_returns_candidates_from_memory_embeddings(temp_db):
+    """Vector voice reads dense vectors from memory_embeddings.
+
+    The pre-fix behavior would return [] because the standalone
+    binary_vectors table is never populated. Post-fix, the voice
+    ranks candidates from memory_embeddings."""
+    beam = BeamMemory(session_id="e5a", db_path=temp_db)
+    # Seed two EM rows with embeddings.
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('em-a', 'alpha content', 'test', datetime('now'), 0.5)"
+    )
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('em-b', 'bravo content', 'test', datetime('now'), 0.5)"
+    )
+    vec_a = _unit_vec(seed=1)
+    vec_b = _unit_vec(seed=2)
+    _seed_embedding(beam.conn, "em-a", vec_a)
+    _seed_embedding(beam.conn, "em-b", vec_b)
+
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    # Query embedding is exactly em-a → similarity ~1.0; em-b is unrelated.
+    results = engine._vector_voice(vec_a)
+
+    assert results, "vector voice returned empty after rewire"
+    ids = [r.memory_id for r in results]
+    assert "em-a" in ids, "expected EM hit em-a missing from vector voice"
+    # em-a should rank above em-b (higher similarity).
+    em_a_score = next(r.score for r in results if r.memory_id == "em-a")
+    em_b_score = next((r.score for r in results if r.memory_id == "em-b"), -1)
+    assert em_a_score > em_b_score, (
+        f"em-a ({em_a_score}) did not outrank em-b ({em_b_score})"
+    )
+    # Voice attribution is correct.
+    assert all(r.voice == "vector" for r in results)
+
+
+def test_vector_voice_covers_both_wm_and_em_tiers(temp_db):
+    """WM AND EM rows should both surface — single source of truth."""
+    beam = BeamMemory(session_id="e5a-wmem", db_path=temp_db)
+    beam.conn.execute(
+        "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance) "
+        "VALUES ('wm-1', 'working row', 'test', datetime('now'), 'e5a-wmem', 0.5)"
+    )
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('em-1', 'episodic row', 'test', datetime('now'), 0.5)"
+    )
+    target_vec = _unit_vec(seed=42)
+    _seed_embedding(beam.conn, "wm-1", target_vec)
+    _seed_embedding(beam.conn, "em-1", target_vec)
+
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    results = engine._vector_voice(target_vec)
+
+    tiers = {r.metadata.get("tier") for r in results}
+    ids = {r.memory_id for r in results}
+    assert "working" in tiers, "WM tier missing from vector voice results"
+    assert "episodic" in tiers, "EM tier missing from vector voice results"
+    assert "wm-1" in ids
+    assert "em-1" in ids
+
+
+def test_vector_voice_skips_superseded_wm_rows(temp_db):
+    """WM rows with superseded_by set must NOT surface — parity with
+    the linear path's _wm_vec_search WHERE clause."""
+    beam = BeamMemory(session_id="e5a-sup", db_path=temp_db)
+    beam.conn.execute(
+        "INSERT INTO working_memory (id, content, source, timestamp, "
+        "session_id, importance, superseded_by) "
+        "VALUES ('wm-old', 'stale', 'test', datetime('now'), 'e5a-sup', 0.5, 'wm-new')"
+    )
+    beam.conn.execute(
+        "INSERT INTO working_memory (id, content, source, timestamp, "
+        "session_id, importance) "
+        "VALUES ('wm-new', 'fresh', 'test', datetime('now'), 'e5a-sup', 0.5)"
+    )
+    vec = _unit_vec(seed=7)
+    _seed_embedding(beam.conn, "wm-old", vec)
+    _seed_embedding(beam.conn, "wm-new", vec)
+
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    results = engine._vector_voice(vec)
+    ids = {r.memory_id for r in results}
+    assert "wm-old" not in ids, "superseded WM row surfaced by vector voice"
+    assert "wm-new" in ids, "non-superseded WM row missing from vector voice"
+
+
+def test_vector_voice_skips_expired_wm_rows(temp_db):
+    """WM rows with valid_until in the past must NOT surface."""
+    beam = BeamMemory(session_id="e5a-exp", db_path=temp_db)
+    beam.conn.execute(
+        "INSERT INTO working_memory (id, content, source, timestamp, "
+        "session_id, importance, valid_until) "
+        "VALUES ('wm-exp', 'old', 'test', datetime('now'), 'e5a-exp', 0.5, "
+        "datetime('now', '-1 day'))"
+    )
+    beam.conn.execute(
+        "INSERT INTO working_memory (id, content, source, timestamp, "
+        "session_id, importance) "
+        "VALUES ('wm-live', 'fresh', 'test', datetime('now'), 'e5a-exp', 0.5)"
+    )
+    vec = _unit_vec(seed=11)
+    _seed_embedding(beam.conn, "wm-exp", vec)
+    _seed_embedding(beam.conn, "wm-live", vec)
+
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    results = engine._vector_voice(vec)
+    ids = {r.memory_id for r in results}
+    assert "wm-exp" not in ids, "expired WM row surfaced by vector voice"
+    assert "wm-live" in ids
+
+
+# ---------------------------------------------------------------------------
+# Contract: defensive fallbacks
+# ---------------------------------------------------------------------------
+
+
+def test_vector_voice_returns_empty_for_none_query_embedding(temp_db):
+    """fastembed-unavailable callers pass query_embedding=None — voice
+    must return [] without crashing. Preserves pre-fix behavior."""
+    beam = BeamMemory(session_id="e5a-none", db_path=temp_db)
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    assert engine._vector_voice(None) == []
+
+
+def test_vector_voice_returns_empty_when_no_embeddings_stored(temp_db):
+    """Fresh DB with no memory_embeddings rows → []. Critical regression
+    guard: ensures we didn't accidentally re-create the silent fallback
+    to the standalone binary_vectors table."""
+    beam = BeamMemory(session_id="e5a-fresh", db_path=temp_db)
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    vec = _unit_vec(seed=0)
+    assert engine._vector_voice(vec) == []
+
+
+def test_vector_voice_tolerates_bad_embedding_json(temp_db):
+    """Malformed embedding_json should be skipped, not crash the voice."""
+    beam = BeamMemory(session_id="e5a-bad", db_path=temp_db)
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('em-bad', 'x', 'test', datetime('now'), 0.5)"
+    )
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('em-good', 'y', 'test', datetime('now'), 0.5)"
+    )
+    # Bad row: invalid JSON
+    beam.conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) "
+        "VALUES ('em-bad', 'not-json', 'test-model')"
+    )
+    # Good row
+    good_vec = _unit_vec(seed=99)
+    _seed_embedding(beam.conn, "em-good", good_vec)
+
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    results = engine._vector_voice(good_vec)
+    ids = {r.memory_id for r in results}
+    assert "em-good" in ids
+    assert "em-bad" not in ids
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: polyphonic recall now has all 4 voices contributing
+# ---------------------------------------------------------------------------
+
+
+def test_polyphonic_recall_includes_vector_voice_in_rrf(temp_db):
+    """Full polyphonic recall path: with memory_embeddings populated,
+    the combined result includes a vector voice score for at least one
+    memory id. This is the headline contract: post-fix the engine is
+    genuinely 4-voice in production-shaped queries."""
+    beam = BeamMemory(session_id="e5a-rrf", db_path=temp_db)
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('em-x', 'target content', 'test', datetime('now'), 0.5)"
+    )
+    target_vec = _unit_vec(seed=123)
+    _seed_embedding(beam.conn, "em-x", target_vec)
+
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    results = engine.recall(
+        query="target content",
+        query_embedding=target_vec,
+        top_k=10,
+    )
+
+    # At least one result should have a non-empty voice_scores dict
+    # containing "vector". This is the inverse of the pre-fix regression
+    # where vector_scores was always empty.
+    has_vector_signal = any(
+        "vector" in r.voice_scores for r in results
+    )
+    assert has_vector_signal, (
+        "no result carries a vector voice score after rewire — "
+        "vector voice still silent in the combine step"
+    )
+
+
+def test_polyphonic_vector_score_outranks_unrelated_query(temp_db):
+    """Two rows: one semantically identical to query, one orthogonal.
+    Polyphonic must rank the identical row above. Pre-fix this would
+    have failed: with vector voice silent, only FTS/temporal/graph
+    contribute, and "target content" only matches FTS-equally."""
+    beam = BeamMemory(session_id="e5a-rank", db_path=temp_db)
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('em-target', 'common phrase A', 'test', datetime('now'), 0.5)"
+    )
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('em-other', 'common phrase B', 'test', datetime('now'), 0.5)"
+    )
+    target_vec = _unit_vec(seed=200)
+    orthogonal = np.zeros(384, dtype=np.float32)
+    orthogonal[0] = 1.0  # Mostly orthogonal to seed=200's random vec
+    orthogonal = orthogonal / np.linalg.norm(orthogonal)
+    _seed_embedding(beam.conn, "em-target", target_vec)
+    _seed_embedding(beam.conn, "em-other", orthogonal)
+
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    results = engine.recall(
+        query="common phrase",
+        query_embedding=target_vec,
+        top_k=10,
+    )
+
+    # em-target should appear at or above em-other in ranking.
+    ids = [r.memory_id for r in results]
+    if "em-target" in ids and "em-other" in ids:
+        assert ids.index("em-target") <= ids.index("em-other"), (
+            f"vector-similar row did not outrank orthogonal: {ids}"
+        )
+    else:
+        # Both might not survive diversity rerank; minimal contract:
+        # em-target must be present.
+        assert "em-target" in ids, (
+            f"vector-similar row absent from results: {ids}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plumbing: engine no longer requires BinaryVectorStore at all
+# ---------------------------------------------------------------------------
+
+
+def test_engine_does_not_construct_binary_vector_store(temp_db):
+    """The BinaryVectorStore class still exists for backward compat
+    with anyone using it standalone, but the engine should not
+    construct one. Verifies the dead-code path is gone."""
+    beam = BeamMemory(session_id="e5a-noref", db_path=temp_db)
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    assert not hasattr(engine, "vector_store"), (
+        "engine still constructs BinaryVectorStore — rewire incomplete"
+    )
+
+
+def test_engine_get_stats_reports_embedded_row_count(temp_db):
+    """get_stats() previously returned BinaryVectorStore.get_stats();
+    post-rewire it should report the memory_embeddings count (the new
+    vector-voice signal-of-life)."""
+    beam = BeamMemory(session_id="e5a-stats", db_path=temp_db)
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('em-s', 's', 'test', datetime('now'), 0.5)"
+    )
+    _seed_embedding(beam.conn, "em-s", _unit_vec(seed=5))
+
+    engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+    stats = engine.get_stats()
+    assert "vector_stats" in stats
+    assert stats["vector_stats"].get("embedded_rows") == 1

--- a/tests/test_e5a_vector_voice_dense_rewire.py
+++ b/tests/test_e5a_vector_voice_dense_rewire.py
@@ -566,6 +566,122 @@ class TestReviewHardening:
             "lazy and never reached on the linear path"
         )
 
+    def test_em_sqlite_vec_fast_path_metadata_backend(self, temp_db):
+        """When sqlite-vec is available + vec_episodes is populated,
+        EM results carry `backend="sqlite-vec"` in metadata. The fast
+        path uses the C-extension ANN index, matching the linear
+        scorer's _vec_search behavior — closes the EM-tier latency
+        gap that would otherwise confound polyphonic-vs-linear
+        comparisons at benchmark scale."""
+        from mnemosyne.core.beam import _vec_available, _vec_insert
+
+        beam = BeamMemory(session_id="e5a-vec-fast", db_path=temp_db)
+
+        # Skip cleanly if sqlite-vec isn't installed in the test
+        # environment. This guards against false test failures in
+        # numpy-only CI configurations.
+        if not _vec_available(beam.conn):
+            pytest.skip("sqlite-vec not available in this environment")
+
+        # Seed an EM row + its vec_episodes entry. The linear path
+        # writes both at consolidation; tests pre-stage them manually.
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+            "VALUES ('em-vec-fast', 'fast path target', 'test', datetime('now'), 0.5)"
+        )
+        em_rowid = beam.conn.execute(
+            "SELECT rowid FROM episodic_memory WHERE id = ?",
+            ("em-vec-fast",),
+        ).fetchone()[0]
+        target_vec = _unit_vec(seed=900)
+        _seed_embedding(beam.conn, "em-vec-fast", target_vec)
+        _vec_insert(beam.conn, em_rowid, target_vec.tolist())
+        beam.conn.commit()
+
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(target_vec)
+        em_results = [r for r in results if r.memory_id == "em-vec-fast"]
+        assert em_results, "EM target not surfaced via sqlite-vec path"
+        # Backend tag pins which retrieval primitive served the row —
+        # operators can confirm the fast path actually fired without
+        # running ad-hoc timing experiments.
+        assert em_results[0].metadata.get("backend") == "sqlite-vec", (
+            f"expected sqlite-vec backend tag, got "
+            f"{em_results[0].metadata.get('backend')!r}"
+        )
+        assert em_results[0].metadata.get("embedding_tier") == "episodic"
+
+    def test_em_falls_back_to_numpy_when_sqlite_vec_absent(
+        self, temp_db, monkeypatch
+    ):
+        """When sqlite-vec is unavailable (or vec_episodes is empty),
+        the EM path falls through cleanly to the numpy fallback.
+        Result metadata carries `backend="memory_embeddings"`."""
+        beam = BeamMemory(session_id="e5a-vec-fb", db_path=temp_db)
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+            "VALUES ('em-fb', 'fallback target', 'test', datetime('now'), 0.5)"
+        )
+        target_vec = _unit_vec(seed=901)
+        _seed_embedding(beam.conn, "em-fb", target_vec)
+        # Intentionally do NOT insert into vec_episodes so the fast
+        # path returns no rowids and we exercise the numpy fallback.
+
+        # Force the fast-path check to report unavailable, so we
+        # don't depend on whether sqlite-vec is installed in CI.
+        import mnemosyne.core.beam as beam_mod
+        monkeypatch.setattr(
+            beam_mod, "_vec_available", lambda conn: False
+        )
+
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(target_vec)
+        em_results = [r for r in results if r.memory_id == "em-fb"]
+        assert em_results, "EM target not surfaced via numpy fallback"
+        assert em_results[0].metadata.get("backend") == "memory_embeddings"
+        assert em_results[0].metadata.get("embedding_tier") == "episodic"
+
+    def test_em_sqlite_vec_filter_parity_superseded(self, temp_db):
+        """The sqlite-vec fast path joins to episodic_memory by rowid
+        AND applies the same superseded_by/valid_until filters as the
+        numpy fallback — so doomed rows that vec_episodes still has
+        an index entry for don't slip into results."""
+        from mnemosyne.core.beam import _vec_available, _vec_insert
+
+        beam = BeamMemory(session_id="e5a-vec-filter", db_path=temp_db)
+        if not _vec_available(beam.conn):
+            pytest.skip("sqlite-vec not available in this environment")
+
+        # Insert a superseded EM row + its vec_episodes entry. The
+        # fast-path SQL filter must drop it even though vec_episodes
+        # has no superseded_by column of its own.
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "importance, superseded_by) "
+            "VALUES ('em-sup-vec', 'doomed', 'test', datetime('now'), 0.5, 'em-live')"
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+            "VALUES ('em-live-vec', 'fresh', 'test', datetime('now'), 0.5)"
+        )
+        for memory_id in ("em-sup-vec", "em-live-vec"):
+            rowid = beam.conn.execute(
+                "SELECT rowid FROM episodic_memory WHERE id = ?",
+                (memory_id,),
+            ).fetchone()[0]
+            v = _unit_vec(seed=902)
+            _seed_embedding(beam.conn, memory_id, v)
+            _vec_insert(beam.conn, rowid, v.tolist())
+        beam.conn.commit()
+
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(_unit_vec(seed=902))
+        ids = {r.memory_id for r in results}
+        assert "em-sup-vec" not in ids, (
+            "sqlite-vec fast path leaked a superseded EM row"
+        )
+        assert "em-live-vec" in ids
+
     def test_module_import_works_when_numpy_absent(self):
         """`from __future__ import annotations` should let
         polyphonic_recall.py import even if numpy fails to load —

--- a/tests/test_e5a_vector_voice_dense_rewire.py
+++ b/tests/test_e5a_vector_voice_dense_rewire.py
@@ -120,7 +120,9 @@ def test_vector_voice_covers_both_wm_and_em_tiers(temp_db):
     engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
     results = engine._vector_voice(target_vec)
 
-    tiers = {r.metadata.get("tier") for r in results}
+    # Post-/review the metadata key was renamed `tier` → `embedding_tier`
+    # to avoid colliding with row-source `tier` label downstream.
+    tiers = {r.metadata.get("embedding_tier") for r in results}
     ids = {r.memory_id for r in results}
     assert "working" in tiers, "WM tier missing from vector voice results"
     assert "episodic" in tiers, "EM tier missing from vector voice results"
@@ -338,3 +340,254 @@ def test_engine_get_stats_reports_embedded_row_count(temp_db):
     stats = engine.get_stats()
     assert "vector_stats" in stats
     assert stats["vector_stats"].get("embedded_rows") == 1
+
+
+# ---------------------------------------------------------------------------
+# /review hardening — second-commit regression guards
+# ---------------------------------------------------------------------------
+
+
+class TestReviewHardening:
+    """Closes the gaps surfaced by the /review army on commit 1.
+
+    Each test pins one of the five must-fix findings + one rename:
+      1. Dedup memory_id across WM+EM (Claude adversarial C1, CRITICAL)
+      2. `from __future__ import annotations` keeps numpy-less import
+         working (Codex structured P2 + maintainability MED)
+      3. EM tier filter parity (Codex adversarial P1 + Claude H1)
+      4. _BEAM_MODE limit honored (Codex adv P2 + Claude M1 + maint MED)
+      5. get_stats() works without shared connection (Codex structured
+         P2 + Claude H3)
+      6. metadata key rename `tier` → `embedding_tier` (Claude M2 +
+         maint LOW)
+    """
+
+    def test_dedup_across_wm_em_same_memory_id(self, temp_db):
+        """Same memory_id in WM AND EM should produce a single
+        RecallResult with the higher-similarity tier's score — not
+        two entries that double-count the RRF contribution in
+        _combine_voices."""
+        beam = BeamMemory(session_id="e5a-dedup", db_path=temp_db)
+        # Insert the same id into both tiers (post-E3 reality: row
+        # persists in WM after sleep produces its EM summary).
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, "
+            "session_id, importance) "
+            "VALUES ('dup-id', 'wm copy', 'test', datetime('now'), 'e5a-dedup', 0.5)"
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+            "VALUES ('dup-id', 'em copy', 'test', datetime('now'), 0.5)"
+        )
+        # Different embeddings → different similarities → we can prove
+        # we kept the higher one (and not the average / sum / last).
+        vec_high = _unit_vec(seed=300)
+        vec_low = np.zeros(384, dtype=np.float32)
+        vec_low[0] = 1.0
+        vec_low = vec_low / np.linalg.norm(vec_low)
+        _seed_embedding(beam.conn, "dup-id", vec_high)  # initial WM-bound write
+        # Replace with low for the second tier — pre-fix we'd get BOTH.
+        # Easier: seed two rows under different ids and assert dedup
+        # only when SAME id.
+        # We just want one row for dup-id with the high vec.
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(vec_high)
+
+        ids = [r.memory_id for r in results]
+        # `dup-id` must appear at most once.
+        assert ids.count("dup-id") == 1, (
+            f"dup-id appeared {ids.count('dup-id')} times — dedup broken"
+        )
+
+    def test_em_tier_excludes_superseded_rows(self, temp_db):
+        """Filter parity: EM rows with superseded_by set must NOT
+        surface from the vector voice. Pre-fix the EM JOIN had no
+        WHERE clause, so cosine compute was wasted on doomed rows."""
+        beam = BeamMemory(session_id="e5a-em-sup", db_path=temp_db)
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "importance, superseded_by) "
+            "VALUES ('em-old', 'stale', 'test', datetime('now'), 0.5, 'em-new')"
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+            "VALUES ('em-new', 'fresh', 'test', datetime('now'), 0.5)"
+        )
+        vec = _unit_vec(seed=400)
+        _seed_embedding(beam.conn, "em-old", vec)
+        _seed_embedding(beam.conn, "em-new", vec)
+
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(vec)
+        ids = {r.memory_id for r in results}
+        assert "em-old" not in ids, "superseded EM row surfaced by vector voice"
+        assert "em-new" in ids
+
+    def test_em_tier_excludes_expired_rows(self, temp_db):
+        """EM rows with valid_until in the past must NOT surface."""
+        beam = BeamMemory(session_id="e5a-em-exp", db_path=temp_db)
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "importance, valid_until) "
+            "VALUES ('em-exp', 'old', 'test', datetime('now'), 0.5, "
+            "datetime('now', '-1 day'))"
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+            "VALUES ('em-live', 'fresh', 'test', datetime('now'), 0.5)"
+        )
+        vec = _unit_vec(seed=401)
+        _seed_embedding(beam.conn, "em-exp", vec)
+        _seed_embedding(beam.conn, "em-live", vec)
+
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(vec)
+        ids = {r.memory_id for r in results}
+        assert "em-exp" not in ids, "expired EM row surfaced by vector voice"
+        assert "em-live" in ids
+
+    def test_get_stats_without_shared_connection(self, tmp_path):
+        """Engine constructed without conn= should still report a
+        truthful embedded_rows count by opening a short-lived
+        connection — pre-fix it hard-coded 0."""
+        db_path = tmp_path / "e5a_stats_standalone.db"
+        # Pre-create the schema using BeamMemory, then close.
+        b = BeamMemory(session_id="seed", db_path=db_path)
+        b.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+            "VALUES ('em-standalone', 'x', 'test', datetime('now'), 0.5)"
+        )
+        _seed_embedding(b.conn, "em-standalone", _unit_vec(seed=500))
+        b.conn.close()
+
+        # Construct without conn=; get_stats should open one.
+        engine = PolyphonicRecallEngine(db_path=db_path)
+        stats = engine.get_stats()
+        assert stats["vector_stats"]["embedded_rows"] == 1, (
+            "get_stats reported 0 with no shared conn — should have "
+            "opened a short-lived one"
+        )
+
+    def test_beam_mode_increases_vector_scan_limit(self, temp_db, monkeypatch):
+        """MNEMOSYNE_BEAM_MODE=1 should raise the per-tier scan limit
+        from 50k → 500k so polyphonic doesn't silently truncate
+        candidates that the linear path's _wm_vec_search (LIMIT 500k
+        in BEAM mode) would have seen.
+
+        We can't easily seed 500k rows in a unit test, so we exercise
+        the limit-construction code path indirectly by inspecting the
+        SQL the engine would execute under the flag. The cheapest
+        observable contract: in BEAM mode the voice continues to
+        return correct results from a small seeded corpus. Combined
+        with the explicit env-var read in _vector_voice, this guards
+        the flag plumbing without claiming we tested 500k rows.
+        """
+        beam = BeamMemory(session_id="e5a-beam", db_path=temp_db)
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+            "VALUES ('em-beam', 'x', 'test', datetime('now'), 0.5)"
+        )
+        vec = _unit_vec(seed=600)
+        _seed_embedding(beam.conn, "em-beam", vec)
+
+        monkeypatch.setenv("MNEMOSYNE_BEAM_MODE", "1")
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(vec)
+        ids = {r.memory_id for r in results}
+        assert "em-beam" in ids, (
+            "vector voice failed under MNEMOSYNE_BEAM_MODE=1"
+        )
+
+    def test_metadata_uses_embedding_tier_not_tier(self, temp_db):
+        """metadata key should be `embedding_tier` (post-rename) to
+        avoid colliding with the row-source `tier` key written by
+        _polyphonic_row_to_dict and with `degradation_tier` for
+        episodic 1→2→3 content tiers."""
+        beam = BeamMemory(session_id="e5a-meta", db_path=temp_db)
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+            "VALUES ('em-meta', 'x', 'test', datetime('now'), 0.5)"
+        )
+        vec = _unit_vec(seed=700)
+        _seed_embedding(beam.conn, "em-meta", vec)
+
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(vec)
+        assert results
+        r = results[0]
+        assert "embedding_tier" in r.metadata
+        assert "tier" not in r.metadata, (
+            "metadata['tier'] would collide with row-source tier label "
+            "in _combine_voices.metadata.update"
+        )
+
+    def test_top_k_cap_at_20_unique(self, temp_db):
+        """Boundary: even with 25 candidate rows we get at most 20
+        unique results back (matches the pre-fix BinaryVectorStore
+        top_k=20 contract)."""
+        beam = BeamMemory(session_id="e5a-cap", db_path=temp_db)
+        target_vec = _unit_vec(seed=800)
+        for i in range(25):
+            mid = f"em-cap-{i}"
+            beam.conn.execute(
+                "INSERT INTO episodic_memory "
+                "(id, content, source, timestamp, importance) "
+                f"VALUES ('{mid}', 'row-{i}', 'test', datetime('now'), 0.5)"
+            )
+            # Slightly perturbed vectors so all 25 differ.
+            v = target_vec.copy()
+            v[i % 384] += 0.01 * i
+            v = v / np.linalg.norm(v)
+            _seed_embedding(beam.conn, mid, v)
+
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        results = engine._vector_voice(target_vec)
+        assert len(results) == 20, (
+            f"expected top-20 cap, got {len(results)}"
+        )
+        # All unique memory_ids
+        assert len({r.memory_id for r in results}) == 20
+
+    def test_flag_off_skips_vector_voice_entirely(
+        self, temp_db, monkeypatch
+    ):
+        """MNEMOSYNE_POLYPHONIC_RECALL not set (or =0) must short-circuit
+        to the linear scorer in BeamMemory.recall — the engine is never
+        instantiated, so the vector voice never runs. This pins the
+        no-op contract that protects production users from any
+        polyphonic behavior change post-rewire."""
+        monkeypatch.delenv("MNEMOSYNE_POLYPHONIC_RECALL", raising=False)
+        beam = BeamMemory(session_id="e5a-flagoff", db_path=temp_db)
+        # Sanity: linear path returns without instantiating engine.
+        beam.recall("any query", top_k=5)
+        # Engine attribute should still be absent (never lazy-built).
+        assert getattr(beam, "_polyphonic_engine", None) is None, (
+            "polyphonic engine instantiated under flag=OFF — should be "
+            "lazy and never reached on the linear path"
+        )
+
+    def test_module_import_works_when_numpy_absent(self):
+        """`from __future__ import annotations` should let
+        polyphonic_recall.py import even if numpy fails to load —
+        the type hint `query_embedding: np.ndarray` should be a
+        string-only forward-ref, not evaluated at module-body load.
+        We can't actually uninstall numpy in a test, but we can
+        verify the module was loaded with `__future__ annotations`
+        active (the symptom of a missing future import would be a
+        NameError on np.ndarray at class-body time, which we'd never
+        reach if it fired)."""
+        import mnemosyne.core.polyphonic_recall as pr
+        # __future__ annotations evidence: type hints are strings.
+        engine_init = pr.PolyphonicRecallEngine.__init__
+        # Annotations stored as strings under __future__.
+        annotations = engine_init.__annotations__
+        # Either the annotation is present as a string, or it's absent
+        # entirely (some Python versions strip when no eval); both are
+        # OK. The failure mode we're guarding against is annotation
+        # *evaluation* at module load.
+        for name, ann in annotations.items():
+            assert isinstance(ann, (str, type(None))) or ann is None, (
+                f"annotation {name}={ann!r} is not a string — "
+                "PEP 563 / from __future__ import annotations may not "
+                "have applied"
+            )


### PR DESCRIPTION
## TL;DR

Mnemosyne's polyphonic recall engine has been silently running with only 3 of its 4 voices in production. The "vector voice" (semantic similarity) was querying a standalone `binary_vectors` table that production never wrote to — so it always returned an empty result list. This PR rewires the vector voice to read from `memory_embeddings` (the dense store the linear scorer already uses) AND wires sqlite-vec ANN acceleration for the EM tier so polyphonic and linear paths share the same retrieval primitive at benchmark scale. After this change polyphonic is genuinely 4-voice and apples-to-apples comparable with the linear scorer — including latency — for the BEAM-recovery experiment.

No new required dependencies. No schema migration. **4 commits**: 2 implementation + 2 cross-source /review hardening rounds. **26 regression tests** in a new test file + 1 updated existing test.

## Why this matters

The BEAM-recovery experiment plan (`.hermes/plans/2026-05-10-beam-recovery-experiment.md`) compares the polyphonic engine against the linear scorer. The polyphonic engine fuses 4 ranked candidate lists via Reciprocal Rank Fusion (RRF):

1. **Vector voice** — dense semantic similarity
2. **Graph voice** — episodic graph traversal
3. **Fact voice** — structured fact matching
4. **Temporal voice** — recency-aware scoring

The linear scorer already uses semantic similarity via `memory_embeddings` + `_wm_vec_search` / `_in_memory_vec_search`, and uses sqlite-vec's `vec_episodes` ANN index for fast EM lookup via `_vec_search`. With the polyphonic vector voice silent, the experiment would have compared linear-with-vector against polyphonic-without-vector — any "polyphonic underperforms" result confounded by the missing voice.

After this PR, both paths use the same retrieval surface (memory_embeddings + sqlite-vec on EM); what the experiment now measures is the actual scoring mechanism difference (RRF fusion vs linear weighted sum), not a retrieval backend confound.

## What was broken

In `mnemosyne/core/polyphonic_recall.py`, the engine constructor instantiated `BinaryVectorStore(db_path, conn)`, which created an empty `binary_vectors` table. `_vector_voice()` called `vector_store.search(query_embedding)` which `SELECT memory_id, binary_vector, magnitude FROM binary_vectors` — a table production code never writes to.

NAI-4 (commit `9f96ded`) stores binary vectors as a **column on `episodic_memory`** (`binary_vector BLOB`), not as rows in the standalone table. So:
- `BinaryVectorStore`'s table: 0 rows in production
- `episodic_memory.binary_vector` column: populated at consolidation
- `memory_embeddings` table: populated at every `remember()` call when fastembed is available, used by linear recall

The vector voice queried the wrong source and silently returned nothing. The audit trail for PR #76 (E5 wire-up) documented this as known limitation #1.

## What this PR does

**Commit 1 (`ab520c5`)** — Rewires `_vector_voice` to query `memory_embeddings` directly — the same dense store the linear path's numpy-cosine fallback layer uses (`_wm_vec_search` at `beam.py:1045`, `_in_memory_vec_search` at `beam.py:863`). Both WM and EM tiers covered.

**Commit 2 (`c2eea27`)** — /review hardening on the dense rewire. 5 must-fix findings from the first review army round addressed: dedup WM+EM duplicate memory_id (avoids RRF double-count), `from __future__ import annotations` (so `np.ndarray` type hints don't break numpy-less import), EM tier filter parity (`superseded_by` + `valid_until`), `MNEMOSYNE_BEAM_MODE` honored, `get_stats()` works with `self.conn = None`. Plus rename `metadata["tier"]` → `metadata["embedding_tier"]` to avoid downstream collision.

**Commit 3 (`976a747`)** — sqlite-vec ANN fast path for the EM tier. Mirrors `beam._vec_search`: detect sqlite-vec via `_vec_available`, pick the matching quantize function based on `_effective_vec_type`, query `vec_episodes` with `MATCH` + `ORDER BY distance LIMIT 60`, JOIN back to `episodic_memory` by rowid with the same filter parity. Falls through cleanly to the numpy path on any failure. Result metadata carries `backend="sqlite-vec"` or `backend="memory_embeddings"` for operator visibility.

**Commit 4 (`9d30c1f`)** — /review hardening on the sqlite-vec path. 4-source convergence on two real bugs: (1) bit-type Hamming distance produced heavily negative scores that corrupted cross-tier dedup against WM cosine ([-1, 1]) — fixed by normalizing all paths to [0, 1] regardless of backend; (2) `em_consumed_via_vec_episodes` flag was set even when all top-60 ANN hits failed the filter, silently starving the numpy fallback — fixed by only consuming EM when results are non-empty. Plus broadened exception catch.

### Why dense vectors instead of fixing the binary path?

Separate pre-deploy research (`.memory_stack_recommendation.md` in this repo) had already concluded that binary vectors were a Mnemosyne design mistake — the doc explicitly says "skip binary vectors as a default (Mnemosyne's mistake — int8 vs bit isn't worth the complexity)" and notes that int8 quantization is 95% the quality of float32 at 4x the speed. Cross-system survey of Hindsight, mem0, Zep, Cognee, and Letta found that **none** of them use binary vectors; all run their vector retrieval voice against the same dense store the rest of the system uses. Single source of truth across the recall stack.

The `BinaryVectorStore` class itself is left in place for backward compatibility with anyone using it standalone. The engine just doesn't instantiate it anymore.

## fastembed dependency

The vector voice requires fastembed to embed the query at `BeamMemory._recall_polyphonic` (`beam.py:2904-2911`). **This was already required pre-PR** — when fastembed was unavailable, `query_embedding` was `None` and the broken vector voice returned `[]`. With this PR, the same `None` path returns `[]`, so the contract is unchanged for fastembed-absent installs.

For the BEAM-recovery experiment to produce a meaningful comparison, fastembed must be installed. Two paths to consider:

1. **Status quo (current PR):** fastembed remains optional. Document in CHANGELOG that polyphonic recall benefits from fastembed installation. Users who run `pip install mnemosyne-memory[embeddings]` get full 4-voice operation. Experiment runners need to ensure they have it.
2. **Make fastembed required:** add it to the base `dependencies` in `pyproject.toml` instead of the `[embeddings]` extra. Pros: zero-friction full-feature install. Cons: ~30MB+ dep that some embedded/lite use cases don't want.

PR is currently (1). If you'd prefer (2) we can fold it in here — happy to take direction.

## Cross-source /review army (twice)

Same `/review` discipline as recent PRs (E5, E4, E3, C25, C4, C13.b): four independent reviewers ran in parallel before each push.

**Round 1 (commits 1 → 2)** — 4 reviewers on the dense rewire. 5 must-fix findings, all addressed:

| Finding | Sources | Fix |
|---|---|---|
| WM+EM duplicate `memory_id` double-counts in RRF; caps unique candidates below 20 | Claude adv CRITICAL | Dedup in `_vector_voice` keeping higher-similarity occurrence |
| `np.ndarray` annotation evaluated at module load defeats numpy guard | Codex structured P2 + Maintainability MED | `from __future__ import annotations` |
| EM tier missing `superseded_by` + `valid_until` filters at SQL layer | Codex adv P1 + Claude adv H1 | Mirror WM WHERE clauses on EM |
| `_BEAM_MODE` not honored — 50K cap silently truncates benchmark-scale recall | Codex adv P2 + Claude adv M1 + Maintainability MED | Read `MNEMOSYNE_BEAM_MODE` and use 500K when set |
| `get_stats()` returns 0 when `self.conn is None` | Codex structured P2 + Claude adv H3 | Mirror `_vector_voice`'s own_conn fallback to open a temp connection |

**Round 2 (commits 3 → 4)** — 4 reviewers on the sqlite-vec fast path. 4-source convergence on two real bugs:

| Finding | Sources | Fix |
|---|---|---|
| Bit-type Hamming `sim = 1.0 - dist` poisons cross-tier dedup (raw distance vs WM cosine [-1, 1]) | Codex structured P2 + Codex adv MED + Claude CRITICAL + Perf HIGH | Normalize all paths to [0, 1] regardless of backend |
| `em_consumed_via_vec_episodes=True` even when all top-60 ANN hits filter out — starves numpy fallback | Codex structured P2 + Codex adv HIGH + Claude HIGH + Perf HIGH | Only set flag when `em_rows_via_vec` non-empty |
| Exception filter too narrow | Claude MEDIUM | Broaden to `(ImportError, AttributeError, sqlite3.Error, ValueError, TypeError)` |

Reviewer false-alarm-checks confirmed: rowid stability across VACUUM is fine (`AUTOINCREMENT` at `beam.py:253`); lazy-import deadlock not a real risk (no top-level mutual imports); concurrent WAL writer can drop rows but doesn't introduce stale-invalid results.

## What is NOT in this PR (intentional)

- **`BinaryVectorStore` deprecation** — class still exists for standalone users. Out of scope.
- **WM binary vectors** — `working_memory` has no `binary_vector` column today; original plan considered extending NAI-4 to add one. Per the dense-store rewire approach, no longer needed.
- **SQL deduplication into shared helpers** — would address SQL duplication noted by maintainability reviewer but risks circular imports. Out of scope.
- **Orphan `vec_episodes` cleanup on EM `forget()` / `import_session`** — Codex adversarial flagged that `beam.py:3991` (import_session) can DELETE+re-INSERT episodic_memory rows without updating `vec_episodes`, accumulating dead index entries. The rowid JOIN drops them cleanly (correctness preserved by this PR's filter logic), but storage grows over time. Out of scope; tracked as a future cleanup.

(Previously out-of-scope and now **IN** this PR: sqlite-vec ANN acceleration for the vector voice — added in commits 3+4 after user raised the experiment-quality concern about retrieval-backend asymmetry between polyphonic numpy-cosine and linear sqlite-vec.)

## Test plan

- [x] All 17 existing tests in `tests/test_beam_e5_polyphonic_recall.py` pass
- [x] All 26 new tests in `tests/test_e5a_vector_voice_dense_rewire.py` pass (20 baseline + 3 sqlite-vec + 3 round-2 hardening)
- [x] Targeted `test_beam.py -k recall` run: 16/16 pass
- [ ] CI: full suite green on Python 3.9 / 3.10 / 3.11 / 3.12
- [ ] Manual smoke against a live DB with `MNEMOSYNE_POLYPHONIC_RECALL=1`: vector voice returns ranked candidates with `backend="sqlite-vec"` when sqlite-vec installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)