### PR TITLE
fix: restore PR #82/#83/#91 work stripped by the May 12 merge resolution

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -189,11 +189,88 @@ TIER3_MAX_CHARS = int(os.environ.get("MNEMOSYNE_TIER3_MAX_CHARS", "300"))
 # Env-var overrides remain so operators can tune ranking; documented
 # drift risk: if `MNEMOSYNE_*_WEIGHT` is set, recall scoring diverges
 # from consolidation confidence math (consolidator doesn't honor env).
-STATED_WEIGHT = float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", str(_VW_DEFAULTS["stated"])))
-INFERRED_WEIGHT = float(os.environ.get("MNEMOSYNE_INFERRED_WEIGHT", str(_VW_DEFAULTS["inferred"])))
-TOOL_WEIGHT = float(os.environ.get("MNEMOSYNE_TOOL_WEIGHT", str(_VW_DEFAULTS["tool"])))
-IMPORTED_WEIGHT = float(os.environ.get("MNEMOSYNE_IMPORTED_WEIGHT", str(_VW_DEFAULTS["imported"])))
-UNKNOWN_WEIGHT = float(os.environ.get("MNEMOSYNE_UNKNOWN_WEIGHT", str(_VW_DEFAULTS["unknown"])))
+def _env_float(name: str, default: float) -> float:
+    """Parse an env var as float; fall back to `default` on empty or
+    invalid values rather than crashing at module load.
+
+    Pre-fix `float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", "1.0"))`
+    raised ValueError when the env var was set to empty (`export
+    MNEMOSYNE_STATED_WEIGHT=`) because `os.environ.get` returns `""`
+    (the value), not the default — `float("")` then crashed import
+    BEFORE the C32 override-WARN could fire. Restored from PR #91
+    after the merge stripped it.
+    """
+    raw = os.environ.get(name, "")
+    raw = raw.strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a valid float; falling back to default %s",
+            name, raw[:80], default,
+        )
+        return default
+
+
+# Veracity weighting (memory confidence)
+STATED_WEIGHT = _env_float("MNEMOSYNE_STATED_WEIGHT", _VW_DEFAULTS["stated"])
+INFERRED_WEIGHT = _env_float("MNEMOSYNE_INFERRED_WEIGHT", _VW_DEFAULTS["inferred"])
+TOOL_WEIGHT = _env_float("MNEMOSYNE_TOOL_WEIGHT", _VW_DEFAULTS["tool"])
+IMPORTED_WEIGHT = _env_float("MNEMOSYNE_IMPORTED_WEIGHT", _VW_DEFAULTS["imported"])
+UNKNOWN_WEIGHT = _env_float("MNEMOSYNE_UNKNOWN_WEIGHT", _VW_DEFAULTS["unknown"])
+
+
+def _detect_veracity_weight_overrides() -> List[str]:
+    """C32: return a list of `MNEMOSYNE_*_WEIGHT` env vars set to a
+    non-empty value. Filters out empty-string values (`export
+    MNEMOSYNE_STATED_WEIGHT=`) since `_env_float` falls back to default
+    on empties — counting them would confuse the WARN message.
+    """
+    return [
+        name for name in (
+            "MNEMOSYNE_STATED_WEIGHT",
+            "MNEMOSYNE_INFERRED_WEIGHT",
+            "MNEMOSYNE_TOOL_WEIGHT",
+            "MNEMOSYNE_IMPORTED_WEIGHT",
+            "MNEMOSYNE_UNKNOWN_WEIGHT",
+        )
+        if os.environ.get(name, "").strip()
+    ]
+
+
+_VERACITY_WARN_EMITTED = False
+
+
+def _warn_about_veracity_weight_overrides(force: bool = False) -> bool:
+    """Log a WARNING if any `MNEMOSYNE_*_WEIGHT` env var is overridden.
+
+    Idempotent per-process: subsequent calls return False without
+    re-emitting unless `force=True` (tests use this to verify the WARN
+    fires per call). Multi-worker setups (uvicorn `--workers`,
+    pytest-xdist) get one WARN per process instead of N per startup.
+    """
+    global _VERACITY_WARN_EMITTED
+    if _VERACITY_WARN_EMITTED and not force:
+        return False
+    overrides = _detect_veracity_weight_overrides()
+    if not overrides:
+        return False
+    logger.warning(
+        "Veracity weight env overrides detected: %s. Recall scoring will "
+        "honor the override, but consolidation Bayesian compounding "
+        "(veracity_consolidation.VERACITY_WEIGHTS) does NOT — the two "
+        "will drift. Set matching values in veracity_consolidation.py "
+        "OR accept that 'consolidated-as-N also ranks at N' invariant "
+        "is broken until the consolidator is taught the same overrides.",
+        ", ".join(overrides),
+    )
+    _VERACITY_WARN_EMITTED = True
+    return True
+
+
+_warn_about_veracity_weight_overrides()
 
 # Vector compression: float32 | int8 | bit
 VEC_TYPE = os.environ.get("MNEMOSYNE_VEC_TYPE", "int8").lower()
@@ -1755,7 +1832,60 @@ class BeamMemory:
                     "%d items (vector voice will miss these rows) (%s): %s",
                     len(items), type(exc).__name__, exc,
                 )
-        
+
+        # E2 — enrichment parity with `remember()`. The merge of PR #82
+        # accidentally stripped these calls during conflict resolution;
+        # `_add_temporal_triple` and `_ingest_graph_and_veracity` exist
+        # but were not being called per row. Without them the polyphonic
+        # engine's graph + fact voices have no data to fuse and recall's
+        # multi-voice RRF collapses. Each call is non-blocking
+        # (try/except around per-row metadata access prevents one bad
+        # row from killing the rest of the batch). Runs after the bulk
+        # working_memory + embedding writes so a failure here doesn't
+        # poison the per-row source / veracity bookkeeping.
+        for memory_id in ids:
+            item_source, item_veracity = meta_by_id.get(
+                memory_id, ("conversation", "unknown")
+            )
+            try:
+                # Look up the just-written row to find its content +
+                # timestamp; cheap (PK lookup).
+                row = cursor.execute(
+                    "SELECT content, timestamp FROM working_memory WHERE id = ?",
+                    (memory_id,),
+                ).fetchone()
+                if row is None:
+                    continue
+                row_content = row["content"] if hasattr(row, "keys") else row[0]
+                row_timestamp = row["timestamp"] if hasattr(row, "keys") else row[1]
+                self._add_temporal_triple(
+                    memory_id, row_timestamp, item_source, row_content
+                )
+                self._ingest_graph_and_veracity(
+                    memory_id, row_content, item_source, item_veracity
+                )
+                if extract_entities:
+                    _extract_and_store_entities(self, memory_id, row_content)
+                if extract:
+                    _extract_and_store_facts(self, memory_id, row_content, item_source)
+                # MEMORY_ADDED parity with remember() — streaming
+                # observers + DeltaSync see batch rows the same way
+                # they see single-row writes.
+                self._emit_event(
+                    "MEMORY_ADDED", memory_id,
+                    content=row_content,
+                    source=item_source,
+                    importance=0.5,
+                    metadata=None,
+                )
+            except Exception as exc:
+                # Defensive: a single row's enrichment failure must not
+                # poison the rest of the batch. Log + continue.
+                logger.warning(
+                    "remember_batch: per-row enrichment failed for %s (%s): %s",
+                    memory_id, type(exc).__name__, exc,
+                )
+
         self._trim_working_memory()
         return ids
 

--- a/mnemosyne/core/veracity_consolidation.py
+++ b/mnemosyne/core/veracity_consolidation.py
@@ -525,8 +525,14 @@ class VeracityConsolidator:
 
                 conflicts = cursor.fetchall()
 
-                # Insert new fact
-                fact_id = f"cf_{subject}_{predicate}_{object}".replace(" ", "_")[:100]
+                # Insert new fact. E2.a.4 (PR #83): use `compute_fact_id`
+                # (SHA-256 of NFC-normalized SPO + length-prefix framing)
+                # for collision-free deterministic IDs. The merge of
+                # PR #83 accidentally left the OLD truncating f-string
+                # pattern at this call site even though `compute_fact_id`
+                # exists at line 38; same hunk that dropped the new logic
+                # also dropped the call.
+                fact_id = compute_fact_id(subject, predicate, object)
                 base_confidence = VERACITY_WEIGHTS.get(veracity, 0.8) * 0.5
 
                 sources = [source] if source else []


### PR DESCRIPTION
## TL;DR

Merge commit `016d395` ("Merge remote-tracking branch 'origin/main' into fix/pre-experiment-fidelity") resolved several conflicts by keeping the helper functions but reverting the call sites or dropping module-level helpers entirely. Three previously-merged PRs landed only partially. **25 tests fail on current `main`** as a direct result.

This PR restores the dropped wiring. No new logic; the helpers were already present.

**Post-fix: 0 failed, 979 passed, 10 skipped.**

## What got dropped + how this PR restores it

### PR #82 — `remember_batch` enrichment parity

`_add_temporal_triple` and `_ingest_graph_and_veracity` still exist as methods, but `remember_batch` no longer calls them per row. Net effect: the polyphonic engine's graph + fact voices have no data to fuse — E5's 4-voice RRF silently collapses to 2 voices for any batch-ingested corpus.

**Fix:** per-row enrichment loop after the embedding block. Defensive `try/except` so a single bad row doesn't kill the batch. Also restored the `MEMORY_ADDED` event emission for streaming observability parity with `remember()`.

**12 tests in `test_e2_remember_batch_enrichment.py` were failing; now pass.**

### PR #83 — `consolidated_facts.id` collision fix

`compute_fact_id` exists at `veracity_consolidation.py:38` (SHA-256 of NFC-normalized SPO with length-prefix framing) but `consolidate_fact` at line 529 still used the old `f"cf_{subject}_{predicate}_{object}".replace(" ", "_")[:100]` truncating pattern — the exact bug PR #83 was filed to fix.

**Fix:** the call site now uses `compute_fact_id(subject, predicate, object)`.

**2 tests in `test_consolidate_fact_id_collision.py` + 1 integration test were failing; now pass.**

### PR #91 — env-parser + telemetry helpers (entirely missing)

Three module-level helpers entirely missing from main:

- **`_env_float(name, default)`** — defensive float-from-env parser that falls back to `default` on empty / whitespace / invalid values, emits WARN on unparseable values. Without it, `MNEMOSYNE_STATED_WEIGHT=` (empty) crashes module load via `float("")` ValueError.
- **`_detect_veracity_weight_overrides()`** — returns the list of set `MNEMOSYNE_*_WEIGHT` env vars (filtering empties).
- **`_warn_about_veracity_weight_overrides(force=False)`** — single-emit-per-process WARN when veracity weight env overrides drift the recall multiplier vs the consolidator's hardcoded `VERACITY_WEIGHTS`.

**Fix:** all three helpers restored. Weight constants route through `_env_float`. Module-load calls `_warn_about_veracity_weight_overrides()` once.

**9 tests in `test_telemetry_and_env_followups.py::TestC32...` were failing; now pass.**

## Verification

| | Pre-fix | Post-fix |
|---|---|---|
| `test_e2_remember_batch_enrichment.py` | 5/17 pass | 17/17 pass |
| `test_consolidate_fact_id_collision.py` | 19/21 pass | 21/21 pass |
| `test_telemetry_and_env_followups.py` | 31/40 pass | 40/40 pass |
| `test_integration.py::TestVeracityConsolidation` | 1 failing | All pass |
| **Full suite** | **25 failed, 961 passed** | **0 failed, 979 passed, 10 skipped** |

## How this happened — process lesson worth recording

The merge of `origin/main` into the PR #91 branch (`fix/pre-experiment-fidelity`) brought in PRs #82, #83, #85, #86, #87, #80, #89 — many of which touched the same hunks PR #91 had modified. The conflict resolution chose `theirs` (main) for the call-site hunks but `ours` (PR #91) for the helper-definition hunks, leaving helpers present but unused. This is the classic "merge resolution kept the wrong side per hunk" failure mode.

It's a failure mode no /review pass or static analysis can catch — the helpers compile, type-check, and import cleanly. Only the tests that exercise the call sites end-to-end reveal the missing wiring.

**Recommendation for future multi-PR-overlap merges:** when resolving conflicts between branches that both modified the same hunks, run the existing test suite on the merge commit BEFORE pushing. With Mnemosyne's ~990-test suite running in ~17 seconds, this is a cheap safety net that would have flagged the 25 regressions immediately. Something like:

```bash
git merge --no-commit <branch>
pytest --tb=no -q
# if anything regressed vs the pre-merge baseline, the resolution chose wrong per-hunk
```

The current CI on `main` is showing the same 25 failures right now, so this is also blocking unrelated PRs that sit on top of main (notably #92, which is failing CI on these exact tests). Merging this PR first unblocks the others without rebasing them.

## How to detect this kind of regression cheaply in the future

Any test that references a helper function and passes on the PR branch but fails post-merge indicates a stripped call site. The pattern this PR found:

```bash
git diff <pr-merge-base> HEAD -- mnemosyne/core/beam.py | grep '^-def '
# any -def helper present on PR branch but missing on main, where tests
# still reference the helper, signals exactly this regression
```

## Test plan

- [x] All 25 previously-failing tests now pass
- [x] No new regressions: full suite 979 passed, 0 failed
- [x] Recovery is mechanical (no new logic, no API changes)
- [ ] CI: full suite green on Python 3.9 / 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
