### PR TITLE
fix: cascade-clean orphaned vec_episodes rows on import_from_dict force-overwrite

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -3978,6 +3978,11 @@ class BeamMemory:
         self.conn.commit()
 
         # -- Episodic memory --
+        # Capture sqlite-vec availability once before the loop. Reused
+        # both for the cascade-cleanup below AND the episodic_embeddings
+        # import section further down.
+        vec_ok = _vec_available(self.conn)
+
         old_to_new_rowid = {}
         for item in data.get("episodic_memory", []):
             mid = item.get("id")
@@ -3988,6 +3993,45 @@ class BeamMemory:
                 old_to_new_rowid[item.get("rowid")] = existing["rowid"]
                 continue
             if existing and force:
+                # Cascade-cleanup vec_episodes before deleting the
+                # episodic_memory row. sqlite-vec's `vec_episodes` is
+                # a virtual table keyed by `episodic_memory.rowid`;
+                # without this DELETE the row vanishes from
+                # episodic_memory but its vector embedding stays in
+                # vec_episodes forever, pointing at a rowid that
+                # episodic_memory's AUTOINCREMENT will never re-issue.
+                # The INSERT below assigns a new rowid via lastrowid;
+                # the orphan from the deleted row would never be
+                # cleaned by natural reuse. Operators with high
+                # import churn would see vec_episodes grow indefinitely
+                # while episodic_memory stays bounded.
+                # /review (E2.a.5 Codex adversarial L6, deferred sibling
+                # cleanup item) flagged this as the canonical orphan
+                # site.
+                if vec_ok:
+                    try:
+                        cursor.execute(
+                            "DELETE FROM vec_episodes WHERE rowid = ?",
+                            (existing["rowid"],),
+                        )
+                    except sqlite3.Error as cleanup_exc:
+                        # Broad sqlite3.Error catch (covers
+                        # OperationalError, DatabaseError,
+                        # NotSupportedError, etc.) — `working_memory`
+                        # was already committed at line 3978, so
+                        # propagating a non-OperationalError mid-loop
+                        # would leave partial state. Best-effort
+                        # cleanup: log and continue with the
+                        # episodic_memory DELETE. Data integrity > orphan
+                        # cleanup. /review (Claude H2 + Codex H2 on
+                        # commit 1) flagged the narrow OperationalError
+                        # catch as a mid-import abort risk.
+                        logger.warning(
+                            "import_from_dict: vec_episodes cleanup "
+                            "failed for rowid=%s: %s; continuing with "
+                            "episodic DELETE (orphan may remain)",
+                            existing["rowid"], cleanup_exc,
+                        )
                 cursor.execute("DELETE FROM episodic_memory WHERE id = ?", (mid,))
                 stats["episodic_memory"]["overwritten"] += 1
             else:
@@ -4010,7 +4054,9 @@ class BeamMemory:
         self.conn.commit()
 
         # -- Episodic embeddings --
-        vec_ok = _vec_available(self.conn)
+        # vec_ok was set above before the episodic_memory loop so the
+        # cascade-cleanup of vec_episodes shares the same availability
+        # check. Reused here.
         for emb_item in data.get("episodic_embeddings", []):
             old_rowid = emb_item.get("rowid")
             new_rowid = old_to_new_rowid.get(old_rowid)

--- a/tests/test_orphan_vec_episodes_cleanup.py
+++ b/tests/test_orphan_vec_episodes_cleanup.py
@@ -1,0 +1,441 @@
+"""
+Regression tests for orphan `vec_episodes` cleanup on import.
+
+`vec_episodes` is a sqlite-vec virtual table keyed by
+`episodic_memory.rowid` (an AUTOINCREMENT integer PK). When
+production code DELETEs from episodic_memory and re-INSERTs, the
+new row gets a fresh rowid via lastrowid — leaving the old row's
+vector embedding stranded in vec_episodes pointing at a rowid that
+will never be reused by AUTOINCREMENT.
+
+Pre-fix: `import_from_dict` (beam.py:3991) DELETE+INSERTs
+episodic_memory rows when `force=True` but didn't clean
+vec_episodes. Operators with high import churn (regular
+backup/restore cycles, multi-source imports) accumulate dead
+vec_episodes entries indefinitely. Each entry is small (~768 bytes
+for float32 / 48 bytes for binary quantized) but unbounded
+accumulation matters at long-running-deployment scale.
+
+Post-fix: when `import_from_dict` finds an existing episodic_memory
+row and `force=True`, it deletes the corresponding vec_episodes
+entry by rowid BEFORE deleting episodic_memory. The new episodic
+row's embedding is re-imported in the same `import_from_dict` call
+via the episodic_embeddings section.
+
+These tests pin:
+  - import_from_dict with force=True cleans vec_episodes orphans
+  - import_from_dict with force=False (skip path) doesn't touch
+    vec_episodes
+  - import_from_dict is idempotent across multiple force=True calls
+    on the same data (no accumulating orphans)
+  - cleanup is best-effort (failure in DELETE FROM vec_episodes
+    doesn't abort the import)
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory, _vec_available, _vec_insert
+
+
+@pytest.fixture
+def temp_db(tmp_path: Path) -> Path:
+    return tmp_path / "orphan_test.db"
+
+
+def _vec_count(conn) -> int:
+    """Count rows in vec_episodes (skip if sqlite-vec unavailable)."""
+    try:
+        return conn.execute(
+            "SELECT COUNT(*) FROM vec_episodes"
+        ).fetchone()[0]
+    except Exception:
+        return -1
+
+
+def _em_count(conn) -> int:
+    return conn.execute(
+        "SELECT COUNT(*) FROM episodic_memory"
+    ).fetchone()[0]
+
+
+# ---------------------------------------------------------------------------
+# Core contract: force=True path cleans vec_episodes
+# ---------------------------------------------------------------------------
+
+
+def test_import_from_dict_force_cleans_vec_episodes_orphan(temp_db):
+    """When import_from_dict DELETEs an episodic_memory row to
+    overwrite (force=True), the corresponding vec_episodes entry
+    must be deleted too. Without this, vec_episodes accumulates
+    dead rowids forever."""
+    beam = BeamMemory(session_id="orphan-test", db_path=temp_db)
+    if not _vec_available(beam.conn):
+        pytest.skip("sqlite-vec not available in this environment")
+
+    # Seed an episodic_memory row + its vec_episodes entry.
+    beam.conn.execute(
+        "INSERT INTO episodic_memory "
+        "(id, content, source, timestamp, importance) "
+        "VALUES ('em-1', 'original content', 'test', "
+        "datetime('now'), 0.5)"
+    )
+    original_rowid = beam.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = ?", ("em-1",)
+    ).fetchone()[0]
+    _vec_insert(
+        beam.conn, original_rowid,
+        [0.1] * 384,  # dummy embedding
+    )
+    beam.conn.commit()
+
+    vec_before = _vec_count(beam.conn)
+    em_before = _em_count(beam.conn)
+    assert vec_before == 1
+    assert em_before == 1
+
+    # Now do an import that overwrites the same id with force=True.
+    payload = {
+        "version": 1,
+        "working_memory": [],
+        "episodic_memory": [
+            {
+                "id": "em-1",
+                "rowid": original_rowid,
+                "content": "new content",
+                "source": "import",
+                "timestamp": "2026-05-11T00:00:00",
+                "session_id": "import-session",
+                "importance": 0.7,
+                "metadata_json": "{}",
+                "summary_of": "",
+                "valid_until": None,
+                "superseded_by": None,
+                "scope": "session",
+                "recall_count": 0,
+                "last_recalled": None,
+                "created_at": "2026-05-11T00:00:00",
+            }
+        ],
+        "episodic_embeddings": [],
+    }
+    beam.import_from_dict(payload, force=True)
+
+    # The episodic_memory row should still be there (new content).
+    assert _em_count(beam.conn) == 1
+    # vec_episodes should not have an orphan — either the old entry
+    # was cleaned (count goes to 0, no new embedding imported), or
+    # it was cleaned and a new one was inserted (count stays at 1).
+    # We seeded no episodic_embeddings in the payload above, so we
+    # expect count == 0 (the orphan was cleaned, no replacement).
+    assert _vec_count(beam.conn) == 0, (
+        f"orphan not cleaned — vec_episodes count is "
+        f"{_vec_count(beam.conn)} after import-with-force"
+    )
+
+
+def test_import_from_dict_no_force_does_not_touch_vec_episodes(temp_db):
+    """When force=False and the row already exists, import_from_dict
+    skips. vec_episodes must NOT be touched in that path."""
+    beam = BeamMemory(session_id="no-force", db_path=temp_db)
+    if not _vec_available(beam.conn):
+        pytest.skip("sqlite-vec not available in this environment")
+
+    beam.conn.execute(
+        "INSERT INTO episodic_memory "
+        "(id, content, source, timestamp, importance) "
+        "VALUES ('em-keep', 'keep me', 'test', "
+        "datetime('now'), 0.5)"
+    )
+    rowid = beam.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = ?", ("em-keep",)
+    ).fetchone()[0]
+    _vec_insert(beam.conn, rowid, [0.2] * 384)
+    beam.conn.commit()
+
+    vec_before = _vec_count(beam.conn)
+    assert vec_before == 1
+
+    payload = {
+        "version": 1,
+        "working_memory": [],
+        "episodic_memory": [
+            {
+                "id": "em-keep",
+                "rowid": rowid,
+                "content": "would overwrite if force=True",
+                "source": "import",
+                "timestamp": "2026-05-11T00:00:00",
+                "session_id": "x",
+                "importance": 0.5,
+                "metadata_json": "{}",
+                "summary_of": "",
+                "valid_until": None,
+                "superseded_by": None,
+                "scope": "session",
+                "recall_count": 0,
+                "last_recalled": None,
+                "created_at": "2026-05-11T00:00:00",
+            }
+        ],
+        "episodic_embeddings": [],
+    }
+    beam.import_from_dict(payload, force=False)
+
+    # vec_episodes entry should be unchanged.
+    assert _vec_count(beam.conn) == 1, (
+        "vec_episodes touched on force=False skip path"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: repeated force imports don't accumulate orphans
+# ---------------------------------------------------------------------------
+
+
+def test_import_from_dict_force_idempotent_no_orphan_accumulation(temp_db):
+    """Running the same force=True import 5 times must not leave
+    5 orphans in vec_episodes — each iteration cleans the previous
+    iteration's entry."""
+    beam = BeamMemory(session_id="idem", db_path=temp_db)
+    if not _vec_available(beam.conn):
+        pytest.skip("sqlite-vec not available in this environment")
+
+    # Seed initial state.
+    beam.conn.execute(
+        "INSERT INTO episodic_memory "
+        "(id, content, source, timestamp, importance) "
+        "VALUES ('em-loop', 'initial', 'test', "
+        "datetime('now'), 0.5)"
+    )
+    initial_rowid = beam.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = ?", ("em-loop",)
+    ).fetchone()[0]
+    _vec_insert(beam.conn, initial_rowid, [0.3] * 384)
+    beam.conn.commit()
+
+    payload_template = {
+        "version": 1,
+        "working_memory": [],
+        "episodic_memory": [
+            {
+                "id": "em-loop",
+                "rowid": initial_rowid,
+                "content": "round X",
+                "source": "import",
+                "timestamp": "2026-05-11T00:00:00",
+                "session_id": "x",
+                "importance": 0.5,
+                "metadata_json": "{}",
+                "summary_of": "",
+                "valid_until": None,
+                "superseded_by": None,
+                "scope": "session",
+                "recall_count": 0,
+                "last_recalled": None,
+                "created_at": "2026-05-11T00:00:00",
+            }
+        ],
+        "episodic_embeddings": [],
+    }
+
+    for i in range(5):
+        # Mutate the rowid to whatever the current row has — since
+        # each import_from_dict reassigns via lastrowid on the new
+        # INSERT, the rowid we pass in the payload only matters for
+        # the old_to_new_rowid mapping used by the embeddings section.
+        beam.import_from_dict(payload_template, force=True)
+
+    # After 5 rounds, episodic_memory should have exactly 1 row.
+    assert _em_count(beam.conn) == 1
+    # vec_episodes should be 0 (each round cleaned, none re-imported).
+    assert _vec_count(beam.conn) == 0, (
+        f"orphan accumulation: vec_episodes count is "
+        f"{_vec_count(beam.conn)} after 5 force-imports — cascade "
+        "cleanup not idempotent"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Robustness: cleanup failure doesn't abort the import
+# ---------------------------------------------------------------------------
+
+
+def test_import_from_dict_cleanup_failure_is_best_effort(temp_db, monkeypatch):
+    """If DELETE FROM vec_episodes raises OperationalError (e.g.,
+    sqlite-vec extension unloaded mid-import, table missing
+    between vec_ok check and DELETE), the import should continue
+    with episodic_memory work. Data integrity over orphan cleanup.
+
+    Exercising the actual try/except path requires a scenario
+    where `_vec_available()` returns True (so the cascade runs)
+    but the DELETE then raises. Codex structured /review (P2 GATE
+    FAIL on commit 1) caught a prior version of this test that
+    just dropped the table — that exercised the `vec_ok=False`
+    skip path, not the try/except failure path.
+
+    We force the scenario by: (1) patching _vec_available to
+    return True even after we drop the table — the production
+    code sees vec_ok=True, attempts the DELETE, gets
+    OperationalError "no such table: vec_episodes", and the
+    try/except swallows it."""
+    beam = BeamMemory(session_id="best-effort", db_path=temp_db)
+    if not _vec_available(beam.conn):
+        pytest.skip("sqlite-vec not available in this environment")
+
+    # Seed initial row.
+    beam.conn.execute(
+        "INSERT INTO episodic_memory "
+        "(id, content, source, timestamp, importance) "
+        "VALUES ('em-best', 'orig', 'test', "
+        "datetime('now'), 0.5)"
+    )
+    rowid = beam.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = ?", ("em-best",)
+    ).fetchone()[0]
+    _vec_insert(beam.conn, rowid, [0.4] * 384)
+    beam.conn.commit()
+
+    # Drop the vec_episodes table so DELETE FROM vec_episodes
+    # raises. Then patch _vec_available so the production code
+    # still thinks sqlite-vec is available — this routes execution
+    # into the cascade-cleanup branch, where the DELETE fails and
+    # the try/except is exercised.
+    beam.conn.execute("DROP TABLE vec_episodes")
+    beam.conn.commit()
+    import mnemosyne.core.beam as beam_module
+    monkeypatch.setattr(
+        beam_module, "_vec_available", lambda conn: True
+    )
+
+    payload = {
+        "version": 1,
+        "working_memory": [],
+        "episodic_memory": [
+            {
+                "id": "em-best",
+                "rowid": rowid,
+                "content": "new",
+                "source": "import",
+                "timestamp": "2026-05-11T00:00:00",
+                "session_id": "x",
+                "importance": 0.5,
+                "metadata_json": "{}",
+                "summary_of": "",
+                "valid_until": None,
+                "superseded_by": None,
+                "scope": "session",
+                "recall_count": 0,
+                "last_recalled": None,
+                "created_at": "2026-05-11T00:00:00",
+            }
+        ],
+        "episodic_embeddings": [],
+    }
+    # Should NOT raise — the cleanup failure is swallowed.
+    # If the try/except were removed from the production fix, this
+    # call would propagate sqlite3.OperationalError.
+    beam.import_from_dict(payload, force=True)
+
+    # episodic_memory should still have the new row (despite vec
+    # cleanup failure).
+    assert _em_count(beam.conn) == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full force-overwrite + new-embedding-arrives round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_import_from_dict_force_with_new_embeddings_no_orphan(temp_db):
+    """End-to-end: force-import a payload that ALSO carries
+    `episodic_embeddings`. Expected final state:
+      - exactly 1 episodic_memory row (the new one)
+      - exactly 1 vec_episodes row (the new embedding at the new
+        rowid; old orphan was cleaned)
+      - vec_episodes.rowid == episodic_memory.rowid (no stale
+        mapping from a payload-stated old rowid)
+
+    /review (Claude H1) flagged this missing coverage: every other
+    test uses `"episodic_embeddings": []`, so the case where the
+    cascade-cleanup AND the re-import both run end-to-end was
+    untested. A future regression in `old_to_new_rowid` mapping
+    would slip through silently."""
+    beam = BeamMemory(session_id="e2e", db_path=temp_db)
+    if not _vec_available(beam.conn):
+        pytest.skip("sqlite-vec not available in this environment")
+
+    # Seed initial state.
+    beam.conn.execute(
+        "INSERT INTO episodic_memory "
+        "(id, content, source, timestamp, importance) "
+        "VALUES ('em-e2e', 'orig', 'test', "
+        "datetime('now'), 0.5)"
+    )
+    initial_rowid = beam.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = ?", ("em-e2e",)
+    ).fetchone()[0]
+    _vec_insert(beam.conn, initial_rowid, [0.5] * 384)
+    beam.conn.commit()
+
+    assert _em_count(beam.conn) == 1
+    assert _vec_count(beam.conn) == 1
+
+    # Import payload with the new content AND a new embedding.
+    payload = {
+        "version": 1,
+        "working_memory": [],
+        "episodic_memory": [
+            {
+                "id": "em-e2e",
+                "rowid": initial_rowid,  # old rowid in payload
+                "content": "new content",
+                "source": "import",
+                "timestamp": "2026-05-11T00:00:00",
+                "session_id": "x",
+                "importance": 0.7,
+                "metadata_json": "{}",
+                "summary_of": "",
+                "valid_until": None,
+                "superseded_by": None,
+                "scope": "session",
+                "recall_count": 0,
+                "last_recalled": None,
+                "created_at": "2026-05-11T00:00:00",
+            }
+        ],
+        # The new embedding is keyed to the OLD rowid in the payload;
+        # `import_from_dict` maps it to the NEW rowid via
+        # `old_to_new_rowid` after the INSERT.
+        "episodic_embeddings": [
+            {
+                "rowid": initial_rowid,
+                "embedding": [0.9] * 384,
+            }
+        ],
+    }
+    beam.import_from_dict(payload, force=True)
+
+    # Final state checks.
+    assert _em_count(beam.conn) == 1, "duplicate episodic_memory rows"
+    assert _vec_count(beam.conn) == 1, (
+        f"expected 1 vec_episodes row (new embedding only); got "
+        f"{_vec_count(beam.conn)} — either orphan not cleaned or "
+        "new embedding not imported"
+    )
+
+    # The vec_episodes rowid should match the NEW episodic_memory rowid.
+    new_em_rowid = beam.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = ?", ("em-e2e",)
+    ).fetchone()[0]
+    vec_rowid = beam.conn.execute(
+        "SELECT rowid FROM vec_episodes"
+    ).fetchone()[0]
+    assert vec_rowid == new_em_rowid, (
+        f"vec_episodes.rowid ({vec_rowid}) != "
+        f"episodic_memory.rowid ({new_em_rowid}) — "
+        "old_to_new_rowid mapping drifted on force path"
+    )


### PR DESCRIPTION
## TL;DR

`vec_episodes` is a sqlite-vec virtual table keyed by `episodic_memory.rowid` (AUTOINCREMENT). When `BeamMemory.import_from_dict(force=True)` DELETEs an existing episodic_memory row to replace it, the new row gets a fresh rowid via `cursor.lastrowid` — leaving the old row's vector embedding stranded in vec_episodes pointing at a rowid that AUTOINCREMENT will never re-issue. Operators with high import churn accumulate dead vec_episodes entries indefinitely.

This PR adds a cascade `DELETE FROM vec_episodes WHERE rowid = existing["rowid"]` BEFORE the episodic_memory DELETE, plus broadens the cleanup exception catch to `sqlite3.Error` so a cleanup failure doesn't abort the import mid-loop.

**5 regression tests, all passing.** Originally flagged by Codex adversarial on PR #84 as a deferred follow-up.

## Why this matters

Storage hygiene: long-running deployments that do regular import/export cycles (backups, multi-source sync) accumulate orphaned vec_episodes rows that never get cleaned. Each entry is ~768 bytes (float32) or ~48 bytes (binary quantized) — small per row but unbounded growth at scale.

This is the **only DELETE FROM episodic_memory** site in production code (verified via grep). `Mnemosyne.forget()` doesn't currently cascade to episodic_memory at all — that's the separate C17 concern in the ledger.

## What this PR does

Single commit:

- `import_from_dict` cascade-cleans `vec_episodes` before the episodic_memory DELETE on the force-overwrite path
- Guarded by `_vec_available(self.conn)` — sqlite-vec is optional
- Hoisted `vec_ok = _vec_available(self.conn)` from before the embeddings-import loop to before the episodic_memory loop — both code paths now share one check
- Broad `except sqlite3.Error` (not narrow `OperationalError`) catches all sqlite3 exception subclasses with WARNING log — `working_memory` was already committed at line 3978, so propagating a cleanup error would abort the import mid-loop with partial state

## /review army findings (all addressed)

| Finding | Sources | Fix |
|---|---|---|
| Initial "best-effort failure" test dropped `vec_episodes` before calling import, causing `vec_ok=False` short-circuit instead of exercising try/except | **2-source** (Codex structured P2 GATE FAIL + Claude C1 CRITICAL) | Test now monkey-patches `_vec_available` to return True after dropping the table, so the cascade runs and the DELETE fails, exercising the try/except |
| Missing end-to-end test with non-empty `episodic_embeddings` payload — every other test used `[]`, leaving the `old_to_new_rowid` mapping path uncovered for the force-overwrite case | Claude H1 | Added `test_import_from_dict_force_with_new_embeddings_no_orphan` |
| `except sqlite3.OperationalError` too narrow — other sqlite3 exception subclasses propagate and abort import mid-loop | Claude H2 | Broadened to `except sqlite3.Error as cleanup_exc` with WARNING log |

## What is NOT in this PR (intentional, documented)

- **`Mnemosyne.forget()` doesn't cascade to episodic_memory at all** (C17 in ledger) — pre-existing different concern
- **`memory_embeddings` fallback table** gets stale content on force-overwrite — different orphan shape, separate concern
- **`binary_vector` column NULL after force-INSERT** — pre-existing, not affected by this PR
- **Concurrent `import_from_dict` race** — `import_from_dict` is not advertised as concurrent-safe; out of scope

## Test plan

- [x] All 5 tests in `tests/test_orphan_vec_episodes_cleanup.py` pass
- [x] All 20 tests in `tests/test_integration.py` pass
- [x] Targeted `test_beam.py -k "import or export"` run: green
- [x] Codex structured /review: GATE PASS after commit 1's fix
- [x] Claude adversarial /review: CRITICAL + 2 HIGH (all addressed)
- [ ] CI: full suite green on Python 3.9 / 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
