### PR TITLE
refactor: DRY consolidate_fact onto _serialized_write helper

### DIFF
--- a/mnemosyne/core/veracity_consolidation.py
+++ b/mnemosyne/core/veracity_consolidation.py
@@ -292,108 +292,143 @@ class VeracityConsolidator:
                         veracity: str = "unknown", source: str = None) -> ConsolidatedFact:
         """
         Add or update a fact in consolidation.
-        
+
         Args:
             subject: Fact subject
             predicate: Fact predicate
             object: Fact object
             veracity: Veracity tier
             source: Source memory ID
-            
+
         Returns:
             ConsolidatedFact: The consolidated result
+
+        Concurrency: SELECT-then-INSERT/UPDATE wrapped in
+        ``_serialized_write``. Pre-fix two threads with same SPO
+        could both pass the no-match SELECT and both attempt
+        INSERT, raising IntegrityError. Bayesian confidence math
+        is path-dependent so concurrent UPDATEs also raced.
+
+        Post-fix: the helper's RLock serializes same-instance
+        callers + `BEGIN IMMEDIATE` serializes cross-connection
+        writers via the SQLite writer lock. Caller-contract caveat
+        for DEFERRED outer txs: see `_serialized_write` docstring.
+
+        Pre-DRY (PR #84) this method had its own inline
+        BEGIN IMMEDIATE pattern. The helper-based version here
+        unifies it with the other three write methods so all four
+        share one canonical pattern AND the instance RLock
+        protects all four (including consolidate_fact, which
+        previously lacked RLock acquisition).
         """
-        cursor = self.conn.cursor()
-        
-        # Check if fact already exists
-        cursor.execute("""
-            SELECT * FROM consolidated_facts
-            WHERE subject = ? AND predicate = ? AND object = ?
-        """, (subject, predicate, object))
-        
-        row = cursor.fetchone()
-        now = datetime.now().isoformat()
-        
-        if row:
-            # Update existing fact
-            new_confidence = self.bayesian_update(row["confidence"], veracity)
-            new_count = row["mention_count"] + 1
-            
-            sources = json.loads(row["sources_json"] or "[]")
-            if source and source not in sources:
-                sources.append(source)
-            
-            cursor.execute("""
-                UPDATE consolidated_facts
-                SET confidence = ?, mention_count = ?, last_seen = ?,
-                    sources_json = ?, veracity = ?, updated_at = ?
-                WHERE id = ?
-            """, (new_confidence, new_count, now, json.dumps(sources),
-                  veracity, now, row["id"]))
-            
-            self.conn.commit()
-            
-            return ConsolidatedFact(
-                subject=subject,
-                predicate=predicate,
-                object=object,
-                confidence=new_confidence,
-                mention_count=new_count,
-                first_seen=row["first_seen"],
-                last_seen=now,
-                sources=sources,
-                veracity=veracity
-            )
-        
-        else:
-            # Check for conflicts (same subject+predicate, different object)
+        with self._serialized_write():
+            cursor = self.conn.cursor()
+
+            # Check if fact already exists
             cursor.execute("""
                 SELECT * FROM consolidated_facts
-                WHERE subject = ? AND predicate = ? AND object != ?
+                WHERE subject = ? AND predicate = ? AND object = ?
             """, (subject, predicate, object))
-            
-            conflicts = cursor.fetchall()
-            
-            # Insert new fact
-            fact_id = f"cf_{subject}_{predicate}_{object}".replace(" ", "_")[:100]
-            base_confidence = VERACITY_WEIGHTS.get(veracity, 0.8) * 0.5
-            
-            sources = [source] if source else []
-            
-            cursor.execute("""
-                INSERT INTO consolidated_facts
-                (id, subject, predicate, object, confidence, mention_count,
-                 first_seen, last_seen, sources_json, veracity)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (fact_id, subject, predicate, object, base_confidence, 1,
-                  now, now, json.dumps(sources), veracity))
-            
-            self.conn.commit()
-            
-            # Record conflicts
-            for conflict in conflicts:
-                self._record_conflict(fact_id, conflict["id"], "contradiction")
-            
-            return ConsolidatedFact(
-                subject=subject,
-                predicate=predicate,
-                object=object,
-                confidence=base_confidence,
-                mention_count=1,
-                first_seen=now,
-                last_seen=now,
-                sources=sources,
-                veracity=veracity
-            )
-    
-    def _record_conflict(self, fact_a_id: str, fact_b_id: str, conflict_type: str):
-        """Record a conflict between two facts."""
+
+            row = cursor.fetchone()
+            now = datetime.now().isoformat()
+
+            if row:
+                # Update existing fact
+                new_confidence = self.bayesian_update(row["confidence"], veracity)
+                new_count = row["mention_count"] + 1
+
+                sources = json.loads(row["sources_json"] or "[]")
+                if source and source not in sources:
+                    sources.append(source)
+
+                cursor.execute("""
+                    UPDATE consolidated_facts
+                    SET confidence = ?, mention_count = ?, last_seen = ?,
+                        sources_json = ?, veracity = ?, updated_at = ?
+                    WHERE id = ?
+                """, (new_confidence, new_count, now, json.dumps(sources),
+                      veracity, now, row["id"]))
+
+                return ConsolidatedFact(
+                    subject=subject,
+                    predicate=predicate,
+                    object=object,
+                    confidence=new_confidence,
+                    mention_count=new_count,
+                    first_seen=row["first_seen"],
+                    last_seen=now,
+                    sources=sources,
+                    veracity=veracity
+                )
+
+            else:
+                # Check for conflicts (same subject+predicate, different object)
+                cursor.execute("""
+                    SELECT * FROM consolidated_facts
+                    WHERE subject = ? AND predicate = ? AND object != ?
+                """, (subject, predicate, object))
+
+                conflicts = cursor.fetchall()
+
+                # Insert new fact
+                fact_id = f"cf_{subject}_{predicate}_{object}".replace(" ", "_")[:100]
+                base_confidence = VERACITY_WEIGHTS.get(veracity, 0.8) * 0.5
+
+                sources = [source] if source else []
+
+                cursor.execute("""
+                    INSERT INTO consolidated_facts
+                    (id, subject, predicate, object, confidence, mention_count,
+                     first_seen, last_seen, sources_json, veracity)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, (fact_id, subject, predicate, object, base_confidence, 1,
+                      now, now, json.dumps(sources), veracity))
+
+                # Record conflicts. Pass `commit=False` so the helper's
+                # internal commit doesn't end our `_serialized_write`
+                # transaction mid-loop — see _record_conflict docstring
+                # for the atomicity rationale.
+                for conflict in conflicts:
+                    self._record_conflict(
+                        fact_id, conflict["id"], "contradiction",
+                        commit=False,
+                    )
+
+                return ConsolidatedFact(
+                    subject=subject,
+                    predicate=predicate,
+                    object=object,
+                    confidence=base_confidence,
+                    mention_count=1,
+                    first_seen=now,
+                    last_seen=now,
+                    sources=sources,
+                    veracity=veracity
+                )
+
+    def _record_conflict(self, fact_a_id: str, fact_b_id: str,
+                         conflict_type: str, commit: bool = True):
+        """Record a conflict between two facts.
+
+        commit (default True): whether to call self.conn.commit() after
+            the INSERT. `consolidate_fact` passes `commit=False` when
+            invoking this helper from within its own `_serialized_write`
+            scope so the fact INSERT and its conflict rows commit
+            atomically as part of the outer transaction. Without this
+            opt-out, _record_conflict's commit would end the outer
+            transaction mid-loop, leaving the fact INSERT durable but
+            allowing later conflict-record failures to leak partial
+            state. /review (E2.a.5 4-source HIGH) caught this pattern
+            in the inline version; preserved in the DRY refactor.
+        """
         cursor = self.conn.cursor()
         cursor.execute("""
             INSERT INTO conflicts (fact_a_id, fact_b_id, conflict_type)
             VALUES (?, ?, ?)
         """, (fact_a_id, fact_b_id, conflict_type))
-        self.conn.commit()
+        if commit:
+            self.conn.commit()
     
     def resolve_conflict(self, conflict_id: int, winning_fact_id: str):
         """

--- a/mnemosyne/core/veracity_consolidation.py
+++ b/mnemosyne/core/veracity_consolidation.py
@@ -22,9 +22,11 @@ Conflict resolution:
 - Consolidation: periodic synthesis of high-confidence facts
 """
 
+import contextlib
 import logging
 import sqlite3
 import json
+import threading
 from datetime import datetime, timedelta
 from typing import Dict, List, Tuple, Optional
 from dataclasses import dataclass
@@ -128,8 +130,37 @@ class VeracityConsolidator:
         else:
             self.db_path = db_path or Path.home() / ".hermes" / "mnemosyne" / "data" / "mnemosyne.db"
             self.conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+            # Apply the same PRAGMA settings BeamMemory's _get_connection
+            # uses (journal_mode=WAL, busy_timeout=5000ms). Required for
+            # `_serialized_write`'s `BEGIN IMMEDIATE` to behave correctly
+            # under contention: without WAL the lock blocks readers; without
+            # busy_timeout contention raises `database is locked` instantly
+            # instead of waiting up to 5s. Duplicated from the E2.a.5 fix
+            # so this branch is self-contained whether it lands before or
+            # after #84. /review (Claude CRITICAL) caught the
+            # branch-rebase dependency.
+            try:
+                self.conn.execute("PRAGMA journal_mode=WAL")
+                self.conn.execute("PRAGMA busy_timeout=5000")
+            except sqlite3.Error:
+                # Best-effort: in-memory or otherwise-constrained
+                # environments may not support WAL. Continue.
+                pass
         self.conn.row_factory = sqlite3.Row
         self._owns_connection = conn is None
+
+        # Same-connection writer serialization. `BEGIN IMMEDIATE` provides
+        # database-level serialization across CONNECTIONS, but two threads
+        # sharing the same `VeracityConsolidator` instance (and therefore
+        # the same `self.conn`) would both see `conn.in_transaction = True`
+        # after the first thread's BEGIN — defeating the nested-tx skip
+        # logic and recreating the race within a single SQL transaction.
+        # `RLock` (not `Lock`) so the contextmanager can recursively enter
+        # for nested calls within the same thread (e.g.,
+        # `run_consolidation_pass` calling `resolve_conflict_by_facts`).
+        # /review (Codex structured P2 GATE FAIL) caught the same-conn race.
+        self._write_lock = threading.RLock()
+
         self._init_tables()
     
     def _init_tables(self):
@@ -173,6 +204,72 @@ class VeracityConsolidator:
         
         self.conn.commit()
     
+    @contextlib.contextmanager
+    def _serialized_write(self):
+        """Serialize the body's SELECT-then-write under the SQLite writer lock.
+
+        Wraps the block in ``BEGIN IMMEDIATE`` when the connection is
+        not already in a transaction. Concurrent calls queue on the
+        writer lock rather than racing on SELECT-then-INSERT/UPDATE
+        patterns. Nested invocations (caller already in a tx)
+        participate in that tx without starting their own BEGIN.
+
+        Shared by ``resolve_conflict``, ``resolve_conflict_by_facts``,
+        and ``run_consolidation_pass`` so the four write methods
+        (including ``consolidate_fact``) all use one canonical
+        serialization pattern.
+
+        Caller-contract caveat (per E2.a.7 ledger row): a DEFERRED
+        outer transaction (Python sqlite3's default implicit tx) does
+        NOT acquire the writer lock until its own first INSERT/UPDATE.
+        Two threads each in their own DEFERRED outer tx can both pass
+        the SELECT-no-match check before either writes — the race
+        window reopens inside the outer scope. Race safety inside a
+        caller-owned outer tx requires either (a) the outer tx is
+        ``BEGIN IMMEDIATE`` or ``BEGIN EXCLUSIVE``, OR (b) the caller
+        is the only writer (e.g., E2's single-threaded batch
+        enrichment loop).
+
+        Raises whatever the body raises after attempting rollback (if
+        we own the tx) so callers can implement retry / circuit-break
+        policies.
+        """
+        # Capture conn at entry — defense against the body swapping
+        # self.conn (closing the original, reassigning, etc.). All of
+        # commit/rollback/cursor must target the SAME connection we
+        # opened BEGIN IMMEDIATE on. /review (Codex adversarial MED).
+        conn = self.conn
+        # Acquire instance lock BEFORE BEGIN IMMEDIATE so two threads
+        # sharing this VeracityConsolidator instance (and therefore
+        # this conn) serialize at the Python level — SQLite's writer
+        # lock alone doesn't protect them because they share the same
+        # transaction once the first thread starts one.
+        with self._write_lock:
+            cursor = conn.cursor()
+            started_tx = False
+            if not conn.in_transaction:
+                # Let OperationalError propagate. If `database is locked`
+                # fires after busy_timeout, the caller's error handler is
+                # the right place to decide what to do; silent fallthrough
+                # would reintroduce the race we're closing.
+                cursor.execute("BEGIN IMMEDIATE")
+                started_tx = True
+            try:
+                yield
+                if started_tx:
+                    conn.commit()
+            except Exception:
+                if started_tx:
+                    try:
+                        conn.rollback()
+                    except sqlite3.Error as rb_exc:
+                        logger.error(
+                            "_serialized_write: rollback failed after "
+                            "error (connection may be in undefined state): %s",
+                            rb_exc,
+                        )
+                raise
+
     def bayesian_update(self, current_confidence: float, veracity: str) -> float:
         """
         Update confidence using Bayesian formula.
@@ -301,39 +398,82 @@ class VeracityConsolidator:
     def resolve_conflict(self, conflict_id: int, winning_fact_id: str):
         """
         Resolve a conflict by marking the losing fact as superseded.
-        
+
         Args:
             conflict_id: Conflict to resolve
             winning_fact_id: The fact that wins
+
+        Concurrency: SELECT-then-write pattern wrapped in
+        ``_serialized_write``. Pre-fix two concurrent
+        ``resolve_conflict`` calls on the same conflict_id with
+        different winning_fact_ids could both pass the SELECT and
+        last-writer-wins on the UPDATE, leaving BOTH facts
+        superseded (each marking the other). Post-fix the second
+        call sees the first's commit and either confirms the same
+        winner or finds the conflict already resolved.
         """
-        cursor = self.conn.cursor()
-        
-        # Get conflict details
-        cursor.execute("SELECT * FROM conflicts WHERE id = ?", (conflict_id,))
-        conflict = cursor.fetchone()
-        
-        if not conflict:
-            return
-        
-        # Determine losing fact
-        losing_id = conflict["fact_b_id"] if winning_fact_id == conflict["fact_a_id"] else conflict["fact_a_id"]
-        
-        # Mark as superseded
-        now = datetime.now().isoformat()
-        cursor.execute("""
-            UPDATE consolidated_facts
-            SET superseded_by = ?, updated_at = ?
-            WHERE id = ?
-        """, (winning_fact_id, now, losing_id))
-        
-        # Mark conflict as resolved
-        cursor.execute("""
-            UPDATE conflicts
-            SET resolution = ?, resolved_at = ?
-            WHERE id = ?
-        """, (f"superseded_by_{winning_fact_id}", now, conflict_id))
-        
-        self.conn.commit()
+        with self._serialized_write():
+            cursor = self.conn.cursor()
+
+            # Get conflict details
+            cursor.execute(
+                "SELECT * FROM conflicts WHERE id = ?", (conflict_id,)
+            )
+            conflict = cursor.fetchone()
+
+            if not conflict:
+                return
+
+            # Already-resolved guard: first-writer-wins semantics. Pre-fix
+            # serialization alone didn't fix the case where two callers
+            # passed different winning_fact_id values — even with BEGIN
+            # IMMEDIATE the second call would still mark the OTHER fact
+            # superseded (the conflict's read returned the same fact ids
+            # both times). With the guard, the second call sees the
+            # conflict is resolved and returns without overwriting. Log
+            # a WARNING so operators can spot conflicting writes.
+            # /review (Codex adv + Maintainability + Claude on E2.a.5)
+            # flagged the same-conflict-id race; the regression test
+            # for E2.a.6 surfaced this additional gap.
+            if conflict["resolution"] is not None:
+                logger.warning(
+                    "resolve_conflict: conflict %d already resolved "
+                    "(resolution=%r); ignoring re-resolution attempt "
+                    "with winning_fact_id=%r",
+                    conflict_id, conflict["resolution"], winning_fact_id,
+                )
+                return
+
+            # Determine losing fact
+            losing_id = (
+                conflict["fact_b_id"]
+                if winning_fact_id == conflict["fact_a_id"]
+                else conflict["fact_a_id"]
+            )
+
+            # Mark as superseded
+            now = datetime.now().isoformat()
+            cursor.execute(
+                """
+                UPDATE consolidated_facts
+                SET superseded_by = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (winning_fact_id, now, losing_id),
+            )
+
+            # Mark conflict as resolved
+            cursor.execute(
+                """
+                UPDATE conflicts
+                SET resolution = ?, resolved_at = ?
+                WHERE id = ?
+                """,
+                (f"superseded_by_{winning_fact_id}", now, conflict_id),
+            )
+
+            # `_serialized_write` commits on context exit when we own
+            # the tx; participates in caller-owned tx otherwise.
     
     def get_conflicts(self) -> List[Dict]:
         """Get all unresolved conflicts."""
@@ -424,50 +564,82 @@ class VeracityConsolidator:
     def run_consolidation_pass(self):
         """
         Background consolidation pass.
-        
+
         1. Find facts with multiple mentions
         2. Boost confidence
         3. Detect conflicts
         4. Auto-resolve obvious conflicts (higher confidence wins)
+
+        Concurrency: wrapped in ``_serialized_write`` so a concurrent
+        write (e.g., `consolidate_fact` or `resolve_conflict`) doesn't
+        interleave with the pass's read-decide-resolve loop. Inner
+        ``resolve_conflict_by_facts`` calls participate in this scope's
+        transaction (their own ``_serialized_write`` will detect the
+        outer tx and skip BEGIN).
         """
-        cursor = self.conn.cursor()
-        
-        # Find facts ready for consolidation (mention_count > 2)
-        cursor.execute("""
-            SELECT * FROM consolidated_facts
-            WHERE mention_count > 2 AND superseded_by IS NULL
-            ORDER BY mention_count DESC
-        """)
-        
-        for row in cursor.fetchall():
-            subject = row["subject"]
-            predicate = row["predicate"]
-            
-            # Find conflicts
-            cursor.execute("""
+        with self._serialized_write():
+            cursor = self.conn.cursor()
+
+            # Find facts ready for consolidation (mention_count > 2)
+            cursor.execute(
+                """
                 SELECT * FROM consolidated_facts
-                WHERE subject = ? AND predicate = ? AND object != ?
-                AND superseded_by IS NULL
-            """, (subject, predicate, row["object"]))
-            
-            conflicts = cursor.fetchall()
-            for conflict in conflicts:
-                # Auto-resolve: higher confidence wins
-                if row["confidence"] > conflict["confidence"]:
-                    self.resolve_conflict_by_facts(row["id"], conflict["id"])
-    
+                WHERE mention_count > 2 AND superseded_by IS NULL
+                ORDER BY mention_count DESC
+                """
+            )
+
+            # Materialize the row list before iterating + writing —
+            # mixing fetch with writes on the same cursor can confuse
+            # the iteration state under some sqlite3 builds.
+            primary_rows = cursor.fetchall()
+
+            for row in primary_rows:
+                subject = row["subject"]
+                predicate = row["predicate"]
+
+                # Find conflicts
+                cursor.execute(
+                    """
+                    SELECT * FROM consolidated_facts
+                    WHERE subject = ? AND predicate = ? AND object != ?
+                    AND superseded_by IS NULL
+                    """,
+                    (subject, predicate, row["object"]),
+                )
+
+                conflicts = cursor.fetchall()
+                for conflict in conflicts:
+                    # Auto-resolve: higher confidence wins
+                    if row["confidence"] > conflict["confidence"]:
+                        self.resolve_conflict_by_facts(
+                            row["id"], conflict["id"]
+                        )
+
     def resolve_conflict_by_facts(self, winning_id: str, losing_id: str):
-        """Resolve conflict by marking losing fact as superseded."""
-        now = datetime.now().isoformat()
-        cursor = self.conn.cursor()
-        
-        cursor.execute("""
-            UPDATE consolidated_facts
-            SET superseded_by = ?, updated_at = ?
-            WHERE id = ?
-        """, (winning_id, now, losing_id))
-        
-        self.conn.commit()
+        """Resolve conflict by marking losing fact as superseded.
+
+        Concurrency: this is a single-statement UPDATE so it doesn't
+        have the SELECT-then-write race shape of ``resolve_conflict``.
+        Still wrapped in ``_serialized_write`` for consistency: a
+        concurrent ``resolve_conflict`` on the same losing_id would
+        interleave on the `superseded_by` column, and the wrap makes
+        the override deterministic (later writer wins after the
+        earlier one commits, instead of both racing inside their
+        respective reads).
+        """
+        with self._serialized_write():
+            now = datetime.now().isoformat()
+            cursor = self.conn.cursor()
+
+            cursor.execute(
+                """
+                UPDATE consolidated_facts
+                SET superseded_by = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (winning_id, now, losing_id),
+            )
     
     def get_stats(self) -> Dict:
         """Get consolidation statistics."""

--- a/tests/test_consolidate_fact_concurrency.py
+++ b/tests/test_consolidate_fact_concurrency.py
@@ -1,0 +1,537 @@
+"""
+Regression tests for `consolidate_fact` concurrent same-SPO race.
+
+Pre-fix: `consolidate_fact` did SELECT-by-SPO then conditional
+INSERT or UPDATE without transaction serialization. Two threads
+both passing the no-match SELECT and both attempting INSERT raced
+on the deterministic PRIMARY KEY — one INSERT succeeded, the
+other raised `IntegrityError` which propagated up to (or was
+swallowed by) the caller's broad `except: pass`. Result: silent
+data loss — the second thread's observation was never recorded.
+
+Bayesian confidence updates were also race-vulnerable. The formula
+`new = old + (1 - old) * weight * 0.3` is path-dependent: two
+concurrent UPDATEs that both read the same baseline confidence
+both compute the same new value, then both write — the second
+UPDATE overwrites the first's effect rather than compounding it.
+
+Post-fix: `consolidate_fact` wraps the SELECT-then-INSERT/UPDATE
+in `BEGIN IMMEDIATE` so concurrent calls serialize at SQLite's
+writer-lock level. Nested-transaction safe (skips BEGIN if the
+caller already opened one, e.g., E2's `_deferred_commits`).
+
+These tests pin:
+  - N threads consolidating the same SPO produce exactly one row
+    with `mention_count == N`.
+  - N threads consolidating distinct SPOs produce N rows.
+  - The nested-transaction path (caller in `BEGIN`) doesn't crash
+    and produces the same end state.
+  - No IntegrityError surfaces under contention.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from mnemosyne.core.veracity_consolidation import VeracityConsolidator
+
+
+@pytest.fixture
+def temp_db(tmp_path: Path) -> Path:
+    """Shared DB path; each thread opens its own connection."""
+    # Pre-init the schema by constructing once. Each thread then
+    # opens its own VeracityConsolidator(db_path=temp_db) which
+    # builds its own connection but finds the schema already created.
+    db_path = tmp_path / "concurrency.db"
+    VeracityConsolidator(db_path=db_path)
+    return db_path
+
+
+def _consolidate_in_thread(
+    db_path: Path,
+    subject: str,
+    predicate: str,
+    object: str,
+    veracity: str,
+    source: str,
+    barrier: threading.Barrier,
+    exceptions: List[BaseException],
+):
+    """Thread worker: wait on barrier so all threads attempt the
+    consolidate_fact concurrently, then record any unexpected
+    exception so the test can fail visibly."""
+    try:
+        cons = VeracityConsolidator(db_path=db_path)
+        # Configure busy_timeout on this connection so BEGIN IMMEDIATE
+        # waits for the lock instead of immediately raising
+        # OperationalError under contention. Matches what
+        # beam._get_connection does at line 187.
+        cons.conn.execute("PRAGMA busy_timeout=5000")
+        barrier.wait()  # synchronize threads to maximize contention
+        cons.consolidate_fact(subject, predicate, object, veracity, source)
+    except BaseException as exc:
+        exceptions.append(exc)
+
+
+# ---------------------------------------------------------------------------
+# Core contract: concurrent same-SPO produces exactly one row
+# ---------------------------------------------------------------------------
+
+
+def test_two_threads_same_spo_produce_one_row_count_2(temp_db):
+    """Pre-fix this test would either crash with IntegrityError on
+    one thread (silent data loss when the upstream `except: pass`
+    swallowed it) or leave mention_count = 1 (one observation
+    lost). Post-fix: serialized via BEGIN IMMEDIATE → exactly one
+    row, mention_count == 2."""
+    exceptions: List[BaseException] = []
+    barrier = threading.Barrier(2)
+    t1 = threading.Thread(target=_consolidate_in_thread, args=(
+        temp_db, "Alice", "is", "developer", "stated", "src_a",
+        barrier, exceptions,
+    ))
+    t2 = threading.Thread(target=_consolidate_in_thread, args=(
+        temp_db, "Alice", "is", "developer", "stated", "src_b",
+        barrier, exceptions,
+    ))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    assert not exceptions, (
+        f"thread raised under contention: {exceptions}"
+    )
+
+    cons = VeracityConsolidator(db_path=temp_db)
+    rows = cons.conn.execute(
+        "SELECT mention_count FROM consolidated_facts "
+        "WHERE subject = 'Alice'"
+    ).fetchall()
+    assert len(rows) == 1, (
+        f"expected exactly 1 row, got {len(rows)} — race produced "
+        "duplicate rows"
+    )
+    assert rows[0]["mention_count"] == 2, (
+        f"expected mention_count == 2, got {rows[0]['mention_count']} "
+        "— one observation lost to race"
+    )
+
+
+def test_eight_threads_same_spo_produce_one_row_count_8(temp_db):
+    """Higher contention: 8 threads all consolidating identical
+    SPO. Pre-fix would lose multiple observations to IntegrityError;
+    post-fix all 8 are recorded."""
+    exceptions: List[BaseException] = []
+    barrier = threading.Barrier(8)
+    threads = [
+        threading.Thread(target=_consolidate_in_thread, args=(
+            temp_db, "Carol", "leads", "team", "stated", f"src_{i}",
+            barrier, exceptions,
+        ))
+        for i in range(8)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not exceptions, (
+        f"{len(exceptions)} threads raised: {exceptions[:3]}"
+    )
+
+    cons = VeracityConsolidator(db_path=temp_db)
+    rows = cons.conn.execute(
+        "SELECT mention_count, sources_json FROM consolidated_facts "
+        "WHERE subject = 'Carol'"
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["mention_count"] == 8, (
+        f"expected mention_count == 8 from 8 threads, got "
+        f"{rows[0]['mention_count']} — race lost observations"
+    )
+
+
+def test_eight_threads_distinct_spos_produce_eight_rows(temp_db):
+    """Different SPOs from different threads shouldn't block each
+    other excessively (BEGIN IMMEDIATE serializes but doesn't drop
+    writes). All 8 distinct rows should land."""
+    exceptions: List[BaseException] = []
+    barrier = threading.Barrier(8)
+    threads = [
+        threading.Thread(target=_consolidate_in_thread, args=(
+            temp_db, f"Person{i}", "is", "engineer", "stated", f"src_{i}",
+            barrier, exceptions,
+        ))
+        for i in range(8)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not exceptions
+
+    cons = VeracityConsolidator(db_path=temp_db)
+    count = cons.conn.execute(
+        "SELECT COUNT(*) FROM consolidated_facts "
+        "WHERE subject LIKE 'Person%'"
+    ).fetchone()[0]
+    assert count == 8, (
+        f"expected 8 distinct rows for 8 distinct SPOs, got {count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Nested-transaction safety
+# ---------------------------------------------------------------------------
+
+
+def test_consolidate_fact_nested_in_outer_transaction(temp_db):
+    """When the caller is already in a transaction (e.g., E2's
+    `_deferred_commits` wrapping a batch enrichment loop),
+    consolidate_fact must NOT try to start its own BEGIN IMMEDIATE
+    (which would raise `OperationalError: cannot start a
+    transaction within a transaction`). It should detect the
+    outer tx via `conn.in_transaction` and skip the BEGIN."""
+    cons = VeracityConsolidator(db_path=temp_db)
+    # Force an outer transaction.
+    cons.conn.execute("BEGIN")
+    assert cons.conn.in_transaction
+
+    # This should NOT raise; should use the existing transaction.
+    fact = cons.consolidate_fact("Dan", "is", "designer", "stated", "src_x")
+    assert fact.subject == "Dan"
+
+    # Commit the outer transaction so the row persists.
+    cons.conn.commit()
+    assert not cons.conn.in_transaction
+
+    # Verify the row was written.
+    rows = cons.conn.execute(
+        "SELECT mention_count FROM consolidated_facts "
+        "WHERE subject = 'Dan'"
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["mention_count"] == 1
+
+
+def test_consolidate_fact_rolls_back_own_transaction_on_error(temp_db):
+    """If consolidate_fact opened its own BEGIN IMMEDIATE and the
+    body raises, the transaction must be rolled back (no partial
+    writes leaking into the DB). We trigger an error by simulating
+    a constraint failure mid-call."""
+    cons = VeracityConsolidator(db_path=temp_db)
+    # Pre-populate with a row that the next consolidate_fact will
+    # find via the SPO match, taking the UPDATE branch.
+    cons.consolidate_fact("Eve", "is", "scientist", "stated", "src_a")
+
+    # Monkey-patch the bayesian_update to raise — this fires inside
+    # the SELECT-then-UPDATE path, after our BEGIN IMMEDIATE.
+    def fail(current_confidence, veracity):
+        raise RuntimeError("simulated mid-update failure")
+
+    cons.bayesian_update = fail  # type: ignore
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        cons.consolidate_fact("Eve", "is", "scientist", "stated", "src_b")
+
+    # Restore.
+    del cons.bayesian_update  # type: ignore
+
+    # State should be unchanged from the first call — mention_count
+    # still 1, sources still just ["src_a"].
+    row = cons.conn.execute(
+        "SELECT mention_count, sources_json FROM consolidated_facts "
+        "WHERE subject = 'Eve'"
+    ).fetchone()
+    assert row["mention_count"] == 1, (
+        f"failed update leaked into DB: mention_count = "
+        f"{row['mention_count']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bayesian confidence under contention
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_updates_compound_confidence_correctly(temp_db):
+    """The Bayesian confidence formula is path-dependent — each
+    update reads the CURRENT confidence and computes a delta. Pre-
+    fix, two concurrent UPDATEs both read the same baseline,
+    computed the same new value, and the second overwrote the
+    first → only one of the two updates' effects landed. Post-fix:
+    serialized via BEGIN IMMEDIATE → both updates compound and
+    the final confidence is strictly greater than the
+    single-update result."""
+    # First call: establish a baseline single-update confidence
+    # value for comparison.
+    cons = VeracityConsolidator(db_path=temp_db)
+    cons.consolidate_fact("Frank", "is", "DBA", "stated", "src_seed")
+    seed_row = cons.conn.execute(
+        "SELECT confidence FROM consolidated_facts WHERE subject = 'Frank'"
+    ).fetchone()
+    seed_confidence = seed_row["confidence"]
+
+    # Now fire 4 concurrent updates with separate connections.
+    exceptions: List[BaseException] = []
+    barrier = threading.Barrier(4)
+    threads = [
+        threading.Thread(target=_consolidate_in_thread, args=(
+            temp_db, "Frank", "is", "DBA", "stated", f"src_{i}",
+            barrier, exceptions,
+        ))
+        for i in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not exceptions
+
+    row = cons.conn.execute(
+        "SELECT confidence, mention_count FROM consolidated_facts "
+        "WHERE subject = 'Frank'"
+    ).fetchone()
+    # Each of the 4 threads should have applied the Bayesian update.
+    # mention_count is the most direct evidence the serialization
+    # held — each update increments by 1.
+    assert row["mention_count"] == 5, (
+        f"expected mention_count == 5 (seed + 4 concurrent updates), "
+        f"got {row['mention_count']} — race lost update(s)"
+    )
+    # Final confidence must be strictly greater than the seed —
+    # at least one of the 4 updates must have compounded the
+    # confidence (pre-fix could have lost all 4 to the
+    # last-writer-wins race and left confidence == seed).
+    assert row["confidence"] > seed_confidence, (
+        f"final confidence {row['confidence']} not greater than "
+        f"seed {seed_confidence} — concurrent updates didn't compound"
+    )
+
+
+# ---------------------------------------------------------------------------
+# /review hardening (commit 2) — 4-source convergence findings
+# ---------------------------------------------------------------------------
+
+
+class TestReviewHardening:
+    """Closes the must-fix /review army findings on commit 1:
+      1. _record_conflict premature commit (4-source HIGH)
+      2. Silent fallthrough on BEGIN IMMEDIATE failure (4-source HIGH)
+      3. WAL + busy_timeout not set on VeracityConsolidator's own
+         connection (Claude C3)
+      4. Test reliability — deterministic race-window widening to
+         prove the original race actually triggers without the fix
+         (Claude H1 + Codex adversarial MED)
+    """
+
+    def test_record_conflict_does_not_commit_when_nested(self, temp_db):
+        """`_record_conflict` must accept `commit=False` so the
+        atomicity of consolidate_fact's BEGIN IMMEDIATE scope is
+        preserved when conflicts are recorded. Pre-fix the
+        unconditional commit ended our outer transaction
+        mid-method — the fact INSERT became durable before all
+        conflicts were recorded."""
+        from mnemosyne.core.veracity_consolidation import VeracityConsolidator
+
+        cons = VeracityConsolidator(db_path=temp_db)
+
+        # Manually open a transaction; call _record_conflict with
+        # commit=False; verify the transaction is still open.
+        cons.conn.execute("BEGIN IMMEDIATE")
+        assert cons.conn.in_transaction
+        cons._record_conflict("fact_x", "fact_y", "test", commit=False)
+        # Tx should still be open — we said commit=False.
+        assert cons.conn.in_transaction, (
+            "_record_conflict committed despite commit=False"
+        )
+        cons.conn.commit()  # clean up
+
+    def test_record_conflict_default_still_commits(self, temp_db):
+        """Backward compat: callers that didn't pass commit= should
+        still get the pre-fix behavior of committing immediately."""
+        from mnemosyne.core.veracity_consolidation import VeracityConsolidator
+
+        cons = VeracityConsolidator(db_path=temp_db)
+        # No outer tx; _record_conflict should commit its own work.
+        cons._record_conflict("fact_a", "fact_b", "test")
+        assert not cons.conn.in_transaction
+        # And the conflict row should be visible.
+        count = cons.conn.execute(
+            "SELECT COUNT(*) FROM conflicts WHERE fact_a_id = 'fact_a'"
+        ).fetchone()[0]
+        assert count == 1
+
+    def test_begin_immediate_failure_raises_does_not_silently_proceed(
+        self, temp_db
+    ):
+        """If BEGIN IMMEDIATE raises (lock held past busy_timeout,
+        or any other OperationalError), `consolidate_fact` must
+        propagate the error rather than fall through to the
+        unprotected SELECT-then-write path. /review caught the
+        pre-fix silent-fallthrough as 4-source HIGH — it
+        reintroduced the exact race the method was trying to close."""
+        from mnemosyne.core.veracity_consolidation import VeracityConsolidator
+
+        cons = VeracityConsolidator(db_path=temp_db)
+
+        # Simulate BEGIN IMMEDIATE failure by holding the writer
+        # lock from a separate connection with a short busy_timeout
+        # on our writer.
+        cons.conn.execute("PRAGMA busy_timeout=100")  # 100ms only
+        blocker = sqlite3.connect(str(temp_db))
+        try:
+            blocker.execute("BEGIN IMMEDIATE")  # hold the lock
+            # Our consolidate_fact should fail rather than proceed.
+            with pytest.raises(sqlite3.OperationalError):
+                cons.consolidate_fact(
+                    "Locked", "is", "blocked", "stated", "src",
+                )
+        finally:
+            blocker.rollback()
+            blocker.close()
+
+    def test_consolidator_sets_wal_and_busy_timeout(self, tmp_path):
+        """`VeracityConsolidator.__init__` should configure WAL +
+        busy_timeout when it owns the connection. Without WAL the
+        BEGIN IMMEDIATE lock blocks readers too; without
+        busy_timeout the second writer fails instantly under
+        contention. /review (Claude C3) caught the missing PRAGMAs."""
+        from mnemosyne.core.veracity_consolidation import VeracityConsolidator
+
+        db_path = tmp_path / "pragma_check.db"
+        cons = VeracityConsolidator(db_path=db_path)
+
+        # Verify journal_mode is WAL
+        mode = cons.conn.execute(
+            "PRAGMA journal_mode"
+        ).fetchone()[0]
+        assert mode.lower() == "wal", (
+            f"expected journal_mode=wal, got {mode!r} — "
+            "VeracityConsolidator.__init__ didn't apply PRAGMA"
+        )
+
+        # Verify busy_timeout is set (non-zero).
+        timeout = cons.conn.execute(
+            "PRAGMA busy_timeout"
+        ).fetchone()[0]
+        assert timeout > 0, (
+            f"expected busy_timeout > 0, got {timeout} — "
+            "VeracityConsolidator.__init__ didn't apply PRAGMA"
+        )
+
+    def test_partial_conflict_rollback_undoes_fact_insert(self, temp_db):
+        """If a conflict-record INSERT fails mid-loop (after the
+        fact INSERT but before all conflicts are recorded), the
+        BEGIN IMMEDIATE scope's rollback should undo the fact
+        INSERT. Pre-fix _record_conflict's commit between the
+        fact INSERT and the conflict INSERT meant a failed
+        second conflict would leave the fact + first conflict
+        durable but later conflicts missing — partial state."""
+        from mnemosyne.core.veracity_consolidation import VeracityConsolidator
+
+        cons = VeracityConsolidator(db_path=temp_db)
+        # Seed two existing facts so the new fact will produce
+        # 2 conflicts when inserted.
+        cons.consolidate_fact("Kate", "is", "X", "stated", "src_x")
+        cons.consolidate_fact("Kate", "is", "Y", "stated", "src_y")
+        # Both Kate-is-X and Kate-is-Y are in the DB.
+
+        # Now monkey-patch _record_conflict to fail on the second
+        # call. The first call should be deferred (commit=False);
+        # the failure on the second should trigger the outer
+        # rollback, undoing the fact INSERT entirely.
+        call_count = {"n": 0}
+        original = cons._record_conflict
+
+        def fail_second(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise sqlite3.OperationalError("simulated mid-loop failure")
+            return original(*args, **kwargs)
+
+        cons._record_conflict = fail_second  # type: ignore
+
+        with pytest.raises(sqlite3.OperationalError, match="simulated"):
+            cons.consolidate_fact("Kate", "is", "Z", "stated", "src_z")
+
+        del cons._record_conflict  # type: ignore
+
+        # The new fact (Kate, is, Z) must NOT be in the DB.
+        rows = cons.conn.execute(
+            "SELECT subject, object FROM consolidated_facts "
+            "WHERE subject = 'Kate' AND object = 'Z'"
+        ).fetchall()
+        assert len(rows) == 0, (
+            "fact INSERT not rolled back after conflict-record "
+            "failure — partial state leaked"
+        )
+
+    def test_race_window_widening_demonstrates_serialization(
+        self, temp_db, monkeypatch
+    ):
+        """A more deterministic regression test than the
+        barrier-only concurrency tests. Injects a small sleep
+        between SELECT and INSERT to widen the race window. With
+        BEGIN IMMEDIATE serialization in place, two threads still
+        produce exactly one row + mention_count=2. Without it
+        (pre-fix), the wide-open window guarantees an
+        IntegrityError on one of them."""
+        from mnemosyne.core.veracity_consolidation import VeracityConsolidator
+        import time
+
+        # Track whether the original bayesian_update was called
+        # during the SELECT-then-write critical section, then
+        # inject a sleep AFTER SELECT but BEFORE INSERT/UPDATE to
+        # widen the race window.
+        original_bayesian = VeracityConsolidator.bayesian_update
+
+        def slow_bayesian(self, current_confidence, veracity):
+            time.sleep(0.05)  # 50ms window
+            return original_bayesian(self, current_confidence, veracity)
+
+        monkeypatch.setattr(
+            VeracityConsolidator, "bayesian_update", slow_bayesian
+        )
+
+        # Seed the row so concurrent calls go through the UPDATE
+        # branch (which is where bayesian_update fires).
+        seeder = VeracityConsolidator(db_path=temp_db)
+        seeder.consolidate_fact("Liam", "is", "seeded", "stated", "src_seed")
+
+        # Fire 4 concurrent updates; each delays inside
+        # bayesian_update. Without BEGIN IMMEDIATE serialization,
+        # at least one would race and lose its update. With
+        # serialization, all 4 land and mention_count == 5.
+        exceptions: List[BaseException] = []
+        barrier = threading.Barrier(4)
+        threads = [
+            threading.Thread(target=_consolidate_in_thread, args=(
+                temp_db, "Liam", "is", "seeded", "stated", f"src_{i}",
+                barrier, exceptions,
+            ))
+            for i in range(4)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not exceptions, (
+            f"race-widened test surfaced exception: {exceptions[:2]}"
+        )
+
+        row = seeder.conn.execute(
+            "SELECT mention_count FROM consolidated_facts "
+            "WHERE subject = 'Liam'"
+        ).fetchone()
+        assert row["mention_count"] == 5, (
+            f"expected mention_count == 5 (seed + 4 concurrent "
+            f"updates with widened race window), got "
+            f"{row['mention_count']} — serialization lost updates"
+        )

--- a/tests/test_consolidate_fact_sibling_races.py
+++ b/tests/test_consolidate_fact_sibling_races.py
@@ -507,3 +507,76 @@ class TestReviewHardening:
     # Adding a deterministic delay-injection test would require a
     # different injection point (e.g., a hook on _serialized_write
     # itself). Tracked as a future test-coverage improvement.
+
+    def test_consolidate_fact_same_connection_serializes_via_rlock(
+        self, temp_db
+    ):
+        """Post-DRY-refactor: `consolidate_fact` uses `_serialized_write`
+        and acquires `_write_lock` like the other three write methods.
+        Pre-DRY (PR #84's inline pattern), `consolidate_fact` did NOT
+        acquire `_write_lock` — so two threads sharing one
+        VeracityConsolidator instance could still race within a single
+        SQL transaction (BEGIN IMMEDIATE protects across connections
+        but not within one).
+
+        Mirrors `test_same_connection_writers_serialize_via_rlock` but
+        exercises `consolidate_fact` rather than
+        `resolve_conflict_by_facts`. Closes the same-conn race shape
+        for the fourth and final write method on
+        VeracityConsolidator."""
+        import time
+        cons = VeracityConsolidator(db_path=temp_db)
+
+        # Inject delay inside `bayesian_update` (UPDATE branch's
+        # only Python-level work outside the SQL UPDATE itself) to
+        # widen the critical section.
+        original_bayesian = cons.bayesian_update
+
+        def slow_bayesian(current_confidence, veracity):
+            time.sleep(0.02)
+            return original_bayesian(current_confidence, veracity)
+
+        cons.bayesian_update = slow_bayesian  # type: ignore
+
+        # Seed so concurrent calls hit the UPDATE branch.
+        cons.consolidate_fact("Diana", "is", "founder", "stated", "seed")
+
+        exceptions: List[BaseException] = []
+        barrier = threading.Barrier(4)
+
+        def in_thread(i: int):
+            try:
+                barrier.wait()
+                # SHARED instance — exercises the same-conn race path.
+                cons.consolidate_fact(
+                    "Diana", "is", "founder", "stated", f"src_{i}",
+                )
+            except BaseException as exc:
+                exceptions.append(exc)
+
+        threads = [
+            threading.Thread(target=in_thread, args=(i,))
+            for i in range(4)
+        ]
+        for t in threads: t.start()
+        for t in threads: t.join()
+
+        del cons.bayesian_update  # type: ignore
+
+        # No exceptions (RLock prevented same-conn interleave).
+        assert not exceptions, (
+            f"same-conn race in consolidate_fact: {exceptions[:1]} — "
+            "DRY refactor's RLock acquisition broken"
+        )
+        # mention_count should be exactly 5: 1 seed + 4 concurrent
+        # updates. Pre-DRY (no RLock for consolidate_fact) the race
+        # would lose at least one update.
+        row = cons.conn.execute(
+            "SELECT mention_count FROM consolidated_facts "
+            "WHERE subject = 'Diana'"
+        ).fetchone()
+        assert row["mention_count"] == 5, (
+            f"expected mention_count == 5 (seed + 4 concurrent "
+            f"updates), got {row['mention_count']} — same-conn race "
+            "lost update(s) in consolidate_fact"
+        )

--- a/tests/test_consolidate_fact_sibling_races.py
+++ b/tests/test_consolidate_fact_sibling_races.py
@@ -1,0 +1,509 @@
+"""
+Regression tests for race-pattern fix on `VeracityConsolidator`
+sibling methods: `resolve_conflict`, `resolve_conflict_by_facts`,
+`run_consolidation_pass`.
+
+E2.a.5 (PR #84) closed the SELECT-then-write race in
+`consolidate_fact`. The /review army on that PR flagged that the
+three sibling write methods on the same class have the same
+shape and are unprotected. E2.a.6 fixes them by extracting a
+shared `_serialized_write` context manager and applying it to all
+three.
+
+Severity profile (analyzed during fix implementation):
+  - `resolve_conflict`: **real bug.** Two concurrent calls with
+    different `winning_fact_id` values on the same conflict_id can
+    leave BOTH facts superseded.
+  - `resolve_conflict_by_facts`: single UPDATE, no SELECT-write
+    race shape. Wrapped for consistency.
+  - `run_consolidation_pass`: read-decide-resolve loop. Race is
+    benign (idempotent decisions) but wrapped to prevent
+    interleaved writes from other writers during the pass.
+
+These tests pin:
+  - Concurrent `resolve_conflict` with conflicting winners produces
+    a deterministic single winner, not both-superseded.
+  - `_serialized_write` participates in caller-owned outer
+    transactions.
+  - `run_consolidation_pass` calling `resolve_conflict_by_facts`
+    nests correctly (inner doesn't try its own BEGIN IMMEDIATE).
+  - All three methods preserve their pre-fix happy-path behavior.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from mnemosyne.core.veracity_consolidation import VeracityConsolidator
+
+
+@pytest.fixture
+def temp_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "sibling_races.db"
+    VeracityConsolidator(db_path=db_path)  # initialize schema
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# resolve_conflict — the real race (different winning_fact_id values)
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_resolve_conflict_different_winners_deterministic(temp_db):
+    """Two threads each pass a different ``winning_fact_id`` for the
+    same conflict. Pre-fix both could pass the SELECT and the
+    second UPDATE would mark the OTHER fact superseded — leaving
+    BOTH facts with superseded_by set. Post-fix serialization makes
+    one winner durable before the second call runs."""
+    cons = VeracityConsolidator(db_path=temp_db)
+    cons.consolidate_fact("Alice", "is", "engineer", "stated", "src_a")
+    cons.consolidate_fact("Alice", "is", "manager", "inferred", "src_b")
+    conflicts = cons.get_conflicts()
+    assert conflicts, "test setup: expected a conflict from Alice's roles"
+    conflict_id = conflicts[0]["id"]
+    fact_a_id = conflicts[0]["fact_a_id"]
+    fact_b_id = conflicts[0]["fact_b_id"]
+
+    exceptions: List[BaseException] = []
+    barrier = threading.Barrier(2)
+
+    def resolve_in_thread(winner_id: str):
+        try:
+            sub_cons = VeracityConsolidator(db_path=temp_db)
+            barrier.wait()
+            sub_cons.resolve_conflict(conflict_id, winner_id)
+        except BaseException as exc:
+            exceptions.append(exc)
+
+    t1 = threading.Thread(target=resolve_in_thread, args=(fact_a_id,))
+    t2 = threading.Thread(target=resolve_in_thread, args=(fact_b_id,))
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    # Either thread's exception is acceptable (the second writer
+    # might see the already-resolved conflict and no-op), but BOTH
+    # facts being superseded is the bug.
+    rows = cons.conn.execute(
+        "SELECT id, superseded_by FROM consolidated_facts "
+        "WHERE subject = 'Alice'"
+    ).fetchall()
+    superseded_count = sum(1 for r in rows if r["superseded_by"] is not None)
+    assert superseded_count <= 1, (
+        f"both facts superseded ({superseded_count}/2) — concurrent "
+        f"resolve_conflict with conflicting winners left a non-coherent "
+        f"state. exceptions: {exceptions[:1]}"
+    )
+
+
+def test_resolve_conflict_happy_path_unchanged(temp_db):
+    """Single-threaded resolve_conflict still produces the same
+    end state as pre-fix. Locks in backward compat."""
+    cons = VeracityConsolidator(db_path=temp_db)
+    cons.consolidate_fact("Bob", "is", "engineer", "stated")
+    cons.consolidate_fact("Bob", "is", "manager", "inferred")
+    conflicts = cons.get_conflicts()
+    assert conflicts
+
+    cons.resolve_conflict(conflicts[0]["id"], conflicts[0]["fact_a_id"])
+
+    # The other fact should be marked superseded.
+    fact_b = cons.conn.execute(
+        "SELECT superseded_by FROM consolidated_facts WHERE id = ?",
+        (conflicts[0]["fact_b_id"],),
+    ).fetchone()
+    assert fact_b["superseded_by"] == conflicts[0]["fact_a_id"]
+
+    # The conflict should be marked resolved.
+    conflict_row = cons.conn.execute(
+        "SELECT resolution FROM conflicts WHERE id = ?",
+        (conflicts[0]["id"],),
+    ).fetchone()
+    assert conflict_row["resolution"] is not None
+
+
+# ---------------------------------------------------------------------------
+# resolve_conflict_by_facts — wrapped for consistency
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_conflict_by_facts_happy_path_unchanged(temp_db):
+    """Single-call behavior is unchanged after wrapping. The
+    serialization is defensive — single-UPDATE doesn't need it for
+    correctness, but the wrap keeps the canonical pattern."""
+    cons = VeracityConsolidator(db_path=temp_db)
+    cons.consolidate_fact("Carol", "is", "lead", "stated")
+    cons.consolidate_fact("Carol", "is", "founder", "stated")
+
+    rows = cons.conn.execute(
+        "SELECT id, object FROM consolidated_facts WHERE subject = 'Carol'"
+    ).fetchall()
+    by_object = {r["object"]: r["id"] for r in rows}
+    winning = by_object["lead"]
+    losing = by_object["founder"]
+
+    cons.resolve_conflict_by_facts(winning, losing)
+
+    superseded = cons.conn.execute(
+        "SELECT superseded_by FROM consolidated_facts WHERE id = ?",
+        (losing,),
+    ).fetchone()
+    assert superseded["superseded_by"] == winning
+
+
+def test_concurrent_resolve_conflict_by_facts_idempotent(temp_db):
+    """Two threads calling resolve_conflict_by_facts with the SAME
+    winner+loser arguments must converge to one durable state with
+    no IntegrityError or partial writes."""
+    cons = VeracityConsolidator(db_path=temp_db)
+    cons.consolidate_fact("Dan", "is", "A", "stated")
+    cons.consolidate_fact("Dan", "is", "B", "stated")
+    rows = cons.conn.execute(
+        "SELECT id, object FROM consolidated_facts WHERE subject = 'Dan'"
+    ).fetchall()
+    winning = next(r["id"] for r in rows if r["object"] == "A")
+    losing = next(r["id"] for r in rows if r["object"] == "B")
+
+    exceptions: List[BaseException] = []
+    barrier = threading.Barrier(4)
+
+    def in_thread():
+        try:
+            sub = VeracityConsolidator(db_path=temp_db)
+            barrier.wait()
+            sub.resolve_conflict_by_facts(winning, losing)
+        except BaseException as exc:
+            exceptions.append(exc)
+
+    threads = [threading.Thread(target=in_thread) for _ in range(4)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    assert not exceptions, f"unexpected: {exceptions[:1]}"
+    final = cons.conn.execute(
+        "SELECT superseded_by FROM consolidated_facts WHERE id = ?",
+        (losing,),
+    ).fetchone()
+    assert final["superseded_by"] == winning
+
+
+# ---------------------------------------------------------------------------
+# run_consolidation_pass — nested-call correctness
+# ---------------------------------------------------------------------------
+
+
+def test_run_consolidation_pass_resolves_obvious_conflicts(temp_db):
+    """Happy-path: pass with high-confidence vs low-confidence
+    facts auto-resolves in favor of high-confidence. Pre-fix
+    behavior unchanged."""
+    cons = VeracityConsolidator(db_path=temp_db)
+    # Seed a high-confidence fact (multiple stated mentions to push
+    # mention_count > 2 AND boost confidence) + a low-confidence
+    # competing fact.
+    for _ in range(4):
+        cons.consolidate_fact("Eve", "is", "CEO", "stated", "src_high")
+    cons.consolidate_fact("Eve", "is", "VP", "inferred", "src_low")
+
+    cons.run_consolidation_pass()
+
+    # VP should be superseded, CEO active.
+    rows = cons.conn.execute(
+        "SELECT object, superseded_by FROM consolidated_facts "
+        "WHERE subject = 'Eve' ORDER BY object"
+    ).fetchall()
+    by_object = {r["object"]: r["superseded_by"] for r in rows}
+    assert by_object["CEO"] is None, "CEO should remain active"
+    assert by_object["VP"] is not None, (
+        "VP should be superseded by run_consolidation_pass"
+    )
+
+
+def test_run_consolidation_pass_nested_resolve_does_not_crash(temp_db):
+    """`run_consolidation_pass` opens BEGIN IMMEDIATE via
+    `_serialized_write`. Inside it calls `resolve_conflict_by_facts`
+    which ALSO uses `_serialized_write`. The inner call's
+    `conn.in_transaction` check must detect the outer scope and
+    skip its own BEGIN — otherwise it would raise
+    `cannot start a transaction within a transaction`."""
+    cons = VeracityConsolidator(db_path=temp_db)
+    # Seed facts ready for the pass.
+    for _ in range(4):
+        cons.consolidate_fact("Frank", "uses", "Python", "stated", "src_x")
+    cons.consolidate_fact("Frank", "uses", "Rust", "inferred", "src_y")
+
+    # Should not raise.
+    cons.run_consolidation_pass()
+
+
+# ---------------------------------------------------------------------------
+# _serialized_write helper directly
+# ---------------------------------------------------------------------------
+
+
+def test_serialized_write_begins_immediate_when_not_in_tx(temp_db):
+    """The helper should issue BEGIN IMMEDIATE and own the
+    commit/rollback lifecycle when the connection isn't in a tx."""
+    cons = VeracityConsolidator(db_path=temp_db)
+    assert not cons.conn.in_transaction
+
+    with cons._serialized_write():
+        assert cons.conn.in_transaction, (
+            "_serialized_write didn't open a transaction"
+        )
+        cons.conn.execute(
+            "INSERT INTO consolidated_facts "
+            "(id, subject, predicate, object, confidence, mention_count, "
+            " first_seen, last_seen, sources_json, veracity) "
+            "VALUES ('cf_test', 's', 'p', 'o', 0.5, 1, "
+            "datetime('now'), datetime('now'), '[]', 'stated')"
+        )
+
+    # After the with-block, tx should be committed and closed.
+    assert not cons.conn.in_transaction
+    row = cons.conn.execute(
+        "SELECT * FROM consolidated_facts WHERE id = 'cf_test'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_serialized_write_rolls_back_on_exception(temp_db):
+    """When the body raises, the helper must roll back its own
+    transaction. Pre-fix consolidate_fact's inline rollback path
+    was tested by E2.a.5; this test pins the helper's version."""
+    cons = VeracityConsolidator(db_path=temp_db)
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        with cons._serialized_write():
+            cons.conn.execute(
+                "INSERT INTO consolidated_facts "
+                "(id, subject, predicate, object, confidence, "
+                " mention_count, first_seen, last_seen, "
+                " sources_json, veracity) "
+                "VALUES ('cf_doomed', 's', 'p', 'o', 0.5, 1, "
+                "datetime('now'), datetime('now'), '[]', 'stated')"
+            )
+            raise RuntimeError("simulated mid-write failure")
+
+    # The INSERT should have been rolled back.
+    row = cons.conn.execute(
+        "SELECT * FROM consolidated_facts WHERE id = 'cf_doomed'"
+    ).fetchone()
+    assert row is None, (
+        "rollback didn't undo the insert — leaked into DB"
+    )
+
+
+def test_serialized_write_participates_in_outer_transaction(temp_db):
+    """When the connection is already in a tx, `_serialized_write`
+    must NOT try BEGIN IMMEDIATE (which would raise) and must NOT
+    issue its own commit on exit (caller owns it)."""
+    cons = VeracityConsolidator(db_path=temp_db)
+    cons.conn.execute("BEGIN")
+    assert cons.conn.in_transaction
+
+    with cons._serialized_write():
+        # Still in the OUTER tx — helper didn't start its own.
+        assert cons.conn.in_transaction
+        cons.conn.execute(
+            "INSERT INTO consolidated_facts "
+            "(id, subject, predicate, object, confidence, "
+            " mention_count, first_seen, last_seen, sources_json, "
+            " veracity) "
+            "VALUES ('cf_nested', 's', 'p', 'o', 0.5, 1, "
+            "datetime('now'), datetime('now'), '[]', 'stated')"
+        )
+
+    # Outer tx still open — helper didn't commit ours.
+    assert cons.conn.in_transaction
+    cons.conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# /review hardening (commit 2) — 4-source convergence
+# ---------------------------------------------------------------------------
+
+
+class TestReviewHardening:
+    """Closes findings from the /review army on commit 1:
+      1. Same-connection writer race (Codex structured GATE FAIL P2) —
+         threading.RLock added to instance
+      2. Missing WAL/busy_timeout PRAGMAs (Claude CRITICAL) — added
+         to __init__
+      3. Self.conn capture in helper (Codex adv MED) — captured once
+      4. WARNING log assertion for first-writer-wins guard
+         (Maintainability MED + Codex adv)
+      5. Race-window-widening test pattern (E2.a.5 reference) —
+         deterministic regression guard
+    """
+
+    def test_consolidator_sets_wal_and_busy_timeout(self, tmp_path):
+        """Mirrors the E2.a.5 PR #84 test. VeracityConsolidator
+        must apply WAL + busy_timeout when constructing its own
+        connection so `_serialized_write`'s BEGIN IMMEDIATE has the
+        correct contention semantics (waits up to 5s rather than
+        raising instantly under default journal_mode=DELETE)."""
+        db_path = tmp_path / "pragma_check.db"
+        cons = VeracityConsolidator(db_path=db_path)
+
+        mode = cons.conn.execute(
+            "PRAGMA journal_mode"
+        ).fetchone()[0]
+        assert mode.lower() == "wal", (
+            f"expected journal_mode=wal, got {mode!r} — "
+            "VeracityConsolidator.__init__ didn't apply PRAGMA"
+        )
+
+        timeout = cons.conn.execute(
+            "PRAGMA busy_timeout"
+        ).fetchone()[0]
+        assert timeout > 0, (
+            f"expected busy_timeout > 0, got {timeout}"
+        )
+
+    def test_same_connection_writers_serialize_via_rlock(self, temp_db):
+        """When two threads share the same VeracityConsolidator
+        instance (and therefore the same self.conn), BEGIN IMMEDIATE
+        alone doesn't protect them — the first thread's BEGIN makes
+        conn.in_transaction=True, and the second sees that and
+        skips BEGIN, entering the critical section within the
+        first's open transaction. The instance-level RLock added in
+        commit 2 closes this gap.
+
+        We verify by setting up the same shared-instance scenario
+        and exercising it with the race-window-widening pattern
+        from E2.a.5: monkey-patch bayesian_update (the deepest
+        helper called inside _serialized_write scope via
+        consolidate_fact) to sleep, deterministically holding the
+        critical section open. Then fire 4 threads doing
+        resolve_conflict_by_facts (also wrapped by _serialized_write)
+        against the same instance — all 4 should serialize on the
+        RLock and produce a coherent end state."""
+        import time
+        cons = VeracityConsolidator(db_path=temp_db)
+        cons.consolidate_fact("Alice", "is", "X", "stated")
+        cons.consolidate_fact("Alice", "is", "Y", "stated")
+        rows = cons.conn.execute(
+            "SELECT id, object FROM consolidated_facts WHERE subject = 'Alice'"
+        ).fetchall()
+        winning = next(r["id"] for r in rows if r["object"] == "X")
+        losing = next(r["id"] for r in rows if r["object"] == "Y")
+
+        # Inject delay inside the critical section. The patch fires
+        # before each resolve_conflict_by_facts UPDATE so concurrent
+        # threads contend on the RLock.
+        original_resolve = cons.resolve_conflict_by_facts
+
+        def slow_resolve(*args, **kwargs):
+            time.sleep(0.02)
+            return original_resolve(*args, **kwargs)
+
+        cons.resolve_conflict_by_facts = slow_resolve  # type: ignore
+
+        exceptions: List[BaseException] = []
+        barrier = threading.Barrier(4)
+
+        def in_thread():
+            try:
+                barrier.wait()
+                # Use the SHARED instance, not a fresh one — that's
+                # the same-conn scenario the RLock protects.
+                cons.resolve_conflict_by_facts(winning, losing)
+            except BaseException as exc:
+                exceptions.append(exc)
+
+        threads = [threading.Thread(target=in_thread) for _ in range(4)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+
+        del cons.resolve_conflict_by_facts  # type: ignore
+
+        # No exceptions (RLock prevented IntegrityError from
+        # interleaved writes via SQLite's same-conn-transaction model).
+        assert not exceptions, (
+            f"same-conn race surfaced exception: {exceptions[:1]} — "
+            "RLock didn't serialize"
+        )
+        # End state coherent: losing fact marked superseded by winning.
+        final = cons.conn.execute(
+            "SELECT superseded_by FROM consolidated_facts WHERE id = ?",
+            (losing,),
+        ).fetchone()
+        assert final["superseded_by"] == winning
+
+    def test_first_writer_wins_logs_warning(self, temp_db, caplog):
+        """When the already-resolved guard kicks in, a WARNING log
+        should fire so operators can spot conflicting writes.
+        /review (Maintainability MED) flagged the missing log
+        assertion."""
+        import logging
+        cons = VeracityConsolidator(db_path=temp_db)
+        cons.consolidate_fact("Bob", "is", "X", "stated")
+        cons.consolidate_fact("Bob", "is", "Y", "inferred")
+        conflicts = cons.get_conflicts()
+        conflict_id = conflicts[0]["id"]
+        fact_a_id = conflicts[0]["fact_a_id"]
+        fact_b_id = conflicts[0]["fact_b_id"]
+
+        # First resolution: succeeds, no warning.
+        with caplog.at_level(logging.WARNING):
+            cons.resolve_conflict(conflict_id, fact_a_id)
+            assert not any(
+                "already resolved" in rec.message
+                for rec in caplog.records
+            )
+
+        # Second resolution on same conflict_id: first-writer-wins
+        # guard kicks in; should log WARNING.
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            cons.resolve_conflict(conflict_id, fact_b_id)
+            assert any(
+                "already resolved" in rec.message
+                for rec in caplog.records
+            ), (
+                f"expected WARNING about already-resolved conflict; "
+                f"got logs: {[r.message for r in caplog.records]}"
+            )
+
+    def test_helper_captures_conn_at_entry(self, temp_db):
+        """_serialized_write captures `conn = self.conn` once at
+        entry so commit/rollback target the same connection BEGIN
+        IMMEDIATE opened on — defense against the body swapping
+        self.conn mid-scope. /review (Codex adv MED)."""
+        cons = VeracityConsolidator(db_path=temp_db)
+        original_conn = cons.conn
+
+        with cons._serialized_write():
+            # Swap to a different (in-memory) conn mid-scope.
+            sqlite_other = sqlite3.connect(":memory:")
+            cons.conn = sqlite_other  # type: ignore
+            # The original conn should still be the one BEGIN
+            # IMMEDIATE was issued on; commit/rollback on context
+            # exit must target it.
+
+        # Restore the original conn for cleanup.
+        cons.conn = original_conn
+
+        # The original conn should NOT be in a transaction
+        # (commit fired against the captured `conn = self.conn`
+        # from entry, which was original_conn).
+        assert not original_conn.in_transaction, (
+            "original conn left mid-transaction — helper didn't "
+            "capture self.conn at entry"
+        )
+
+    # Race-window-widening test was attempted but `datetime.datetime.now`
+    # can't be monkey-patched (immutable C type). The other tests in
+    # this class cover the same regression surface:
+    #   - test_same_connection_writers_serialize_via_rlock exercises
+    #     real contention via slow_resolve injection
+    #   - test_first_writer_wins_logs_warning pins the
+    #     already-resolved guard
+    #   - test_concurrent_resolve_conflict_different_winners_deterministic
+    #     exercises the cross-thread race shape
+    # Adding a deterministic delay-injection test would require a
+    # different injection point (e.g., a hook on _serialized_write
+    # itself). Tracked as a future test-coverage improvement.


### PR DESCRIPTION
## TL;DR

DRY refactor of `VeracityConsolidator.consolidate_fact` to use the `_serialized_write` helper introduced in PR #85. Closes the same-connection race for consolidate_fact (which was left open by PR #84's inline-only pattern), unifies all 4 write methods on one canonical concurrency pattern, and removes ~85 lines of duplicated transaction-management code.

**14 regression tests, all passing.** Codex structured /review: **GATE PASS**, no P0/P1/P2 issues.

## What this PR closes

After PR #85 introduced `threading.RLock` on the instance + applied `_serialized_write` to 3 sibling methods, `consolidate_fact` was the ONLY method on `VeracityConsolidator` still using PR #84's inline pattern. Two consequences this PR closes:

1. **Same-connection race left open for consolidate_fact.** PR #85's RLock protects 3 of 4 methods. `consolidate_fact` didn't acquire it because it didn't go through the helper. Two threads sharing one `VeracityConsolidator` instance (e.g., via `polyphonic_recall.py:88`'s `conn=conn` passthrough) could still race in consolidate_fact.

2. **Code duplication.** Two patterns for the same concurrency concern made it easy for future modifications to drift between methods.

## What this PR does

Single commit:

- `consolidate_fact` body wrapped in `with self._serialized_write():` — no inline `BEGIN IMMEDIATE`, no try/except for tx management, no `self.conn.commit()` calls (the helper handles all of that)
- `_record_conflict` gains `commit: bool = True` kwarg (mirroring PR #84's pattern); consolidate_fact passes `commit=False` from inside the helper scope so the fact INSERT + conflict rows commit atomically
- New test `test_consolidate_fact_same_connection_serializes_via_rlock` (mirrors PR #85's `test_same_connection_writers_serialize_via_rlock` but exercises consolidate_fact)

Net effect: **all 4 write methods now share one canonical pattern + all 4 are protected by the RLock**.

## PR stacking + maintainer notes

This PR depends on PR #85's `_serialized_write` helper and `_write_lock` RLock.

**Merge order options:**

| Order | Result |
|---|---|
| #85 first, then this | Clean. consolidate_fact starts un-fixed (pre-#84 state on this branch's base), this PR fixes it via the helper. |
| #84, #85, this | Clean. #84's inline pattern lands, #85 adds helper for siblings, this PR migrates consolidate_fact onto helper. |
| #85, this, #84 | Awkward. #84 would re-introduce the inline pattern that this PR removed. Maintainer should probably close #84 in this case. |

**Cleanest story:** #85 + this PR together supersede #84. If the maintainer prefers to land the helper-based approach end-to-end, they can close #84 in favor of #85 + this. The end state is identical for consolidate_fact's race-fix behavior; this PR just uses the canonical helper instead of inline.

## Test plan

- [x] All 14 tests in `tests/test_consolidate_fact_sibling_races.py` pass (13 from #85 + 1 new)
- [x] All 20 tests in `tests/test_integration.py` pass
- [x] All 24 tests in `tests/test_beam_e4_remember_batch_veracity.py` pass
- [x] Codex structured /review: GATE PASS
- [ ] Claude adversarial review (in progress)
- [ ] CI: full suite green on Python 3.9 / 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
