### PR TITLE
fix: pre-experiment fidelity bundle (E4.a.1 + E2.a.10 + C29)

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -62,6 +62,7 @@ try:
         VeracityConsolidator,
         VERACITY_WEIGHTS,
         clamp_veracity,
+        aggregate_veracity,
     )
 except ImportError:
     VeracityConsolidator = None
@@ -77,6 +78,11 @@ except ImportError:
         "silently (no per-call WARNING). Operators should resolve the "
         "import to restore full audit logging."
     )
+
+    def aggregate_veracity(source_veracities) -> str:
+        """Fallback aggregator when veracity_consolidation is unavailable.
+        Returns 'unknown' unconditionally so consolidation doesn't crash."""
+        return "unknown"
 
     def clamp_veracity(raw, *, context: str = "veracity") -> str:
         """Fallback when veracity_consolidation is unavailable.
@@ -1811,9 +1817,19 @@ class BeamMemory:
     def consolidate_to_episodic(self, summary: str, source_wm_ids: List[str],
                                 source: str = "consolidation", importance: float = 0.6,
                                 metadata: Dict = None, valid_until: str = None,
-                                scope: str = "session") -> str:
+                                scope: str = "session",
+                                veracity: Optional[str] = None) -> str:
         """
         Store a consolidated summary into episodic_memory with optional embedding.
+
+        E4.a.1: `veracity` kwarg threads the aggregated source-row veracity
+        into the episodic INSERT. Pre-fix the INSERT didn't include the
+        veracity column at all, so post-sleep rows took the schema default
+        'unknown' — destroying the per-row veracity signal `remember_batch`
+        had populated. Callers (typically `sleep()`) should compute the
+        aggregate via `aggregate_veracity()` over the source rows' veracity
+        values and pass it here. `None` falls back to 'unknown' (matches
+        legacy behavior + schema default).
         """
         memory_id = _generate_id(summary)
         timestamp = datetime.now().isoformat()
@@ -1825,15 +1841,23 @@ class BeamMemory:
                 ep_type = result.memory_type.value
             except Exception:
                 pass
+        # Clamp to canonical allowlist at the trust boundary. Defaults to
+        # 'unknown' if not provided (back-compat with pre-E4.a.1 callers).
+        if veracity is None:
+            row_veracity = "unknown"
+        else:
+            row_veracity = clamp_veracity(
+                veracity, context="consolidate_to_episodic.veracity"
+            )
         cursor = self.conn.cursor()
         cursor.execute("""
             INSERT INTO episodic_memory
             (id, content, source, timestamp, session_id, importance, metadata_json, summary_of, valid_until, scope,
-             author_id, author_type, channel_id, memory_type)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             author_id, author_type, channel_id, memory_type, veracity)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (memory_id, summary, source, timestamp, self.session_id, importance,
               json.dumps(metadata or {}), ",".join(source_wm_ids), valid_until, scope,
-              self.author_id, self.author_type, self.channel_id, ep_type))
+              self.author_id, self.author_type, self.channel_id, ep_type, row_veracity))
         rowid = cursor.lastrowid
 
         if _embeddings.available():
@@ -3601,8 +3625,10 @@ class BeamMemory:
         # and miss the NULL rows. See Codex /review note for C9.
         # consolidated_at IS NULL filters out rows already processed by
         # a prior sleep so we don't re-summarize the same originals.
+        # E4.a.1: select veracity so the summary can inherit aggregated
+        # source-row trust signal (instead of defaulting to 'unknown').
         cursor.execute(f"""
-            SELECT id, content, source, timestamp, importance, metadata_json, scope, valid_until
+            SELECT id, content, source, timestamp, importance, metadata_json, scope, valid_until, veracity
             FROM working_memory
             WHERE COALESCE(session_id, 'default') = ?
               AND timestamp < ?
@@ -3683,6 +3709,15 @@ class BeamMemory:
                     if aggregated_valid_until is None or item["valid_until"] < aggregated_valid_until:
                         aggregated_valid_until = item["valid_until"]
 
+            # E4.a.1: aggregate per-row veracity into the summary's
+            # veracity label. Mode of sources with conservative tie-break.
+            # Pre-fix the episodic INSERT omitted veracity and the row
+            # took 'unknown' (0.8 multiplier) regardless of how confident
+            # the sources were.
+            aggregated_veracity = aggregate_veracity(
+                [item.get("veracity") for item in items]
+            )
+
             # --- Try LLM summarization (chunked to fit context) ---
             summary = None
             llm_succeeded = False
@@ -3734,6 +3769,7 @@ class BeamMemory:
                     importance=0.6,
                     scope=aggregated_scope,
                     valid_until=aggregated_valid_until,
+                    veracity=aggregated_veracity,
                     metadata={
                         "original_count": len(items),
                         "source": source,

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -64,9 +64,21 @@ try:
         clamp_veracity,
         aggregate_veracity,
     )
+    # Alias used below to construct STATED_WEIGHT et al. — same dict as
+    # the canonical VERACITY_WEIGHTS so changes propagate.
+    _VW_DEFAULTS = VERACITY_WEIGHTS
 except ImportError:
     VeracityConsolidator = None
     VERACITY_WEIGHTS = {}
+    # Hardcoded backstop so degraded-import mode doesn't crash module
+    # load when constructing STATED_WEIGHT et al. (C1 review fix).
+    _VW_DEFAULTS = {
+        "stated": 1.0,
+        "inferred": 0.7,
+        "tool": 0.5,
+        "imported": 0.6,
+        "unknown": 0.8,
+    }
 
     # Surface degraded mode at import time so operators see ONE signal
     # in startup logs that the canonical helper isn't available. Without
@@ -168,14 +180,14 @@ DEGRADE_BATCH_SIZE = int(os.environ.get("MNEMOSYNE_DEGRADE_BATCH", "100"))
 SMART_COMPRESS = os.environ.get("MNEMOSYNE_SMART_COMPRESS", "1") not in ("0", "false", "no")
 TIER3_MAX_CHARS = int(os.environ.get("MNEMOSYNE_TIER3_MAX_CHARS", "300"))
 
-# Veracity weighting (memory confidence). C29: defaults come from the
-# canonical VERACITY_WEIGHTS dict in veracity_consolidation.py so the
-# consolidator's Bayesian compounding and recall's veracity multiplier
-# share a single source of truth. Env-var overrides remain so operators
-# can tune ranking, but the drift risk is documented: if an operator
-# sets a *_WEIGHT env var, recall scoring diverges from consolidation
-# confidence math (consolidator doesn't honor env overrides).
-from mnemosyne.core.veracity_consolidation import VERACITY_WEIGHTS as _VW_DEFAULTS
+# Veracity weighting (memory confidence). C29: defaults come from
+# `_VW_DEFAULTS` which mirrors `veracity_consolidation.VERACITY_WEIGHTS`
+# in normal mode and falls back to a hardcoded literal in degraded-import
+# mode (the import block above sets it). Single source of truth for the
+# consolidator's Bayesian compounding and recall's veracity multiplier.
+# Env-var overrides remain so operators can tune ranking; documented
+# drift risk: if `MNEMOSYNE_*_WEIGHT` is set, recall scoring diverges
+# from consolidation confidence math (consolidator doesn't honor env).
 STATED_WEIGHT = float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", str(_VW_DEFAULTS["stated"])))
 INFERRED_WEIGHT = float(os.environ.get("MNEMOSYNE_INFERRED_WEIGHT", str(_VW_DEFAULTS["inferred"])))
 TOOL_WEIGHT = float(os.environ.get("MNEMOSYNE_TOOL_WEIGHT", str(_VW_DEFAULTS["tool"])))
@@ -1368,6 +1380,14 @@ class BeamMemory:
             # a fresh summary. Pre-E3 this scenario didn't exist because
             # consolidated rows were deleted; the additive design has to
             # opt back in.
+            # E4.a.1 review fix (P1): refresh veracity on dedup-update too.
+            # Without this, a row first stored as 'unknown' and later
+            # re-remembered as 'stated' kept the stale 'unknown' label,
+            # which E4.a.1's sleep-time aggregator then propagates into
+            # the episodic summary — defeating the trust-signal refresh.
+            # Conservative policy: only upgrade if the new call passes a
+            # non-'unknown' veracity (preserves per-row trust on
+            # backfills that don't carry a meaningful veracity arg).
             cursor.execute("""
                 UPDATE working_memory
                 SET importance = MAX(importance, ?), timestamp = ?, source = ?,
@@ -1377,12 +1397,14 @@ class BeamMemory:
                     author_type = COALESCE(?, author_type),
                     channel_id = COALESCE(?, channel_id),
                     memory_type = COALESCE(?, memory_type),
+                    veracity = CASE WHEN ? != 'unknown' THEN ? ELSE veracity END,
                     consolidated_at = NULL
                 WHERE id = ? AND session_id = ?
             """, (importance, datetime.now().isoformat(), source,
                   valid_until, scope,
                   self.author_id, self.author_type, self.channel_id,
                   memory_type,
+                  veracity, veracity,
                   existing_id, self.session_id))
             self.conn.commit()
             # Run the same entity/fact extraction the new-row path runs, so
@@ -1575,10 +1597,13 @@ class BeamMemory:
                             (memory_id, emb_json, model)
                         )
             except Exception as exc:
+                # M3 review fix: include exception type name so operators
+                # can distinguish sqlite3.OperationalError from RuntimeError
+                # etc. without parsing the message string.
                 logger.warning(
                     "remember_batch: embedding storage failed for batch of "
-                    "%d items (vector voice will miss these rows): %s",
-                    len(items), exc,
+                    "%d items (vector voice will miss these rows) (%s): %s",
+                    len(items), type(exc).__name__, exc,
                 )
         
         self._trim_working_memory()
@@ -1886,7 +1911,14 @@ class BeamMemory:
         self.conn.commit()
 
         # Phase 3-4: Graph + veracity for consolidated episodic memory
-        self._ingest_graph_and_veracity(memory_id, summary, source, veracity="inferred")
+        # E4.a.1 review fix (H2): thread the aggregated row_veracity into
+        # graph + fact extraction so Bayesian compounding on consolidated
+        # facts uses the source-aggregated signal, not a hardcoded
+        # 'inferred'. Pre-fix this line passed 'inferred' regardless, which
+        # the consolidator's `consolidate_fact` then used as the veracity
+        # weight in its confidence update — undermining the very signal
+        # we just preserved in the episodic INSERT.
+        self._ingest_graph_and_veracity(memory_id, summary, source, veracity=row_veracity)
 
         self._emit_event("MEMORY_CONSOLIDATED", memory_id, content=summary,
                          source=source, importance=importance,

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1532,12 +1532,35 @@ class BeamMemory:
             ))
         self.conn.commit()
         
-        # Generate vector embeddings for working memory hybrid search
+        # Generate vector embeddings for working memory hybrid search.
+        # E2.a.10: pre-fix this block had two silent-failure modes:
+        # (a) if `embed()` returns a shorter array than inputs (partial
+        # fastembed failure), `vectors[i]` raises IndexError mid-loop →
+        # caught by bare except → the entire batch's embeddings are
+        # lost since cursor execution stops at the IndexError row;
+        # (b) any embed failure during ingest was silent. At 250K-row
+        # scale the vector voice (35% RRF weight) would silently bias
+        # toward earlier-ingested rows without any operator signal.
+        # Fix: length-mismatch check + WARNING log on the swallow.
         if _embeddings.available():
             try:
                 contents = [item["content"] for item in items]
                 vectors = _embeddings.embed(contents)
-                if vectors is not None:
+                if vectors is None:
+                    logger.warning(
+                        "remember_batch: _embeddings.embed returned None for "
+                        "batch of %d items — no vectors stored, vector voice "
+                        "will miss these rows",
+                        len(contents),
+                    )
+                elif len(vectors) != len(contents):
+                    logger.warning(
+                        "remember_batch: embedding count mismatch (%d vectors "
+                        "for %d inputs) — skipping vector storage for this "
+                        "batch to avoid partial-alignment errors",
+                        len(vectors), len(contents),
+                    )
+                else:
                     model = _embeddings._DEFAULT_MODEL
                     for i, memory_id in enumerate(ids):
                         emb_json = _embeddings.serialize(vectors[i])
@@ -1545,8 +1568,12 @@ class BeamMemory:
                             "INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
                             (memory_id, emb_json, model)
                         )
-            except Exception:
-                pass  # Vector embedding is best-effort, non-blocking
+            except Exception as exc:
+                logger.warning(
+                    "remember_batch: embedding storage failed for batch of "
+                    "%d items (vector voice will miss these rows): %s",
+                    len(items), exc,
+                )
         
         self._trim_working_memory()
         return ids

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -162,12 +162,19 @@ DEGRADE_BATCH_SIZE = int(os.environ.get("MNEMOSYNE_DEGRADE_BATCH", "100"))
 SMART_COMPRESS = os.environ.get("MNEMOSYNE_SMART_COMPRESS", "1") not in ("0", "false", "no")
 TIER3_MAX_CHARS = int(os.environ.get("MNEMOSYNE_TIER3_MAX_CHARS", "300"))
 
-# Veracity weighting (memory confidence)
-STATED_WEIGHT = float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", "1.0"))
-INFERRED_WEIGHT = float(os.environ.get("MNEMOSYNE_INFERRED_WEIGHT", "0.7"))
-TOOL_WEIGHT = float(os.environ.get("MNEMOSYNE_TOOL_WEIGHT", "0.5"))
-IMPORTED_WEIGHT = float(os.environ.get("MNEMOSYNE_IMPORTED_WEIGHT", "0.6"))
-UNKNOWN_WEIGHT = float(os.environ.get("MNEMOSYNE_UNKNOWN_WEIGHT", "0.8"))
+# Veracity weighting (memory confidence). C29: defaults come from the
+# canonical VERACITY_WEIGHTS dict in veracity_consolidation.py so the
+# consolidator's Bayesian compounding and recall's veracity multiplier
+# share a single source of truth. Env-var overrides remain so operators
+# can tune ranking, but the drift risk is documented: if an operator
+# sets a *_WEIGHT env var, recall scoring diverges from consolidation
+# confidence math (consolidator doesn't honor env overrides).
+from mnemosyne.core.veracity_consolidation import VERACITY_WEIGHTS as _VW_DEFAULTS
+STATED_WEIGHT = float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", str(_VW_DEFAULTS["stated"])))
+INFERRED_WEIGHT = float(os.environ.get("MNEMOSYNE_INFERRED_WEIGHT", str(_VW_DEFAULTS["inferred"])))
+TOOL_WEIGHT = float(os.environ.get("MNEMOSYNE_TOOL_WEIGHT", str(_VW_DEFAULTS["tool"])))
+IMPORTED_WEIGHT = float(os.environ.get("MNEMOSYNE_IMPORTED_WEIGHT", str(_VW_DEFAULTS["imported"])))
+UNKNOWN_WEIGHT = float(os.environ.get("MNEMOSYNE_UNKNOWN_WEIGHT", str(_VW_DEFAULTS["unknown"])))
 
 # Vector compression: float32 | int8 | bit
 VEC_TYPE = os.environ.get("MNEMOSYNE_VEC_TYPE", "int8").lower()

--- a/mnemosyne/core/veracity_consolidation.py
+++ b/mnemosyne/core/veracity_consolidation.py
@@ -96,6 +96,57 @@ def clamp_veracity(raw, *, context: str = "veracity") -> str:
     return "unknown"
 
 
+def aggregate_veracity(source_veracities) -> str:
+    """E4.a.1: aggregate per-source veracity labels into one summary label.
+
+    Used at consolidation time when a `sleep()` summarizes N working_memory
+    rows into one episodic_memory row. Pre-fix the episodic INSERT didn't
+    set the veracity column, so it defaulted to 'unknown' (0.8 multiplier)
+    even when every source row was 'stated' (1.0). That destroys the
+    trust signal `remember_batch` had populated per-row.
+
+    Aggregation rule (mode + conservative tie-breaking):
+        - Empty / no-valid-labels input → 'unknown' (matches schema default)
+        - Single distinct label → that label
+        - Clear majority → the majority label
+        - Multi-way tie → the label with the LOWEST weight (most conservative)
+
+    Rationale: a summary inherits the confidence of its sources collectively.
+    Homogeneous-stated sources should produce a stated summary (don't
+    overclaim by inflating, don't underclaim by deflating). Mixed sources
+    should produce a label that reflects the most-common signal. Tied
+    multi-way sources resolve toward caution rather than overclaiming.
+
+    Non-canonical labels in input (e.g., raw LLM output bleeding through
+    a caller's clamp) are silently dropped from the count — operators
+    rely on `clamp_veracity()` at the trust boundary; the aggregator is
+    not a clamp, it's a reducer.
+
+    Args:
+        source_veracities: iterable of veracity strings (typically from
+            a SELECT on working_memory.veracity for source rows).
+
+    Returns:
+        One canonical veracity label (member of VERACITY_ALLOWED).
+    """
+    if not source_veracities:
+        return "unknown"
+    # Filter to canonical labels; non-canonical values don't vote.
+    valid = [v for v in source_veracities if v in VERACITY_ALLOWED]
+    if not valid:
+        return "unknown"
+    # Mode (most-frequent label).
+    counts: Dict[str, int] = {}
+    for v in valid:
+        counts[v] = counts.get(v, 0) + 1
+    max_count = max(counts.values())
+    most_common = [v for v, c in counts.items() if c == max_count]
+    if len(most_common) == 1:
+        return most_common[0]
+    # Tie: pick the most conservative (lowest weight).
+    return min(most_common, key=lambda v: VERACITY_WEIGHTS[v])
+
+
 @dataclass
 class ConsolidatedFact:
     """A fact that has been through consolidation."""

--- a/mnemosyne/core/veracity_consolidation.py
+++ b/mnemosyne/core/veracity_consolidation.py
@@ -105,17 +105,26 @@ def aggregate_veracity(source_veracities) -> str:
     even when every source row was 'stated' (1.0). That destroys the
     trust signal `remember_batch` had populated per-row.
 
-    Aggregation rule (mode + conservative tie-breaking):
+    Aggregation rule:
         - Empty / no-valid-labels input → 'unknown' (matches schema default)
-        - Single distinct label → that label
-        - Clear majority → the majority label
-        - Multi-way tie → the label with the LOWEST weight (most conservative)
+        - 'unknown' is treated as low-priority: only counted when NO
+          non-'unknown' canonical labels are present in the source set.
+          Rationale: the column default is 'unknown', so legacy rows that
+          never had veracity explicitly set store the literal 'unknown'
+          string. The aggregator can't distinguish "operator marked unknown"
+          from "nobody set it" — letting 'unknown' dilute confident
+          signals systematically deflates summaries from mixed-vintage
+          sessions (review H1, 2026-05-11).
+        - Within the candidates (non-'unknown' if any, else all-'unknown'):
+            * Single distinct label → that label
+            * Clear majority → the majority label
+            * Multi-way tie → the label with the LOWEST weight (most
+              conservative; e.g. {stated, tool} ties resolve to 'tool')
 
-    Rationale: a summary inherits the confidence of its sources collectively.
-    Homogeneous-stated sources should produce a stated summary (don't
-    overclaim by inflating, don't underclaim by deflating). Mixed sources
-    should produce a label that reflects the most-common signal. Tied
-    multi-way sources resolve toward caution rather than overclaiming.
+    Rationale: a summary inherits confidence of its sources collectively.
+    Homogeneous-stated sources should produce stated summaries (don't
+    deflate). Mixed sources reflect the most-common signal. Tied multi-way
+    sources resolve toward caution rather than overclaiming.
 
     Non-canonical labels in input (e.g., raw LLM output bleeding through
     a caller's clamp) are silently dropped from the count — operators
@@ -135,9 +144,13 @@ def aggregate_veracity(source_veracities) -> str:
     valid = [v for v in source_veracities if v in VERACITY_ALLOWED]
     if not valid:
         return "unknown"
-    # Mode (most-frequent label).
+    # H1 review fix: 'unknown' is the schema default — treat as
+    # low-priority so legacy rows don't dilute confident signals.
+    non_unknown = [v for v in valid if v != "unknown"]
+    candidates = non_unknown if non_unknown else valid
+    # Mode (most-frequent label) among candidates.
     counts: Dict[str, int] = {}
-    for v in valid:
+    for v in candidates:
         counts[v] = counts.get(v, 0) + 1
     max_count = max(counts.values())
     most_common = [v for v, c in counts.items() if c == max_count]

--- a/tests/test_pre_experiment_fidelity.py
+++ b/tests/test_pre_experiment_fidelity.py
@@ -1,0 +1,384 @@
+"""Pre-experiment fidelity fixes — regression tests for E4.a.1, E2.a.10, C29.
+
+This file pins three pre-BEAM-recovery-experiment fixes surfaced by the
+end-to-end audit on 2026-05-11:
+
+- **E4.a.1 (experiment-relevant):** `consolidate_to_episodic` destroys source-row
+  veracity at consolidation. Pre-fix the INSERT omitted the veracity column;
+  post-sleep rows took schema default 'unknown' (0.8 multiplier) regardless
+  of how confident the sources were. Post-E4 `remember_batch` populates
+  veracity per-row, so the destruction is asymmetric and contaminates
+  the experiment's ability to measure consolidated-memory recall quality.
+
+- **E2.a.10 (defensive):** `remember_batch` embedding loop silently
+  swallowed partial-failure (IndexError mid-loop on short vectors array,
+  exception during embed). At 250K-row scale a transient failure would
+  invisibly bias the vector voice toward earlier-ingested rows with zero
+  operator signal.
+
+- **C29 (cleanup):** veracity weight constants were duplicated across
+  `veracity_consolidation.py` (Bayesian compounding) and `beam.py`
+  (recall multiplier). Drift risk under env-var overrides.
+
+Why bundle: all three are pre-experiment fidelity work; all three are
+small; all three share the veracity / consolidation / embedding ingest
+surface. One PR + one /review pass minimizes maintainer review overhead.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List
+from unittest.mock import patch
+
+import pytest
+import numpy as np
+
+from mnemosyne.core.beam import (
+    BeamMemory,
+    STATED_WEIGHT,
+    INFERRED_WEIGHT,
+    TOOL_WEIGHT,
+    IMPORTED_WEIGHT,
+    UNKNOWN_WEIGHT,
+)
+from mnemosyne.core.veracity_consolidation import (
+    VERACITY_WEIGHTS,
+    VERACITY_ALLOWED,
+    aggregate_veracity,
+)
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+# ─────────────────────────────────────────────────────────────────
+# C29 — VERACITY_WEIGHTS centralization
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestC29WeightCentralization:
+    """beam.py reads default values from veracity_consolidation.VERACITY_WEIGHTS
+    so a single change in one place is reflected everywhere — eliminating
+    silent drift between Bayesian compounding (consolidation) and the
+    veracity multiplier (recall)."""
+
+    def test_default_weights_match_canonical_dict(self):
+        """When no env vars set, all beam.py constants equal the canonical
+        VERACITY_WEIGHTS dict values."""
+        assert STATED_WEIGHT == VERACITY_WEIGHTS["stated"]
+        assert INFERRED_WEIGHT == VERACITY_WEIGHTS["inferred"]
+        assert TOOL_WEIGHT == VERACITY_WEIGHTS["tool"]
+        assert IMPORTED_WEIGHT == VERACITY_WEIGHTS["imported"]
+        assert UNKNOWN_WEIGHT == VERACITY_WEIGHTS["unknown"]
+
+    def test_canonical_dict_labels_match_allowlist(self):
+        """The keys of VERACITY_WEIGHTS must equal VERACITY_ALLOWED —
+        clamp_veracity uses VERACITY_ALLOWED as the gate; if a weight
+        exists for a label outside the allowlist, callers can never
+        reach that branch (dead weight)."""
+        assert set(VERACITY_WEIGHTS.keys()) == VERACITY_ALLOWED
+
+
+# ─────────────────────────────────────────────────────────────────
+# E4.a.1 — aggregate_veracity helper + consolidate_to_episodic wiring
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestAggregateVeracityHelper:
+    """Direct unit tests on `aggregate_veracity` — no DB, bypasses sleep
+    complexity so the aggregation logic is testable in isolation."""
+
+    def test_empty_input_returns_unknown(self):
+        assert aggregate_veracity([]) == "unknown"
+
+    def test_none_input_returns_unknown(self):
+        # Defensive: caller might pass None when source rows had no
+        # veracity column populated.
+        assert aggregate_veracity(None) == "unknown"
+
+    def test_all_invalid_input_returns_unknown(self):
+        """Non-canonical labels don't vote; if all sources are invalid,
+        the aggregate falls back to 'unknown'."""
+        assert aggregate_veracity(["bogus", "made-up", None]) == "unknown"
+
+    def test_single_label_returns_that_label(self):
+        assert aggregate_veracity(["stated"]) == "stated"
+        assert aggregate_veracity(["inferred"]) == "inferred"
+
+    def test_all_same_label_returns_that_label(self):
+        assert aggregate_veracity(["stated"] * 5) == "stated"
+        assert aggregate_veracity(["inferred"] * 10) == "inferred"
+
+    def test_clear_majority_wins(self):
+        assert aggregate_veracity(["stated", "stated", "stated", "inferred"]) == "stated"
+        assert aggregate_veracity(["tool", "tool", "tool", "stated", "inferred"]) == "tool"
+
+    def test_two_way_tie_breaks_to_most_conservative(self):
+        """Tied counts → pick the lowest-weight label (most conservative).
+        stated=1.0, inferred=0.7 → 'inferred' (lower weight) wins the tie."""
+        assert aggregate_veracity(["stated", "inferred"]) == "inferred"
+        assert aggregate_veracity(["stated", "tool"]) == "tool"  # tool=0.5
+        assert aggregate_veracity(["inferred", "unknown"]) == "inferred"  # inferred=0.7 < unknown=0.8
+
+    def test_three_way_tie_breaks_to_lowest_weight(self):
+        # tool=0.5, inferred=0.7, imported=0.6 → tool wins (lowest)
+        assert aggregate_veracity(["tool", "inferred", "imported"]) == "tool"
+
+    def test_invalid_values_dropped_then_aggregate(self):
+        """Non-canonical labels filtered out; canonical labels still vote."""
+        assert aggregate_veracity(["stated", "bogus", "stated", None]) == "stated"
+        # Junk-only with one valid: that one wins
+        assert aggregate_veracity(["junk", "more junk", "inferred"]) == "inferred"
+
+
+class TestE4a1ConsolidateToEpisodicVeracity:
+    """`consolidate_to_episodic` now takes a `veracity` kwarg; the INSERT
+    populates the column. Pre-fix the column wasn't included in the INSERT
+    so post-sleep rows defaulted to 'unknown'."""
+
+    def test_consolidate_with_explicit_veracity_stored(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        mid = beam.consolidate_to_episodic(
+            summary="The user said they prefer dark mode",
+            source_wm_ids=["wm-1", "wm-2"],
+            veracity="stated",
+        )
+        row = beam.conn.execute(
+            "SELECT veracity FROM episodic_memory WHERE id = ?", (mid,)
+        ).fetchone()
+        assert row["veracity"] == "stated"
+
+    def test_consolidate_with_no_veracity_defaults_unknown(self, temp_db):
+        """Back-compat: legacy callers that don't pass veracity get
+        the schema default 'unknown', matching pre-fix behavior."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        mid = beam.consolidate_to_episodic(
+            summary="Legacy caller without veracity",
+            source_wm_ids=["wm-1"],
+        )
+        row = beam.conn.execute(
+            "SELECT veracity FROM episodic_memory WHERE id = ?", (mid,)
+        ).fetchone()
+        assert row["veracity"] == "unknown"
+
+    def test_consolidate_clamps_invalid_veracity(self, temp_db):
+        """Trust-boundary clamp at the kwarg: bogus values fall back
+        to 'unknown' with a WARNING log."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        mid = beam.consolidate_to_episodic(
+            summary="Caller passed garbage veracity",
+            source_wm_ids=["wm-1"],
+            veracity="some-random-junk",
+        )
+        row = beam.conn.execute(
+            "SELECT veracity FROM episodic_memory WHERE id = ?", (mid,)
+        ).fetchone()
+        assert row["veracity"] == "unknown"
+
+
+class TestE4a1SleepEndToEndVeracity:
+    """Full sleep() flow with E4-style per-row veracity should preserve
+    the aggregated signal in the episodic summary."""
+
+    def _seed_wm_with_veracity(self, db_path, session_id, ts, items):
+        """Insert N working_memory rows with explicit veracity values.
+        Returns the list of inserted ids."""
+        conn = sqlite3.connect(db_path)
+        ids = []
+        for i, (content, veracity) in enumerate(items):
+            rid = f"wm-{session_id}-{i}"
+            ids.append(rid)
+            conn.execute(
+                "INSERT INTO working_memory (id, content, source, timestamp, "
+                "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (rid, content, "conversation", ts, session_id, 0.5, veracity),
+            )
+        conn.commit()
+        conn.close()
+        return ids
+
+    def test_all_stated_sources_produce_stated_summary(self, temp_db, monkeypatch):
+        """Homogeneous-stated sources → stated summary (1.0 multiplier,
+        not the legacy 0.8 unknown default)."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        self._seed_wm_with_veracity(temp_db, "s1", old_ts, [
+            ("user wants feature A", "stated"),
+            ("user wants feature B", "stated"),
+            ("user wants feature C", "stated"),
+        ])
+
+        beam.sleep(dry_run=False)
+        ep_rows = beam.conn.execute(
+            "SELECT veracity FROM episodic_memory"
+        ).fetchall()
+        assert len(ep_rows) == 1
+        assert ep_rows[0]["veracity"] == "stated", (
+            "Homogeneous stated sources must produce a stated summary; "
+            "pre-fix this would have been 'unknown'."
+        )
+
+    def test_mixed_sources_aggregate_correctly(self, temp_db, monkeypatch):
+        """Majority stated, minority inferred → stated wins by count."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        self._seed_wm_with_veracity(temp_db, "s1", old_ts, [
+            ("explicit user fact 1", "stated"),
+            ("explicit user fact 2", "stated"),
+            ("explicit user fact 3", "stated"),
+            ("derived note", "inferred"),
+        ])
+
+        beam.sleep(dry_run=False)
+        ep_rows = beam.conn.execute(
+            "SELECT veracity FROM episodic_memory"
+        ).fetchall()
+        assert len(ep_rows) == 1
+        assert ep_rows[0]["veracity"] == "stated"
+
+    def test_tied_sources_conservative_resolution(self, temp_db, monkeypatch):
+        """2-stated + 2-inferred → tie → inferred wins (lower weight)."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        self._seed_wm_with_veracity(temp_db, "s1", old_ts, [
+            ("fact 1", "stated"),
+            ("fact 2", "stated"),
+            ("note 1", "inferred"),
+            ("note 2", "inferred"),
+        ])
+
+        beam.sleep(dry_run=False)
+        ep_rows = beam.conn.execute(
+            "SELECT veracity FROM episodic_memory"
+        ).fetchall()
+        assert len(ep_rows) == 1
+        assert ep_rows[0]["veracity"] == "inferred"
+
+    def test_legacy_null_veracity_sources_default_unknown(self, temp_db, monkeypatch):
+        """Pre-E4 source rows had no veracity set (column NULL or 'unknown');
+        the aggregator falls back to 'unknown' for them — back-compat."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        # Insert via raw SQL with NULL veracity to simulate pre-E4 rows.
+        conn = sqlite3.connect(temp_db)
+        conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, NULL)",
+            ("wm-legacy-1", "legacy row", "conversation", old_ts, "s1", 0.5),
+        )
+        conn.commit()
+        conn.close()
+
+        beam.sleep(dry_run=False)
+        ep_rows = beam.conn.execute(
+            "SELECT veracity FROM episodic_memory"
+        ).fetchall()
+        assert len(ep_rows) == 1
+        # No valid labels in sources → 'unknown' fallback.
+        assert ep_rows[0]["veracity"] == "unknown"
+
+
+# ─────────────────────────────────────────────────────────────────
+# E2.a.10 — embedding loop bounds check + logging
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestE2a10EmbeddingLoopDefense:
+    """`remember_batch` embedding block: length mismatch must skip + log
+    rather than partially-store; exception must log + skip rather than
+    silently swallow."""
+
+    def test_length_mismatch_skips_storage_with_warning(self, temp_db, caplog):
+        """If `_embeddings.embed()` returns fewer vectors than inputs,
+        skip vector storage entirely and log a WARNING — pre-fix the
+        IndexError mid-loop would have silently dropped the whole batch."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        items = [{"content": f"row {i}"} for i in range(5)]
+
+        # Patch _embeddings.embed to return short vectors.
+        with patch("mnemosyne.core.beam._embeddings") as mock_emb:
+            mock_emb.available.return_value = True
+            mock_emb.embed.return_value = np.zeros((3, 384), dtype=np.float32)
+            mock_emb._DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
+            mock_emb.serialize.side_effect = lambda v: "[serialized]"
+            with caplog.at_level(logging.WARNING):
+                beam.remember_batch(items)
+
+        # No embeddings should have been stored (skip-on-mismatch).
+        rows = beam.conn.execute(
+            "SELECT COUNT(*) FROM memory_embeddings"
+        ).fetchone()
+        assert rows[0] == 0
+        # WARNING log captured.
+        warnings = [r for r in caplog.records
+                    if r.levelno == logging.WARNING and "mismatch" in r.message]
+        assert warnings, (
+            "Expected a WARNING log for the length mismatch; got: "
+            f"{[r.message for r in caplog.records]}"
+        )
+
+    def test_embed_returns_none_logs_warning(self, temp_db, caplog):
+        """If embed() returns None, log + skip cleanly."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        items = [{"content": "row"}]
+
+        with patch("mnemosyne.core.beam._embeddings") as mock_emb:
+            mock_emb.available.return_value = True
+            mock_emb.embed.return_value = None
+            with caplog.at_level(logging.WARNING):
+                beam.remember_batch(items)
+
+        warnings = [r for r in caplog.records
+                    if r.levelno == logging.WARNING and "returned None" in r.message]
+        assert warnings
+
+    def test_embed_exception_logs_with_diagnostic(self, temp_db, caplog):
+        """If embed() raises, the WARNING log carries the exception
+        repr so operators can diagnose."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        items = [{"content": "row"}]
+
+        with patch("mnemosyne.core.beam._embeddings") as mock_emb:
+            mock_emb.available.return_value = True
+            mock_emb.embed.side_effect = RuntimeError("disk full sim")
+            with caplog.at_level(logging.WARNING):
+                beam.remember_batch(items)
+
+        warnings = [r for r in caplog.records
+                    if r.levelno == logging.WARNING
+                    and "embedding storage failed" in r.message]
+        assert warnings, (
+            "Expected a WARNING log on embed() exception; got: "
+            f"{[r.message for r in caplog.records]}"
+        )
+        assert any("disk full sim" in r.message for r in warnings), (
+            "Exception repr should appear in the log for operator diagnosis."
+        )
+
+    def test_happy_path_still_stores_embeddings(self, temp_db):
+        """Sanity: normal flow with matched-length vectors still stores."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        items = [{"content": f"row {i}"} for i in range(3)]
+
+        with patch("mnemosyne.core.beam._embeddings") as mock_emb:
+            mock_emb.available.return_value = True
+            mock_emb.embed.return_value = np.zeros((3, 384), dtype=np.float32)
+            mock_emb._DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
+            mock_emb.serialize.side_effect = lambda v: "[serialized]"
+            beam.remember_batch(items)
+
+        rows = beam.conn.execute(
+            "SELECT COUNT(*) FROM memory_embeddings"
+        ).fetchone()
+        assert rows[0] == 3

--- a/tests/test_pre_experiment_fidelity.py
+++ b/tests/test_pre_experiment_fidelity.py
@@ -120,16 +120,41 @@ class TestAggregateVeracityHelper:
         assert aggregate_veracity(["stated", "stated", "stated", "inferred"]) == "stated"
         assert aggregate_veracity(["tool", "tool", "tool", "stated", "inferred"]) == "tool"
 
-    def test_two_way_tie_breaks_to_most_conservative(self):
-        """Tied counts → pick the lowest-weight label (most conservative).
-        stated=1.0, inferred=0.7 → 'inferred' (lower weight) wins the tie."""
+    def test_two_way_tie_among_non_unknown_breaks_to_lowest_weight(self):
+        """Tied counts among non-'unknown' labels → pick lowest weight.
+        stated=1.0, inferred=0.7 → 'inferred' (lower weight) wins."""
         assert aggregate_veracity(["stated", "inferred"]) == "inferred"
         assert aggregate_veracity(["stated", "tool"]) == "tool"  # tool=0.5
-        assert aggregate_veracity(["inferred", "unknown"]) == "inferred"  # inferred=0.7 < unknown=0.8
+
+    def test_unknown_is_low_priority_not_counted_against_canonical(self):
+        """H1 review fix: 'unknown' is the schema default — operator
+        intent vs. never-set can't be distinguished. So 'unknown' is
+        filtered out of the candidate set whenever any non-'unknown'
+        label is present, preventing legacy rows from diluting
+        confident signals."""
+        # Single 'stated' beats five 'unknown' (pre-H1 would have been 'unknown').
+        assert aggregate_veracity(["stated", "unknown", "unknown",
+                                    "unknown", "unknown", "unknown"]) == "stated"
+        # 'inferred' + 'unknown' → 'inferred' wins (unknown filtered).
+        assert aggregate_veracity(["inferred", "unknown"]) == "inferred"
+        # All-'unknown' falls back to 'unknown' (no other candidates).
+        assert aggregate_veracity(["unknown", "unknown"]) == "unknown"
+        # 'tool' + 'unknown' → 'tool' wins (unknown filtered, single
+        # candidate beats no competition).
+        assert aggregate_veracity(["tool", "unknown", "unknown"]) == "tool"
 
     def test_three_way_tie_breaks_to_lowest_weight(self):
         # tool=0.5, inferred=0.7, imported=0.6 → tool wins (lowest)
         assert aggregate_veracity(["tool", "inferred", "imported"]) == "tool"
+
+    def test_balanced_three_way_majority_tie_at_count(self):
+        """M1 review fix: 3 + 3 + 3 across stated/tool/inferred ties at
+        max_count=3 → tie-break to lowest weight = 'tool'. The realistic
+        BEAM-scale case where a session has balanced contributions from
+        all three sources is more common than singleton-each."""
+        assert aggregate_veracity(
+            ["stated"] * 3 + ["tool"] * 3 + ["inferred"] * 3
+        ) == "tool"
 
     def test_invalid_values_dropped_then_aggregate(self):
         """Non-canonical labels filtered out; canonical labels still vote."""
@@ -382,3 +407,182 @@ class TestE2a10EmbeddingLoopDefense:
             "SELECT COUNT(*) FROM memory_embeddings"
         ).fetchone()
         assert rows[0] == 3
+
+    def test_wm_rows_persisted_even_on_length_mismatch(self, temp_db):
+        """L4 review fix: the embedding skip must not roll back the
+        working_memory rows themselves — those committed before the
+        embedding block runs. Only vectors are dropped."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        items = [{"content": f"row {i}"} for i in range(5)]
+
+        with patch("mnemosyne.core.beam._embeddings") as mock_emb:
+            mock_emb.available.return_value = True
+            mock_emb.embed.return_value = np.zeros((3, 384), dtype=np.float32)
+            mock_emb._DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
+            mock_emb.serialize.side_effect = lambda v: "[serialized]"
+            beam.remember_batch(items)
+
+        # WM rows survive; only embeddings are skipped.
+        wm_count = beam.conn.execute(
+            "SELECT COUNT(*) FROM working_memory"
+        ).fetchone()[0]
+        emb_count = beam.conn.execute(
+            "SELECT COUNT(*) FROM memory_embeddings"
+        ).fetchone()[0]
+        assert wm_count == 5
+        assert emb_count == 0
+
+    def test_exception_log_includes_exception_type(self, temp_db, caplog):
+        """M3 review fix: log message includes `type(exc).__name__` so
+        operators can distinguish `sqlite3.OperationalError` from
+        `RuntimeError` etc. without parsing the message."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        items = [{"content": "row"}]
+
+        class CustomKaboom(Exception):
+            pass
+
+        with patch("mnemosyne.core.beam._embeddings") as mock_emb:
+            mock_emb.available.return_value = True
+            mock_emb.embed.side_effect = CustomKaboom("boom")
+            with caplog.at_level(logging.WARNING):
+                beam.remember_batch(items)
+
+        warnings = [r for r in caplog.records
+                    if r.levelno == logging.WARNING
+                    and "embedding storage failed" in r.message]
+        assert warnings
+        assert any("CustomKaboom" in r.message for r in warnings), (
+            "Expected exception type name to appear in the log; got: "
+            f"{[r.message for r in warnings]}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# Review-hardening tests
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestReviewHardening:
+    """Tests pinning the cross-source-convergent review findings on
+    commit 4 of the bundle: dedup-veracity refresh (P1), graph veracity
+    threading (H2), polyphonic-arm veracity reach (L2)."""
+
+    def test_dedup_remember_refreshes_veracity_to_non_unknown(self, temp_db):
+        """P1 review fix: re-remembering the same content with a stronger
+        veracity must update the row (don't strand the stale label).
+        Without this, E4.a.1's sleep-time aggregator inherits the old
+        label and re-deflates the summary."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        content = "same content reasserted with stronger veracity"
+        # First remember with default (which clamps via remember(), but
+        # let's pass an explicit 'unknown' to simulate a system-default ingest).
+        mid = beam.remember(content, source="conversation", veracity="unknown")
+        row = beam.conn.execute(
+            "SELECT veracity FROM working_memory WHERE id = ?", (mid,)
+        ).fetchone()
+        assert row["veracity"] == "unknown"
+
+        # Re-remember the same content as 'stated' — should upgrade.
+        beam.remember(content, source="conversation", veracity="stated")
+        row = beam.conn.execute(
+            "SELECT veracity FROM working_memory WHERE id = ?", (mid,)
+        ).fetchone()
+        assert row["veracity"] == "stated", (
+            "dedup-update should have refreshed veracity from 'unknown' "
+            "to 'stated'; pre-fix the stale label persisted."
+        )
+
+    def test_dedup_remember_with_unknown_preserves_existing_stronger_label(self, temp_db):
+        """P1 fix policy: only upgrade when new veracity is non-'unknown'.
+        A backfill call that doesn't carry trust signal (defaults to
+        'unknown' via the clamp) must NOT downgrade an existing 'stated'."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        content = "stated content that gets backfilled later"
+        # First remember as 'stated'.
+        mid = beam.remember(content, source="conversation", veracity="stated")
+        # Backfill with no explicit veracity (defaults to 'unknown').
+        beam.remember(content, source="conversation", veracity="unknown")
+        row = beam.conn.execute(
+            "SELECT veracity FROM working_memory WHERE id = ?", (mid,)
+        ).fetchone()
+        assert row["veracity"] == "stated", (
+            "'unknown' backfill should not have downgraded existing 'stated'; "
+            "the CASE-WHEN guard protects against this."
+        )
+
+    def test_consolidate_threads_aggregated_veracity_into_graph_ingest(
+        self, temp_db, monkeypatch
+    ):
+        """H2 review fix: `consolidate_to_episodic` now passes the
+        aggregated veracity (not hardcoded 'inferred') into
+        `_ingest_graph_and_veracity`, so downstream Bayesian compounding
+        on consolidated facts uses the source-aggregated signal."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+
+        captured = {}
+
+        def spy(memory_id, content, source, veracity="unknown"):
+            captured["veracity"] = veracity
+
+        monkeypatch.setattr(beam, "_ingest_graph_and_veracity", spy)
+        beam.consolidate_to_episodic(
+            summary="some stated summary",
+            source_wm_ids=["wm-1"],
+            veracity="stated",
+        )
+        assert captured["veracity"] == "stated", (
+            "graph/fact extraction should have received the aggregated "
+            "'stated' veracity; pre-fix it received hardcoded 'inferred'."
+        )
+
+    def test_polyphonic_arm_consumes_aggregated_veracity(self, temp_db, monkeypatch):
+        """L2 review fix: end-to-end test that Arm B's polyphonic recall
+        path applies the new aggregated veracity multiplier. Without this
+        test, a future refactor could silently strip the multiplier from
+        the engine path and the experiment would lose the trust-signal
+        ranking entirely on Arm B."""
+        from mnemosyne.core.polyphonic_recall import PolyphonicResult
+
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Two episodic rows: one stated, one unknown. Same content matches
+        # the query equally — only veracity multiplier differentiates.
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-stated", "user wants dark mode", "consolidation",
+             datetime.now().isoformat(), "s1", 0.5, "stated"),
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-unknown", "user wants dark mode", "consolidation",
+             datetime.now().isoformat(), "s1", 0.5, "unknown"),
+        )
+        beam.conn.commit()
+
+        # Mock the engine to return both rows with equal RRF score so
+        # the veracity multiplier is the only differentiator.
+        class _FakeEngine:
+            def __init__(self, results):
+                self._results = results
+            def recall(self, *, query, query_embedding, top_k):
+                return self._results
+
+        engine = _FakeEngine([
+            PolyphonicResult(memory_id="ep-stated", combined_score=0.5,
+                             voice_scores={"vector": 0.5}, metadata={}),
+            PolyphonicResult(memory_id="ep-unknown", combined_score=0.5,
+                             voice_scores={"vector": 0.5}, metadata={}),
+        ])
+        monkeypatch.setattr(beam, "_get_polyphonic_engine", lambda: engine)
+
+        results = beam.recall("dark mode", top_k=10)
+        # Both surface; stated ranks higher because veracity multiplier
+        # 1.0 > 0.8 for unknown.
+        ids = [r["id"] for r in results if r["id"] in {"ep-stated", "ep-unknown"}]
+        assert len(ids) == 2
+        assert ids[0] == "ep-stated", (
+            f"stated row should rank above unknown row; got order: {ids}"
+        )


### PR DESCRIPTION
## TL;DR

Three bundled fixes surfaced by the pre-BEAM-recovery-experiment end-to-end audit (2026-05-11). All three touch the ingest → consolidation → recall fidelity pipeline; bundling them is one /review pass rather than three.

- **E4.a.1** (experiment-relevant) — `consolidate_to_episodic` was destroying source-row veracity at consolidation time. New `aggregate_veracity()` helper + thread through `sleep()` preserves the trust signal `remember_batch` populates per-row.
- **E2.a.10** (defensive) — `remember_batch` embedding loop silently swallowed partial-failure (IndexError mid-loop on short vectors, exceptions during embed). At 250K-row scale a transient failure invisibly biased the vector voice. Added length-mismatch guard + WARNING logs.
- **C29** (cleanup) — beam.py's veracity weight constants now derive from the canonical `VERACITY_WEIGHTS` dict in veracity_consolidation.py, eliminating drift risk.

**30 regression tests, full suite 806 passed, 1 skipped, 0 failures.**

## Why this matters for the BEAM-recovery experiment

The experiment ingests ~250K messages via `remember_batch`, runs `sleep()` to consolidate, then compares recall across Arms A (linear), B (polyphonic, flag=ON), C (algorithmic enrichment). Pre-fix:

- **Veracity loss at consolidation:** post-E4 (PR #74) `remember_batch` populates `veracity` per-row, but `consolidate_to_episodic` omitted the column from its INSERT — every post-sleep episodic row took schema-default 'unknown' (0.8 multiplier) regardless of source. With E3.a.3 dedup (PR #88) post-multiplier scores favored WM-source over ep-summary every time the source was 'stated'. Contaminates measurement of how well each arm uses consolidated memory.
- **Silent embed failures:** `remember_batch` had `except Exception: pass` around the vector loop. Operator gets zero diagnostic signal if 1000 rows of a 250K ingest silently lose their embeddings.
- **Weight constant drift:** consolidator's Bayesian compounding and recall's veracity multiplier were defined in separate files. Currently identical values, but env-var overrides break the invariant silently.

## E4.a.1 — aggregate_veracity at consolidation

New `aggregate_veracity(source_veracities)` helper in `veracity_consolidation.py`. Rule:

- Empty / no-valid-labels → `'unknown'` (schema default fallback).
- `'unknown'` treated as low-priority: only counted when no other canonical labels exist. Schema-default 'unknown' is indistinguishable from operator-set 'unknown', so giving it low priority preserves any explicit signal in the source set.
- Within candidates: mode wins; ties resolve to lowest weight (most conservative).

Examples:
- `[stated, stated, stated]` → `'stated'` (was 'unknown' pre-fix)
- `[stated, stated, inferred]` → `'stated'` (majority)
- `[stated, inferred]` → `'inferred'` (tied, lower weight wins)
- `[stated, unknown, unknown, unknown, unknown]` → `'stated'` (unknown is low-priority)
- `[unknown, unknown]` → `'unknown'` (no other candidates)

`consolidate_to_episodic` accepts a new `veracity` kwarg (clamped via `clamp_veracity`); `sleep()` SELECTs source veracity values and passes the aggregate. Downstream `_ingest_graph_and_veracity` also receives the aggregated value (was hardcoded 'inferred') so Bayesian compounding on consolidated facts uses the trust-signal-consistent multiplier.

## E2.a.10 — embedding loop defense

Pre-fix:
```python
vectors = _embeddings.embed(contents)
if vectors is not None:
    for i, memory_id in enumerate(ids):
        emb_json = _embeddings.serialize(vectors[i])  # IndexError-prone
        cursor.execute(...)
except Exception:
    pass  # silent
```

Post-fix: three guards (vectors=None, length mismatch, exception) each emit a WARNING with batch size + exception type. Operators tailing logs during the experiment will now see silent vector-voice degradation.

## C29 — VERACITY_WEIGHTS centralization

`beam.py` imports `VERACITY_WEIGHTS as _VW_DEFAULTS` and derives `STATED_WEIGHT` etc. from it. Env-var overrides preserved (with documented drift risk). Degraded-import fallback retained so module load doesn't crash if `veracity_consolidation` is unavailable.

## /review army findings (all addressed)

| Finding | Severity / Sources | Fix |
|---|---|---|
| C29 unguarded import broke degraded-import fallback | **CRITICAL** (Claude C1) + **P2** (Codex) | `_VW_DEFAULTS` now set inside the existing try/except — aliased to VERACITY_WEIGHTS in success branch, hardcoded literal in fallback |
| Schema-default 'unknown' diluted confident signals in aggregator | **HIGH** (Claude H1) | 'unknown' treated as low-priority; filtered out of mode candidates when any non-'unknown' label is present |
| `_ingest_graph_and_veracity` still hardcoded 'inferred' for consolidated rows | **HIGH** (Claude H2) | Thread aggregated `row_veracity` through to the graph/fact call |
| Dedup `remember()` doesn't refresh `veracity` | **P1** (Codex) | Added `veracity = CASE WHEN ? != 'unknown' THEN ? ELSE veracity END` to the dedup UPDATE; only upgrade on non-'unknown' |
| Exception log missing type name | MEDIUM (Claude M3) | Prefix with `type(exc).__name__` |
| 3-way balanced tie at majority count untested | MEDIUM (Claude M1) | Added explicit test |
| Polyphonic arm not tested for aggregated veracity consumption | LOW (Claude L2) + P2 (Codex) | Added test mocking engine, asserting stated > unknown ranking on Arm B |
| WM persistence on length-mismatch not asserted | LOW (Claude L4) | Added explicit assert |

## What is NOT in this PR (deferred + documented)

- **Rate-limited warning on persistent length-mismatch** (Claude M2 LOW) — defensible-to-defer; one WARNING per batch is acceptable at experiment scale.
- **Startup WARN when env-var overrides break consolidator/recall invariant** (Claude M4 LOW) — documented in code comment; not blocking.
- **`dry_run=True` still computes aggregate** (Claude L1 LOW) — trivially cheap, intentional for symmetry.

## Test plan

- [x] All 30 tests in `tests/test_pre_experiment_fidelity.py` pass
- [x] Full suite: 806 passed, 1 skipped, 0 failures
- [x] Codex structured /review on commit 3: 1 P1 + 2 P2s (all addressed in commit 4)
- [x] Claude adversarial /review on commit 3: 1 CRITICAL + 2 HIGH + 3 MEDIUM + 4 LOW (all material findings addressed in commit 4)
- [ ] CI: full suite green on Python 3.9 / 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)