### PR TITLE
fix(C30+C31+C32): pre-experiment telemetry + env-parser cleanup (stacks on #90)

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -169,6 +169,56 @@ TOOL_WEIGHT = float(os.environ.get("MNEMOSYNE_TOOL_WEIGHT", "0.5"))
 IMPORTED_WEIGHT = float(os.environ.get("MNEMOSYNE_IMPORTED_WEIGHT", "0.6"))
 UNKNOWN_WEIGHT = float(os.environ.get("MNEMOSYNE_UNKNOWN_WEIGHT", "0.8"))
 
+
+def _detect_veracity_weight_overrides() -> List[str]:
+    """C32: return a list of `MNEMOSYNE_*_WEIGHT` env vars that are set.
+
+    Used at module-load time to emit a single WARNING per process when
+    operators override recall-side veracity weights. The consolidator
+    (`veracity_consolidation.VERACITY_WEIGHTS`) does NOT honor these
+    env vars, so any override creates drift between Bayesian
+    compounding (consolidation) and the recall multiplier — breaking
+    the invariant 'consolidated-as-N also ranks at N.'
+    """
+    return [
+        name for name in (
+            "MNEMOSYNE_STATED_WEIGHT",
+            "MNEMOSYNE_INFERRED_WEIGHT",
+            "MNEMOSYNE_TOOL_WEIGHT",
+            "MNEMOSYNE_IMPORTED_WEIGHT",
+            "MNEMOSYNE_UNKNOWN_WEIGHT",
+        )
+        if name in os.environ
+    ]
+
+
+def _warn_about_veracity_weight_overrides() -> bool:
+    """Log a single WARNING if any `MNEMOSYNE_*_WEIGHT` env var is set.
+
+    Returns True if a warning was emitted. Idempotent: calling twice
+    will emit twice — callers control firing frequency. Module-load
+    calls this once below.
+
+    Testable without reloading the module: tests can monkeypatch env
+    and call this directly + assert on caplog.
+    """
+    overrides = _detect_veracity_weight_overrides()
+    if not overrides:
+        return False
+    logger.warning(
+        "Veracity weight env overrides detected: %s. Recall scoring will "
+        "honor the override, but consolidation Bayesian compounding "
+        "(veracity_consolidation.VERACITY_WEIGHTS) does NOT — the two "
+        "will drift. Set matching values in veracity_consolidation.py "
+        "OR accept that 'consolidated-as-N also ranks at N' invariant "
+        "is broken until the consolidator is taught the same overrides.",
+        ", ".join(overrides),
+    )
+    return True
+
+
+_warn_about_veracity_weight_overrides()
+
 # Vector compression: float32 | int8 | bit
 VEC_TYPE = os.environ.get("MNEMOSYNE_VEC_TYPE", "int8").lower()
 if VEC_TYPE not in ("float32", "int8", "bit"):
@@ -2668,7 +2718,16 @@ class BeamMemory:
                         "tier": "episodic",
                         "score": round(score, 4),
                         "keyword_score": round(relevance, 4),
-                        "dense_score": round(wm_vec_sims.get(row["id"], 0.0), 4),
+                        # C30: dense_score is 0.0 by design for EM
+                        # fallback rows — they reach this loop precisely
+                        # because the vec/FTS-driven episodic path
+                        # produced no candidates (no `sim` is computed
+                        # here). Pre-fix this line looked up
+                        # `wm_vec_sims[row["id"]]` which always returned
+                        # 0.0 since `row["id"]` is an episodic id, not
+                        # a working-memory id — same numeric value,
+                        # misleading provenance. Now explicit.
+                        "dense_score": 0.0,
                         "fts_score": 0.0,
                         "importance": row["importance"],
                         "recall_count": row["recall_count"] or 0,

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -162,23 +162,47 @@ DEGRADE_BATCH_SIZE = int(os.environ.get("MNEMOSYNE_DEGRADE_BATCH", "100"))
 SMART_COMPRESS = os.environ.get("MNEMOSYNE_SMART_COMPRESS", "1") not in ("0", "false", "no")
 TIER3_MAX_CHARS = int(os.environ.get("MNEMOSYNE_TIER3_MAX_CHARS", "300"))
 
+def _env_float(name: str, default: float) -> float:
+    """Parse an env var as float; fall back to `default` on empty or
+    invalid values rather than crashing at module load.
+
+    Pre-fix `float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", "1.0"))`
+    raised ValueError when the env var was set to empty (`export
+    MNEMOSYNE_STATED_WEIGHT=`) because `os.environ.get` returns `""`
+    (the value), not the default — `float("")` then crashed import
+    BEFORE the C32 override-WARN could fire. Robust path: strip,
+    treat empty as "fall back," log a WARN on actually-bad values.
+    """
+    raw = os.environ.get(name, "")
+    raw = raw.strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a valid float; falling back to default %s",
+            name, raw[:80], default,
+        )
+        return default
+
+
 # Veracity weighting (memory confidence)
-STATED_WEIGHT = float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", "1.0"))
-INFERRED_WEIGHT = float(os.environ.get("MNEMOSYNE_INFERRED_WEIGHT", "0.7"))
-TOOL_WEIGHT = float(os.environ.get("MNEMOSYNE_TOOL_WEIGHT", "0.5"))
-IMPORTED_WEIGHT = float(os.environ.get("MNEMOSYNE_IMPORTED_WEIGHT", "0.6"))
-UNKNOWN_WEIGHT = float(os.environ.get("MNEMOSYNE_UNKNOWN_WEIGHT", "0.8"))
+STATED_WEIGHT = _env_float("MNEMOSYNE_STATED_WEIGHT", 1.0)
+INFERRED_WEIGHT = _env_float("MNEMOSYNE_INFERRED_WEIGHT", 0.7)
+TOOL_WEIGHT = _env_float("MNEMOSYNE_TOOL_WEIGHT", 0.5)
+IMPORTED_WEIGHT = _env_float("MNEMOSYNE_IMPORTED_WEIGHT", 0.6)
+UNKNOWN_WEIGHT = _env_float("MNEMOSYNE_UNKNOWN_WEIGHT", 0.8)
 
 
 def _detect_veracity_weight_overrides() -> List[str]:
-    """C32: return a list of `MNEMOSYNE_*_WEIGHT` env vars that are set.
+    """C32: return a list of `MNEMOSYNE_*_WEIGHT` env vars that are
+    set to a non-empty value.
 
-    Used at module-load time to emit a single WARNING per process when
-    operators override recall-side veracity weights. The consolidator
-    (`veracity_consolidation.VERACITY_WEIGHTS`) does NOT honor these
-    env vars, so any override creates drift between Bayesian
-    compounding (consolidation) and the recall multiplier — breaking
-    the invariant 'consolidated-as-N also ranks at N.'
+    Filters out empty-string values (e.g., `export MNEMOSYNE_STATED_WEIGHT=`)
+    since those don't actually override anything — `_env_float` falls
+    back to the default for empties. Counting them as overrides would
+    confuse the WARN message.
     """
     return [
         name for name in (
@@ -188,20 +212,28 @@ def _detect_veracity_weight_overrides() -> List[str]:
             "MNEMOSYNE_IMPORTED_WEIGHT",
             "MNEMOSYNE_UNKNOWN_WEIGHT",
         )
-        if name in os.environ
+        if os.environ.get(name, "").strip()
     ]
 
 
-def _warn_about_veracity_weight_overrides() -> bool:
-    """Log a single WARNING if any `MNEMOSYNE_*_WEIGHT` env var is set.
+_VERACITY_WARN_EMITTED = False
 
-    Returns True if a warning was emitted. Idempotent: calling twice
-    will emit twice — callers control firing frequency. Module-load
-    calls this once below.
 
-    Testable without reloading the module: tests can monkeypatch env
-    and call this directly + assert on caplog.
+def _warn_about_veracity_weight_overrides(force: bool = False) -> bool:
+    """Log a WARNING if any `MNEMOSYNE_*_WEIGHT` env var is overridden.
+
+    Idempotent per-process: subsequent calls return False without
+    re-emitting unless `force=True` (tests use this to verify the WARN
+    fires per call). Module-load calls this once below. The guard
+    matters for multi-worker setups (uvicorn `--workers`, pytest-xdist)
+    where each worker reloads the module — each process gets one WARN
+    instead of N per worker startup.
+
+    Returns True iff a warning was emitted on this call.
     """
+    global _VERACITY_WARN_EMITTED
+    if _VERACITY_WARN_EMITTED and not force:
+        return False
     overrides = _detect_veracity_weight_overrides()
     if not overrides:
         return False
@@ -214,6 +246,7 @@ def _warn_about_veracity_weight_overrides() -> bool:
         "is broken until the consolidator is taught the same overrides.",
         ", ".join(overrides),
     )
+    _VERACITY_WARN_EMITTED = True
     return True
 
 
@@ -2296,7 +2329,14 @@ class BeamMemory:
                         "tier": "episodic",
                         "score": round(score, 4),
                         "keyword_score": 0.0,
-                        "dense_score": round(wm_vec_sims.get(row["id"], 0.0), 4),
+                        # C30: episodic rows never key into wm_vec_sims
+                        # (that dict holds working_memory ids only). Set
+                        # 0.0 explicitly rather than lookup-that-always-
+                        # returns-default, so post-run analysis isn't
+                        # misled into thinking dense similarity was
+                        # computed. The entity/fact-matched episodic
+                        # paths don't compute ep dense sim themselves.
+                        "dense_score": 0.0,
                         "fts_score": 0.0,
                         "importance": row["importance"],
                         "recall_count": row["recall_count"] or 0,
@@ -2409,7 +2449,14 @@ class BeamMemory:
                         "tier": "episodic",
                         "score": round(score, 4),
                         "keyword_score": 0.0,
-                        "dense_score": round(wm_vec_sims.get(row["id"], 0.0), 4),
+                        # C30: episodic rows never key into wm_vec_sims
+                        # (that dict holds working_memory ids only). Set
+                        # 0.0 explicitly rather than lookup-that-always-
+                        # returns-default, so post-run analysis isn't
+                        # misled into thinking dense similarity was
+                        # computed. The entity/fact-matched episodic
+                        # paths don't compute ep dense sim themselves.
+                        "dense_score": 0.0,
                         "fts_score": 0.0,
                         "importance": row["importance"],
                         "recall_count": row["recall_count"] or 0,

--- a/tests/test_benchmark_pure_recall_gate.py
+++ b/tests/test_benchmark_pure_recall_gate.py
@@ -154,6 +154,49 @@ class TestPureRecallModeDisablesBypasses:
         # Whatever the LLM returned is the answer (our fake returns LLM-FALLBACK-ANSWER).
         assert ans == "LLM-FALLBACK-ANSWER"
 
+    # TR fixture: must use "Month Day, Year" format which is what
+    # `_extract_timeline_from_conversation`'s Pattern 1 matches. ISO
+    # `2024-01-15` format DOES NOT match the regex — using ISO would
+    # make the test pass vacuously (the bypass wouldn't fire in either
+    # mode, so "absent in pure-recall mode" is trivially true).
+    _TR_FIXTURE_MSGS = [
+        {"role": "user", "content": "I started the project on March 15, 2024 with the team."},
+        {"role": "user", "content": "Then I deployed it on June 30, 2024 after testing."},
+        {"role": "user", "content": "The final release was September 10, 2024."},
+    ]
+    _TR_FIXTURE_QUESTION = "how many days between project start and deployment?"
+
+    # CR fixture: `_detect_contradictions` needs key terms from the
+    # question to appear in the conversation AND at least one message
+    # must contain a negation word (never/not/n't/no/etc.) in the
+    # sentence with the term. Using "never" satisfies that.
+    _CR_FIXTURE_MSGS = [
+        {"role": "user", "content": "I love flask routes and use them for all HTTP requests."},
+        {"role": "user", "content": "I never use flask routes — I prefer raw WSGI handlers."},
+    ]
+    _CR_FIXTURE_QUESTION = "Have I worked with flask routes?"
+
+    def test_default_tr_oracle_fires_positive_control(self, temp_db, fake_llm, monkeypatch):
+        """Positive control: in DEFAULT mode, the TR-bypass DOES fire
+        with this fixture. Without this control, the pure-recall TR
+        test (below) passes vacuously when the extractor returns empty."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        answer_with_memory(
+            llm=fake_llm, beam=beam,
+            question=self._TR_FIXTURE_QUESTION,
+            conversation_messages=self._TR_FIXTURE_MSGS,
+            top_k=5, ability="TR",
+        )
+        sent_messages = fake_llm.chat.call_args[0][0]
+        system_msg = next(m for m in sent_messages if m["role"] == "system")
+        assert "date calculator" in system_msg["content"].lower(), (
+            f"TR-bypass did NOT fire in DEFAULT mode — fixture is too weak "
+            f"to discriminate. Got system prompt: {system_msg['content'][:200]}"
+        )
+
     def test_pure_recall_tr_does_not_short_circuit_via_oracle(
         self, temp_db, fake_llm, monkeypatch
     ):
@@ -164,29 +207,36 @@ class TestPureRecallModeDisablesBypasses:
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         from tools.evaluate_beam_end_to_end import answer_with_memory
 
-        # TR-shaped question with multiple date references that would
-        # otherwise trigger the oracle.
-        msgs = [
-            {"role": "user", "content": "I started the project on 2024-01-15"},
-            {"role": "user", "content": "Then I deployed on 2024-03-22"},
-            {"role": "user", "content": "Final release was 2024-06-30"},
-        ]
         answer_with_memory(
-            llm=fake_llm,
-            beam=beam,
-            question="how many days between project start and deployment?",
-            conversation_messages=msgs,
-            top_k=5,
-            ability="TR",
+            llm=fake_llm, beam=beam,
+            question=self._TR_FIXTURE_QUESTION,
+            conversation_messages=self._TR_FIXTURE_MSGS,
+            top_k=5, ability="TR",
         )
-        # The TR-bypass returns the LLM answer with a date-calculator
-        # system prompt; the pure-recall path uses ANSWER_SYSTEM_PROMPT.
-        # Inspect the system prompt sent to the LLM to distinguish.
         sent_messages = fake_llm.chat.call_args[0][0]
         system_msg = next(m for m in sent_messages if m["role"] == "system")
         assert "date calculator" not in system_msg["content"].lower(), (
             f"TR-bypass fired despite pure-recall mode; got system prompt: "
             f"{system_msg['content'][:200]}"
+        )
+
+    def test_default_cr_detection_fires_positive_control(self, temp_db, fake_llm, monkeypatch):
+        """Positive control: in DEFAULT mode, the CR-detect injection
+        DOES fire with this fixture. Pinpoints fixture strength."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        answer_with_memory(
+            llm=fake_llm, beam=beam,
+            question=self._CR_FIXTURE_QUESTION,
+            conversation_messages=self._CR_FIXTURE_MSGS,
+            top_k=5, ability="CR",
+        )
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        assert "contradictory information" in user_msg, (
+            f"CR-detect did NOT inject in DEFAULT mode — fixture is too "
+            f"weak to discriminate. Got prompt: {user_msg[:400]}"
         )
 
     def test_pure_recall_cr_does_not_inject_contradiction_context(
@@ -198,22 +248,13 @@ class TestPureRecallModeDisablesBypasses:
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         from tools.evaluate_beam_end_to_end import answer_with_memory
 
-        # Contradictory statements that would trigger _detect_contradictions.
-        msgs = [
-            {"role": "user", "content": "I love coffee, it's my favorite drink"},
-            {"role": "user", "content": "Actually, I prefer tea over coffee"},
-        ]
         answer_with_memory(
-            llm=fake_llm,
-            beam=beam,
-            question="what is my preferred drink?",
-            conversation_messages=msgs,
-            top_k=5,
-            ability="CR",
+            llm=fake_llm, beam=beam,
+            question=self._CR_FIXTURE_QUESTION,
+            conversation_messages=self._CR_FIXTURE_MSGS,
+            top_k=5, ability="CR",
         )
         user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
-        # The CR-inject prefix is "I notice you've mentioned contradictory…"
-        # — assert it's NOT in the prompt.
         assert "contradictory information" not in user_msg, (
             f"CR-bypass injected contradiction context despite pure-recall mode; "
             f"prompt: {user_msg[:300]}"
@@ -281,3 +322,113 @@ class TestPureRecallEnvValueParsing:
         # IE bypass SHOULD fire — LLM not called, value returned directly.
         assert ans == "blue"
         fake_llm.chat.assert_not_called()
+
+
+class TestPureRecallPrecedenceOverFullContext:
+    """Codex /review P1: when both pure_recall and full_context are
+    active, pure_recall MUST win — otherwise the full-context path
+    silently invalidates the recall-only guarantee by shipping the
+    entire raw conversation to the LLM."""
+
+    def test_pure_recall_disables_full_context_mode_even_when_both_set(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """Both env vars set → pure_recall wins; FULL CONVERSATION
+        block must NOT appear in the prompt."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        monkeypatch.setenv("FULL_CONTEXT_MODE", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        msgs = _build_msgs(20)
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="some abstract reasoning question",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="ABS",
+        )
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        assert "FULL CONVERSATION" not in user_msg, (
+            "FULL_CONTEXT_MODE leaked despite pure-recall being set; "
+            f"prompt: {user_msg[:400]}"
+        )
+
+    def test_full_context_alone_still_works_when_pure_recall_off(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """Sanity: existing FULL_CONTEXT behavior unchanged when only
+        full-context is set."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        monkeypatch.setenv("FULL_CONTEXT_MODE", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        msgs = _build_msgs(5)
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="some abstract reasoning question",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="ABS",
+        )
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        assert "FULL CONVERSATION" in user_msg, (
+            "FULL_CONTEXT_MODE didn't fire when pure-recall was off; "
+            "preserving the existing benchmark mode is a regression "
+            f"if this fails. Prompt: {user_msg[:300]}"
+        )
+
+
+class TestPureRecallActuallyRoutesThroughRecall:
+    """Codex /review P2: prior tests only assert "X not present in
+    prompt" — that passes under both pure-recall AND full-context
+    paths. Strengthen by spying on `_multi_strategy_recall` to confirm
+    pure-recall actually goes through the recall pipeline."""
+
+    def test_pure_recall_invokes_multi_strategy_recall(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        import tools.evaluate_beam_end_to_end as harness
+
+        spy = MagicMock(return_value=[])
+        monkeypatch.setattr(harness, "_multi_strategy_recall", spy)
+        harness.answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="some reasoning question",
+            conversation_messages=_build_msgs(20),
+            top_k=5,
+            ability="ABS",
+        )
+        spy.assert_called_once()
+
+    def test_pure_recall_tr_routes_through_recall_not_oracle(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """Even with a TR-shaped question that would have triggered
+        the timeline oracle, pure-recall mode reaches the recall
+        pipeline."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        import tools.evaluate_beam_end_to_end as harness
+
+        spy = MagicMock(return_value=[])
+        monkeypatch.setattr(harness, "_multi_strategy_recall", spy)
+        msgs = [
+            {"role": "user", "content": "started project 2024-01-15"},
+            {"role": "user", "content": "deployed 2024-03-22"},
+        ]
+        harness.answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="days between?",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="TR",
+        )
+        spy.assert_called_once()

--- a/tests/test_benchmark_pure_recall_gate.py
+++ b/tests/test_benchmark_pure_recall_gate.py
@@ -1,0 +1,283 @@
+"""Regression tests for E7/E8/E9 — `MNEMOSYNE_BENCHMARK_PURE_RECALL` gate.
+
+`tools/evaluate_beam_end_to_end.py` historically shipped four bypass
+paths that let the harness answer benchmark questions WITHOUT going
+through Mnemosyne recall:
+
+- **E7 TR oracle:** TR (Temporal Reasoning) questions extracted a
+  timeline from raw `conversation_messages` and returned the LLM
+  answer directly (line 1080) before any `BeamMemory.recall()`.
+- **E7 CR augmentation:** CR (Contradiction Resolution) questions
+  injected contradiction context built from raw messages into the
+  answer prompt (line 1089).
+- **E8 IE/KU side-index:** `_context_facts` (built from raw messages
+  at ingest, line 418) was queried by IE/KU questions; matching
+  values were returned directly at line 1291.
+- **E9 RECENT CONVERSATION:** the last 12 raw messages were prepended
+  to every answer prompt (line 1282) regardless of arm or recall
+  quality.
+
+For the BEAM-recovery experiment (Arms A/B/C compare recall pathways),
+these bypasses mean the harness measures a harness-side oracle on
+TR/CR/IE/KU and the recent-context shortcut on every question type —
+NOT what the arms actually retrieve. `MNEMOSYNE_BENCHMARK_PURE_RECALL=1`
+(or `--pure-recall`) disables all four.
+
+Default behavior preserved when env unset.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+@pytest.fixture
+def fake_llm():
+    """LLMClient stand-in that captures the messages it was called with."""
+    llm = MagicMock()
+    llm.chat = MagicMock(return_value="LLM-FALLBACK-ANSWER")
+    return llm
+
+
+def _build_msgs(n: int = 20) -> List[dict]:
+    """Synthetic conversation messages — `n` user turns."""
+    msgs = []
+    for i in range(n):
+        msgs.append({"role": "user", "content": f"message-{i} payload alpha"})
+    return msgs
+
+
+@pytest.fixture
+def beam_with_context_facts(temp_db):
+    """A BeamMemory with a non-empty `_context_facts` map so we can
+    exercise the IE/KU side-index path."""
+    beam = BeamMemory(session_id="s1", db_path=temp_db)
+    beam._context_facts = {"favorite color blue": ["blue"]}
+    return beam
+
+
+# ─────────────────────────────────────────────────────────────────
+# Default mode (env unset) — existing bypasses still fire
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestDefaultModeBehaviorUnchanged:
+    """When `MNEMOSYNE_BENCHMARK_PURE_RECALL` is unset, the existing
+    bypass paths still fire (zero behavioral regression for callers
+    who haven't migrated)."""
+
+    def test_default_ie_returns_context_fact_value(self, beam_with_context_facts, fake_llm, monkeypatch):
+        """IE question with a matching `_context_facts` entry returns
+        the value directly — bypass is active."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        ans = answer_with_memory(
+            llm=fake_llm,
+            beam=beam_with_context_facts,
+            question="what is favorite color blue",
+            conversation_messages=_build_msgs(20),
+            top_k=5,
+            ability="IE",
+        )
+        assert ans == "blue"
+        # LLM was NOT called — bypass returned the value directly.
+        fake_llm.chat.assert_not_called()
+
+    def test_default_recent_context_included(self, temp_db, fake_llm, monkeypatch):
+        """When LLM is invoked (e.g., for ABS questions), the prompt
+        includes the RECENT CONVERSATION section by default."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        msgs = _build_msgs(20)
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="some abstract reasoning question",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="ABS",
+        )
+        # LLM called; its prompt includes "RECENT CONVERSATION".
+        fake_llm.chat.assert_called()
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        assert "RECENT CONVERSATION" in user_msg
+
+
+# ─────────────────────────────────────────────────────────────────
+# Pure-recall mode — all bypasses disabled
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPureRecallModeDisablesBypasses:
+    """When `MNEMOSYNE_BENCHMARK_PURE_RECALL=1`, every bypass is
+    disabled and every answer must go through the full LLM path with
+    only retrieved memories in context."""
+
+    def test_pure_recall_ie_does_not_return_context_fact_value(
+        self, beam_with_context_facts, fake_llm, monkeypatch
+    ):
+        """IE question with matching `_context_facts` should NOT short-
+        circuit in pure-recall mode — the LLM gets called instead."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        ans = answer_with_memory(
+            llm=fake_llm,
+            beam=beam_with_context_facts,
+            question="what is favorite color blue",
+            conversation_messages=_build_msgs(20),
+            top_k=5,
+            ability="IE",
+        )
+        # LLM was called — bypass disabled.
+        fake_llm.chat.assert_called_once()
+        # Whatever the LLM returned is the answer (our fake returns LLM-FALLBACK-ANSWER).
+        assert ans == "LLM-FALLBACK-ANSWER"
+
+    def test_pure_recall_tr_does_not_short_circuit_via_oracle(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """TR question should NOT take the timeline-oracle path that
+        returns an LLM answer directly from extracted dates. Instead
+        it falls through to the standard recall + LLM path."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        # TR-shaped question with multiple date references that would
+        # otherwise trigger the oracle.
+        msgs = [
+            {"role": "user", "content": "I started the project on 2024-01-15"},
+            {"role": "user", "content": "Then I deployed on 2024-03-22"},
+            {"role": "user", "content": "Final release was 2024-06-30"},
+        ]
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="how many days between project start and deployment?",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="TR",
+        )
+        # The TR-bypass returns the LLM answer with a date-calculator
+        # system prompt; the pure-recall path uses ANSWER_SYSTEM_PROMPT.
+        # Inspect the system prompt sent to the LLM to distinguish.
+        sent_messages = fake_llm.chat.call_args[0][0]
+        system_msg = next(m for m in sent_messages if m["role"] == "system")
+        assert "date calculator" not in system_msg["content"].lower(), (
+            f"TR-bypass fired despite pure-recall mode; got system prompt: "
+            f"{system_msg['content'][:200]}"
+        )
+
+    def test_pure_recall_cr_does_not_inject_contradiction_context(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """CR question should NOT inject `_detect_contradictions`
+        output into the prompt — pure recall means recall alone."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        # Contradictory statements that would trigger _detect_contradictions.
+        msgs = [
+            {"role": "user", "content": "I love coffee, it's my favorite drink"},
+            {"role": "user", "content": "Actually, I prefer tea over coffee"},
+        ]
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="what is my preferred drink?",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="CR",
+        )
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        # The CR-inject prefix is "I notice you've mentioned contradictory…"
+        # — assert it's NOT in the prompt.
+        assert "contradictory information" not in user_msg, (
+            f"CR-bypass injected contradiction context despite pure-recall mode; "
+            f"prompt: {user_msg[:300]}"
+        )
+
+    def test_pure_recall_excludes_recent_conversation_section(
+        self, temp_db, fake_llm, monkeypatch
+    ):
+        """The 'RECENT CONVERSATION' block (last 12 raw messages) is
+        always included pre-fix. Pure-recall mode strips it so the LLM
+        sees only what each arm's recall returned."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        msgs = _build_msgs(20)
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam,
+            question="some abstract reasoning question",
+            conversation_messages=msgs,
+            top_k=5,
+            ability="ABS",
+        )
+        user_msg = fake_llm.chat.call_args[0][0][-1]["content"]
+        assert "RECENT CONVERSATION" not in user_msg, (
+            f"RECENT CONVERSATION section leaked into pure-recall prompt: "
+            f"{user_msg[:300]}"
+        )
+
+
+class TestPureRecallEnvValueParsing:
+    """The env var is treated as truthy on '1', 'true', 'yes' (lowercase
+    or any case), falsy/unset otherwise. Locks the parsing surface."""
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "True", "yes", "YES"])
+    def test_truthy_values_enable_gate(self, value, beam_with_context_facts, fake_llm, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", value)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        answer_with_memory(
+            llm=fake_llm,
+            beam=beam_with_context_facts,
+            question="what is favorite color blue",
+            conversation_messages=_build_msgs(5),
+            top_k=5,
+            ability="IE",
+        )
+        # IE bypass should NOT fire; LLM should be called.
+        fake_llm.chat.assert_called()
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "", "anything-else"])
+    def test_falsy_values_preserve_default(self, value, beam_with_context_facts, fake_llm, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", value)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        ans = answer_with_memory(
+            llm=fake_llm,
+            beam=beam_with_context_facts,
+            question="what is favorite color blue",
+            conversation_messages=_build_msgs(5),
+            top_k=5,
+            ability="IE",
+        )
+        # IE bypass SHOULD fire — LLM not called, value returned directly.
+        assert ans == "blue"
+        fake_llm.chat.assert_not_called()

--- a/tests/test_telemetry_and_env_followups.py
+++ b/tests/test_telemetry_and_env_followups.py
@@ -1,0 +1,287 @@
+"""Regression tests for C30 + C31 + C32 — pre-experiment cleanup follow-ups.
+
+Three small fidelity fixes surfaced by the /review army on PRs #89 and
+#90 that weren't bundled into those PRs because they're independent:
+
+- **C30** (telemetry): `beam.py:2671` set `dense_score` for episodic
+  fallback rows via `wm_vec_sims.get(row["id"], 0.0)` — but `wm_vec_sims`
+  is the working-memory dict, ep ids aren't in it, so the value was
+  always 0.0. Misleading provenance for post-run analysis. Fixed by
+  setting `dense_score: 0.0` explicitly with a comment.
+- **C31** (env parser): `MNEMOSYNE_BENCHMARK_PURE_RECALL=on` and
+  `FULL_CONTEXT_MODE=on` were treated as falsy because the parser only
+  accepted `1|true|yes`. Whitespace-padded values (`" 1 "`) were also
+  treated as falsy. Fixed by routing through a new `_env_truthy()`
+  helper that accepts `1|true|yes|on` and strips whitespace.
+- **C32** (drift WARN): `MNEMOSYNE_*_WEIGHT` env vars override recall
+  scoring but NOT consolidation Bayesian compounding. Fixed by emitting
+  a single startup WARNING listing the overrides.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+# ─────────────────────────────────────────────────────────────────
+# C30 — episodic fallback `dense_score` explicit 0.0
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestC30EpisodicFallbackDenseScore:
+    """Pre-fix: `beam.py:2671` set `dense_score` via `wm_vec_sims.get(row["id"], 0.0)`.
+    Since `row["id"]` is always an episodic id and `wm_vec_sims` keys
+    are working-memory ids, the lookup always returned 0.0 (the
+    default). Same numeric value as the fix, but the wrong-dict
+    lookup is misleading provenance: someone reading the code would
+    think `dense_score` reflects a WM-vector similarity for ep rows.
+
+    Fix: set `dense_score: 0.0` explicitly with a comment explaining
+    that EM fallback rows reach this code path precisely because
+    vec/FTS produced no episodic candidates, so no `sim` is computed."""
+
+    def test_fallback_rows_have_explicit_zero_dense_score(self, temp_db, monkeypatch):
+        """Seed an episodic row whose content has no vector embedding
+        (so fallback is the only path that returns it), recall a query
+        matching its content, assert the surviving row has dense_score=0.0."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Insert via SQL to skip embedding generation, forcing fallback path.
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("ep-no-emb", "unique-zorblax-token for fallback test",
+             "consolidation", datetime.now().isoformat(), "s1", 0.5),
+        )
+        beam.conn.commit()
+
+        results = beam.recall("zorblax", top_k=10)
+        ep_rows = [r for r in results if r["id"] == "ep-no-emb"]
+        assert ep_rows, (
+            f"Expected fallback to surface seeded row; got: "
+            f"{[(r['id'], r.get('tier'), r.get('content', '')[:50]) for r in results]}"
+        )
+        ep = ep_rows[0]
+        # Field is present, explicit float 0.0.
+        assert ep["dense_score"] == 0.0
+        # Type is float (not None, not int) — keep downstream consumers stable.
+        assert isinstance(ep["dense_score"], float)
+
+
+# ─────────────────────────────────────────────────────────────────
+# C31 — env-var truthy parser accepts `on` + trims whitespace
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestC31EnvTruthyParser:
+    """Pre-fix the parser was `lower() in ("1", "true", "yes")` — `on`
+    and whitespace-padded values were treated as falsy. Fix: route
+    through `_env_truthy()` which accepts `1|true|yes|on` (case-
+    insensitive, whitespace-stripped)."""
+
+    @pytest.fixture(autouse=True)
+    def _ensure_clean_env(self, monkeypatch):
+        # Clear both env vars before each test.
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        monkeypatch.delenv("FULL_CONTEXT_MODE", raising=False)
+
+    @pytest.mark.parametrize("value", [
+        "1", "true", "yes", "on",
+        "TRUE", "True", "YES", "ON", "On",
+        " 1 ", "  true  ", "\ton\t",  # whitespace
+    ])
+    def test_env_truthy_accepts_value(self, value, monkeypatch):
+        from tools.evaluate_beam_end_to_end import _env_truthy
+
+        monkeypatch.setenv("TEST_ENV_VAR", value)
+        assert _env_truthy("TEST_ENV_VAR") is True
+
+    @pytest.mark.parametrize("value", [
+        "0", "false", "no", "off",
+        "FALSE", "OFF",
+        "", " ", "  ",
+        "garbage", "maybe", "2", "y",  # non-canonical
+    ])
+    def test_env_truthy_rejects_value(self, value, monkeypatch):
+        from tools.evaluate_beam_end_to_end import _env_truthy
+
+        monkeypatch.setenv("TEST_ENV_VAR", value)
+        assert _env_truthy("TEST_ENV_VAR") is False
+
+    def test_env_truthy_unset_variable_is_false(self, monkeypatch):
+        from tools.evaluate_beam_end_to_end import _env_truthy
+        monkeypatch.delenv("TEST_ENV_VAR", raising=False)
+        assert _env_truthy("TEST_ENV_VAR") is False
+
+    def test_pure_recall_accepts_on(self, temp_db, monkeypatch):
+        """End-to-end: `MNEMOSYNE_BENCHMARK_PURE_RECALL=on` now enables
+        the gate. Pre-fix this was silently treated as off."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "on")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        beam._context_facts = {"favorite color blue": ["blue"]}
+        fake_llm = MagicMock()
+        fake_llm.chat = MagicMock(return_value="LLM-FALLBACK")
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        msgs = [{"role": "user", "content": f"row {i}"} for i in range(5)]
+        answer_with_memory(
+            llm=fake_llm, beam=beam,
+            question="what is favorite color blue",
+            conversation_messages=msgs, top_k=5, ability="IE",
+        )
+        # Pure-recall mode active → IE bypass disabled → LLM called.
+        fake_llm.chat.assert_called_once()
+
+    def test_pure_recall_accepts_whitespace_padded(self, temp_db, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", " 1 ")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        beam._context_facts = {"favorite color blue": ["blue"]}
+        fake_llm = MagicMock()
+        fake_llm.chat = MagicMock(return_value="LLM-FALLBACK")
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        answer_with_memory(
+            llm=fake_llm, beam=beam,
+            question="what is favorite color blue",
+            conversation_messages=[{"role": "user", "content": "x"}],
+            top_k=5, ability="IE",
+        )
+        fake_llm.chat.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────
+# C32 — MNEMOSYNE_*_WEIGHT env override startup WARN
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestC32VeracityWeightOverrideWarn:
+    """Pre-fix: operators setting `MNEMOSYNE_STATED_WEIGHT=0.9` (etc.)
+    silently broke the 'consolidated-as-N also ranks at N' invariant
+    because the consolidator's Bayesian compounding doesn't honor env
+    overrides. Fix: emit a single WARNING listing the override(s).
+    """
+
+    def test_no_overrides_returns_empty_list(self, monkeypatch):
+        """Sanity: when no env vars set, the helper returns empty."""
+        from mnemosyne.core.beam import _detect_veracity_weight_overrides
+
+        for name in (
+            "MNEMOSYNE_STATED_WEIGHT", "MNEMOSYNE_INFERRED_WEIGHT",
+            "MNEMOSYNE_TOOL_WEIGHT", "MNEMOSYNE_IMPORTED_WEIGHT",
+            "MNEMOSYNE_UNKNOWN_WEIGHT",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        assert _detect_veracity_weight_overrides() == []
+
+    def test_single_override_returned(self, monkeypatch):
+        from mnemosyne.core.beam import _detect_veracity_weight_overrides
+
+        for name in (
+            "MNEMOSYNE_INFERRED_WEIGHT",
+            "MNEMOSYNE_TOOL_WEIGHT", "MNEMOSYNE_IMPORTED_WEIGHT",
+            "MNEMOSYNE_UNKNOWN_WEIGHT",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("MNEMOSYNE_STATED_WEIGHT", "0.95")
+        assert _detect_veracity_weight_overrides() == ["MNEMOSYNE_STATED_WEIGHT"]
+
+    def test_multiple_overrides_returned_in_canonical_order(self, monkeypatch):
+        """Order matches the function's hard-coded canonical list so
+        the warning log is deterministic across runs."""
+        from mnemosyne.core.beam import _detect_veracity_weight_overrides
+
+        monkeypatch.setenv("MNEMOSYNE_STATED_WEIGHT", "1.0")
+        monkeypatch.setenv("MNEMOSYNE_UNKNOWN_WEIGHT", "0.5")
+        monkeypatch.setenv("MNEMOSYNE_TOOL_WEIGHT", "0.4")
+        # Set some but not all; the others stay absent.
+        monkeypatch.delenv("MNEMOSYNE_INFERRED_WEIGHT", raising=False)
+        monkeypatch.delenv("MNEMOSYNE_IMPORTED_WEIGHT", raising=False)
+
+        result = _detect_veracity_weight_overrides()
+        # Canonical order from the function definition.
+        assert result == [
+            "MNEMOSYNE_STATED_WEIGHT",
+            "MNEMOSYNE_TOOL_WEIGHT",
+            "MNEMOSYNE_UNKNOWN_WEIGHT",
+        ]
+
+    def test_empty_string_value_still_counted_as_override(self, monkeypatch):
+        """Operators sometimes export `VAR=` (empty) intending to
+        unset; the helper treats presence as override. This is a
+        defensible call — if the var is exported, the operator likely
+        wanted it to affect something. Test pins the behavior so a
+        future change to filter empty values is explicit."""
+        from mnemosyne.core.beam import _detect_veracity_weight_overrides
+
+        monkeypatch.setenv("MNEMOSYNE_STATED_WEIGHT", "")
+        for name in (
+            "MNEMOSYNE_INFERRED_WEIGHT", "MNEMOSYNE_TOOL_WEIGHT",
+            "MNEMOSYNE_IMPORTED_WEIGHT", "MNEMOSYNE_UNKNOWN_WEIGHT",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        assert _detect_veracity_weight_overrides() == ["MNEMOSYNE_STATED_WEIGHT"]
+
+    def test_warn_fires_when_overrides_present(self, monkeypatch, caplog):
+        """Call `_warn_about_veracity_weight_overrides()` directly with
+        env overrides set; assert WARN logged + returns True.
+
+        This avoids `importlib.reload(beam_module)` — reloading the
+        module poisons the test session because other tests imported
+        constants like `STATED_WEIGHT` at session start. The helper-
+        function approach exercises identical code without touching
+        module-level state."""
+        from mnemosyne.core.beam import _warn_about_veracity_weight_overrides
+
+        monkeypatch.setenv("MNEMOSYNE_STATED_WEIGHT", "0.5")
+        with caplog.at_level(logging.WARNING, logger="mnemosyne.core.beam"):
+            emitted = _warn_about_veracity_weight_overrides()
+
+        assert emitted is True
+        warnings = [r for r in caplog.records
+                    if r.levelno == logging.WARNING
+                    and "Veracity weight env overrides detected" in r.message]
+        assert warnings, (
+            f"Expected veracity-weight WARN; got records: "
+            f"{[r.message[:100] for r in caplog.records]}"
+        )
+        # The WARN should mention the specific env var.
+        assert any("MNEMOSYNE_STATED_WEIGHT" in r.message for r in warnings)
+
+    def test_warn_silent_when_no_overrides(self, monkeypatch, caplog):
+        """Negative control: clean env → no WARN, returns False."""
+        from mnemosyne.core.beam import _warn_about_veracity_weight_overrides
+
+        for name in (
+            "MNEMOSYNE_STATED_WEIGHT", "MNEMOSYNE_INFERRED_WEIGHT",
+            "MNEMOSYNE_TOOL_WEIGHT", "MNEMOSYNE_IMPORTED_WEIGHT",
+            "MNEMOSYNE_UNKNOWN_WEIGHT",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+        with caplog.at_level(logging.WARNING, logger="mnemosyne.core.beam"):
+            emitted = _warn_about_veracity_weight_overrides()
+
+        assert emitted is False
+        warnings = [r for r in caplog.records
+                    if r.levelno == logging.WARNING
+                    and "Veracity weight env overrides detected" in r.message]
+        assert warnings == []

--- a/tests/test_telemetry_and_env_followups.py
+++ b/tests/test_telemetry_and_env_followups.py
@@ -81,10 +81,73 @@ class TestC30EpisodicFallbackDenseScore:
             f"{[(r['id'], r.get('tier'), r.get('content', '')[:50]) for r in results]}"
         )
         ep = ep_rows[0]
+        # Pin tier provenance — Claude MEDIUM noted the original test
+        # could pass via entity/fact branches too. Lock to fallback.
+        assert ep.get("tier") == "episodic"
         # Field is present, explicit float 0.0.
         assert ep["dense_score"] == 0.0
         # Type is float (not None, not int) — keep downstream consumers stable.
         assert isinstance(ep["dense_score"], float)
+
+    def test_main_path_episodic_dense_score_not_clobbered(self, temp_db, monkeypatch):
+        """Negative control: main-path episodic rows (vec+FTS-driven)
+        DO compute a real `sim` and set `dense_score` to it. Pin this
+        so a future refactor that collapses everything to 0.0 breaks
+        the test, not just experiment provenance."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Use the BEAM-real path: insert via consolidate_to_episodic so
+        # it gets a real vector embedding (if fastembed is available).
+        mid = beam.consolidate_to_episodic(
+            summary="The user wants dark mode for the editor",
+            source_wm_ids=["wm-1"],
+        )
+        # Recall a similar query — the main path's `sim` is non-zero
+        # if embedding worked, OR rev would still surface via FTS.
+        results = beam.recall("dark mode", top_k=10)
+        ep_rows = [r for r in results if r["id"] == mid]
+        if not ep_rows:
+            pytest.skip("main-path recall returned no candidates in this env")
+        # The main path SHOULD set dense_score to a meaningful sim value.
+        # The fix only touched fallback + entity/fact branches.
+        # We can't assert > 0 reliably (fastembed may not be installed),
+        # but we CAN assert the field is present + a float.
+        assert "dense_score" in ep_rows[0]
+        assert isinstance(ep_rows[0]["dense_score"], float)
+
+
+class TestC30ExtendedToEntityFactPaths:
+    """C30 fix had to extend beyond the EM fallback path. Codex P2 +
+    Claude HIGH noted that entity-aware (beam.py:~2306) and fact-aware
+    (beam.py:~2426) episodic recall branches had the SAME wrong-dict
+    pattern. Pin behavior for those two paths."""
+
+    def test_entity_branch_returns_explicit_dense_score(self, temp_db, monkeypatch):
+        """The entity-aware ep branch now sets `dense_score: 0.0`
+        explicitly rather than the misleading WM-dict lookup. We
+        can't easily force this branch in a unit test (needs entity
+        extraction wired), so verify by inspecting the source: line
+        2306 region should have `"dense_score": 0.0,` not the
+        `wm_vec_sims.get(...)` pattern. Belt-and-suspenders alongside
+        the integration test."""
+        from pathlib import Path
+        import mnemosyne.core.beam as beam_module
+        src = Path(beam_module.__file__).read_text()
+        # Count remaining wrong-pattern sites that target ep rows.
+        # The two valid `wm_vec_sims.get` lines (`tier: "working"` at
+        # ~2238 and ~2359) should remain; the two ep-tier sites we
+        # fixed should be gone.
+        wrong_pattern_count = src.count(
+            'dense_score": round(wm_vec_sims.get(row["id"], 0.0), 4)'
+        )
+        # Only the two `tier: "working"` sites should match the old pattern.
+        # If a future change adds a new `tier: "episodic"` site with the
+        # wrong pattern, this count rises and the test fails.
+        assert wrong_pattern_count == 2, (
+            f"Expected exactly 2 `wm_vec_sims.get(row[id], 0.0)` sites "
+            f"(both `tier: working`); found {wrong_pattern_count}. A new "
+            f"episodic site may have reintroduced the C30 bug pattern."
+        )
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -224,36 +287,61 @@ class TestC32VeracityWeightOverrideWarn:
             "MNEMOSYNE_UNKNOWN_WEIGHT",
         ]
 
-    def test_empty_string_value_still_counted_as_override(self, monkeypatch):
-        """Operators sometimes export `VAR=` (empty) intending to
-        unset; the helper treats presence as override. This is a
-        defensible call — if the var is exported, the operator likely
-        wanted it to affect something. Test pins the behavior so a
-        future change to filter empty values is explicit."""
+    def test_empty_string_value_not_counted_as_override(self, monkeypatch):
+        """Codex P1 fix: `export MNEMOSYNE_STATED_WEIGHT=` (empty)
+        falls back to default in `_env_float`, so it doesn't actually
+        override anything. The detection helper should match — empty
+        values are NOT overrides. Pre-fix the test pinned the OPPOSITE
+        behavior; that was operationally moot because `float("")` would
+        have crashed module load before the WARN could fire."""
         from mnemosyne.core.beam import _detect_veracity_weight_overrides
 
         monkeypatch.setenv("MNEMOSYNE_STATED_WEIGHT", "")
+        monkeypatch.setenv("MNEMOSYNE_TOOL_WEIGHT", "   ")  # whitespace-only
         for name in (
-            "MNEMOSYNE_INFERRED_WEIGHT", "MNEMOSYNE_TOOL_WEIGHT",
+            "MNEMOSYNE_INFERRED_WEIGHT",
             "MNEMOSYNE_IMPORTED_WEIGHT", "MNEMOSYNE_UNKNOWN_WEIGHT",
         ):
             monkeypatch.delenv(name, raising=False)
-        assert _detect_veracity_weight_overrides() == ["MNEMOSYNE_STATED_WEIGHT"]
+        # Empty + whitespace-only → neither counts.
+        assert _detect_veracity_weight_overrides() == []
+
+    def test_env_float_falls_back_on_empty_value(self, monkeypatch):
+        """Pre-fix: `float(os.environ.get('MNEMOSYNE_STATED_WEIGHT', '1.0'))`
+        crashed with ValueError when env was set to empty (`os.environ.get`
+        returns `""` for set-but-empty, not the default). Fixed via
+        `_env_float` which strips + falls back."""
+        from mnemosyne.core.beam import _env_float
+
+        monkeypatch.setenv("MY_TEST_VAR", "")
+        assert _env_float("MY_TEST_VAR", 0.7) == 0.7
+        monkeypatch.setenv("MY_TEST_VAR", "   ")
+        assert _env_float("MY_TEST_VAR", 0.5) == 0.5
+        monkeypatch.delenv("MY_TEST_VAR", raising=False)
+        assert _env_float("MY_TEST_VAR", 0.3) == 0.3
+
+    def test_env_float_falls_back_on_invalid_value_with_warn(self, monkeypatch, caplog):
+        """Garbage value → fall back + WARN."""
+        from mnemosyne.core.beam import _env_float
+
+        monkeypatch.setenv("MY_TEST_VAR", "not-a-number")
+        with caplog.at_level(logging.WARNING, logger="mnemosyne.core.beam"):
+            value = _env_float("MY_TEST_VAR", 0.42)
+        assert value == 0.42
+        assert any("not a valid float" in r.message for r in caplog.records
+                   if r.levelno == logging.WARNING)
 
     def test_warn_fires_when_overrides_present(self, monkeypatch, caplog):
-        """Call `_warn_about_veracity_weight_overrides()` directly with
-        env overrides set; assert WARN logged + returns True.
+        """Call `_warn_about_veracity_weight_overrides(force=True)`
+        directly with env overrides set; assert WARN logged + returns True.
 
-        This avoids `importlib.reload(beam_module)` — reloading the
-        module poisons the test session because other tests imported
-        constants like `STATED_WEIGHT` at session start. The helper-
-        function approach exercises identical code without touching
-        module-level state."""
+        `force=True` because module load already called the helper once
+        and the idempotency guard would otherwise suppress this call."""
         from mnemosyne.core.beam import _warn_about_veracity_weight_overrides
 
         monkeypatch.setenv("MNEMOSYNE_STATED_WEIGHT", "0.5")
         with caplog.at_level(logging.WARNING, logger="mnemosyne.core.beam"):
-            emitted = _warn_about_veracity_weight_overrides()
+            emitted = _warn_about_veracity_weight_overrides(force=True)
 
         assert emitted is True
         warnings = [r for r in caplog.records
@@ -278,10 +366,39 @@ class TestC32VeracityWeightOverrideWarn:
             monkeypatch.delenv(name, raising=False)
 
         with caplog.at_level(logging.WARNING, logger="mnemosyne.core.beam"):
-            emitted = _warn_about_veracity_weight_overrides()
+            emitted = _warn_about_veracity_weight_overrides(force=True)
 
         assert emitted is False
         warnings = [r for r in caplog.records
                     if r.levelno == logging.WARNING
                     and "Veracity weight env overrides detected" in r.message]
         assert warnings == []
+
+    def test_warn_is_idempotent_per_process(self, monkeypatch, caplog):
+        """Claude MEDIUM fix: the WARN guards against multi-emission
+        within a single process. Module load already called it once;
+        a second non-force call returns False without re-emitting.
+        Pins the contract so multi-worker setups (uvicorn workers,
+        pytest-xdist) don't spam N identical WARNs per startup."""
+        from mnemosyne.core.beam import _warn_about_veracity_weight_overrides
+        import mnemosyne.core.beam as beam_module
+
+        # Reset the guard so we can simulate "fresh process" — module
+        # load already flipped the flag at session start, so we have
+        # to clear it manually to test the gate.
+        monkeypatch.setattr(beam_module, "_VERACITY_WARN_EMITTED", False)
+        monkeypatch.setenv("MNEMOSYNE_STATED_WEIGHT", "0.5")
+
+        with caplog.at_level(logging.WARNING, logger="mnemosyne.core.beam"):
+            first = _warn_about_veracity_weight_overrides()
+            second = _warn_about_veracity_weight_overrides()
+            third = _warn_about_veracity_weight_overrides()
+
+        assert first is True
+        assert second is False
+        assert third is False
+        warnings = [r for r in caplog.records
+                    if r.levelno == logging.WARNING
+                    and "Veracity weight env overrides detected" in r.message]
+        # Exactly one WARN fired despite three calls.
+        assert len(warnings) == 1

--- a/tools/evaluate_beam_end_to_end.py
+++ b/tools/evaluate_beam_end_to_end.py
@@ -1055,17 +1055,34 @@ def _detect_contradictions(messages: list, question: str) -> str | None:
     return None
 
 
-def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str, 
+def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
                       conversation_messages: list = None, top_k: int = DEFAULT_TOP_K,
                       ability: str = None) -> str:
-    """Retrieve memories and have LLM answer, with context strategy based on conversation size."""
-    
+    """Retrieve memories and have LLM answer, with context strategy based on conversation size.
+
+    Set `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` to disable the per-ability
+    bypass paths (TR oracle, CR contradiction injection, IE/KU
+    context→value side-index) AND the always-included RECENT
+    CONVERSATION raw-message prompt section. Pure-recall mode forces
+    every answer through the full Mnemosyne retrieval pipeline so the
+    BEAM-recovery experiment can measure each arm's recall quality
+    without contamination from harness-side oracles. Default behavior
+    (env unset or '0') preserves the existing benchmark mode.
+    """
+    # E7/E8/E9 gate: when set, the harness disables every shortcut that
+    # would let the LLM produce an answer without going through
+    # BeamMemory.recall(). The bypasses were useful for measuring
+    # LLM-ceiling-with-help on isolated abilities; the BEAM-recovery
+    # experiment instead needs to compare Arm A vs Arm B vs Arm C on
+    # the recall surface itself.
+    _pure_recall = os.environ.get("MNEMOSYNE_BENCHMARK_PURE_RECALL", "").lower() in ("1", "true", "yes")
+
     total_msgs = len(conversation_messages) if conversation_messages else 0
-    
+
     # ---- PER-ABILITY BYPASSES (zero-LLM or augmented) ----
-    
+
     # TR (Temporal Reasoning): compute answer from extracted dates
-    if ability == 'TR' and conversation_messages:
+    if not _pure_recall and ability == 'TR' and conversation_messages:
         timeline = _extract_timeline_from_conversation(conversation_messages)
         print(f"    [TR-bypass] extracted {len(timeline)} dates from {len(conversation_messages)} msgs")
         if timeline and len(timeline) >= 2:
@@ -1085,7 +1102,7 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     
     # CR (Contradiction Resolution): detect contradictory statements
     _cr_context = None
-    if ability == 'CR' and conversation_messages:
+    if not _pure_recall and ability == 'CR' and conversation_messages:
         _cr_context = _detect_contradictions(conversation_messages, question)
         if _cr_context:
             print(f"    [CR-detect] FOUND contradictions, injecting context ({len(_cr_context)} chars)")
@@ -1106,8 +1123,10 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
         # ---- Phase 1: Try context→value matching for factual questions ----
         # Only use context→value for Information Extraction (IE) and Knowledge Understanding (KU).
         # MR (Multi-hop) requires reasoning across multiple messages; let full-context handle it.
+        # Gated by pure_recall — when ON, full-context mode still hits the LLM with raw
+        # conversation but skips the zero-LLM context→value shortcut.
         _FACT_ABILITIES = {'IE', 'KU'}
-        if ability in _FACT_ABILITIES and hasattr(beam, '_context_facts') and beam._context_facts:
+        if not _pure_recall and ability in _FACT_ABILITIES and hasattr(beam, '_context_facts') and beam._context_facts:
             _q_stop = {'when','does','do','did','what','how','where','which','who','why',
                        'is','are','was','were','can','will','would','should','could','may',
                        'the','a','an','in','on','at','to','for','of','with','my','me','i','you'}
@@ -1169,8 +1188,10 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     context_answer = None
     # Only use context→value for Information Extraction (IE) and Knowledge Understanding (KU).
     # MR (Multi-hop) requires reasoning across multiple messages; CR/TR/EO/SUM need LLM.
+    # Gated by pure_recall — when ON, IE/KU questions go through full recall+LLM
+    # rather than returning a side-indexed value directly.
     _FACT_ABILITIES = {'IE', 'KU'}
-    if ability in _FACT_ABILITIES and hasattr(beam, '_context_facts') and beam._context_facts:
+    if not _pure_recall and ability in _FACT_ABILITIES and hasattr(beam, '_context_facts') and beam._context_facts:
         # Build question word set (filtered like FTS5 search does)
         _q_stop = {'when','does','do','did','what','how','where','which','who','why',
                    'is','are','was','were','can','will','would','should','could','may',
@@ -1242,9 +1263,14 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     
     context = ""  # Built below from memories
 
-    # Build recent context from last N messages
+    # Build recent context from last N messages. Pure-recall mode SKIPS
+    # this entirely — the LLM sees only RETRIEVED MEMORIES, so the
+    # answer quality reflects what each arm's recall produced (rather
+    # than the harness silently leaking the last 12 raw messages into
+    # every prompt, which inflates recency-anchored answers and masks
+    # recall weakness across all arms).
     recent_parts = []
-    if conversation_messages:
+    if not _pure_recall and conversation_messages:
         recent = conversation_messages[-RECENT_CONTEXT_COUNT:]
         for msg in recent:
             role = msg.get("role", "unknown")
@@ -1595,6 +1621,12 @@ def main():
                         help="Separate LLM for judging (default: same as --model)")
     parser.add_argument("--full-context", action="store_true",
                         help="Send full conversation to LLM (ceiling test, bypasses retrieval)")
+    parser.add_argument("--pure-recall", action="store_true",
+                        help="Disable per-ability bypasses + RECENT CONVERSATION injection. "
+                             "Forces every answer through Mnemosyne recall — what the "
+                             "BEAM-recovery experiment needs to measure arm-vs-arm "
+                             "recall quality without harness-side oracle contamination. "
+                             "Equivalent to MNEMOSYNE_BENCHMARK_PURE_RECALL=1.")
     parser.add_argument("--resume", action="store_true",
                         help="Resume from previous results file")
     parser.add_argument("--dry-run", action="store_true",
@@ -1615,6 +1647,13 @@ def main():
     if args.full_context:
         os.environ["FULL_CONTEXT_MODE"] = "1"
         print("  Mode: FULL-CONTEXT (bypassing retrieval)")
+    if args.pure_recall:
+        os.environ["MNEMOSYNE_BENCHMARK_PURE_RECALL"] = "1"
+        print("  Mode: PURE-RECALL (per-ability bypasses + RECENT CONTEXT disabled — "
+              "every answer goes through Mnemosyne recall)")
+    elif os.environ.get("MNEMOSYNE_BENCHMARK_PURE_RECALL", "").lower() in ("1", "true", "yes"):
+        # Env var set externally — surface it so the run banner shows the mode.
+        print("  Mode: PURE-RECALL (via env var)")
     print(f"{'='*80}")
 
     # Load data

--- a/tools/evaluate_beam_end_to_end.py
+++ b/tools/evaluate_beam_end_to_end.py
@@ -75,6 +75,25 @@ DEFAULT_MODEL = "deepseek-v4-pro"
 FALLBACK_MODELS = []  # Disabled — fallback cascade burned $30 in credits
 DEFAULT_TOP_K = 10  # Memories to retrieve per question
 MAX_MEMORY_CONTEXT_CHARS = 8000  # Max chars of retrieved context to send to LLM
+
+
+# C31: env-var truthy parser. Accepts standard truthy values
+# (1/true/yes/on, case-insensitive) and explicit falsies (0/false/no/off).
+# Strips whitespace so accidental leading/trailing spaces in shell
+# exports don't get treated as falsy. Anything else → False.
+# Pre-fix the parser was `lower() in ("1", "true", "yes")` which
+# rejected `on` and was whitespace-sensitive — surprised at least one
+# operator running with `MNEMOSYNE_BENCHMARK_PURE_RECALL=on`.
+_ENV_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _env_truthy(name: str) -> bool:
+    """Return True iff env var `name` is set to a canonical truthy value.
+
+    Truthy: 1, true, yes, on (case-insensitive, whitespace-stripped).
+    Everything else (including 0, false, no, off, empty, garbage) is False.
+    """
+    return os.environ.get(name, "").strip().lower() in _ENV_TRUTHY_VALUES
 BENCHMARK_QUERIES_PER_CONV = 50  # Max probing questions per conversation
 RESULTS_FILE = PROJECT_ROOT / "results" / "beam_e2e_results.json"
 
@@ -1075,7 +1094,7 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     # LLM-ceiling-with-help on isolated abilities; the BEAM-recovery
     # experiment instead needs to compare Arm A vs Arm B vs Arm C on
     # the recall surface itself.
-    _pure_recall = os.environ.get("MNEMOSYNE_BENCHMARK_PURE_RECALL", "").lower() in ("1", "true", "yes")
+    _pure_recall = _env_truthy("MNEMOSYNE_BENCHMARK_PURE_RECALL")
 
     total_msgs = len(conversation_messages) if conversation_messages else 0
 
@@ -1115,7 +1134,7 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     # Controlled by FULL_CONTEXT_MODE env var.
     # HYBRID: try context→value matching first for factual questions (IE/MR/KU),
     # then fall through to full-context for complex reasoning (ABS/CR/EO/SUM/TR).
-    _full_context = os.environ.get("FULL_CONTEXT_MODE", "").lower() in ("1", "true", "yes")
+    _full_context = _env_truthy("FULL_CONTEXT_MODE")
     # Precedence: pure-recall overrides full-context. The point of
     # pure-recall is to force every answer through Mnemosyne recall;
     # full-context's "ship the whole conversation to the LLM" path
@@ -1654,10 +1673,10 @@ def main():
     # Mode resolution + banner. Pure-recall overrides full-context
     # because the bypass that full-context provides (raw conversation
     # straight to LLM) is exactly what pure-recall is meant to forbid.
-    _pure_recall_env = os.environ.get("MNEMOSYNE_BENCHMARK_PURE_RECALL", "").lower() in ("1", "true", "yes")
+    _pure_recall_env = _env_truthy("MNEMOSYNE_BENCHMARK_PURE_RECALL")
     if args.pure_recall or _pure_recall_env:
         os.environ["MNEMOSYNE_BENCHMARK_PURE_RECALL"] = "1"
-        if args.full_context or os.environ.get("FULL_CONTEXT_MODE"):
+        if args.full_context or _env_truthy("FULL_CONTEXT_MODE"):
             # Conflict: warn loudly so the operator isn't surprised.
             print("  Mode: PURE-RECALL (overrides FULL_CONTEXT/--full-context — "
                   "every answer goes through Mnemosyne recall)")

--- a/tools/evaluate_beam_end_to_end.py
+++ b/tools/evaluate_beam_end_to_end.py
@@ -1116,9 +1116,16 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     # HYBRID: try context→value matching first for factual questions (IE/MR/KU),
     # then fall through to full-context for complex reasoning (ABS/CR/EO/SUM/TR).
     _full_context = os.environ.get("FULL_CONTEXT_MODE", "").lower() in ("1", "true", "yes")
+    # Precedence: pure-recall overrides full-context. The point of
+    # pure-recall is to force every answer through Mnemosyne recall;
+    # full-context's "ship the whole conversation to the LLM" path
+    # would silently invalidate that guarantee (the LLM would answer
+    # from raw `FULL CONVERSATION:` regardless of arm).
+    if _full_context and _pure_recall:
+        _full_context = False
     # DEBUG
     if os.environ.get("FULL_CONTEXT_MODE"):
-        print(f"    [DEBUG full-context] env={_full_context}, msgs={bool(conversation_messages)}, count={len(conversation_messages) if conversation_messages else 0}")
+        print(f"    [DEBUG full-context] env={_full_context}, msgs={bool(conversation_messages)}, count={len(conversation_messages) if conversation_messages else 0} (pure_recall={_pure_recall})")
     if _full_context and conversation_messages:
         # ---- Phase 1: Try context→value matching for factual questions ----
         # Only use context→value for Information Extraction (IE) and Knowledge Understanding (KU).
@@ -1644,16 +1651,22 @@ def main():
     print(f"  Sample: {sample_size or 'ALL'} conversations/scale")
     print(f"  Model: {args.model}")
     print(f"  Judge: {args.judge_model or args.model}")
-    if args.full_context:
+    # Mode resolution + banner. Pure-recall overrides full-context
+    # because the bypass that full-context provides (raw conversation
+    # straight to LLM) is exactly what pure-recall is meant to forbid.
+    _pure_recall_env = os.environ.get("MNEMOSYNE_BENCHMARK_PURE_RECALL", "").lower() in ("1", "true", "yes")
+    if args.pure_recall or _pure_recall_env:
+        os.environ["MNEMOSYNE_BENCHMARK_PURE_RECALL"] = "1"
+        if args.full_context or os.environ.get("FULL_CONTEXT_MODE"):
+            # Conflict: warn loudly so the operator isn't surprised.
+            print("  Mode: PURE-RECALL (overrides FULL_CONTEXT/--full-context — "
+                  "every answer goes through Mnemosyne recall)")
+        else:
+            print("  Mode: PURE-RECALL (per-ability bypasses + RECENT CONTEXT disabled — "
+                  "every answer goes through Mnemosyne recall)")
+    elif args.full_context:
         os.environ["FULL_CONTEXT_MODE"] = "1"
         print("  Mode: FULL-CONTEXT (bypassing retrieval)")
-    if args.pure_recall:
-        os.environ["MNEMOSYNE_BENCHMARK_PURE_RECALL"] = "1"
-        print("  Mode: PURE-RECALL (per-ability bypasses + RECENT CONTEXT disabled — "
-              "every answer goes through Mnemosyne recall)")
-    elif os.environ.get("MNEMOSYNE_BENCHMARK_PURE_RECALL", "").lower() in ("1", "true", "yes"):
-        # Env var set externally — surface it so the run banner shows the mode.
-        print("  Mode: PURE-RECALL (via env var)")
     print(f"{'='*80}")
 
     # Load data

--- a/tools/evaluate_beam_end_to_end.py
+++ b/tools/evaluate_beam_end_to_end.py
@@ -1142,8 +1142,8 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     # from raw `FULL CONVERSATION:` regardless of arm).
     if _full_context and _pure_recall:
         _full_context = False
-    # DEBUG
-    if os.environ.get("FULL_CONTEXT_MODE"):
+    # DEBUG (use _env_truthy so `FULL_CONTEXT_MODE=0` doesn't fire the print)
+    if _env_truthy("FULL_CONTEXT_MODE"):
         print(f"    [DEBUG full-context] env={_full_context}, msgs={bool(conversation_messages)}, count={len(conversation_messages) if conversation_messages else 0} (pure_recall={_pure_recall})")
     if _full_context and conversation_messages:
         # ---- Phase 1: Try context→value matching for factual questions ----


### PR DESCRIPTION
## TL;DR

Three follow-up fixes surfaced by /review on PRs #89 and #90, bundled here. **Stacks on PR #90** — merge that first.

- **C30 (telemetry):** episodic recall paths set `dense_score` from a working-memory dict, returning 0.0 always with misleading provenance. Three sites (fallback + entity-aware + fact-aware) now set `dense_score: 0.0` explicitly with a comment.
- **C31 (env parser):** `MNEMOSYNE_BENCHMARK_PURE_RECALL=on` and `FULL_CONTEXT_MODE=on` were treated as falsy; whitespace-padded values too. New `_env_truthy()` helper accepts `1|true|yes|on` case-insensitively + strips whitespace. Routed both env vars through it.
- **C32 (drift WARN):** `MNEMOSYNE_*_WEIGHT` env overrides break the consolidator-vs-recall invariant silently. Added a single startup WARNING listing overridden vars + noting the divergence. Defensive parser handles empty/invalid env values without crashing.

**40 regression tests, full suite 839 passed, 1 skipped, 0 failures.**

## Why these matter for the BEAM-recovery experiment

- **C30:** Post-run analysis of `dense_score` distributions on ep-tier rows would be misleading. Not ranking-affecting, but post-experiment debugging is contaminated. Especially relevant for Arms B/C analysis where polyphonic vs algorithmic provenance matters.
- **C31:** Operator surprise. Standard env-var practice is `VAR=on`/`VAR=off`. Pre-fix `MNEMOSYNE_BENCHMARK_PURE_RECALL=on` silently disabled the gate — operator thinks they're running pure-recall but the bypasses fire.
- **C32:** If anyone tunes weights for the experiment via env vars (likely for ablation runs), the consolidator's Bayesian compounding stays on the canonical 1.0/0.7/0.5/0.6/0.8 even though recall scoring shifted. Silent invariant break. WARN fires loudly so operators notice.

## /review army findings (all addressed)

| Finding | Severity / Sources | Fix |
|---|---|---|
| C30 narrower than the bug — entity + fact ep branches still wrong-dict | **HIGH** (Codex P2 + Claude HIGH 2-source) | Both branches now set `dense_score: 0.0` with comment; source-grep canary test pins exactly 2 remaining `wm_vec_sims.get` sites (both `tier: working`) |
| `float()` crash on empty env value before C32 WARN runs | **P1** (Codex) | New `_env_float(name, default)` strips + falls back; logs WARN on invalid values |
| Empty-string-as-override policy pinned the wrong direction | **MEDIUM** (Codex) | `_detect_veracity_weight_overrides` filters empty/whitespace values; test inverted |
| C32 WARN idempotency missing → multi-worker spam | **MEDIUM** (Claude) | Module-level `_VERACITY_WARN_EMITTED` flag; new test pins single-emission-per-process contract |
| C30 test didn't pin tier provenance | **MEDIUM** (Claude) | Added `tier == "episodic"` assertion + main-path negative control + source-grep canary |
| Bare-truthy debug check at `:1146` inconsistent with C31 | **LOW** (Claude) | Migrated to `_env_truthy` |

## Out of scope (documented)

- **`local_llm.py` un-migrated env-parse sites** (Claude LOW). Would need `_env_truthy(name, default=False)` signature; deferred since BEAM-recovery experiment doesn't go through that surface.
- **`SMART_COMPRESS` migration** (Codex P2). Intentionally inverse parser (default True, accepts 0/false/no to opt out). Don't migrate without a parallel `_env_falsy` helper.

## How this changes the experiment workflow

```bash
# These all now work identically (pre-fix only the first did):
python tools/evaluate_beam_end_to_end.py --scales 100K --pure-recall
MNEMOSYNE_BENCHMARK_PURE_RECALL=1 python tools/evaluate_beam_end_to_end.py --scales 100K
MNEMOSYNE_BENCHMARK_PURE_RECALL=on python tools/evaluate_beam_end_to_end.py --scales 100K
MNEMOSYNE_BENCHMARK_PURE_RECALL=yes python tools/evaluate_beam_end_to_end.py --scales 100K

# Veracity-weight ablation runs get a loud WARN at startup:
MNEMOSYNE_STATED_WEIGHT=0.9 python tools/evaluate_beam_end_to_end.py --pure-recall
# stderr: "Veracity weight env overrides detected: MNEMOSYNE_STATED_WEIGHT.
# Recall scoring will honor the override, but consolidation Bayesian
# compounding (veracity_consolidation.VERACITY_WEIGHTS) does NOT — the
# two will drift..."
```

## Test plan

- [x] All 40 tests in `tests/test_telemetry_and_env_followups.py` pass
- [x] Full suite: 839 passed, 1 skipped, 0 failures
- [x] Codex structured /review: 1 P1 + 2 P2 (all addressed)
- [x] Claude adversarial /review: 1 HIGH + 3 MEDIUM + 2 LOW (all relevant addressed; out-of-scope items documented)
- [ ] CI: full suite green on Python 3.9 / 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)