### PR TITLE
fix(E7+E8+E9): gate harness bypasses behind MNEMOSYNE_BENCHMARK_PURE_RECALL

### DIFF
--- a/tests/test_benchmark_pure_recall_gate.py
+++ b/tests/test_benchmark_pure_recall_gate.py
@@ -154,6 +154,49 @@ class TestPureRecallModeDisablesBypasses:
         # Whatever the LLM returned is the answer (our fake returns LLM-FALLBACK-ANSWER).
         assert ans == "LLM-FALLBACK-ANSWER"
 
+    # TR fixture: must use "Month Day, Year" format which is what
+    # `_extract_timeline_from_conversation`'s Pattern 1 matches. ISO
+    # `2024-01-15` format DOES NOT match the regex — using ISO would
+    # make the test pass vacuously (the bypass wouldn't fire in either
+    # mode, so "absent in pure-recall mode" is trivially true).
+    _TR_FIXTURE_MSGS = [
+        {"role": "user", "content": "I started the project on March 15, 2024 with the team."},
+        {"role": "user", "content": "Then I deployed it on June 30, 2024 after testing."},
+        {"role": "user", "content": "The final release was September 10, 2024."},
+    ]
+    _TR_FIXTURE_QUESTION = "how many days between project start and deployment?"
+
+    # CR fixture: `_detect_contradictions` needs key terms from the
+    # question to appear in the conversation AND at least one message
+    # must contain a negation word (never/not/n't/no/etc.) in the
+    # sentence with the term. Using "never" satisfies that.
+    _CR_FIXTURE_MSGS = [
+        {"role": "user", "content": "I love flask routes and use them for all HTTP requests."},
+        {"role": "user", "content": "I never use flask routes — I prefer raw WSGI handlers."},
+    ]
+    _CR_FIXTURE_QUESTION = "Have I worked with flask routes?"
+
+    def test_default_tr_oracle_fires_positive_control(self, temp_db, fake_llm, monkeypatch):
+        """Positive control: in DEFAULT mode, the TR-bypass DOES fire
+        with this fixture. Without this control, the pure-recall TR
+        test (below) passes vacuously when the extractor returns empty."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        answer_with_memory(
+            llm=fake_llm, beam=beam,
+            question=self._TR_FIXTURE_QUESTION,
+            conversation_messages=self._TR_FIXTURE_MSGS,
+            top_k=5, ability="TR",
+        )
+        sent_messages = fake_llm.chat.call_args[0][0]
+        system_msg = next(m for m in sent_messages if m["role"] == "system")
+        assert "date calculator" in system_msg["content"].lower(), (
+            f"TR-bypass did NOT fire in DEFAULT mode — fixture is too weak "
+            f"to discriminate. Got system prompt: {system_msg['content'][:200]}"
+        )
+
     def test_pure_recall_tr_does_not_short_circuit_via_oracle(
         self, temp_db, fake_llm, monkeypatch
     ):
@@ -164,29 +207,36 @@ class TestPureRecallModeDisablesBypasses:
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         from tools.evaluate_beam_end_to_end import answer_with_memory
 
-        # TR-shaped question with multiple date references that would
-        # otherwise trigger the oracle.
-        msgs = [
-            {"role": "user", "content": "I started the project on 2024-01-15"},
-            {"role": "user", "content": "Then I deployed on 2024-03-22"},
-            {"role": "user", "content": "Final release was 2024-06-30"},
-        ]
         answer_with_memory(
-            llm=fake_llm,
-            beam=beam,
-            question="how many days between project start and deployment?",
-            conversation_messages=msgs,
-            top_k=5,
-            ability="TR",
+            llm=fake_llm, beam=beam,
+            question=self._TR_FIXTURE_QUESTION,
+            conversation_messages=self._TR_FIXTURE_MSGS,
+            top_k=5, ability="TR",
         )
-        # The TR-bypass returns the LLM answer with a date-calculator
-        # system prompt; the pure-recall path uses ANSWER_SYSTEM_PROMPT.
-        # Inspect the system prompt sent to the LLM to distinguish.
         sent_messages = fake_llm.chat.call_args[0][0]
         system_msg = next(m for m in sent_messages if m["role"] == "system")
         assert "date calculator" not in system_msg["content"].lower(), (
             f"TR-bypass fired despite pure-recall mode; got system prompt: "
             f"{system_msg['content'][:200]}"
+        )
+
+    def test_default_cr_detection_fires_positive_control(self, temp_db, fake_llm, monkeypatch):
+        """Positive control: in DEFAULT mode, the CR-detect injection
+        DOES fire with this fixture. Pinpoints fixture strength."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        answer_with_memory(
+            llm=fake_llm, beam=beam,
+            question=self._CR_FIXTURE_QUESTION,
+            conversation_messages=self._CR_FIXTURE_MSGS,
+            top_k=5, ability="CR",
+        )
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        assert "contradictory information" in user_msg, (
+            f"CR-detect did NOT inject in DEFAULT mode — fixture is too "
+            f"weak to discriminate. Got prompt: {user_msg[:400]}"
         )
 
     def test_pure_recall_cr_does_not_inject_contradiction_context(
@@ -198,22 +248,13 @@ class TestPureRecallModeDisablesBypasses:
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         from tools.evaluate_beam_end_to_end import answer_with_memory
 
-        # Contradictory statements that would trigger _detect_contradictions.
-        msgs = [
-            {"role": "user", "content": "I love coffee, it's my favorite drink"},
-            {"role": "user", "content": "Actually, I prefer tea over coffee"},
-        ]
         answer_with_memory(
-            llm=fake_llm,
-            beam=beam,
-            question="what is my preferred drink?",
-            conversation_messages=msgs,
-            top_k=5,
-            ability="CR",
+            llm=fake_llm, beam=beam,
+            question=self._CR_FIXTURE_QUESTION,
+            conversation_messages=self._CR_FIXTURE_MSGS,
+            top_k=5, ability="CR",
         )
         user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
-        # The CR-inject prefix is "I notice you've mentioned contradictory…"
-        # — assert it's NOT in the prompt.
         assert "contradictory information" not in user_msg, (
             f"CR-bypass injected contradiction context despite pure-recall mode; "
             f"prompt: {user_msg[:300]}"
@@ -281,3 +322,113 @@ class TestPureRecallEnvValueParsing:
         # IE bypass SHOULD fire — LLM not called, value returned directly.
         assert ans == "blue"
         fake_llm.chat.assert_not_called()
+
+
+class TestPureRecallPrecedenceOverFullContext:
+    """Codex /review P1: when both pure_recall and full_context are
+    active, pure_recall MUST win — otherwise the full-context path
+    silently invalidates the recall-only guarantee by shipping the
+    entire raw conversation to the LLM."""
+
+    def test_pure_recall_disables_full_context_mode_even_when_both_set(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """Both env vars set → pure_recall wins; FULL CONVERSATION
+        block must NOT appear in the prompt."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        monkeypatch.setenv("FULL_CONTEXT_MODE", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        msgs = _build_msgs(20)
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="some abstract reasoning question",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="ABS",
+        )
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        assert "FULL CONVERSATION" not in user_msg, (
+            "FULL_CONTEXT_MODE leaked despite pure-recall being set; "
+            f"prompt: {user_msg[:400]}"
+        )
+
+    def test_full_context_alone_still_works_when_pure_recall_off(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """Sanity: existing FULL_CONTEXT behavior unchanged when only
+        full-context is set."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        monkeypatch.setenv("FULL_CONTEXT_MODE", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        msgs = _build_msgs(5)
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="some abstract reasoning question",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="ABS",
+        )
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        assert "FULL CONVERSATION" in user_msg, (
+            "FULL_CONTEXT_MODE didn't fire when pure-recall was off; "
+            "preserving the existing benchmark mode is a regression "
+            f"if this fails. Prompt: {user_msg[:300]}"
+        )
+
+
+class TestPureRecallActuallyRoutesThroughRecall:
+    """Codex /review P2: prior tests only assert "X not present in
+    prompt" — that passes under both pure-recall AND full-context
+    paths. Strengthen by spying on `_multi_strategy_recall` to confirm
+    pure-recall actually goes through the recall pipeline."""
+
+    def test_pure_recall_invokes_multi_strategy_recall(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        import tools.evaluate_beam_end_to_end as harness
+
+        spy = MagicMock(return_value=[])
+        monkeypatch.setattr(harness, "_multi_strategy_recall", spy)
+        harness.answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="some reasoning question",
+            conversation_messages=_build_msgs(20),
+            top_k=5,
+            ability="ABS",
+        )
+        spy.assert_called_once()
+
+    def test_pure_recall_tr_routes_through_recall_not_oracle(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """Even with a TR-shaped question that would have triggered
+        the timeline oracle, pure-recall mode reaches the recall
+        pipeline."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        import tools.evaluate_beam_end_to_end as harness
+
+        spy = MagicMock(return_value=[])
+        monkeypatch.setattr(harness, "_multi_strategy_recall", spy)
+        msgs = [
+            {"role": "user", "content": "started project 2024-01-15"},
+            {"role": "user", "content": "deployed 2024-03-22"},
+        ]
+        harness.answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="days between?",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="TR",
+        )
+        spy.assert_called_once()

--- a/tests/test_benchmark_pure_recall_gate.py
+++ b/tests/test_benchmark_pure_recall_gate.py
@@ -1,0 +1,283 @@
+"""Regression tests for E7/E8/E9 — `MNEMOSYNE_BENCHMARK_PURE_RECALL` gate.
+
+`tools/evaluate_beam_end_to_end.py` historically shipped four bypass
+paths that let the harness answer benchmark questions WITHOUT going
+through Mnemosyne recall:
+
+- **E7 TR oracle:** TR (Temporal Reasoning) questions extracted a
+  timeline from raw `conversation_messages` and returned the LLM
+  answer directly (line 1080) before any `BeamMemory.recall()`.
+- **E7 CR augmentation:** CR (Contradiction Resolution) questions
+  injected contradiction context built from raw messages into the
+  answer prompt (line 1089).
+- **E8 IE/KU side-index:** `_context_facts` (built from raw messages
+  at ingest, line 418) was queried by IE/KU questions; matching
+  values were returned directly at line 1291.
+- **E9 RECENT CONVERSATION:** the last 12 raw messages were prepended
+  to every answer prompt (line 1282) regardless of arm or recall
+  quality.
+
+For the BEAM-recovery experiment (Arms A/B/C compare recall pathways),
+these bypasses mean the harness measures a harness-side oracle on
+TR/CR/IE/KU and the recent-context shortcut on every question type —
+NOT what the arms actually retrieve. `MNEMOSYNE_BENCHMARK_PURE_RECALL=1`
+(or `--pure-recall`) disables all four.
+
+Default behavior preserved when env unset.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+@pytest.fixture
+def fake_llm():
+    """LLMClient stand-in that captures the messages it was called with."""
+    llm = MagicMock()
+    llm.chat = MagicMock(return_value="LLM-FALLBACK-ANSWER")
+    return llm
+
+
+def _build_msgs(n: int = 20) -> List[dict]:
+    """Synthetic conversation messages — `n` user turns."""
+    msgs = []
+    for i in range(n):
+        msgs.append({"role": "user", "content": f"message-{i} payload alpha"})
+    return msgs
+
+
+@pytest.fixture
+def beam_with_context_facts(temp_db):
+    """A BeamMemory with a non-empty `_context_facts` map so we can
+    exercise the IE/KU side-index path."""
+    beam = BeamMemory(session_id="s1", db_path=temp_db)
+    beam._context_facts = {"favorite color blue": ["blue"]}
+    return beam
+
+
+# ─────────────────────────────────────────────────────────────────
+# Default mode (env unset) — existing bypasses still fire
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestDefaultModeBehaviorUnchanged:
+    """When `MNEMOSYNE_BENCHMARK_PURE_RECALL` is unset, the existing
+    bypass paths still fire (zero behavioral regression for callers
+    who haven't migrated)."""
+
+    def test_default_ie_returns_context_fact_value(self, beam_with_context_facts, fake_llm, monkeypatch):
+        """IE question with a matching `_context_facts` entry returns
+        the value directly — bypass is active."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        ans = answer_with_memory(
+            llm=fake_llm,
+            beam=beam_with_context_facts,
+            question="what is favorite color blue",
+            conversation_messages=_build_msgs(20),
+            top_k=5,
+            ability="IE",
+        )
+        assert ans == "blue"
+        # LLM was NOT called — bypass returned the value directly.
+        fake_llm.chat.assert_not_called()
+
+    def test_default_recent_context_included(self, temp_db, fake_llm, monkeypatch):
+        """When LLM is invoked (e.g., for ABS questions), the prompt
+        includes the RECENT CONVERSATION section by default."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        msgs = _build_msgs(20)
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="some abstract reasoning question",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="ABS",
+        )
+        # LLM called; its prompt includes "RECENT CONVERSATION".
+        fake_llm.chat.assert_called()
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        assert "RECENT CONVERSATION" in user_msg
+
+
+# ─────────────────────────────────────────────────────────────────
+# Pure-recall mode — all bypasses disabled
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPureRecallModeDisablesBypasses:
+    """When `MNEMOSYNE_BENCHMARK_PURE_RECALL=1`, every bypass is
+    disabled and every answer must go through the full LLM path with
+    only retrieved memories in context."""
+
+    def test_pure_recall_ie_does_not_return_context_fact_value(
+        self, beam_with_context_facts, fake_llm, monkeypatch
+    ):
+        """IE question with matching `_context_facts` should NOT short-
+        circuit in pure-recall mode — the LLM gets called instead."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        ans = answer_with_memory(
+            llm=fake_llm,
+            beam=beam_with_context_facts,
+            question="what is favorite color blue",
+            conversation_messages=_build_msgs(20),
+            top_k=5,
+            ability="IE",
+        )
+        # LLM was called — bypass disabled.
+        fake_llm.chat.assert_called_once()
+        # Whatever the LLM returned is the answer (our fake returns LLM-FALLBACK-ANSWER).
+        assert ans == "LLM-FALLBACK-ANSWER"
+
+    def test_pure_recall_tr_does_not_short_circuit_via_oracle(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """TR question should NOT take the timeline-oracle path that
+        returns an LLM answer directly from extracted dates. Instead
+        it falls through to the standard recall + LLM path."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        # TR-shaped question with multiple date references that would
+        # otherwise trigger the oracle.
+        msgs = [
+            {"role": "user", "content": "I started the project on 2024-01-15"},
+            {"role": "user", "content": "Then I deployed on 2024-03-22"},
+            {"role": "user", "content": "Final release was 2024-06-30"},
+        ]
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="how many days between project start and deployment?",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="TR",
+        )
+        # The TR-bypass returns the LLM answer with a date-calculator
+        # system prompt; the pure-recall path uses ANSWER_SYSTEM_PROMPT.
+        # Inspect the system prompt sent to the LLM to distinguish.
+        sent_messages = fake_llm.chat.call_args[0][0]
+        system_msg = next(m for m in sent_messages if m["role"] == "system")
+        assert "date calculator" not in system_msg["content"].lower(), (
+            f"TR-bypass fired despite pure-recall mode; got system prompt: "
+            f"{system_msg['content'][:200]}"
+        )
+
+    def test_pure_recall_cr_does_not_inject_contradiction_context(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """CR question should NOT inject `_detect_contradictions`
+        output into the prompt — pure recall means recall alone."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        # Contradictory statements that would trigger _detect_contradictions.
+        msgs = [
+            {"role": "user", "content": "I love coffee, it's my favorite drink"},
+            {"role": "user", "content": "Actually, I prefer tea over coffee"},
+        ]
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="what is my preferred drink?",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="CR",
+        )
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        # The CR-inject prefix is "I notice you've mentioned contradictory…"
+        # — assert it's NOT in the prompt.
+        assert "contradictory information" not in user_msg, (
+            f"CR-bypass injected contradiction context despite pure-recall mode; "
+            f"prompt: {user_msg[:300]}"
+        )
+
+    def test_pure_recall_excludes_recent_conversation_section(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """The 'RECENT CONVERSATION' block (last 12 raw messages) is
+        always included pre-fix. Pure-recall mode strips it so the LLM
+        sees only what each arm's recall returned."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        msgs = _build_msgs(20)
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="some abstract reasoning question",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="ABS",
+        )
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        assert "RECENT CONVERSATION" not in user_msg, (
+            f"RECENT CONVERSATION section leaked into pure-recall prompt: "
+            f"{user_msg[:300]}"
+        )
+
+
+class TestPureRecallEnvValueParsing:
+    """The env var is treated as truthy on '1', 'true', 'yes' (lowercase
+    or any case), falsy/unset otherwise. Locks the parsing surface."""
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "True", "yes", "YES"])
+    def test_truthy_values_enable_gate(self, value, beam_with_context_facts, fake_llm, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", value)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam_with_context_facts,
+            question="what is favorite color blue",
+            conversation_messages=_build_msgs(5),
+            top_k=5,
+            ability="IE",
+        )
+        # IE bypass should NOT fire; LLM should be called.
+        fake_llm.chat.assert_called()
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "", "anything-else"])
+    def test_falsy_values_preserve_default(self, value, beam_with_context_facts, fake_llm, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", value)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        ans = answer_with_memory(
+            llm=fake_llm,
+            beam=beam_with_context_facts,
+            question="what is favorite color blue",
+            conversation_messages=_build_msgs(5),
+            top_k=5,
+            ability="IE",
+        )
+        # IE bypass SHOULD fire — LLM not called, value returned directly.
+        assert ans == "blue"
+        fake_llm.chat.assert_not_called()

--- a/tools/evaluate_beam_end_to_end.py
+++ b/tools/evaluate_beam_end_to_end.py
@@ -1055,17 +1055,34 @@ def _detect_contradictions(messages: list, question: str) -> str | None:
     return None
 
 
-def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str, 
+def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
                       conversation_messages: list = None, top_k: int = DEFAULT_TOP_K,
                       ability: str = None) -> str:
-    """Retrieve memories and have LLM answer, with context strategy based on conversation size."""
-    
+    """Retrieve memories and have LLM answer, with context strategy based on conversation size.
+
+    Set `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` to disable the per-ability
+    bypass paths (TR oracle, CR contradiction injection, IE/KU
+    context→value side-index) AND the always-included RECENT
+    CONVERSATION raw-message prompt section. Pure-recall mode forces
+    every answer through the full Mnemosyne retrieval pipeline so the
+    BEAM-recovery experiment can measure each arm's recall quality
+    without contamination from harness-side oracles. Default behavior
+    (env unset or '0') preserves the existing benchmark mode.
+    """
+    # E7/E8/E9 gate: when set, the harness disables every shortcut that
+    # would let the LLM produce an answer without going through
+    # BeamMemory.recall(). The bypasses were useful for measuring
+    # LLM-ceiling-with-help on isolated abilities; the BEAM-recovery
+    # experiment instead needs to compare Arm A vs Arm B vs Arm C on
+    # the recall surface itself.
+    _pure_recall = os.environ.get("MNEMOSYNE_BENCHMARK_PURE_RECALL", "").lower() in ("1", "true", "yes")
+
     total_msgs = len(conversation_messages) if conversation_messages else 0
-    
+
     # ---- PER-ABILITY BYPASSES (zero-LLM or augmented) ----
-    
+
     # TR (Temporal Reasoning): compute answer from extracted dates
-    if ability == 'TR' and conversation_messages:
+    if not _pure_recall and ability == 'TR' and conversation_messages:
         timeline = _extract_timeline_from_conversation(conversation_messages)
         print(f"    [TR-bypass] extracted {len(timeline)} dates from {len(conversation_messages)} msgs")
         if timeline and len(timeline) >= 2:
@@ -1085,7 +1102,7 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     
     # CR (Contradiction Resolution): detect contradictory statements
     _cr_context = None
-    if ability == 'CR' and conversation_messages:
+    if not _pure_recall and ability == 'CR' and conversation_messages:
         _cr_context = _detect_contradictions(conversation_messages, question)
         if _cr_context:
             print(f"    [CR-detect] FOUND contradictions, injecting context ({len(_cr_context)} chars)")
@@ -1106,8 +1123,10 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
         # ---- Phase 1: Try context→value matching for factual questions ----
         # Only use context→value for Information Extraction (IE) and Knowledge Understanding (KU).
         # MR (Multi-hop) requires reasoning across multiple messages; let full-context handle it.
+        # Gated by pure_recall — when ON, full-context mode still hits the LLM with raw
+        # conversation but skips the zero-LLM context→value shortcut.
         _FACT_ABILITIES = {'IE', 'KU'}
-        if ability in _FACT_ABILITIES and hasattr(beam, '_context_facts') and beam._context_facts:
+        if not _pure_recall and ability in _FACT_ABILITIES and hasattr(beam, '_context_facts') and beam._context_facts:
             _q_stop = {'when','does','do','did','what','how','where','which','who','why',
                        'is','are','was','were','can','will','would','should','could','may',
                        'the','a','an','in','on','at','to','for','of','with','my','me','i','you'}
@@ -1169,8 +1188,10 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     context_answer = None
     # Only use context→value for Information Extraction (IE) and Knowledge Understanding (KU).
     # MR (Multi-hop) requires reasoning across multiple messages; CR/TR/EO/SUM need LLM.
+    # Gated by pure_recall — when ON, IE/KU questions go through full recall+LLM
+    # rather than returning a side-indexed value directly.
     _FACT_ABILITIES = {'IE', 'KU'}
-    if ability in _FACT_ABILITIES and hasattr(beam, '_context_facts') and beam._context_facts:
+    if not _pure_recall and ability in _FACT_ABILITIES and hasattr(beam, '_context_facts') and beam._context_facts:
         # Build question word set (filtered like FTS5 search does)
         _q_stop = {'when','does','do','did','what','how','where','which','who','why',
                    'is','are','was','were','can','will','would','should','could','may',
@@ -1242,9 +1263,14 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     
     context = ""  # Built below from memories
 
-    # Build recent context from last N messages
+    # Build recent context from last N messages. Pure-recall mode SKIPS
+    # this entirely — the LLM sees only RETRIEVED MEMORIES, so the
+    # answer quality reflects what each arm's recall produced (rather
+    # than the harness silently leaking the last 12 raw messages into
+    # every prompt, which inflates recency-anchored answers and masks
+    # recall weakness across all arms).
     recent_parts = []
-    if conversation_messages:
+    if not _pure_recall and conversation_messages:
         recent = conversation_messages[-RECENT_CONTEXT_COUNT:]
         for msg in recent:
             role = msg.get("role", "unknown")
@@ -1595,6 +1621,12 @@ def main():
                         help="Separate LLM for judging (default: same as --model)")
     parser.add_argument("--full-context", action="store_true",
                         help="Send full conversation to LLM (ceiling test, bypasses retrieval)")
+    parser.add_argument("--pure-recall", action="store_true",
+                        help="Disable per-ability bypasses + RECENT CONVERSATION injection. "
+                             "Forces every answer through Mnemosyne recall — what the "
+                             "BEAM-recovery experiment needs to measure arm-vs-arm "
+                             "recall quality without harness-side oracle contamination. "
+                             "Equivalent to MNEMOSYNE_BENCHMARK_PURE_RECALL=1.")
     parser.add_argument("--resume", action="store_true",
                         help="Resume from previous results file")
     parser.add_argument("--dry-run", action="store_true",
@@ -1615,6 +1647,13 @@ def main():
     if args.full_context:
         os.environ["FULL_CONTEXT_MODE"] = "1"
         print("  Mode: FULL-CONTEXT (bypassing retrieval)")
+    if args.pure_recall:
+        os.environ["MNEMOSYNE_BENCHMARK_PURE_RECALL"] = "1"
+        print("  Mode: PURE-RECALL (per-ability bypasses + RECENT CONTEXT disabled — "
+              "every answer goes through Mnemosyne recall)")
+    elif os.environ.get("MNEMOSYNE_BENCHMARK_PURE_RECALL", "").lower() in ("1", "true", "yes"):
+        # Env var set externally — surface it so the run banner shows the mode.
+        print("  Mode: PURE-RECALL (via env var)")
     print(f"{'='*80}")
 
     # Load data

--- a/tools/evaluate_beam_end_to_end.py
+++ b/tools/evaluate_beam_end_to_end.py
@@ -1116,9 +1116,16 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     # HYBRID: try context→value matching first for factual questions (IE/MR/KU),
     # then fall through to full-context for complex reasoning (ABS/CR/EO/SUM/TR).
     _full_context = os.environ.get("FULL_CONTEXT_MODE", "").lower() in ("1", "true", "yes")
+    # Precedence: pure-recall overrides full-context. The point of
+    # pure-recall is to force every answer through Mnemosyne recall;
+    # full-context's "ship the whole conversation to the LLM" path
+    # would silently invalidate that guarantee (the LLM would answer
+    # from raw `FULL CONVERSATION:` regardless of arm).
+    if _full_context and _pure_recall:
+        _full_context = False
     # DEBUG
     if os.environ.get("FULL_CONTEXT_MODE"):
-        print(f"    [DEBUG full-context] env={_full_context}, msgs={bool(conversation_messages)}, count={len(conversation_messages) if conversation_messages else 0}")
+        print(f"    [DEBUG full-context] env={_full_context}, msgs={bool(conversation_messages)}, count={len(conversation_messages) if conversation_messages else 0} (pure_recall={_pure_recall})")
     if _full_context and conversation_messages:
         # ---- Phase 1: Try context→value matching for factual questions ----
         # Only use context→value for Information Extraction (IE) and Knowledge Understanding (KU).
@@ -1644,16 +1651,22 @@ def main():
     print(f"  Sample: {sample_size or 'ALL'} conversations/scale")
     print(f"  Model: {args.model}")
     print(f"  Judge: {args.judge_model or args.model}")
-    if args.full_context:
+    # Mode resolution + banner. Pure-recall overrides full-context
+    # because the bypass that full-context provides (raw conversation
+    # straight to LLM) is exactly what pure-recall is meant to forbid.
+    _pure_recall_env = os.environ.get("MNEMOSYNE_BENCHMARK_PURE_RECALL", "").lower() in ("1", "true", "yes")
+    if args.pure_recall or _pure_recall_env:
+        os.environ["MNEMOSYNE_BENCHMARK_PURE_RECALL"] = "1"
+        if args.full_context or os.environ.get("FULL_CONTEXT_MODE"):
+            # Conflict: warn loudly so the operator isn't surprised.
+            print("  Mode: PURE-RECALL (overrides FULL_CONTEXT/--full-context — "
+                  "every answer goes through Mnemosyne recall)")
+        else:
+            print("  Mode: PURE-RECALL (per-ability bypasses + RECENT CONTEXT disabled — "
+                  "every answer goes through Mnemosyne recall)")
+    elif args.full_context:
         os.environ["FULL_CONTEXT_MODE"] = "1"
         print("  Mode: FULL-CONTEXT (bypassing retrieval)")
-    if args.pure_recall:
-        os.environ["MNEMOSYNE_BENCHMARK_PURE_RECALL"] = "1"
-        print("  Mode: PURE-RECALL (per-ability bypasses + RECENT CONTEXT disabled — "
-              "every answer goes through Mnemosyne recall)")
-    elif os.environ.get("MNEMOSYNE_BENCHMARK_PURE_RECALL", "").lower() in ("1", "true", "yes"):
-        # Env var set externally — surface it so the run banner shows the mode.
-        print("  Mode: PURE-RECALL (via env var)")
     print(f"{'='*80}")
 
     # Load data


### PR DESCRIPTION
## TL;DR

The BEAM benchmark harness (`tools/evaluate_beam_end_to_end.py`) shipped four hardcoded paths that produced answers WITHOUT going through `BeamMemory.recall()`. For the BEAM-recovery experiment that compares Arms A (linear) / B (polyphonic) / C (algorithmic enrichment), these bypasses contaminate arm-vs-arm comparison — all four shortcuts produce the same answer regardless of which arm is active.

This PR adds a `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` env var (also `--pure-recall` CLI flag) that disables all four. Default behavior preserved when env unset.

**23 regression tests, 799 full-suite passing.**

## Why this matters

Without this gate, the BEAM-recovery experiment can't measure what it claims to measure. Concretely:

- **TR (Temporal Reasoning) scores** measure a regex-extracted timeline + date-calculator LLM prompt — the harness side-channel, not the arm.
- **CR (Contradiction Resolution) scores** measure `_detect_contradictions(raw_messages)` injection, not the arm's contradiction recall.
- **IE/KU (Information Extraction / Knowledge Understanding) scores** measure a `_context_facts` phrase-overlap lookup populated at ingest from raw messages, not the arm's fact recall.
- **All question types** are inflated by the always-included "RECENT CONVERSATION" block — the last 12 raw messages prepended to every prompt regardless of arm or recall quality. Recency-anchored answers succeed even when recall returns garbage.

These were defensible benchmark choices for measuring LLM-ceiling-with-help on isolated abilities. They're the wrong choice for an experiment whose goal is comparing recall-pathway quality across arms.

## What the gate does

| Path | Pre-fix line | When `_pure_recall=True` |
|---|---|---|
| TR timeline oracle | `:1068` | Skipped → falls through to recall+LLM |
| CR contradiction injection | `:1086` | Skipped → `_cr_context = None`, no prefix |
| IE/KU full-context phrase match | `:1110` | Skipped → goes to retrieval |
| IE/KU hybrid phrase match | `:1172` | Skipped → goes to LLM with retrieved memories |
| RECENT CONVERSATION injection | `:1245` | Skipped → prompt has retrieved memories only |
| `FULL_CONTEXT_MODE` conflict | `:1122` | Overridden to False with banner warning |

## /review army findings (all addressed)

| Finding | Severity / Source | Fix |
|---|---|---|
| `--pure-recall` doesn't override `--full-context` / `FULL_CONTEXT_MODE` | **P1** (Codex) | Pure-recall now wins at both levels: in-function (`_full_context = False`) and CLI banner ("PURE-RECALL (overrides FULL_CONTEXT...)") |
| TR + CR fixtures didn't actually trigger the underlying extractors in default mode → tests passed vacuously | **HIGH** (Claude H1) | TR fixture rewritten to `"Month Day, Year"` (Pattern 1 match); CR fixture uses `"never"` (NEGATION_WORDS match); added 2 positive-control tests that pin default-mode behavior bidirectionally |
| No test pins precedence rule | **P2** (Codex) | Added 2 precedence tests: both env vars set → pure-recall wins; full-context-alone still fires |

## Test breakdown (23 tests)

- **Default-mode preservation (2):** IE context-fact bypass fires; RECENT CONVERSATION included.
- **Pure-recall disables bypasses (4):** IE doesn't short-circuit; TR doesn't take oracle; CR doesn't inject; RECENT CONVERSATION absent.
- **Positive controls (2):** TR oracle DOES fire in default mode with fixture; CR injection DOES fire in default mode with fixture.
- **Env-var parsing (11):** truthy values `1|true|TRUE|True|yes|YES`; falsy `0|false|no|""|garbage`.
- **Precedence (2):** pure-recall overrides full-context when both set; full-context still works when pure-recall off.
- **Recall-routing verification (2):** spy on `_multi_strategy_recall` confirms pure-recall actually goes through the recall pipeline (not just "X not in prompt", which can pass under multiple paths).

## How to run the experiment with this fix

```bash
# Arm A baseline (linear recall, no bypasses):
python tools/evaluate_beam_end_to_end.py --scales 100K --pure-recall

# Arm B (polyphonic recall, no bypasses):
MNEMOSYNE_POLYPHONIC_RECALL=1 python tools/evaluate_beam_end_to_end.py --scales 100K --pure-recall

# Existing benchmark mode unchanged (no flag):
python tools/evaluate_beam_end_to_end.py --scales 100K
```

## Discovery

Found by an independent Codex audit of the experiment-runner file. The prior Explore-agent audit completely missed these — it scanned core Mnemosyne code but didn't deep-read the benchmark harness. Lesson recorded in the ledger: when auditing for experiment fidelity, the experiment-runner file should be the first place to look, not the last.

## Test plan

- [x] All 23 tests in `tests/test_benchmark_pure_recall_gate.py` pass
- [x] Full suite: 799 passed, 1 skipped, 0 failures
- [x] Codex structured /review: P1 + P2 both addressed
- [x] Claude adversarial /review: HIGH-1 vacuous-fixture issue caught + fixed with positive controls
- [ ] CI: full suite green on Python 3.9 / 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)