### PR TITLE
feat: 9 A/B ablation toggles for the BEAM-recovery experiment (Gap B)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Local-first, zero-cloud memory for AI agents. SQLite-backed. Sub-millisecond. Fu
 | [Hermes Integration](hermes-integration.md) | Using Mnemosyne as a Hermes memory backend |
 | [LLM Installation Guide](llm-installation-guide.md) | Installation instructions for AI agents/LLMs |
 | [Configuration](configuration.md) | Environment variables, data directory, vector compression |
+| [Benchmarking](benchmarking.md) | Maintainer guide: per-tool A/B benchmark env vars, diagnostics, pure-recall mode, test sequence template |
 | [Changelog](changelog.md) | Version history and release notes |
 
 ## Quick Links

--- a/docs/beam-benchmark.md
+++ b/docs/beam-benchmark.md
@@ -3,6 +3,8 @@
 **Evaluated against ICLR 2026 BEAM dataset (Tavakoli et al.)**
 **Date:** 2026-05-06 | **Version:** Mnemosyne 2.5 | **Model:** Gemini 2.5 Flash via OpenRouter
 
+> **⚠ Results pre-date the May 2026 benchmark-infrastructure fixes.** Between this run and May 12, 2026, several silent-failure surfaces and harness-side oracles were corrected (see [benchmarking.md](benchmarking.md) for the full list). The numbers below were generated against a pipeline that had: cross-tier `(summary, source)` duplicate ranking under the linear scorer, veracity destroyed at consolidation, harness oracles answering TR/CR/IE/KU outside `BeamMemory.recall()`, and the last 12 raw conversation messages always prepended to every answer prompt. They are not credible evidence for any specific tool's contribution to total score. A re-run under the new infrastructure is tracked at [`experiments/2026-05-12-beam-recovery-arms-abc.md`](experiments/2026-05-12-beam-recovery-arms-abc.md).
+
 ---
 
 ## End-to-End Results (LLM-as-Judge, Rubric Scoring)

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -108,7 +108,7 @@ Applied in both linear (post-FTS+vec scoring) and polyphonic (post-RRF) paths. A
 
 **Drift caveat:** these env vars override the recall multiplier in `beam.py`, but the consolidator's Bayesian compounding in `veracity_consolidation.py` does NOT honor env overrides — it reads `VERACITY_WEIGHTS` directly. Setting `MNEMOSYNE_STATED_WEIGHT=0.9` breaks the invariant "consolidated-as-N also ranks at N." `beam.py` module-load emits a single WARNING when any of these env vars are set, surfacing the drift risk.
 
-If you want to disable the multiplier entirely for an A/B baseline, setting all five to `1.0` makes the multiplier a constant — see [Future toggles](#future-toggles-needed) for the proposed cleaner `MNEMOSYNE_VERACITY_MULTIPLIER=0` flag.
+If you want to disable the multiplier entirely for an A/B baseline, set `MNEMOSYNE_VERACITY_MULTIPLIER=0` — see [A/B ablation toggles](#ab-ablation-toggles).
 
 ### Episodic tier degradation
 
@@ -250,23 +250,35 @@ The current harness does not yet emit the diagnostic snapshots or paired outcome
 
 ---
 
-## Future toggles needed
+## A/B ablation toggles
 
-The following A/B isolation knobs do **not** yet exist in code. They are tracked here so future contributors can add them or use them once added.
+Nine env-var toggles allow disabling specific components for experimental ablation. **Each defaults to ON** (production behavior preserved); set the env var to `0`/`false`/`no`/`off` (case-insensitive, whitespace-stripped) to disable. Truthy/garbage/unset values keep the feature enabled — these are opt-out flags, not opt-in.
 
-| Proposed env var | Purpose | Affects |
+The toggle helper is `mnemosyne.core.beam._env_disabled(name)` (and a mirror in `polyphonic_recall.py`). For the experiment plan's phase-by-phase usage of each toggle, see [`experiments/2026-05-12-beam-recovery-arms-abc.md`](experiments/2026-05-12-beam-recovery-arms-abc.md).
+
+| Env var | Disables when set falsy | Affects |
 |---|---|---|
-| `MNEMOSYNE_VOICE_VECTOR=0/1` | Disable polyphonic vector voice for ablation | `polyphonic_recall._vector_voice` |
-| `MNEMOSYNE_VOICE_GRAPH=0/1` | Disable polyphonic graph voice | `polyphonic_recall._graph_voice` |
-| `MNEMOSYNE_VOICE_FACT=0/1` | Disable polyphonic fact voice | `polyphonic_recall._fact_voice` |
-| `MNEMOSYNE_VOICE_TEMPORAL=0/1` | Disable polyphonic temporal voice | `polyphonic_recall._temporal_voice` |
-| `MNEMOSYNE_GRAPH_BONUS=0/1` | Disable linear-path graph-edge bonus | `beam.py` linear ep loop |
-| `MNEMOSYNE_FACT_BONUS=0/1` | Disable linear-path fact-table bonus | `beam.py` linear ep loop |
-| `MNEMOSYNE_BINARY_BONUS=0/1` | Disable linear-path binary-vector Hamming bonus | `beam.py` linear ep loop |
-| `MNEMOSYNE_VERACITY_MULTIPLIER=0/1` | Short-circuit veracity multiplier to 1.0 in both engines | `beam.py` linear + polyphonic |
-| `MNEMOSYNE_CROSS_TIER_DEDUP=0/1` | Disable `_dedup_cross_tier_summary_links` for ablation | `beam.py` linear + polyphonic |
+| `MNEMOSYNE_VOICE_VECTOR` | Polyphonic vector voice (Phase 3d ablation) | `polyphonic_recall._vector_voice` early-return |
+| `MNEMOSYNE_VOICE_GRAPH` | Polyphonic graph voice (Phase 3b) | `polyphonic_recall._graph_voice` early-return |
+| `MNEMOSYNE_VOICE_FACT` | Polyphonic fact voice (Phase 3a) | `polyphonic_recall._fact_voice` early-return |
+| `MNEMOSYNE_VOICE_TEMPORAL` | Polyphonic temporal voice (Phase 3c) | `polyphonic_recall._temporal_voice` early-return |
+| `MNEMOSYNE_GRAPH_BONUS` | Linear-path graph-edge bonus | `beam.py` ep main loop + fallback |
+| `MNEMOSYNE_FACT_BONUS` | Linear-path fact-table bonus | `beam.py` ep main loop + fallback |
+| `MNEMOSYNE_BINARY_BONUS` | Linear-path binary-vector Hamming bonus | `beam.py` ep main loop |
+| `MNEMOSYNE_VERACITY_MULTIPLIER` | Veracity multiplier (Phase 0/1) | `beam.py` linear + polyphonic |
+| `MNEMOSYNE_CROSS_TIER_DEDUP` | `_dedup_cross_tier_summary_links` (Phase 4) | `beam.py` linear + polyphonic |
 
-Each is a small implementation (~20–30 LOC plus tests). Total ~225 LOC if all nine ship as one PR. Without them, several phases of the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md) cannot be executed cleanly because the alternative (modifying veracity values, deleting code paths, manipulating fixture data) introduces multiple confounded variables.
+Example:
+
+```bash
+# Phase 3a: disable the polyphonic fact voice to measure its contribution
+MNEMOSYNE_VOICE_FACT=0 \
+MNEMOSYNE_POLYPHONIC_RECALL=1 \
+MNEMOSYNE_BENCHMARK_PURE_RECALL=1 \
+python tools/evaluate_beam_end_to_end.py --scales 100K --sample 3
+```
+
+Pin each toggle in your `.env` or shell environment across an A/B run. The harness preflight snapshots all `MNEMOSYNE_*` env vars into the results JSON under `metadata.config.env` so you can verify the configuration retroactively.
 
 ---
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,279 @@
+# Benchmarking and Testing Infrastructure
+
+**Audience:** maintainers and contributors running benchmarks against the Mnemosyne recall stack. This is not part of the normal user-facing setup — see [getting-started.md](getting-started.md) and [configuration.md](configuration.md) for those.
+
+This document is the single source of truth for the levers that affect benchmark results: env vars, recall modes, diagnostic instrumentation, and the methodology for running rigorous A/B tests. It exists because Mnemosyne has multiple recall paths (linear + polyphonic), per-tool toggles, and harness modes that aren't relevant to normal usage but matter a great deal when measuring per-component contribution to scores.
+
+---
+
+## Why a separate doc
+
+Past benchmark results (see [beam-benchmark.md](beam-benchmark.md)) were collected before several silent-failure surfaces were closed (May 2026, PRs #80–#91). Those results are not credible evidence for any specific tool's contribution to total score, because the prior pipeline had:
+
+- Harness-side oracles that answered TR/CR/IE/KU questions without going through `BeamMemory.recall()` (PR #90).
+- Last 12 raw conversation messages always prepended to every answer prompt — recency-anchored answers succeeded regardless of recall quality (PR #90).
+- Cross-tier `(summary, source)` duplicates ranked side-by-side under the linear scorer but collapsed under polyphonic's diversity rerank, confounding arm-vs-arm comparison (PR #88).
+- Veracity destroyed at consolidation — every post-`sleep()` episodic row scored at the 0.8 `unknown` multiplier regardless of source-row veracity (PR #89).
+- `remember_batch` silently swallowing partial embedding failures, biasing the vector voice toward early-ingested rows (PR #89).
+- Benchmark adapter writing template summaries and destroying source rows; the corpus recall actually saw was ~500 rows of "Batch N: …" stubs (PR #75 → E1).
+
+This doc encodes what those fixes opened up: the ability to run **per-tool A/B tests** with a single variable changed per run. Use this document as the reference when designing or executing a benchmark; the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md) is a concrete application.
+
+---
+
+## Setup
+
+These prerequisites are benchmark-only. They are **not** required to run Mnemosyne under normal use.
+
+### Python dependencies
+
+```bash
+# Already in pyproject as optional groups:
+pip install 'mnemosyne-memory[embeddings]'    # fastembed — vector voice + dense recall
+pip install 'mnemosyne-memory[llm]'           # llama-cpp-python — sleep summarization (else AAAK fallback)
+
+# Benchmark-only — NOT in pyproject:
+pip install datasets                           # HuggingFace BEAM dataset loader
+pip install sqlite-vec                         # ANN backend for vec_episodes virtual table
+pip install numpy                              # benchmark harness requires it unconditionally
+```
+
+The benchmark harness (`tools/evaluate_beam_end_to_end.py`) imports `numpy` and `datasets` unconditionally. Neither is declared as an installable extra of the package. Track these in your local venv setup or via `requirements-benchmark.txt`.
+
+### Environment variables required for any benchmark run
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `OPENROUTER_API_KEY` | yes | LLM that answers benchmark questions (or read from `/tmp/openrouter_key.txt`) |
+| `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` | yes (recommended) | Disables harness-side oracles; forces every answer through Mnemosyne recall. See [Pure-recall mode](#pure-recall-mode). |
+| `HF_TOKEN` | only if BEAM gets gated | Currently public at `Mohammadta/BEAM`; HF token only needed if access changes |
+| `OPENROUTER_BASE_URL` | optional | Defaults to `https://openrouter.ai/api/v1` |
+
+### Resource budget (per phase)
+
+| Resource | 100K scale (3 conversations) | 250K scale (3 conversations) |
+|---|---|---|
+| Wall clock | ~20–30 min | ~60–90 min |
+| Peak RSS | ~2–4 GB | ~4–8 GB |
+| Disk for DB | ~500 MB | ~2–4 GB |
+| LLM API spend | ~$0.50–$2 | ~$5–$15 |
+
+API spend is dominated by per-question answer LLM calls. Caching identical queries can lower this; quantify on the first phase before committing to a long run.
+
+---
+
+## Environment variable reference
+
+Every env var that affects recall ranking or benchmark behavior. Pin them across phases of an A/B run or the comparisons are meaningless. The harness should snapshot all of these into the results JSON (see [Recording](#recording-per-run)).
+
+### Test mode / harness
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_BENCHMARK_PURE_RECALL` | unset (`0`) | When truthy (`1`/`true`/`yes`/`on`), disables four harness bypass paths: TR timeline oracle, CR contradiction injection, IE/KU `_context_facts` side-index, "RECENT CONVERSATION" raw-message prompt section. Forces every answer through `BeamMemory.recall()`. **Required for credible arm-vs-arm comparison.** Also exposed as `--pure-recall` CLI flag. |
+| `FULL_CONTEXT_MODE` | unset (`0`) | Sends the entire conversation to the answer LLM, bypassing retrieval. Useful for measuring the "LLM ceiling without recall" upper bound. Overridden by `MNEMOSYNE_BENCHMARK_PURE_RECALL` if both are set. Also exposed as `--full-context`. |
+
+Both parsers accept `1`/`true`/`yes`/`on` (case-insensitive, whitespace-stripped). Anything else is falsy.
+
+### Recall path selection
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_POLYPHONIC_RECALL` | unset (`0`) | When truthy, routes `BeamMemory.recall()` through `PolyphonicRecallEngine` (RRF fusion across vector / graph / fact / temporal voices + diversity rerank). When unset, uses the linear scorer with inline `graph_bonus` / `fact_bonus` / `binary_bonus` terms. Read at recall time, not init time — can be toggled per-call by changing the env. |
+
+**Linear vs polyphonic implement related signals via DIFFERENT mechanisms.** The linear path's `graph_bonus` is an edge-count LIKE-match on `graph_edges`. The polyphonic engine's `_graph_voice` does entity extraction + `find_facts_by_subject`. They have different failure modes; do not assume an ablation on one engine carries over to the other.
+
+### Linear-path scoring weights
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_VEC_WEIGHT` | `0.5` | Weight of vector similarity in the linear hybrid score. Normalized to sum to 1.0 with FTS + importance. |
+| `MNEMOSYNE_FTS_WEIGHT` | `0.4` | Weight of FTS5 score in the linear hybrid score. |
+| `MNEMOSYNE_IMPORTANCE_WEIGHT` | `0.1` | Weight of stored `importance` in the linear hybrid score. |
+| `MNEMOSYNE_TEMPORAL_HALFLIFE_HOURS` | (caller arg) | Temporal-boost half-life for the linear path's `_temporal_boost`. Only active when caller passes `temporal_weight > 0`. |
+
+These three (`VEC` / `FTS` / `IMPORTANCE`) interact — changing one alters the relative weight of the others. Treat as a triple to pin together.
+
+### Veracity multipliers
+
+Applied in both linear (post-FTS+vec scoring) and polyphonic (post-RRF) paths. Affect ranking; do not affect ingest.
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_STATED_WEIGHT` | `1.0` | Multiplier for rows tagged `veracity='stated'` |
+| `MNEMOSYNE_INFERRED_WEIGHT` | `0.7` | Multiplier for `veracity='inferred'` |
+| `MNEMOSYNE_TOOL_WEIGHT` | `0.5` | Multiplier for `veracity='tool'` |
+| `MNEMOSYNE_IMPORTED_WEIGHT` | `0.6` | Multiplier for `veracity='imported'` |
+| `MNEMOSYNE_UNKNOWN_WEIGHT` | `0.8` | Multiplier for `veracity='unknown'` (the schema default) |
+
+**Drift caveat:** these env vars override the recall multiplier in `beam.py`, but the consolidator's Bayesian compounding in `veracity_consolidation.py` does NOT honor env overrides — it reads `VERACITY_WEIGHTS` directly. Setting `MNEMOSYNE_STATED_WEIGHT=0.9` breaks the invariant "consolidated-as-N also ranks at N." `beam.py` module-load emits a single WARNING when any of these env vars are set, surfacing the drift risk.
+
+If you want to disable the multiplier entirely for an A/B baseline, setting all five to `1.0` makes the multiplier a constant — see [Future toggles](#future-toggles-needed) for the proposed cleaner `MNEMOSYNE_VERACITY_MULTIPLIER=0` flag.
+
+### Episodic tier degradation
+
+Applied to episodic results based on their `tier` column (1, 2, 3 — set by `degrade_episodic`).
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_TIER1_WEIGHT` | `1.0` | Hot tier multiplier (rows < `TIER2_DAYS` old) |
+| `MNEMOSYNE_TIER2_WEIGHT` | `0.5` | Mid tier multiplier |
+| `MNEMOSYNE_TIER3_WEIGHT` | `0.25` | Cold tier multiplier (rows > `TIER3_DAYS` old) |
+| `MNEMOSYNE_TIER2_DAYS` | `30` | Threshold for tier 1→2 transition |
+| `MNEMOSYNE_TIER3_DAYS` | `180` | Threshold for tier 2→3 transition |
+
+For benchmark runs on synthetic short-time-span data, tier degradation typically doesn't fire and all weights collapse to `TIER1_WEIGHT`. Pin them to `1.0` if you want zero tier effect.
+
+### Vector backend
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_VEC_TYPE` | `int8` | Storage format for vector embeddings: `float32` (full precision, 1536 bytes/vec), `int8` (384 bytes/vec, default), `bit` (48 bytes/vec, binary-quantized). Changes candidate set for `_vec_search` and ranking quality. |
+
+`bit` mode trades recall quality for storage; expect lower scores on semantic-heavy questions.
+
+### Scan breadth / FTS semantics
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_BEAM_OPTIMIZATIONS` | unset (`0`) | When truthy, switches FTS5 to OR-semantics, raises vector-scan limit, and always includes vector results. Designed for benchmark-scale recall over large corpora. Distinct from `MNEMOSYNE_BENCHMARK_PURE_RECALL` — the latter is harness-side, this is recall-side. |
+
+If you don't enable this for benchmarks ≥100K, expect FTS-driven recall to miss substring partial matches that the benchmark questions expect.
+
+### Working memory / sleep
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_WM_TTL_HOURS` | `24` | Working memory rows older than this get pulled into `sleep()`. The benchmark harness backdates timestamps to ensure rows are eligible. |
+| `MNEMOSYNE_SLEEP_BATCH` | `5000` | Max rows pulled per `sleep()` invocation. Larger batches reduce sleep overhead; smaller batches reduce peak memory during summarization. |
+| `MNEMOSYNE_LLM_ENABLED` | `true` | When `false`, `sleep()` skips local LLM summarization and falls back to AAAK encoding. Useful for benchmark runs that want deterministic summaries without per-row LLM latency. |
+
+---
+
+## Pure-recall mode
+
+`MNEMOSYNE_BENCHMARK_PURE_RECALL=1` (or `--pure-recall`) is the single most important flag for any A/B benchmark. It disables four hardcoded paths in the harness that produce answers *without* going through `BeamMemory.recall()`:
+
+1. **TR (Temporal Reasoning) oracle** — pre-fix, TR questions extracted a timeline from raw `conversation_messages` and answered via an LLM-with-dates prompt, returning before any recall. Pure-recall lets TR questions flow through normal recall.
+2. **CR (Contradiction Resolution) injection** — pre-fix, raw-message contradiction detection injected a "you mentioned contradictory things" hint into the answer prompt. Pure-recall disables this hint; the arm must surface the contradiction via recall.
+3. **IE/KU `_context_facts` side-index** — pre-fix, the harness built a regex-keyed phrase-to-value index at ingest from raw messages, then matched questions against it and returned the value directly. Pure-recall disables the lookup.
+4. **"RECENT CONVERSATION" injection** — pre-fix, the last 12 raw conversation messages were always prepended to every answer prompt. Recency-anchored answers succeeded regardless of recall quality. Pure-recall strips the section; only retrieved memories reach the LLM.
+
+Without these gates, any "Arm B beats Arm A by 5pp" claim is suspect — the harness might have produced identical answers across arms for the questions hitting the bypass paths.
+
+The flag was added in May 2026. Default behavior (env unset) preserves the legacy benchmark mode for backward compatibility, but new runs targeting per-tool A/B claims should always set it.
+
+---
+
+## Diagnostic instrumentation
+
+Two diagnostic modules emit per-run snapshots that should be captured into results JSON.
+
+### Recall diagnostics
+
+```python
+from mnemosyne.core.recall_diagnostics import (
+    get_recall_diagnostics,      # returns Dict snapshot
+    reset_recall_diagnostics,    # clears process-global counters
+)
+```
+
+`get_recall_diagnostics()` returns a JSON-serializable dict with:
+
+| Field | Meaning |
+|---|---|
+| `wm_fts_kept` | Working-memory rows kept via FTS5 |
+| `wm_vec_kept` | Working-memory rows kept via vector search |
+| `wm_fallback_kept` | Working-memory rows kept via substring fallback |
+| `em_fts_kept` | Episodic rows kept via FTS5 |
+| `em_vec_kept` | Episodic rows kept via vector search |
+| `em_fallback_kept` | Episodic rows kept via substring fallback |
+| `total_kept` | Sum across all tiers |
+| `truly_empty_calls` | Calls where every tier produced zero kept rows |
+| `fallback_rate` | `(wm_fallback + em_fallback) / total_kept` |
+
+High `fallback_rate` (>30%) on a benchmark run is a red flag — it means most recall is coming from the weak-signal substring scan, not FTS or vector. Investigate before trusting the score.
+
+Call `reset_recall_diagnostics()` at the start of each phase to keep counters clean per-run.
+
+### Extraction diagnostics
+
+```python
+from mnemosyne.extraction.diagnostics import get_extraction_stats
+```
+
+Returns per-tier (host / remote / local / cloud / wrapper) extraction call counts plus bounded error samples (10 samples per tier, 200 chars per message). Surfaces silent failures in the fact-extraction pipeline.
+
+---
+
+## Test sequence template
+
+The general shape of a credible A/B benchmark:
+
+1. **Preflight** — assert pure-recall is active, snapshot every `MNEMOSYNE_*` env var, log recall path per call.
+2. **Phase 0 (baseline floor)** — minimum configuration: linear scorer, all veracity weights = 1.0, no enrichment.
+3. **+ one variable** per subsequent phase. Run on a 100K-message slice (~20 min); save full 250K runs for confirming the top two configurations from the small-scale screen.
+4. **Record** per-question paired outcomes plus the diagnostic snapshots. Compute bootstrap CIs on per-ability score deltas.
+5. **Falsification criterion:** for "tool X contributes near-zero" claims, the 95% CI must exclude ±2pp before treating the prediction as confirmed.
+
+See the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md) for a concrete instantiation with 10 phases and 8 theses.
+
+### Preflight checklist
+
+Every benchmark run should:
+
+- [ ] Confirm pure-recall mode is active (`MNEMOSYNE_BENCHMARK_PURE_RECALL=1` or `--pure-recall`).
+- [ ] Set `OPENROUTER_API_KEY` (or its fallback file).
+- [ ] Pin all ranking weights (`MNEMOSYNE_VEC_WEIGHT`, `FTS_WEIGHT`, `IMPORTANCE_WEIGHT`, `TEMPORAL_HALFLIFE_HOURS`, `VEC_TYPE`, `BEAM_OPTIMIZATIONS`) identically across phases.
+- [ ] Reset diagnostics before each phase.
+- [ ] Verify the recall path (linear vs polyphonic) matches what the phase intends.
+
+A small Python helper or shell wrapper that asserts all of these and refuses to run if any are missing is cheap insurance against accidentally-invalid runs.
+
+---
+
+## Recording per run
+
+Capture into `results/beam_e2e_results.json` (or equivalent):
+
+- **Per-ability score** — TR / CR / IE / KU / MR / ABS / EO / SUM, plus total.
+- **Run config** — phase name, sample size, scale, all `MNEMOSYNE_*` + `FULL_CONTEXT_MODE` env vars at start.
+- **Recall diagnostics** — full `get_recall_diagnostics()` snapshot at run end (or aggregated per-call).
+- **Extraction diagnostics** — full `get_extraction_stats()` snapshot.
+- **Latency** — p50 / p95 / p99 per-question recall + answer roundtrip.
+- **Storage** — final row counts in `working_memory`, `episodic_memory`, `memory_embeddings`, `vec_episodes`, `annotations`, `consolidated_facts`.
+- **Peak RSS** during ingest and recall phases separately.
+
+For statistical reporting, also output a flat `paired_outcomes.jsonl` with `{config_id, question_id, ability, correct}` rows so bootstrap CIs on paired deltas can be computed without re-parsing the main results.
+
+The current harness does not yet emit the diagnostic snapshots or paired outcomes; wiring them in is tracked as Gap D + Gap E in the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md#implementation-gaps).
+
+---
+
+## Future toggles needed
+
+The following A/B isolation knobs do **not** yet exist in code. They are tracked here so future contributors can add them or use them once added.
+
+| Proposed env var | Purpose | Affects |
+|---|---|---|
+| `MNEMOSYNE_VOICE_VECTOR=0/1` | Disable polyphonic vector voice for ablation | `polyphonic_recall._vector_voice` |
+| `MNEMOSYNE_VOICE_GRAPH=0/1` | Disable polyphonic graph voice | `polyphonic_recall._graph_voice` |
+| `MNEMOSYNE_VOICE_FACT=0/1` | Disable polyphonic fact voice | `polyphonic_recall._fact_voice` |
+| `MNEMOSYNE_VOICE_TEMPORAL=0/1` | Disable polyphonic temporal voice | `polyphonic_recall._temporal_voice` |
+| `MNEMOSYNE_GRAPH_BONUS=0/1` | Disable linear-path graph-edge bonus | `beam.py` linear ep loop |
+| `MNEMOSYNE_FACT_BONUS=0/1` | Disable linear-path fact-table bonus | `beam.py` linear ep loop |
+| `MNEMOSYNE_BINARY_BONUS=0/1` | Disable linear-path binary-vector Hamming bonus | `beam.py` linear ep loop |
+| `MNEMOSYNE_VERACITY_MULTIPLIER=0/1` | Short-circuit veracity multiplier to 1.0 in both engines | `beam.py` linear + polyphonic |
+| `MNEMOSYNE_CROSS_TIER_DEDUP=0/1` | Disable `_dedup_cross_tier_summary_links` for ablation | `beam.py` linear + polyphonic |
+
+Each is a small implementation (~20–30 LOC plus tests). Total ~225 LOC if all nine ship as one PR. Without them, several phases of the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md) cannot be executed cleanly because the alternative (modifying veracity values, deleting code paths, manipulating fixture data) introduces multiple confounded variables.
+
+---
+
+## How this doc evolves
+
+When a new env var is added that affects recall ranking or benchmark behavior, update the [Environment variable reference](#environment-variable-reference) table here. When a new diagnostic counter ships, add it to [Diagnostic instrumentation](#diagnostic-instrumentation). When a new experiment runs, add a dated artifact under `docs/experiments/`.
+
+Past experiment artifacts:
+- [2026-05-12 — BEAM-recovery Arms A/B/C](experiments/2026-05-12-beam-recovery-arms-abc.md)
+- (older runs documented in [beam-benchmark.md](beam-benchmark.md) — note that those pre-date the May 2026 fix bundle and aren't credible for per-tool claims)

--- a/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
+++ b/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
@@ -206,7 +206,7 @@ This is the complete list of functionality the plan assumes exists but doesn't (
 
 Merging PRs #80, #82, #88, #89, #90, #91 closes most of the prerequisite footprint. PRs #83, #85, #86, #87 are also open but not strictly required for the experiment to run — they harden surrounding paths against silent failure but don't gate the test sequence itself.
 
-### Gap B — Nine A/B toggles (the big one — ~225 LOC) — ⏳ in PR A (separate)
+### Gap B — Nine A/B toggles (the big one — ~225 LOC) — ✅ closed in PR A
 
 See §6 above. Without these, phases 0, 1, 3a–3d, 3-LIN-*, and 4 cannot be run cleanly — they either change multiple variables at once or have no working knob. **Required to execute phases 0–5 as designed.**
 

--- a/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
+++ b/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
@@ -1,0 +1,305 @@
+# BEAM-Recovery Experiment — Test Sequence and Theses
+
+**Date:** 2026-05-12 | **Status:** Plan, pre-execution. References [docs/benchmarking.md](../benchmarking.md) for env-var definitions and methodology.
+
+This is a dated experiment artifact. For the reusable test-infrastructure reference (env vars, diagnostic instrumentation, pure-recall mode, recording template), see [benchmarking.md](../benchmarking.md). This file describes the specific 10-phase ablation sequence planned for the post-May-2026 fix bundle and the theses each phase tests.
+
+---
+
+## Why this exists
+
+The goal is to measure, per tool, what each component of the Mnemosyne recall stack contributes to BEAM scores — not to demonstrate Mnemosyne wins. PRs #80–#91 were filed specifically to enable that per-tool isolation, and **stats collected before those land are not credible evidence for or against any specific tool**, because the prior pipeline had silent failure modes and harness-side oracles that made it impossible to attribute deltas to a single change.
+
+The proposed sequence below is designed to commit each tool to a measurable A/B test rather than a "polyphonic vs linear" bundle comparison.
+
+---
+
+## Hard prerequisites before any phase runs
+
+### Code prerequisites — PRs to merge first
+
+**This plan is only valid against a checkout that has these PRs merged:** #80 (polyphonic vector voice rewire to `memory_embeddings` + sqlite-vec), #82 (`remember_batch` enrichment parity), #88 (cross-tier dedup), #89 (veracity preservation through consolidation), #90 (pure-recall harness gate), #91 (env-parser + telemetry). On current `main` (pre-merge) several plan claims are factually wrong — `_dedup_cross_tier_summary_links` doesn't exist, `_recall_polyphonic` still uses `BinaryVectorStore`, the harness has no `--pure-recall` flag. If those PRs haven't merged when you run this, stop and merge them first.
+
+### Python / system dependencies
+
+```bash
+# Core (already in pyproject as optional groups):
+pip install 'mnemosyne-memory[embeddings]'   # fastembed (≥0.3.0) — recall vector voice
+pip install 'mnemosyne-memory[llm]'          # llama-cpp-python — sleep summarization (else AAAK fallback)
+
+# Benchmark-only — NOT in pyproject yet:
+pip install datasets                          # HuggingFace BEAM dataset loader (tools/evaluate_beam_end_to_end.py:183)
+pip install sqlite-vec                        # vec_episodes ANN backend (linear path + polyphonic post-#80)
+pip install numpy                             # tools/evaluate_beam_end_to_end.py:54 import is unconditional
+```
+
+`numpy` and `datasets` are runtime requirements of the benchmark harness but not declared as installable extras of the package — install them in the same venv. Recommend tracking these in a `requirements-benchmark.txt` (see Implementation Gaps §6 below).
+
+### External services / API keys
+
+| Variable | Required for | Source |
+|---|---|---|
+| `OPENROUTER_API_KEY` | LLM that answers benchmark questions | OpenRouter account |
+| `HF_TOKEN` (optional) | If BEAM dataset turns gated; currently public at `Mohammadta/BEAM` | HuggingFace |
+| `OPENROUTER_BASE_URL` (optional) | API base URL override; default `https://openrouter.ai/api/v1` | env-only |
+
+The harness falls back to reading `OPENROUTER_API_KEY` from `/tmp/opencode_key.txt` or `/tmp/openrouter_key.txt` if the env isn't set (`tools/evaluate_beam_end_to_end.py:60-71`).
+
+### Compute / resource budget
+
+| Resource | 100K phase | 250K phase |
+|---|---|---|
+| Wall clock | ~20–30 min per run | ~60–90 min per run |
+| Peak RSS | ~2–4 GB (fastembed + LLM) | ~4–8 GB |
+| Disk for DB | ~500 MB per conversation | ~2–4 GB per conversation |
+| LLM API spend | ~$0.50–$2 per phase | ~$5–$15 per phase |
+
+API spend is dominated by per-question answer LLM calls (BEAM has up to 50 questions per conversation per scale). Cache hits via deduplication of identical queries can lower this; quantify on first phase before committing to all 10.
+
+**Preflight (run once per session, then per phase):**
+
+1. **Assert pure-recall mode is active.** The harness should refuse to run if `MNEMOSYNE_BENCHMARK_PURE_RECALL` is unset. The bypasses don't produce identical answers across arms; running without the gate silently invalidates every comparison.
+2. **Dump every `MNEMOSYNE_*` env var into results JSON.** A toggle the operator forgot is a confound in disguise.
+3. **Pin all ranking knobs.** `MNEMOSYNE_VEC_WEIGHT`, `MNEMOSYNE_FTS_WEIGHT`, `MNEMOSYNE_IMPORTANCE_WEIGHT`, `MNEMOSYNE_TEMPORAL_HALFLIFE_HOURS`, `MNEMOSYNE_VEC_TYPE`, `MNEMOSYNE_BEAM_OPTIMIZATIONS`, `MNEMOSYNE_TIER{1,2,3}_WEIGHT`, `MNEMOSYNE_*_WEIGHT` veracity values must be set identically across phases — pin them in a `.env` file or assert in the runner.
+4. **Sanity-check the active recall path.** Log whether each call went through linear or polyphonic; the env var is read at call time, not init time, so accidental flips mid-run are possible.
+5. **Record per-result `voice_scores` and tier provenance** (from C4 + C13.b diagnostics). Without these, a "tool contributes nothing" finding is unfalsifiable.
+
+---
+
+## Why prior stats are suspect
+
+- The benchmark harness answered TR/CR/IE/KU questions from a regex-extracted timeline, raw-message contradiction detection, and a `_context_facts` side-index — bypassing `BeamMemory.recall()` entirely on those ability dimensions (PR #90).
+- Every answer prompt was always prepended with the last 12 raw conversation messages, so any recency-anchored answer could succeed regardless of recall quality and arm choice (PR #90).
+- Post-E3 additive sleep left both the source `working_memory` row and the episodic summary discoverable by recall, double-incrementing `recall_count` and ranking duplicates side-by-side under the linear scorer while polyphonic's diversity rerank silently collapsed them — asymmetric dedup confounded any arm-vs-arm comparison (PR #88).
+- `consolidate_to_episodic` never populated the `veracity` column on the summary row, so post-E4 per-row veracity got destroyed the moment sleep ran — every episodic row scored at the 0.8 `unknown` multiplier (PR #89).
+- `remember_batch` swallowed partial embedding failures via a bare `except Exception: pass`, silently losing entire batches of vectors at scale (PR #89).
+- Pre-E1 the benchmark adapter wrote template summaries and destroyed source rows; the corpus most prior runs actually recalled against was ~500 episodic rows of "Batch N: first_3_msg_contents[:100chars]" stubs, not the 250K-message dataset (PR #75).
+
+Each is fixed; their combined effect on prior numbers is unknowable.
+
+---
+
+## What's now controllable for A/B
+
+**Key disambiguation up front:** the linear path and the polyphonic engine implement related signals through DIFFERENT mechanisms. The linear scorer applies `graph_bonus` / `fact_bonus` / `binary_bonus` as inline additions (`beam.py:~2497-2545`); the polyphonic engine runs separate voices (`polyphonic_recall.py:_graph_voice`, `_fact_voice`, `_vector_voice` which is binary-vector-driven). They have different failure modes and different ablation surfaces. Toggles must specify which engine they gate.
+
+| Tool / axis | Engine | On/off mechanism | Landed in |
+|---|---|---|---|
+| Polyphonic engine vs linear scorer | both | `MNEMOSYNE_POLYPHONIC_RECALL=1` selects polyphonic | E5 (#76) |
+| Polyphonic vector voice (post-#80: `memory_embeddings` + sqlite-vec ANN; pre-#80: `BinaryVectorStore`) | polyphonic | Implicit when polyphonic on; ANN gated by `_vec_available`. **Proposed:** `MNEMOSYNE_VOICE_VECTOR=0` for ablation | E5.a (#80) |
+| Polyphonic graph voice (`find_gists_by_participant` / `find_facts_by_subject`) | polyphonic | **Proposed:** `MNEMOSYNE_VOICE_GRAPH=0` |  |
+| Linear graph bonus (edge-count LIKE-match on `graph_edges`) | linear | **Proposed:** `MNEMOSYNE_GRAPH_BONUS=0`; **separate toggle from polyphonic graph voice** |  |
+| Polyphonic fact voice (synthetic `cf_*` IDs from `consolidated_facts`) | polyphonic | **Proposed:** `MNEMOSYNE_VOICE_FACT=0` |  |
+| Linear fact bonus (per-row `facts` table query) | linear | **Proposed:** `MNEMOSYNE_FACT_BONUS=0` |  |
+| Polyphonic temporal voice | polyphonic | **Proposed:** `MNEMOSYNE_VOICE_TEMPORAL=0` |  |
+| Linear temporal boost (`_temporal_boost` × `temporal_weight`) | linear | `temporal_weight=0` per-call arg (already exposed); needs harness flag |  |
+| Linear binary-vector bonus (capped at 0.08) | linear | **Proposed:** `MNEMOSYNE_BINARY_BONUS=0` |  |
+| Veracity multiplier | both | **Proposed:** `MNEMOSYNE_VERACITY_MULTIPLIER=0` — gates the multiplier in linear + polyphonic |  |
+| Tier-degradation multiplier | both | `MNEMOSYNE_TIER{1,2,3}_WEIGHT=1.0` neutralizes (existing env vars) |  |
+| Cross-tier (summary, source) dedup | both | **Proposed:** `MNEMOSYNE_CROSS_TIER_DEDUP=0` (requires #88 merged) | E3.a.3 (#88) |
+| Algorithmic enrichment in `remember_batch` | ingest | `extract_entities=False`, `extract=False` kwargs (rule-based always-on post-E2 is not separately toggled) | E2 (#82) |
+| LLM extraction | ingest | `extract=True` kwarg (per-row cost); out of scope for Arms A–C |  |
+| Pure-recall mode (no harness oracles) | harness | `--pure-recall` or `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` (requires #90/#91) | #90, #91 |
+| Veracity tagging at ingest | ingest | `remember_batch(items, veracity=...)` per-item or default | E4 (#74), E4.a.1 (#89) |
+| Score-component weights | linear | `MNEMOSYNE_VEC_WEIGHT`, `MNEMOSYNE_FTS_WEIGHT`, `MNEMOSYNE_IMPORTANCE_WEIGHT` (existing; normalized to 1.0) |  |
+| FTS5 / vec scan breadth | both | `MNEMOSYNE_BEAM_OPTIMIZATIONS=1` widens FTS OR-semantics + raises vec scan limits |  |
+| Vector storage backend | both | `MNEMOSYNE_VEC_TYPE` ∈ {`float32`, `int8`, `bit`} |  |
+| Recall diagnostics (per-tier hits, fallback rate) | observability | `mnemosyne.core.recall_diagnostics.get_recall_diagnostics()` | C4 (#79) |
+| Extraction diagnostics (per-tier extract counts) | observability | `mnemosyne.extraction.diagnostics.get_extraction_stats()` | C13.b (#78) |
+
+The "proposed" rows are the gap between today's code (assuming #80–#91 merged) and a clean A/B matrix. Scope is in §6.
+
+---
+
+## Proposed test sequence
+
+Each phase changes exactly one variable from the prior. Run on the 100K slice unless noted; budget ~20–30 minutes per phase on a single conversation. Use `--pure-recall` on every phase — running without it reintroduces the harness oracles and invalidates per-tool deltas.
+
+Phases 3a–3d ablate components of the polyphonic engine specifically. They can run in parallel from a frozen DB snapshot taken at Phase 2 ingest completion, since each toggle is independent of the others. Phase 3-LIN-* exercises the analogous LINEAR-path bonus blocks separately — those aren't redundant with 3a–3d because the linear graph/fact mechanisms are different functions on different data.
+
+**Every phase requires:** `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` (or `--pure-recall`), `OPENROUTER_API_KEY` set, and the Python deps from §1 installed. The per-phase table below lists only the variables that change from defaults.
+
+| Phase | Name | Setup (delta from prior) | What to measure | Expectation |
+|---|---|---|---|---|
+| 0 | Baseline floor | Linear scorer, pure-recall, `MNEMOSYNE_VERACITY_MULTIPLIER=0` (explicit toggle, NOT data labeling — uniform `unknown` rows still get the 0.8 multiplier), no enrichment | Per-ability score + total | The "raw working_memory + episodic via FTS + numpy-vec, no multipliers" floor |
+| 1 | + veracity | Phase 0 + `MNEMOSYNE_VERACITY_MULTIPLIER=1`, rows tagged via `remember_batch` defaults | Δ vs phase 0 | Test Thesis 5 (prior: small Δ on uniform corpora; report CIs) |
+| 2 | + polyphonic engine | Phase 1 + `MNEMOSYNE_POLYPHONIC_RECALL=1`, all voices on | Δ vs phase 1 | Net engine contribution — RRF + diversity rerank vs linear scorer |
+| 3a | − fact voice (polyphonic) | Phase 2 + `MNEMOSYNE_VOICE_FACT=0` | Δ vs phase 2 | Test Thesis 1: predict near-zero — see thesis details below |
+| 3b | − graph voice (polyphonic) | Phase 2 + `MNEMOSYNE_VOICE_GRAPH=0` | Δ vs phase 2 | Test Thesis 2a (polyphonic graph voice contribution) |
+| 3c | − temporal voice (polyphonic) | Phase 2 + `MNEMOSYNE_VOICE_TEMPORAL=0` | Δ vs phase 2 | Question-mix dependent |
+| 3d | − polyphonic vector voice | Phase 2 + `MNEMOSYNE_VOICE_VECTOR=0` | Δ vs phase 2 | **This is the polyphonic-engine analog of "no vector signal" — gates `_vector_voice()` in `polyphonic_recall.py:113-151`, NOT the linear binary_bonus block. Vector voice is the heaviest contributor; predict large Δ.** |
+| 3-LIN-bin | − linear binary bonus | Phase 1 (linear) + `MNEMOSYNE_BINARY_BONUS=0` (gates `beam.py:2527-2545`) | Δ vs phase 1 | Test Thesis 3a (linear-only binary bonus deprecation) — predict near-zero |
+| 3-LIN-graph | − linear graph bonus | Phase 1 + `MNEMOSYNE_GRAPH_BONUS=0` (gates `beam.py:2497-2521`, 2632-2656) | Δ vs phase 1 | Test Thesis 2b (linear graph-bonus contribution) |
+| 3-LIN-fact | − linear fact bonus | Phase 1 + `MNEMOSYNE_FACT_BONUS=0` (gates `beam.py:2508-2521`, 2640-2655) | Δ vs phase 1 | Test Thesis 1b (linear fact-bonus contribution) |
+| 4 | + cross-tier dedup off | Phase 2 + `MNEMOSYNE_CROSS_TIER_DEDUP=0` | Δ vs phase 2 | Test Thesis 4 |
+| 5 | + algorithmic enrichment | Phase 2 + `extract_entities=True` at ingest | Δ vs phase 2 | Graph+fact data populated → voices have substance |
+| 6 | Full 250K confirmation | Top-2 configurations from phases 0–5 + Phase 0 floor | Per-ability + total + latency | Confirms 100K findings hold at scale |
+
+A full 2^N factorial across the voices is more rigorous but costs N²-ish runs; the single-variable ablations capture the dominant per-component contributions cheaply. If any 3a–3d delta surprises (e.g., voice X looks important when predicted dead), follow up with a paired-voice ablation (X + Y both off).
+
+---
+
+## Theses
+
+Each is a **prior** with code grounding, plus the test that would prove or disprove it. **The quantitative predictions are priors, not measurement-backed claims** — there are no pilot runs with confidence intervals behind them. Report bootstrap CIs or per-question paired deltas during execution; a "prediction confirmed" with overlapping CIs is not confirmation.
+
+**Thesis 1a — The polyphonic fact voice contributes effectively zero to final recall.**
+`_fact_voice` (`polyphonic_recall.py:~200-217`) emits synthetic `cf_{subject}_{predicate}_{object}` IDs. `_recall_polyphonic` (`beam.py:~2935-2938`) skips any ID starting with `cf_` because `_fetch_polyphonic_row` can't map them to a real row. `_combine_voices` (`polyphonic_recall.py:~295-336`) does not join `cf_*` IDs to source memory rows — the consolidator's `sources` list isn't threaded through. So when the fact voice "fires," its rows are filtered out before composition. Indirect contribution via RRF on memory_ids surfaced by other voices is also zero in this code, because the fact voice doesn't surface those IDs. **Prior:** Δ ≤ 0.5pp on total score, indistinguishable from noise. **Test:** Phase 3a. If true, the polyphonic fact voice is currently dead code in the recall path — the cost is the consolidator's ingest-time Bayesian compounding, which has separate value but isn't tested here.
+
+**Thesis 1b — The LINEAR fact bonus is on a different mechanism and should be tested separately.**
+The linear path at `beam.py:~2508-2521` per-row queries the `facts` table by `source_msg_id` and adds a capped bonus (max 0.1) when query tokens overlap with extracted fact tokens. This is NOT the same code path as the polyphonic fact voice — it operates on `facts`, not `consolidated_facts`. **Prior:** Δ small-but-positive (1–3pp) on questions whose answer involves an extracted fact; zero on others. **Test:** Phase 3-LIN-fact.
+
+**Thesis 2a — The polyphonic graph voice's contribution depends heavily on entity-extraction quality.**
+`_graph_voice` (`polyphonic_recall.py:~160-183`) extracts capitalized tokens from the query and calls `find_gists_by_participant` / `find_facts_by_subject`. Failure modes: case-sensitivity (lowercase entities ignored), brittle entity extraction, and the suspect `fact.id.split("_")[-1]` mapping that assumes a particular ID schema. **Prior:** uneven Δ — 2–4pp on questions with clearly-capitalized proper-noun entities, near-zero otherwise. **Test:** Phase 3b. Stratify the analysis by whether the question contains capitalized tokens.
+
+**Thesis 2b — The LINEAR graph bonus rewards connectivity, not query relevance.**
+`beam.py:~2497-2505` counts edges in `graph_edges` via `subject LIKE %memory_id% OR target LIKE %memory_id%`, capped at 0.08. Densely-connected rows get the bonus regardless of whether they're actually relevant to the query — well-connected rows are surfaced more often than they should be. **Prior:** Δ near-zero on total score (the cap is small), possibly negative on questions where the densely-connected rows aren't the answer. **Test:** Phase 3-LIN-graph.
+
+**Thesis 3a — The LINEAR binary-vector bonus block is deprecation-eligible.**
+`beam.py:~2527-2545` adds a tanh-normalized Hamming-distance bonus capped at 0.08 from the `binary_vector` column when both query and row vectors are present. The float-vector signal in `vec_results` already drives most of the ranking through `vec_sim * vw`. **Prior:** Δ < 1pp. **Test:** Phase 3-LIN-bin.
+
+**Thesis 3b — The POLYPHONIC vector voice is the heaviest contributor and should NOT be conflated with 3a.**
+`_vector_voice` (`polyphonic_recall.py:113-151`) runs `BinaryVectorStore.search` (pre-#80) or sqlite-vec ANN over `memory_embeddings` (post-#80). Either way it's the highest-RRF-rank-weight voice and dominates the polyphonic engine's signal. Deprecating it via Phase 3d would tank polyphonic recall scores. **Prior:** Δ large-negative (5–20pp) when disabled. **Test:** Phase 3d. **Do not conclude binary-vector deprecation from Phase 3d** — that decision is Phase 3-LIN-bin's territory, not 3d's.
+
+**Thesis 4 — Cross-tier dedup matters more for linear than polyphonic.**
+Pre-#88 the linear path returned (summary, source) pairs ranked side-by-side. Polyphonic's diversity rerank handles this approximately via embedding similarity. **Prior:** linear regresses 3–8pp without dedup; polyphonic regresses <2pp. **Test:** Phase 4 × {Phase 0 baseline, Phase 2}. Requires #88 merged (`_dedup_cross_tier_summary_links` doesn't exist pre-merge).
+
+**Thesis 5 — Veracity multiplier is near-noise on uniform-veracity BEAM data.**
+If every WM and EP row has the same veracity label, the multiplier becomes a global scalar that doesn't change ranking. Post-#89 the consolidator now aggregates source veracity, so summary rows can have different veracity from sources — slightly breaking uniformity. **Prior:** Δ < 1pp on total score, possibly larger on questions answered from consolidated summaries vs raw sources. **Test:** Phase 1 vs Phase 0 with explicit multiplier toggle (NOT data labeling — uniform rows still get the multiplier applied; only the toggle short-circuits it).
+
+**Thesis 6 — The RECENT CONVERSATION leak was the dominant prior driver of arm-vs-arm equivalence.**
+Pre-#90 every answer prompt included the last 12 raw messages. Recency-anchored answers succeeded without needing recall — arm choice was invisible. **Prior:** pure-recall mode shows arm-vs-arm deltas 2–5× larger than legacy mode. **Test:** Phase 2 with `--pure-recall` vs without (legacy harness behavior). Also serves as a sanity check that #90's gate is actually firing.
+
+**Thesis 7 — sqlite-vec ANN vs numpy exact-vec affects latency, not score (post-#80).**
+The polyphonic engine over-fetches `top_k * 2`; the final RRF + multiplier + dedup pipeline returns top_k. ANN-vs-exact differences in the long tail past position ~60 get truncated. **Prior:** Δ score < 0.5pp; p95 latency divergence 5–20×. **Test:** Phase 2 with `sqlite-vec` importable vs mocked-unavailable (numpy fallback). Requires #80 merged.
+
+**Thesis 8 — Algorithmic enrichment captures most of what LLM extraction would.**
+BEAM facts are predominantly subject-verb-object patterns the regex extractor handles. LLM extraction catches more nuance at $25–$2500 + 35–138h per 250K pass (E2.a.3 ledger note). **Prior:** ≤5pp gap between Phase 5 (algorithmic) and a separate `extract=True` LLM-extraction run. **Test:** Phase 5 vs a separate Arm D run. If gap ≤5pp, LLM extraction is cost overhead; if gap >10pp, it's a real capability.
+
+---
+
+## Toggles needed before full A/B
+
+Each toggle is its own scope (not 5 LOC). LOC estimates include the env-parse code, the gate site(s), invalidation of cached `PolyphonicRecallEngine` if the toggle affects voice construction, and 2–3 regression tests per toggle.
+
+| Toggle | Purpose | Sites | LOC (incl. tests) |
+|---|---|---|---|
+| `MNEMOSYNE_VOICE_VECTOR=0/1` | Phase 3d — polyphonic vector voice | `polyphonic_recall.py:_vector_voice` early-return when off | ~25 |
+| `MNEMOSYNE_VOICE_GRAPH=0/1` | Phase 3b — polyphonic graph voice | `polyphonic_recall.py:_graph_voice` early-return | ~25 |
+| `MNEMOSYNE_VOICE_FACT=0/1` | Phase 3a — polyphonic fact voice | `polyphonic_recall.py:_fact_voice` early-return | ~25 |
+| `MNEMOSYNE_VOICE_TEMPORAL=0/1` | Phase 3c — polyphonic temporal voice | `polyphonic_recall.py:_temporal_voice` early-return | ~25 |
+| `MNEMOSYNE_GRAPH_BONUS=0/1` | Phase 3-LIN-graph — linear graph bonus | Gate `beam.py:~2497-2521` (main ep loop) AND `:~2632-2645` (fallback) | ~30 |
+| `MNEMOSYNE_FACT_BONUS=0/1` | Phase 3-LIN-fact — linear fact bonus | Gate `beam.py:~2508-2521` AND `:~2640-2655` | ~30 |
+| `MNEMOSYNE_BINARY_BONUS=0/1` | Phase 3-LIN-bin — linear binary-vector bonus | Gate `beam.py:~2527-2545` | ~20 |
+| `MNEMOSYNE_VERACITY_MULTIPLIER=0/1` | Phase 0/1 — disable veracity multiplier in both engines | Short-circuit to 1.0 in linear (`beam.py:~2700-2719`) + polyphonic (`beam.py:~3015-3017`) | ~25 |
+| `MNEMOSYNE_CROSS_TIER_DEDUP=0/1` | Phase 4 — disable E3.a.3 dedup | Short-circuit `_dedup_cross_tier_summary_links` to return input list unchanged | ~20 |
+
+Total ~225 LOC across ~30 tests if all nine are implemented in one PR. A subset is fine if you want to prioritize: vector-voice toggle (3d) + veracity toggle (0/1) + cross-tier toggle (4) are the three most important for the experiment's central claims. The linear-bonus toggles (3-LIN-*) matter only if you want to deprecate components of the linear scorer; they're independent of the polyphonic-vs-linear comparison.
+
+---
+
+## Implementation gaps — what the plan needs that does NOT yet exist
+
+This is the complete list of functionality the plan assumes exists but doesn't (as of 2026-05-12, prior to PRs #80–#91 merging). The plan can't be executed cleanly until these gaps close. Each item is callable as its own small PR; estimates include tests.
+
+### Gap A — PR merges (no new code; just merge what's open) — ✅ closed 2026-05-12
+
+Merging PRs #80, #82, #88, #89, #90, #91 closes most of the prerequisite footprint. PRs #83, #85, #86, #87 are also open but not strictly required for the experiment to run — they harden surrounding paths against silent failure but don't gate the test sequence itself.
+
+### Gap B — Nine A/B toggles (the big one — ~225 LOC) — ⏳ in PR A (separate)
+
+See §6 above. Without these, phases 0, 1, 3a–3d, 3-LIN-*, and 4 cannot be run cleanly — they either change multiple variables at once or have no working knob. **Required to execute phases 0–5 as designed.**
+
+### Gap C — Harness preflight assertions (~80 LOC) — ✅ closed in this PR
+
+Add to `tools/evaluate_beam_end_to_end.py:main()` near argument parsing:
+
+1. **Pure-recall guard:** `sys.exit(1)` with explanatory message if `MNEMOSYNE_BENCHMARK_PURE_RECALL` is not truthy AND `--pure-recall` was not passed AND a new `--allow-harness-oracles` opt-out wasn't passed (existing benchmark workflows might legitimately want the legacy mode for ceiling tests; require explicit opt-in to be sure).
+2. **Env-var dump:** at run start, snapshot every env var matching `^MNEMOSYNE_|^FULL_CONTEXT_MODE$|^OPENROUTER_BASE_URL$` into the results JSON under `config.env`.
+3. **Active recall path logger:** wrap `BeamMemory.recall` to record whether each call took the linear or polyphonic branch; emit a count in the per-conversation summary so an accidental mid-run mode flip is visible.
+4. **Sentinel feature checks:** assert importable: `_dedup_cross_tier_summary_links` from `beam.py` (proves #88 merged), `aggregate_veracity` from `veracity_consolidation.py` (proves #89 merged), `_env_truthy` from the harness module itself (proves #91 merged). Fail fast with the missing-PR name.
+
+### Gap D — Harness diagnostic capture (~60 LOC) — ✅ closed in this PR
+
+Wire the harness to call `get_recall_diagnostics()` and `get_extraction_stats()` and write their JSON snapshots into `results/beam_e2e_results.json` per-conversation per-phase. Also call `reset_recall_diagnostics()` at the start of each phase to keep counters clean. The functions exist (PR #78 + #79); the harness simply doesn't use them.
+
+### Gap E — Per-question paired-outcome recording for CIs (~40 LOC)
+
+Currently the harness writes per-question scores but doesn't structure them for paired statistical analysis. Add: for each (config, question) pair, record whether the answer was correct. Output a flat `paired_outcomes.jsonl` with `{config_id, question_id, ability, correct}` rows so a downstream notebook can bootstrap CIs without re-parsing the main results.
+
+### Gap F — `requirements-benchmark.txt` (~5 LOC) — ✅ closed in this PR
+
+Add a top-level file listing `numpy`, `datasets`, `sqlite-vec`, `fastembed`, optionally `llama-cpp-python` and `huggingface-hub`. Reference it from the README under "Running the BEAM benchmark." The current pyproject `[project.optional-dependencies]` groups (`llm`, `embeddings`, `mcp`, `all`) don't cover the benchmark-only deps (`numpy`, `datasets`, `sqlite-vec`).
+
+### Gap G — Voice-score capture in linear-path results (~20 LOC)
+
+The polyphonic results already carry `voice_scores: dict` per result dict (`beam.py:~2969`). Linear-path results don't — they have `dense_score`, `keyword_score`, `fts_score` separately but no unified provenance dict. For uniform post-hoc analysis ("which signal drove this row?"), add a similarly-shaped provenance dict to linear results too. Not strictly required to run the plan, but materially eases analysis. Defer if scope is tight.
+
+### Total effort to close all gaps
+
+- Required for plan execution (A + B + C + D): ~365 LOC + 40 tests + 6 PR merges
+- Highly recommended (E + F): ~45 LOC + 1 doc file
+- Nice-to-have (G): ~20 LOC
+
+A single "experiment-readiness" PR bundling B + C + D + E + F is ~510 LOC and one /review pass. Or split into three smaller PRs:
+1. Toggles (B) — biggest, most reviewable on its own
+2. Preflight + diagnostic capture (C + D + F) — harness-only, no recall-path changes
+3. Paired-outcome recording (E) — orthogonal, easy
+
+Tell me which order you want them in.
+
+---
+
+## What to record per run
+
+Capture into `results/beam_e2e_results.json`:
+
+- **Per-ability score** — TR / CR / IE / KU / MR / ABS / EO / SUM, plus total.
+- **Run config** — phase number, all toggle states, polyphonic flag, sample size, scale.
+- **Recall diagnostics** (`mnemosyne.core.recall_diagnostics.get_recall_diagnostics()` returns a JSON-serializable Dict snapshot; call once per recall and aggregate, OR once at run end): per-tier kept counts (`wm_fts`, `wm_vec`, `wm_fallback`, `em_fts`, `em_vec`, `em_fallback`), `fallback_rate`, `truly_empty` count. Use `reset_recall_diagnostics()` from the same module to clear counters before each phase. **The harness currently does NOT call these — wiring this in is part of the implementation-gaps list below.**
+- **Extraction diagnostics** (`mnemosyne.extraction.diagnostics.get_extraction_stats()`): per-tier extract counts + bounded error samples. Also not currently called by the harness.
+- **Latency** — p50 / p95 / p99 per-question recall + answer roundtrip.
+- **Storage** — final row counts in `working_memory`, `episodic_memory`, `memory_embeddings`, `vec_episodes`, `annotations`, `consolidated_facts`.
+- **Peak RSS** during ingest phase and recall phase separately.
+
+The diagnostics fields are the single biggest improvement to post-hoc analysis — they tell you WHICH tier produced each kept row, which lets you attribute score deltas to specific code paths instead of guessing.
+
+**Statistical reporting:** record per-question paired outcomes (was the answer correct in config A and config B for the same question?) and compute bootstrap CIs on the per-ability score deltas. With ~50 questions per conversation and 1–3 conversations per scale, a 2pp delta on total score is likely within noise; treat sub-3pp deltas as inconclusive until CIs separate. Where a thesis predicts "near-zero Δ," the right falsification criterion is "95% CI excludes ±2pp," not point-estimate equality.
+
+---
+
+## Recommended sequence of runs
+
+Minimum credible A/B requires ~10–12 runs:
+
+1. Phase 0 — 100K (baseline floor, all multipliers off)
+2. Phase 1 — 100K (+ veracity multiplier)
+3. Phase 2 — 100K (+ polyphonic engine)
+4. Phase 3a — 100K (− polyphonic fact voice)
+5. Phase 3b — 100K (− polyphonic graph voice)
+6. Phase 3c — 100K (− polyphonic temporal voice)
+7. Phase 3d — 100K (− polyphonic vector voice — expected large negative Δ; this is the polyphonic-engine analog of "no vector signal")
+8. Phase 4 — 100K (− cross-tier dedup)
+9. Phase 5 — 100K (+ algorithmic enrichment, populates entity/fact data)
+10. Phase 6 — 250K confirmation on the top-2 configs + Phase-0 floor
+
+Phases 3a–3d can run in parallel from a Phase-2 DB snapshot since each toggle is independent of the others.
+
+Approximate wall-clock budget: 5–6 hours total if 100K phases land in ~20 min each and the 250K run takes 60–90 min. Run a sample-1 conversation dry-run first to confirm corpus loaded, embeddings populated, and the preflight assertions fire.
+
+**Optional linear-scorer ablations** (only if you want to deprecate components of the linear path; not required for the polyphonic-vs-linear comparison):
+
+- Phase 3-LIN-bin — linear binary-vector bonus off
+- Phase 3-LIN-graph — linear graph bonus off
+- Phase 3-LIN-fact — linear fact bonus off
+
+**Optional ceiling and lower-bound bookends:**
+
+- Phase 7 — `--full-context` (LLM ceiling without recall). Sets the upper bound.
+- Phase 8 — Phase 6 with `MNEMOSYNE_VERACITY_MULTIPLIER=0`. Cleanest possible linear-vs-polyphonic A/B at scale.
+
+If any thesis turns out wildly wrong (e.g., fact voice contributes 5+pp on Thesis 1a), pause and investigate before continuing — the surprise likely indicates a code path the plan doesn't account for. The PRs ship the harness changes; the testing remains yours.
+
+---
+
+**Open PRs at handoff:** #80, #82, #83, #85, #86, #87, #88, #89, #90, #91. None are experiment-blocking individually, but the experiment can't run cleanly until at least #82, #88, #89, and #90 are merged. The rest improve specific tools' measurability and observability.

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -181,6 +181,23 @@ DEGRADE_BATCH_SIZE = int(os.environ.get("MNEMOSYNE_DEGRADE_BATCH", "100"))
 SMART_COMPRESS = os.environ.get("MNEMOSYNE_SMART_COMPRESS", "1") not in ("0", "false", "no")
 TIER3_MAX_CHARS = int(os.environ.get("MNEMOSYNE_TIER3_MAX_CHARS", "300"))
 
+
+def _env_disabled(name: str) -> bool:
+    """A/B toggle helper: return True iff the env var is explicitly
+    set to a falsy value (`0`/`false`/`no`/`off`, case-insensitive,
+    whitespace-stripped).
+
+    Used by experiment ablation toggles where the feature is ON by
+    default (production behavior) and operators can disable it
+    explicitly via env var. Distinct from `_env_truthy` from the
+    benchmark harness — that one defaults to OFF, this one defaults
+    to ON. See `docs/benchmarking.md` for the full toggle reference.
+
+    Unset / empty / non-falsy → False (feature enabled).
+    """
+    val = os.environ.get(name, "").strip().lower()
+    return val in ("0", "false", "no", "off")
+
 # Veracity weighting (memory confidence). C29: defaults come from
 # `_VW_DEFAULTS` which mirrors `veracity_consolidation.VERACITY_WEIGHTS`
 # in normal mode and falls back to a hardcoded literal in degraded-import
@@ -2871,14 +2888,18 @@ class BeamMemory:
             # vec_weight + fts_weight + importance_weight are normalized to sum to 1.0
             base_score = sim * vw + fts * fw + row["importance"] * iw
 
-            # Phase 5: Graph + fact voices (polyphonic recall bonus)
+            # Phase 5: Graph + fact voices (polyphonic recall bonus).
+            # Each block gated by an A/B toggle: `MNEMOSYNE_GRAPH_BONUS=0`,
+            # `MNEMOSYNE_FACT_BONUS=0`, `MNEMOSYNE_BINARY_BONUS=0` to
+            # disable individually for ablation. Default ON — production
+            # behavior unchanged.
             graph_bonus = 0.0
             fact_bonus = 0.0
             binary_bonus = 0.0
             memory_id = row["id"]
             content_lower = row["content"].lower()
             bv = row["binary_vector"]
-            if self.episodic_graph is not None:
+            if self.episodic_graph is not None and not _env_disabled("MNEMOSYNE_GRAPH_BONUS"):
                 try:
                     # Count graph edges for this memory (well-connected = more relevant)
                     cursor2 = self.conn.cursor()
@@ -2889,7 +2910,7 @@ class BeamMemory:
                     graph_bonus = min(edge_count * 0.02, 0.08)
                 except Exception:
                     pass
-            if self.episodic_graph is not None:
+            if self.episodic_graph is not None and not _env_disabled("MNEMOSYNE_FACT_BONUS"):
                 try:
                     # Check if facts from graph match query terms via set-overlap
                     cursor2 = self.conn.cursor()
@@ -2908,7 +2929,7 @@ class BeamMemory:
             # Binary vector voice (Phase 5): re-enabled — binary vectors are now
             # backfilled for all episodic entries. ITS discriminability improves at
             # scale (1033 entries); clustering concern was for small synthetic sets.
-            if query_bv is not None and bv is not None:
+            if query_bv is not None and bv is not None and not _env_disabled("MNEMOSYNE_BINARY_BONUS"):
                 try:
                     # Compute hamming distance via XOR + popcount
                     q_arr = np.frombuffer(query_bv, dtype=np.uint8)
@@ -3009,32 +3030,37 @@ class BeamMemory:
                     base_score = relevance * kw_share + row["importance"] * iw
                     score = base_score * (rc_share + (1.0 - rc_share) * decay)
 
-                    # Phase 5: Graph + fact + binary bonuses for fallback
+                    # Phase 5: Graph + fact + binary bonuses for fallback.
+                    # Gated by the same toggles as the main loop above
+                    # so ablation behavior is consistent across both
+                    # episodic paths.
                     graph_b = 0.0
                     fact_b = 0.0
                     binary_b = 0.0
-                    try:
-                        cursor2 = self.conn.cursor()
-                        cursor2.execute(
-                            "SELECT COUNT(*) FROM graph_edges WHERE source LIKE ? OR target LIKE ?",
-                            (f"%{row['id']}%", f"%{row['id']}%"))
-                        graph_b = min(cursor2.fetchone()[0] * 0.02, 0.08)
-                    except Exception:
-                        pass
-                    try:
-                        cursor2 = self.conn.cursor()
-                        cursor2.execute(
-                            "SELECT subject, predicate, object FROM facts WHERE source_msg_id = ?",
-                            (row["id"],))
-                        q_word_set = {w for w in query.lower().split() if len(w) > 2}
-                        mc = 0
-                        for frow in cursor2.fetchall():
-                            f_tokens = {t.lower() for t in (f"{frow['subject']} {frow['predicate']} {frow['object']}").split() if len(t) > 2}
-                            if q_word_set & f_tokens:
-                                mc += 1
-                        fact_b = min(mc * 0.04, 0.1)
-                    except Exception:
-                        pass
+                    if not _env_disabled("MNEMOSYNE_GRAPH_BONUS"):
+                        try:
+                            cursor2 = self.conn.cursor()
+                            cursor2.execute(
+                                "SELECT COUNT(*) FROM graph_edges WHERE source LIKE ? OR target LIKE ?",
+                                (f"%{row['id']}%", f"%{row['id']}%"))
+                            graph_b = min(cursor2.fetchone()[0] * 0.02, 0.08)
+                        except Exception:
+                            pass
+                    if not _env_disabled("MNEMOSYNE_FACT_BONUS"):
+                        try:
+                            cursor2 = self.conn.cursor()
+                            cursor2.execute(
+                                "SELECT subject, predicate, object FROM facts WHERE source_msg_id = ?",
+                                (row["id"],))
+                            q_word_set = {w for w in query.lower().split() if len(w) > 2}
+                            mc = 0
+                            for frow in cursor2.fetchall():
+                                f_tokens = {t.lower() for t in (f"{frow['subject']} {frow['predicate']} {frow['object']}").split() if len(t) > 2}
+                                if q_word_set & f_tokens:
+                                    mc += 1
+                            fact_b = min(mc * 0.04, 0.1)
+                        except Exception:
+                            pass
                     # Binary vector bonus disabled (same reason as main path — ITS clustering)
                     binary_b = 0.0
                     score += graph_b + fact_b + binary_b
@@ -3095,6 +3121,11 @@ class BeamMemory:
             tier_lookup = {r["id"]: (r["tier"] or 1) for r in tier_rows}
             veracity_lookup = {r["id"]: (r["veracity"] or "unknown") for r in tier_rows}
             ep_summary_of_map = {r["id"]: (r["summary_of"] or "") for r in tier_rows}
+            # A/B toggle: `MNEMOSYNE_VERACITY_MULTIPLIER=0` short-circuits
+            # the multiplier so ranking depends on hybrid score alone.
+            # Useful for Phase 0/1 ablation in the BEAM-recovery
+            # experiment. Default ON.
+            apply_veracity = not _env_disabled("MNEMOSYNE_VERACITY_MULTIPLIER")
             for r in results:
                 if r.get("tier") == "episodic":
                     ep_tier = tier_lookup.get(r["id"], 1)
@@ -3102,7 +3133,8 @@ class BeamMemory:
                     r["degradation_tier"] = ep_tier
                     r["veracity"] = ep_veracity
                     r["score"] *= weight_map.get(ep_tier, 1.0)
-                    r["score"] *= veracity_map.get(ep_veracity, UNKNOWN_WEIGHT)
+                    if apply_veracity:
+                        r["score"] *= veracity_map.get(ep_veracity, UNKNOWN_WEIGHT)
 
         # [E4] Apply the veracity multiplier to working_memory results
         # too. Pre-E4 the multiplier was episodic-only, so per-row
@@ -3111,10 +3143,11 @@ class BeamMemory:
         # batch-ingested 'stated' content didn't rank above 'unknown'.
         # The row dicts already carry "veracity" from the SELECT
         # populated earlier in this function, so no second query needed.
-        for r in results:
-            if r.get("tier") == "working":
-                wm_veracity = r.get("veracity") or "unknown"
-                r["score"] *= veracity_map.get(wm_veracity, UNKNOWN_WEIGHT)
+        if not _env_disabled("MNEMOSYNE_VERACITY_MULTIPLIER"):
+            for r in results:
+                if r.get("tier") == "working":
+                    wm_veracity = r.get("veracity") or "unknown"
+                    r["score"] *= veracity_map.get(wm_veracity, UNKNOWN_WEIGHT)
 
         results.sort(key=lambda x: x["score"], reverse=True)
         # E3.a.3: collapse (episodic_summary, working_memory_source)
@@ -3261,7 +3294,13 @@ class BeamMemory:
             `sleep()` / `forget()` between them could yield stale linkage
             data. Acceptable under SQLite WAL + busy_timeout: the worst
             case is a one-call dedup miss, not data loss.
+
+        A/B toggle: `MNEMOSYNE_CROSS_TIER_DEDUP=0` disables the dedup,
+        returning the input list unchanged. Used by the BEAM-recovery
+        Phase 4 ablation to isolate the dedup's contribution.
         """
+        if _env_disabled("MNEMOSYNE_CROSS_TIER_DEDUP"):
+            return results
         ep_ids = [r["id"] for r in results if r.get("tier") == "episodic"]
         if not ep_ids:
             return results
@@ -3490,9 +3529,13 @@ class BeamMemory:
             # flag=ON callers don't silently lose the veracity rank
             # signal or tier degradation. Veracity multiplier applies
             # to both tiers (matching the post-E4 linear behavior).
+            # A/B toggle: `MNEMOSYNE_VERACITY_MULTIPLIER=0` disables
+            # veracity scaling here too — mirroring the linear path so
+            # both arms ablate identically.
             score = r.combined_score
             row_veracity = row_dict.get("veracity") or "unknown"
-            score *= weight_map.get(row_veracity, UNKNOWN_WEIGHT)
+            if not _env_disabled("MNEMOSYNE_VERACITY_MULTIPLIER"):
+                score *= weight_map.get(row_veracity, UNKNOWN_WEIGHT)
             if row_dict.get("tier") == "episodic":
                 ep_tier = row_dict.get("degradation_tier") or 1
                 score *= tier_weight_map.get(ep_tier, 1.0)

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -189,11 +189,88 @@ TIER3_MAX_CHARS = int(os.environ.get("MNEMOSYNE_TIER3_MAX_CHARS", "300"))
 # Env-var overrides remain so operators can tune ranking; documented
 # drift risk: if `MNEMOSYNE_*_WEIGHT` is set, recall scoring diverges
 # from consolidation confidence math (consolidator doesn't honor env).
-STATED_WEIGHT = float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", str(_VW_DEFAULTS["stated"])))
-INFERRED_WEIGHT = float(os.environ.get("MNEMOSYNE_INFERRED_WEIGHT", str(_VW_DEFAULTS["inferred"])))
-TOOL_WEIGHT = float(os.environ.get("MNEMOSYNE_TOOL_WEIGHT", str(_VW_DEFAULTS["tool"])))
-IMPORTED_WEIGHT = float(os.environ.get("MNEMOSYNE_IMPORTED_WEIGHT", str(_VW_DEFAULTS["imported"])))
-UNKNOWN_WEIGHT = float(os.environ.get("MNEMOSYNE_UNKNOWN_WEIGHT", str(_VW_DEFAULTS["unknown"])))
+def _env_float(name: str, default: float) -> float:
+    """Parse an env var as float; fall back to `default` on empty or
+    invalid values rather than crashing at module load.
+
+    Pre-fix `float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", "1.0"))`
+    raised ValueError when the env var was set to empty (`export
+    MNEMOSYNE_STATED_WEIGHT=`) because `os.environ.get` returns `""`
+    (the value), not the default — `float("")` then crashed import
+    BEFORE the C32 override-WARN could fire. Restored from PR #91
+    after the merge stripped it.
+    """
+    raw = os.environ.get(name, "")
+    raw = raw.strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a valid float; falling back to default %s",
+            name, raw[:80], default,
+        )
+        return default
+
+
+# Veracity weighting (memory confidence)
+STATED_WEIGHT = _env_float("MNEMOSYNE_STATED_WEIGHT", _VW_DEFAULTS["stated"])
+INFERRED_WEIGHT = _env_float("MNEMOSYNE_INFERRED_WEIGHT", _VW_DEFAULTS["inferred"])
+TOOL_WEIGHT = _env_float("MNEMOSYNE_TOOL_WEIGHT", _VW_DEFAULTS["tool"])
+IMPORTED_WEIGHT = _env_float("MNEMOSYNE_IMPORTED_WEIGHT", _VW_DEFAULTS["imported"])
+UNKNOWN_WEIGHT = _env_float("MNEMOSYNE_UNKNOWN_WEIGHT", _VW_DEFAULTS["unknown"])
+
+
+def _detect_veracity_weight_overrides() -> List[str]:
+    """C32: return a list of `MNEMOSYNE_*_WEIGHT` env vars set to a
+    non-empty value. Filters out empty-string values (`export
+    MNEMOSYNE_STATED_WEIGHT=`) since `_env_float` falls back to default
+    on empties — counting them would confuse the WARN message.
+    """
+    return [
+        name for name in (
+            "MNEMOSYNE_STATED_WEIGHT",
+            "MNEMOSYNE_INFERRED_WEIGHT",
+            "MNEMOSYNE_TOOL_WEIGHT",
+            "MNEMOSYNE_IMPORTED_WEIGHT",
+            "MNEMOSYNE_UNKNOWN_WEIGHT",
+        )
+        if os.environ.get(name, "").strip()
+    ]
+
+
+_VERACITY_WARN_EMITTED = False
+
+
+def _warn_about_veracity_weight_overrides(force: bool = False) -> bool:
+    """Log a WARNING if any `MNEMOSYNE_*_WEIGHT` env var is overridden.
+
+    Idempotent per-process: subsequent calls return False without
+    re-emitting unless `force=True` (tests use this to verify the WARN
+    fires per call). Multi-worker setups (uvicorn `--workers`,
+    pytest-xdist) get one WARN per process instead of N per startup.
+    """
+    global _VERACITY_WARN_EMITTED
+    if _VERACITY_WARN_EMITTED and not force:
+        return False
+    overrides = _detect_veracity_weight_overrides()
+    if not overrides:
+        return False
+    logger.warning(
+        "Veracity weight env overrides detected: %s. Recall scoring will "
+        "honor the override, but consolidation Bayesian compounding "
+        "(veracity_consolidation.VERACITY_WEIGHTS) does NOT — the two "
+        "will drift. Set matching values in veracity_consolidation.py "
+        "OR accept that 'consolidated-as-N also ranks at N' invariant "
+        "is broken until the consolidator is taught the same overrides.",
+        ", ".join(overrides),
+    )
+    _VERACITY_WARN_EMITTED = True
+    return True
+
+
+_warn_about_veracity_weight_overrides()
 
 # Vector compression: float32 | int8 | bit
 VEC_TYPE = os.environ.get("MNEMOSYNE_VEC_TYPE", "int8").lower()
@@ -1755,7 +1832,60 @@ class BeamMemory:
                     "%d items (vector voice will miss these rows) (%s): %s",
                     len(items), type(exc).__name__, exc,
                 )
-        
+
+        # E2 — enrichment parity with `remember()`. The merge of PR #82
+        # accidentally stripped these calls during conflict resolution;
+        # `_add_temporal_triple` and `_ingest_graph_and_veracity` exist
+        # but were not being called per row. Without them the polyphonic
+        # engine's graph + fact voices have no data to fuse and recall's
+        # multi-voice RRF collapses. Each call is non-blocking
+        # (try/except around per-row metadata access prevents one bad
+        # row from killing the rest of the batch). Runs after the bulk
+        # working_memory + embedding writes so a failure here doesn't
+        # poison the per-row source / veracity bookkeeping.
+        for memory_id in ids:
+            item_source, item_veracity = meta_by_id.get(
+                memory_id, ("conversation", "unknown")
+            )
+            try:
+                # Look up the just-written row to find its content +
+                # timestamp; cheap (PK lookup).
+                row = cursor.execute(
+                    "SELECT content, timestamp FROM working_memory WHERE id = ?",
+                    (memory_id,),
+                ).fetchone()
+                if row is None:
+                    continue
+                row_content = row["content"] if hasattr(row, "keys") else row[0]
+                row_timestamp = row["timestamp"] if hasattr(row, "keys") else row[1]
+                self._add_temporal_triple(
+                    memory_id, row_timestamp, item_source, row_content
+                )
+                self._ingest_graph_and_veracity(
+                    memory_id, row_content, item_source, item_veracity
+                )
+                if extract_entities:
+                    _extract_and_store_entities(self, memory_id, row_content)
+                if extract:
+                    _extract_and_store_facts(self, memory_id, row_content, item_source)
+                # MEMORY_ADDED parity with remember() — streaming
+                # observers + DeltaSync see batch rows the same way
+                # they see single-row writes.
+                self._emit_event(
+                    "MEMORY_ADDED", memory_id,
+                    content=row_content,
+                    source=item_source,
+                    importance=0.5,
+                    metadata=None,
+                )
+            except Exception as exc:
+                # Defensive: a single row's enrichment failure must not
+                # poison the rest of the batch. Log + continue.
+                logger.warning(
+                    "remember_batch: per-row enrichment failed for %s (%s): %s",
+                    memory_id, type(exc).__name__, exc,
+                )
+
         self._trim_working_memory()
         return ids
 

--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -48,6 +48,17 @@ from mnemosyne.core.veracity_consolidation import (
 )
 
 
+def _env_disabled(name: str) -> bool:
+    """A/B toggle helper: return True iff env var is set to a falsy
+    value (`0`/`false`/`no`/`off`). Used by the per-voice ablation
+    toggles. Mirrors the helper in `beam.py` so each module is
+    self-contained — duplicated rather than imported to avoid a
+    cross-module dependency for a 4-line helper.
+    """
+    val = os.environ.get(name, "").strip().lower()
+    return val in ("0", "false", "no", "off")
+
+
 @dataclass
 class RecallResult:
     """Result from a single recall voice."""
@@ -179,7 +190,13 @@ class PolyphonicRecallEngine:
         higher-similarity occurrence — without this, a memory that
         exists in both tiers post-E3 would be double-counted in RRF
         and silently cap unique candidates below `top_k=20`.
+
+        A/B toggle: `MNEMOSYNE_VOICE_VECTOR=0` disables this voice for
+        ablation experiments. Returns empty so RRF fusion sees no
+        vector contribution.
         """
+        if _env_disabled("MNEMOSYNE_VOICE_VECTOR"):
+            return []
         if query_embedding is None or np is None:
             return []
 
@@ -471,10 +488,14 @@ class PolyphonicRecallEngine:
     def _graph_voice(self, query: str) -> List[RecallResult]:
         """
         Voice 2: Episodic graph traversal.
-        
+
         Extracts entities from query, finds related memories
         through graph edges.
+
+        A/B toggle: `MNEMOSYNE_VOICE_GRAPH=0` disables this voice.
         """
+        if _env_disabled("MNEMOSYNE_VOICE_GRAPH"):
+            return []
         # Extract entities (simple noun extraction)
         entities = self._extract_entities(query)
         
@@ -505,9 +526,13 @@ class PolyphonicRecallEngine:
     def _fact_voice(self, query: str) -> List[RecallResult]:
         """
         Voice 3: Structured fact matching.
-        
+
         Matches query against consolidated facts.
+
+        A/B toggle: `MNEMOSYNE_VOICE_FACT=0` disables this voice.
         """
+        if _env_disabled("MNEMOSYNE_VOICE_FACT"):
+            return []
         # Extract potential subject from query
         words = query.lower().split()
         
@@ -553,7 +578,11 @@ class PolyphonicRecallEngine:
 
         Boosts recent memories, penalizes old ones.
         Uses exponential decay based on age.
+
+        A/B toggle: `MNEMOSYNE_VOICE_TEMPORAL=0` disables this voice.
         """
+        if _env_disabled("MNEMOSYNE_VOICE_TEMPORAL"):
+            return []
         # Check for temporal keywords
         temporal_keywords = [
             "yesterday", "today", "recent", "last", "latest",

--- a/mnemosyne/core/veracity_consolidation.py
+++ b/mnemosyne/core/veracity_consolidation.py
@@ -525,8 +525,14 @@ class VeracityConsolidator:
 
                 conflicts = cursor.fetchall()
 
-                # Insert new fact
-                fact_id = f"cf_{subject}_{predicate}_{object}".replace(" ", "_")[:100]
+                # Insert new fact. E2.a.4 (PR #83): use `compute_fact_id`
+                # (SHA-256 of NFC-normalized SPO + length-prefix framing)
+                # for collision-free deterministic IDs. The merge of
+                # PR #83 accidentally left the OLD truncating f-string
+                # pattern at this call site even though `compute_fact_id`
+                # exists at line 38; same hunk that dropped the new logic
+                # also dropped the call.
+                fact_id = compute_fact_id(subject, predicate, object)
                 base_confidence = VERACITY_WEIGHTS.get(veracity, 0.8) * 0.5
 
                 sources = [source] if source else []

--- a/requirements-benchmark.txt
+++ b/requirements-benchmark.txt
@@ -1,0 +1,18 @@
+# Benchmark-only dependencies for `tools/evaluate_beam_end_to_end.py`.
+#
+# These are NOT required for normal Mnemosyne use — install them only when
+# running BEAM benchmarks or comparing recall configurations. The package
+# proper declares `embeddings`, `llm`, `mcp`, `all`, and `dev` extras in
+# pyproject.toml; the harness needs `numpy` + `datasets` + `sqlite-vec` on
+# top of those.
+#
+# Install: pip install -r requirements-benchmark.txt
+# See docs/benchmarking.md for the full benchmark setup guide.
+
+datasets>=2.0      # HuggingFace BEAM dataset loader
+numpy>=1.20        # Required unconditionally by the harness
+sqlite-vec>=0.1    # ANN backend for vec_episodes virtual table
+
+# Plus the package's own extras — install separately:
+#   pip install 'mnemosyne-memory[embeddings,llm]'
+# (fastembed for the vector voice + optional llama-cpp for sleep summarization)

--- a/tests/test_ab_toggles.py
+++ b/tests/test_ab_toggles.py
@@ -1,0 +1,447 @@
+"""Regression tests for the BEAM-recovery experiment A/B toggles.
+
+Each toggle is default-ON (production behavior unchanged) and disables
+the corresponding feature when set to a falsy value (`0`/`false`/`no`/
+`off`, case-insensitive, whitespace-stripped). See
+`docs/benchmarking.md` for the full toggle catalog.
+
+These tests pin three properties per toggle:
+  1. Default behavior (env unset) — feature ENABLED.
+  2. Falsy values disable the feature.
+  3. The disable surfaces in actual recall results (when feasible) —
+     not just an internal flag — so a future refactor that strips the
+     gate from the code path fails this test instead of silently
+     reverting the experiment's ability to ablate.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from mnemosyne.core.beam import BeamMemory, _env_disabled
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+@pytest.fixture(autouse=True)
+def _clean_toggle_env(monkeypatch):
+    """Each test starts from a clean env. Clears every toggle so
+    test order can't affect outcomes."""
+    for name in (
+        "MNEMOSYNE_VOICE_VECTOR", "MNEMOSYNE_VOICE_GRAPH",
+        "MNEMOSYNE_VOICE_FACT", "MNEMOSYNE_VOICE_TEMPORAL",
+        "MNEMOSYNE_GRAPH_BONUS", "MNEMOSYNE_FACT_BONUS",
+        "MNEMOSYNE_BINARY_BONUS", "MNEMOSYNE_VERACITY_MULTIPLIER",
+        "MNEMOSYNE_CROSS_TIER_DEDUP",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+# ─────────────────────────────────────────────────────────────────
+# _env_disabled helper itself
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestEnvDisabledHelper:
+    """Pins the default-ON-with-opt-out semantics so future toggles
+    that use this helper inherit the same falsy-value parsing."""
+
+    @pytest.mark.parametrize("value", [
+        "0", "false", "no", "off",
+        "FALSE", "OFF", "False", "No",
+        " 0 ", "  false  ", "\toff\t",
+    ])
+    def test_falsy_values_disable(self, value, monkeypatch):
+        monkeypatch.setenv("X_TEST_TOGGLE", value)
+        assert _env_disabled("X_TEST_TOGGLE") is True
+
+    @pytest.mark.parametrize("value", [
+        "1", "true", "yes", "on",
+        "TRUE", "ON",
+        "", " ", "anything-else", "maybe",
+    ])
+    def test_truthy_or_garbage_enable(self, value, monkeypatch):
+        """Unset / empty / truthy / unrecognized → feature stays ON."""
+        monkeypatch.setenv("X_TEST_TOGGLE", value)
+        assert _env_disabled("X_TEST_TOGGLE") is False
+
+    def test_unset_returns_false(self, monkeypatch):
+        monkeypatch.delenv("X_TEST_TOGGLE", raising=False)
+        assert _env_disabled("X_TEST_TOGGLE") is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# Polyphonic voice toggles (4)
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPolyphonicVoiceToggles:
+    """Each polyphonic voice has a toggle. When disabled, the voice
+    returns `[]`, contributing nothing to the engine's RRF fusion."""
+
+    @pytest.fixture
+    def engine(self, temp_db):
+        from mnemosyne.core.polyphonic_recall import PolyphonicRecallEngine
+        # Construct with default args; uses temp_db for any state.
+        eng = PolyphonicRecallEngine(db_path=temp_db)
+        yield eng
+        eng.close()
+
+    def test_vector_voice_disabled_returns_empty(self, engine, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_VOICE_VECTOR", "0")
+        # Pass a dummy embedding; with toggle off we should short-circuit
+        # before any DB work.
+        import numpy as np
+        result = engine._vector_voice(np.zeros(384, dtype=np.float32))
+        assert result == []
+
+    def test_vector_voice_enabled_runs(self, engine, monkeypatch):
+        """With toggle unset (default), the voice attempts to run.
+        We don't assert specific results — only that we got past the
+        early-return guard (returns a list, even if empty)."""
+        monkeypatch.delenv("MNEMOSYNE_VOICE_VECTOR", raising=False)
+        import numpy as np
+        result = engine._vector_voice(np.zeros(384, dtype=np.float32))
+        assert isinstance(result, list)
+        # No memories in fresh DB → empty list, but we got past the gate.
+
+    def test_graph_voice_disabled_returns_empty(self, engine, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_VOICE_GRAPH", "false")
+        result = engine._graph_voice("any query here")
+        assert result == []
+
+    def test_graph_voice_enabled_runs(self, engine, monkeypatch):
+        monkeypatch.delenv("MNEMOSYNE_VOICE_GRAPH", raising=False)
+        result = engine._graph_voice("any query here")
+        assert isinstance(result, list)
+
+    def test_fact_voice_disabled_returns_empty(self, engine, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_VOICE_FACT", "off")
+        result = engine._fact_voice("any query here")
+        assert result == []
+
+    def test_fact_voice_enabled_runs(self, engine, monkeypatch):
+        monkeypatch.delenv("MNEMOSYNE_VOICE_FACT", raising=False)
+        result = engine._fact_voice("any query here")
+        assert isinstance(result, list)
+
+    def test_temporal_voice_disabled_returns_empty(self, engine, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_VOICE_TEMPORAL", "no")
+        result = engine._temporal_voice("recent activity yesterday")
+        assert result == []
+
+    def test_temporal_voice_enabled_runs(self, engine, monkeypatch):
+        monkeypatch.delenv("MNEMOSYNE_VOICE_TEMPORAL", raising=False)
+        result = engine._temporal_voice("recent activity yesterday")
+        assert isinstance(result, list)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Linear-path bonus toggles (3)
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLinearBonusToggles:
+    """Linear path's `graph_bonus` / `fact_bonus` / `binary_bonus` add
+    capped (0.08, 0.1, 0.08) score lifts to episodic rows. With the
+    toggles disabled, those lifts must not be applied.
+
+    Direct assertion: with toggle OFF, the score is what hybrid scoring
+    produces WITHOUT the bonus block running. We check this by
+    structural test of beam.py — the toggles short-circuit the entire
+    bonus-computation block, not just the final addition, so any rows
+    that would have received a bonus get a strictly lower score.
+    """
+
+    def _seed_episodic_with_graph_data(self, beam: BeamMemory):
+        """Seed one episodic row + corresponding graph_edges + facts
+        rows so a recall query has bonuses available to claim."""
+        ts = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("ep-bonus", "deploy production rollout plan", "consolidation",
+             ts, "s1", 0.5),
+        )
+        # graph_edges: this memory_id has connections
+        beam.conn.execute(
+            "INSERT INTO graph_edges (source, target, edge_type) "
+            "VALUES (?, ?, ?)",
+            ("ep-bonus", "ep-other", "related"),
+        )
+        beam.conn.execute(
+            "INSERT INTO graph_edges (source, target, edge_type) "
+            "VALUES (?, ?, ?)",
+            ("ep-other", "ep-bonus", "related"),
+        )
+        # facts: this memory has extracted facts that match a query word
+        beam.conn.execute(
+            "INSERT INTO facts (fact_id, session_id, source_msg_id, subject, predicate, object) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("fact-1", "s1", "ep-bonus", "team", "deploys", "production"),
+        )
+        beam.conn.commit()
+
+    def test_graph_bonus_disabled_does_not_apply(self, temp_db, monkeypatch):
+        """With `MNEMOSYNE_GRAPH_BONUS=0`, the graph-edge bonus block is
+        skipped. We construct the same scenario twice and assert the
+        scores differ by the expected bonus amount."""
+        # Run 1: default ON — score includes graph bonus.
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        self._seed_episodic_with_graph_data(beam)
+        # Defang downstream multipliers we don't care about.
+        monkeypatch.setenv("MNEMOSYNE_VERACITY_MULTIPLIER", "0")
+        monkeypatch.delenv("MNEMOSYNE_GRAPH_BONUS", raising=False)
+        on_results = beam.recall("deploy production rollout", top_k=5)
+        beam.conn.close()
+
+        # Run 2: bonus OFF, otherwise identical.
+        with tempfile.TemporaryDirectory() as tmpdir2:
+            db2 = Path(tmpdir2) / "test.db"
+            beam2 = BeamMemory(session_id="s1", db_path=db2)
+            self._seed_episodic_with_graph_data(beam2)
+            monkeypatch.setenv("MNEMOSYNE_GRAPH_BONUS", "0")
+            off_results = beam2.recall("deploy production rollout", top_k=5)
+            beam2.conn.close()
+
+        on_hit = next((r for r in on_results if r["id"] == "ep-bonus"), None)
+        off_hit = next((r for r in off_results if r["id"] == "ep-bonus"), None)
+        assert on_hit is not None and off_hit is not None
+        # When bonus is enabled, score is strictly higher (bonus is
+        # additive on the linear ep path). Allow for floating-point
+        # noise.
+        assert on_hit["score"] > off_hit["score"], (
+            f"graph_bonus toggle had no effect on score: "
+            f"on={on_hit['score']} off={off_hit['score']}"
+        )
+
+    def test_fact_bonus_disabled_does_not_apply(self, temp_db, monkeypatch):
+        """Same shape for fact_bonus: with toggle off, score is strictly
+        lower than with toggle on."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        self._seed_episodic_with_graph_data(beam)
+        # Defang other lifts so the only difference is fact_bonus.
+        monkeypatch.setenv("MNEMOSYNE_VERACITY_MULTIPLIER", "0")
+        monkeypatch.setenv("MNEMOSYNE_GRAPH_BONUS", "0")
+        monkeypatch.delenv("MNEMOSYNE_FACT_BONUS", raising=False)
+        on_results = beam.recall("deploys production", top_k=5)
+        beam.conn.close()
+
+        with tempfile.TemporaryDirectory() as tmpdir2:
+            db2 = Path(tmpdir2) / "test.db"
+            beam2 = BeamMemory(session_id="s1", db_path=db2)
+            self._seed_episodic_with_graph_data(beam2)
+            monkeypatch.setenv("MNEMOSYNE_FACT_BONUS", "0")
+            off_results = beam2.recall("deploys production", top_k=5)
+            beam2.conn.close()
+
+        on_hit = next((r for r in on_results if r["id"] == "ep-bonus"), None)
+        off_hit = next((r for r in off_results if r["id"] == "ep-bonus"), None)
+        assert on_hit is not None and off_hit is not None
+        assert on_hit["score"] > off_hit["score"], (
+            f"fact_bonus toggle had no effect: "
+            f"on={on_hit['score']} off={off_hit['score']}"
+        )
+
+    def test_binary_bonus_toggle_structural(self):
+        """Source-level check: `MNEMOSYNE_BINARY_BONUS` is referenced
+        in both linear main loop and fallback (so disabling it gates
+        both branches). End-to-end test would require a query embedding
+        + binary vector setup that's brittle; this catches the regression
+        where someone strips the gate."""
+        src = (Path(__file__).resolve().parents[1] / "mnemosyne" / "core" / "beam.py").read_text()
+        # Should be referenced in the binary_bonus gate site
+        assert src.count("MNEMOSYNE_BINARY_BONUS") >= 1, (
+            "MNEMOSYNE_BINARY_BONUS gate missing from beam.py — "
+            "ablation toggle stripped"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# Veracity multiplier toggle
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestVeracityMultiplierToggle:
+    """`MNEMOSYNE_VERACITY_MULTIPLIER=0` short-circuits the multiplier
+    in BOTH the linear and polyphonic paths so Phase 0/1 ablation works
+    identically across engines."""
+
+    def test_disabled_makes_stated_unknown_score_equal(self, temp_db, monkeypatch):
+        """Two episodic rows with identical content but different
+        veracity ('stated' vs 'unknown') should score IDENTICALLY when
+        the multiplier is disabled, regardless of their veracity."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ts = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-stated", "the user prefers dark mode", "consolidation",
+             ts, "s1", 0.5, "stated"),
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-unknown", "the user prefers dark mode", "consolidation",
+             ts, "s1", 0.5, "unknown"),
+        )
+        beam.conn.commit()
+
+        monkeypatch.setenv("MNEMOSYNE_VERACITY_MULTIPLIER", "0")
+        # Defang other bonuses
+        monkeypatch.setenv("MNEMOSYNE_GRAPH_BONUS", "0")
+        monkeypatch.setenv("MNEMOSYNE_FACT_BONUS", "0")
+        monkeypatch.setenv("MNEMOSYNE_BINARY_BONUS", "0")
+        results = beam.recall("dark mode", top_k=10)
+        by_id = {r["id"]: r for r in results}
+        if "ep-stated" in by_id and "ep-unknown" in by_id:
+            assert by_id["ep-stated"]["score"] == by_id["ep-unknown"]["score"], (
+                "Veracity multiplier toggle OFF, but stated/unknown rows "
+                f"scored differently: {by_id['ep-stated']['score']} vs "
+                f"{by_id['ep-unknown']['score']}"
+            )
+
+    def test_enabled_makes_stated_outrank_unknown(self, temp_db, monkeypatch):
+        """Sanity / positive control: with toggle ON (default), the
+        stated row should rank above the unknown one (1.0 > 0.8
+        multiplier)."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ts = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-stated", "the user prefers dark mode", "consolidation",
+             ts, "s1", 0.5, "stated"),
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-unknown", "the user prefers dark mode", "consolidation",
+             ts, "s1", 0.5, "unknown"),
+        )
+        beam.conn.commit()
+
+        monkeypatch.delenv("MNEMOSYNE_VERACITY_MULTIPLIER", raising=False)
+        monkeypatch.setenv("MNEMOSYNE_GRAPH_BONUS", "0")
+        monkeypatch.setenv("MNEMOSYNE_FACT_BONUS", "0")
+        monkeypatch.setenv("MNEMOSYNE_BINARY_BONUS", "0")
+        results = beam.recall("dark mode", top_k=10)
+        by_id = {r["id"]: r for r in results}
+        if "ep-stated" in by_id and "ep-unknown" in by_id:
+            assert by_id["ep-stated"]["score"] > by_id["ep-unknown"]["score"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Cross-tier dedup toggle
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCrossTierDedupToggle:
+    """`MNEMOSYNE_CROSS_TIER_DEDUP=0` short-circuits
+    `_dedup_cross_tier_summary_links` to return the input list unchanged."""
+
+    def test_disabled_returns_input_unchanged(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        monkeypatch.setenv("MNEMOSYNE_CROSS_TIER_DEDUP", "0")
+
+        # Construct a (summary, source) pair that WOULD normally dedup.
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, "
+            "session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("wm-src", "raw text content", "conversation",
+             datetime.now().isoformat(), "s1", 0.5),
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, summary_of) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-sum", "summary of raw text content", "consolidation",
+             datetime.now().isoformat(), "s1", 0.5, "wm-src"),
+        )
+        beam.conn.commit()
+
+        # Synthetic results — both should survive when dedup is off.
+        results = [
+            {"id": "wm-src", "tier": "working", "score": 0.9, "content": "raw"},
+            {"id": "ep-sum", "tier": "episodic", "score": 0.5, "content": "sum"},
+        ]
+        out = beam._dedup_cross_tier_summary_links(results)
+        assert len(out) == 2
+        assert out is results, "Toggle-off path must short-circuit to identity"
+
+    def test_enabled_dedups_normally(self, temp_db, monkeypatch):
+        """Positive control: with toggle ON, the lower-scored side gets
+        dropped per E3.a.3 logic."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        monkeypatch.delenv("MNEMOSYNE_CROSS_TIER_DEDUP", raising=False)
+
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, "
+            "session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("wm-src", "raw text", "conversation",
+             datetime.now().isoformat(), "s1", 0.5),
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, summary_of) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-sum", "summary", "consolidation",
+             datetime.now().isoformat(), "s1", 0.5, "wm-src"),
+        )
+        beam.conn.commit()
+
+        results = [
+            {"id": "wm-src", "tier": "working", "score": 0.9, "content": "raw"},
+            {"id": "ep-sum", "tier": "episodic", "score": 0.5, "content": "sum"},
+        ]
+        out = beam._dedup_cross_tier_summary_links(results)
+        # Dedup should drop the lower-scored ep
+        assert len(out) == 1
+        assert out[0]["id"] == "wm-src"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Coverage map: every toggle has at least one disabled-path test
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestToggleCoverageMap:
+    """Pin that the 9 documented toggles are each present in the code.
+    A future refactor that strips one of them fails this test even if
+    no specific functional test was written for that one."""
+
+    REQUIRED_TOGGLES = [
+        "MNEMOSYNE_VOICE_VECTOR",
+        "MNEMOSYNE_VOICE_GRAPH",
+        "MNEMOSYNE_VOICE_FACT",
+        "MNEMOSYNE_VOICE_TEMPORAL",
+        "MNEMOSYNE_GRAPH_BONUS",
+        "MNEMOSYNE_FACT_BONUS",
+        "MNEMOSYNE_BINARY_BONUS",
+        "MNEMOSYNE_VERACITY_MULTIPLIER",
+        "MNEMOSYNE_CROSS_TIER_DEDUP",
+    ]
+
+    def test_all_toggles_present_in_source(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        sources = (
+            (repo_root / "mnemosyne" / "core" / "beam.py").read_text()
+            + (repo_root / "mnemosyne" / "core" / "polyphonic_recall.py").read_text()
+        )
+        missing = [t for t in self.REQUIRED_TOGGLES if t not in sources]
+        assert not missing, (
+            f"Required A/B toggles missing from source: {missing}. "
+            f"docs/benchmarking.md promises these toggles exist."
+        )

--- a/tests/test_benchmark_preflight.py
+++ b/tests/test_benchmark_preflight.py
@@ -1,0 +1,120 @@
+"""Preflight regression tests for the BEAM benchmark harness.
+
+Pre-fix, `tools/evaluate_beam_end_to_end.py` ran with harness oracles
+(TR timeline, CR injection, IE/KU `_context_facts`, RECENT CONVERSATION
+raw-message injection) by default — without pure-recall mode the
+oracles produce answers that bypass `BeamMemory.recall()`, contaminating
+arm-vs-arm comparisons.
+
+Post-fix the harness refuses to run unless either:
+  - `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` (or `--pure-recall`), or
+  - `--allow-harness-oracles` (explicit opt-in for ceiling tests / legacy
+    reproduction)
+
+These tests pin the preflight gate. They subprocess the harness in
+`--help` / argument-parsing mode rather than running a full benchmark.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_HARNESS = _REPO_ROOT / "tools" / "evaluate_beam_end_to_end.py"
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Clear all benchmark-mode env vars so each test starts from a
+    known state."""
+    monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+    monkeypatch.delenv("FULL_CONTEXT_MODE", raising=False)
+    return monkeypatch
+
+
+def _run_harness(*args, env_overrides=None):
+    """Invoke the harness with the given CLI args + env overrides.
+    Returns CompletedProcess. Uses --dry-run when possible to avoid
+    actually loading the BEAM dataset."""
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+    # Always include --sample 0 + --scales (a single small scale) so we
+    # don't accidentally hit the full pipeline if dry-run isn't enough.
+    return subprocess.run(
+        [sys.executable, str(_HARNESS), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+class TestPreflightRefusesWithoutPureRecall:
+    """When neither pure-recall nor --allow-harness-oracles is set,
+    the harness must exit with a non-zero status BEFORE doing any work
+    (no dataset load, no LLM calls)."""
+
+    def test_no_flags_no_env_exits_with_error(self, clean_env):
+        """Default invocation — should refuse."""
+        result = _run_harness("--sample", "1", "--scales", "100K")
+        assert result.returncode == 2, (
+            f"Expected exit code 2 (preflight refusal); got {result.returncode}.\n"
+            f"stdout: {result.stdout[:400]}\nstderr: {result.stderr[:400]}"
+        )
+        assert "harness oracles are active" in result.stderr, (
+            f"Expected preflight error message in stderr; got: {result.stderr[:400]}"
+        )
+
+    def test_full_context_alone_is_not_enough(self, clean_env):
+        """`FULL_CONTEXT_MODE=1` doesn't disable the oracles — it adds
+        a different bypass. Should still refuse without pure-recall."""
+        result = _run_harness(
+            "--sample", "1", "--scales", "100K",
+            env_overrides={"FULL_CONTEXT_MODE": "1"},
+        )
+        assert result.returncode == 2
+
+    def test_pure_recall_flag_satisfies_preflight(self, clean_env):
+        """`--pure-recall` enables the bypass-disabling mode; preflight
+        should let the run proceed (it may fail later for unrelated
+        reasons like missing API key, but not at preflight)."""
+        result = _run_harness("--pure-recall", "--dry-run")
+        # Either it proceeded past preflight (returncode != 2) or it
+        # failed for some OTHER reason (dataset / network). The
+        # preflight-error string is what we're checking is absent.
+        assert "harness oracles are active" not in result.stderr
+
+    def test_pure_recall_env_satisfies_preflight(self, clean_env):
+        result = _run_harness(
+            "--dry-run",
+            env_overrides={"MNEMOSYNE_BENCHMARK_PURE_RECALL": "1"},
+        )
+        assert "harness oracles are active" not in result.stderr
+
+    def test_pure_recall_env_accepts_on(self, clean_env):
+        """C31 helper accepts `on`; preflight should honor that."""
+        result = _run_harness(
+            "--dry-run",
+            env_overrides={"MNEMOSYNE_BENCHMARK_PURE_RECALL": "on"},
+        )
+        assert "harness oracles are active" not in result.stderr
+
+    def test_allow_harness_oracles_explicit_opt_in(self, clean_env):
+        """Operators that explicitly want the legacy bypass behavior
+        (ceiling tests, pre-fix reproduction) can opt in."""
+        result = _run_harness("--allow-harness-oracles", "--dry-run")
+        assert "harness oracles are active" not in result.stderr
+
+    def test_preflight_runs_before_dataset_load(self, clean_env):
+        """The preflight should fail BEFORE attempting to load the
+        BEAM dataset, so operators with no HuggingFace access still
+        get a clean error message."""
+        result = _run_harness("--sample", "1", "--scales", "100K")
+        # If we got past preflight to dataset loading, we'd see
+        # 'Loading BEAM dataset' in stdout. Should not be there.
+        assert "Loading BEAM dataset" not in result.stdout

--- a/tools/evaluate_beam_end_to_end.py
+++ b/tools/evaluate_beam_end_to_end.py
@@ -1659,10 +1659,63 @@ def main():
                         help="Download data and print stats, don't evaluate")
     parser.add_argument("--use-cloud", action="store_true",
                         help="Enable LLM fact extraction (cloud tier). Requires OPENROUTER_API_KEY.")
+    parser.add_argument("--allow-harness-oracles", action="store_true",
+                        help="Opt out of the pure-recall safety check that requires "
+                             "MNEMOSYNE_BENCHMARK_PURE_RECALL=1 (or --pure-recall). The "
+                             "harness's TR/CR/IE/KU bypasses and RECENT CONVERSATION raw-"
+                             "message injection produce answers without going through "
+                             "BeamMemory.recall(), which contaminates arm-vs-arm "
+                             "comparisons. Set this flag only for ceiling-test or legacy-"
+                             "reproduction runs where you explicitly want the bypasses.")
     args = parser.parse_args()
 
     scales = [s.strip() for s in args.scales.split(",")]
     sample_size = args.sample if args.sample > 0 else None
+
+    # ---- Preflight: refuse to run with harness oracles unless explicitly opted in.
+    # The TR/CR/IE/KU bypasses and the always-included RECENT CONVERSATION block
+    # produce answers WITHOUT going through BeamMemory.recall(), contaminating any
+    # arm-vs-arm comparison. Pure-recall mode disables all four. See
+    # docs/benchmarking.md for the full rationale.
+    _pr_active = args.pure_recall or _env_truthy("MNEMOSYNE_BENCHMARK_PURE_RECALL")
+    if not _pr_active and not args.allow_harness_oracles:
+        print(
+            "ERROR: harness oracles are active by default but contaminate arm-vs-arm "
+            "comparisons. Pass --pure-recall (recommended) or set "
+            "MNEMOSYNE_BENCHMARK_PURE_RECALL=1 to disable them. If you genuinely want "
+            "the legacy bypass behavior (e.g., for a ceiling test or reproducing pre-"
+            "fix results), pass --allow-harness-oracles explicitly.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # Snapshot the full benchmark-relevant env-var surface so results JSON captures
+    # exactly which configuration the run executed under. A toggle the operator
+    # forgot to set is a silent confound otherwise.
+    _benchmark_env_snapshot = {
+        k: v for k, v in os.environ.items()
+        if k.startswith("MNEMOSYNE_") or k in ("FULL_CONTEXT_MODE", "OPENROUTER_BASE_URL")
+    }
+    print(f"\n  Env snapshot ({len(_benchmark_env_snapshot)} vars):")
+    for k in sorted(_benchmark_env_snapshot):
+        # Don't echo API keys even if they accidentally got the MNEMOSYNE_ prefix.
+        v = _benchmark_env_snapshot[k]
+        if "KEY" in k or "TOKEN" in k or "SECRET" in k:
+            v = "***redacted***"
+        print(f"    {k}={v}")
+
+    # Reset recall + extraction diagnostics so per-run counters are clean. The
+    # snapshots are captured at the end of main() and written into results JSON.
+    try:
+        from mnemosyne.core.recall_diagnostics import reset_recall_diagnostics
+        reset_recall_diagnostics()
+    except ImportError:
+        pass  # Diagnostics module is optional; older checkouts may lack it.
+    try:
+        from mnemosyne.extraction.diagnostics import reset_extraction_stats
+        reset_extraction_stats()
+    except ImportError:
+        pass
 
     print(f"{'='*80}")
     print(f"  BEAM End-to-End Evaluation Pipeline")
@@ -1755,8 +1808,23 @@ def main():
                 all_results.append(conv_result)
                 beam.conn.close()
 
-            # Save progress after each conversation
+            # Save progress after each conversation. Includes the env-var
+            # snapshot + diagnostic snapshots so post-hoc analysis can attribute
+            # score deltas to specific configurations without re-running.
             os.makedirs(RESULTS_FILE.parent, exist_ok=True)
+            _recall_diag = None
+            _extraction_diag = None
+            try:
+                from mnemosyne.core.recall_diagnostics import get_recall_diagnostics
+                _recall_diag = get_recall_diagnostics()
+            except ImportError:
+                pass
+            try:
+                from mnemosyne.extraction.diagnostics import get_extraction_stats
+                _extraction_diag = get_extraction_stats()
+            except ImportError:
+                pass
+
             metadata = {
                 "date": datetime.now(timezone.utc).isoformat(),
                 "model": args.model,
@@ -1765,6 +1833,17 @@ def main():
                 "sample_size": sample_size or "ALL",
                 "scales": scales,
                 "total_conversations": len(all_results),
+                "config": {
+                    "env": _benchmark_env_snapshot,
+                    "pure_recall": _pr_active,
+                    "allow_harness_oracles": args.allow_harness_oracles,
+                    "full_context": args.full_context,
+                    "use_cloud": args.use_cloud,
+                },
+                "diagnostics": {
+                    "recall": _recall_diag,
+                    "extraction": _extraction_diag,
+                },
             }
             with open(RESULTS_FILE, "w") as f:
                 json.dump({"metadata": metadata, "results": all_results}, f, indent=2)


### PR DESCRIPTION
## TL;DR

Adds the nine A/B ablation toggles the BEAM-recovery experiment plan needs. Each defaults to ON (production behavior preserved); set the env var to a falsy value (`0`/`false`/`no`/`off`, case-insensitive, whitespace-stripped) to disable the corresponding feature.

**This closes the last blocking gap (Gap B) for executing the experiment.** Stacked on #92 (which provides the harness preflight + benchmarking docs).

**Full suite: 1024 passed, 10 skipped, 0 failed.**

## Why these toggles

Without them, the experiment plan's Phase 3a–3d, Phase 3-LIN-*, and Phase 4 can't run as one-variable-at-a-time ablations. The alternative — modifying veracity values, deleting code paths, manipulating fixture data — introduces multiple confounded variables that invalidate any per-tool A/B claim.

## Toggles added

| Env var | Disables when set falsy | Affects |
|---|---|---|
| `MNEMOSYNE_VOICE_VECTOR` | Polyphonic vector voice (Phase 3d) | `polyphonic_recall._vector_voice` |
| `MNEMOSYNE_VOICE_GRAPH` | Polyphonic graph voice (Phase 3b) | `polyphonic_recall._graph_voice` |
| `MNEMOSYNE_VOICE_FACT` | Polyphonic fact voice (Phase 3a) | `polyphonic_recall._fact_voice` |
| `MNEMOSYNE_VOICE_TEMPORAL` | Polyphonic temporal voice (Phase 3c) | `polyphonic_recall._temporal_voice` |
| `MNEMOSYNE_GRAPH_BONUS` | Linear graph-edge bonus | `beam.py` ep main loop + fallback |
| `MNEMOSYNE_FACT_BONUS` | Linear fact-table bonus | `beam.py` ep main loop + fallback |
| `MNEMOSYNE_BINARY_BONUS` | Linear binary-vector Hamming bonus | `beam.py` ep main loop |
| `MNEMOSYNE_VERACITY_MULTIPLIER` | Veracity multiplier (Phase 0/1) | `beam.py` linear + polyphonic |
| `MNEMOSYNE_CROSS_TIER_DEDUP` | `_dedup_cross_tier_summary_links` (Phase 4) | `beam.py` linear + polyphonic |

## Helper design

New `mnemosyne.core.beam._env_disabled(name)` returns True iff env is explicitly set to a falsy value. Mirrored in `polyphonic_recall.py` (4-line duplicate — avoids a cross-module dependency for a tiny helper).

Default-ON semantics deliberately distinct from PR #91's `_env_truthy` (default-OFF). Both helpers strip whitespace and accept the same falsy/truthy literals; they exist as complements for different default-state use cases.

## Tests — `tests/test_ab_toggles.py` (38 new)

- **11 helper tests** — falsy/truthy/unset parsing (case + whitespace).
- **8 polyphonic voice tests** — each voice returns `[]` when toggle off; runs when on (positive control).
- **3 linear bonus tests** — `graph_bonus` + `fact_bonus` end-to-end recall shows strictly lower scores when toggle is OFF (proves the gate skips the computation, not just a flag). `binary_bonus` is structural-checked because binary-vector query setup is brittle.
- **2 veracity multiplier tests** — stated/unknown rows score identically when toggle off; stated outranks unknown when on.
- **2 cross-tier dedup tests** — helper returns input unchanged when toggle off; dedups normally when on.
- **1 coverage-map test** — greps both source files for all 9 toggle names; fails if a future refactor strips one.

## Cross-engine consistency

Two toggles gate BOTH the linear path and the polyphonic engine so the A/B comparison stays apples-to-apples:

- **`MNEMOSYNE_VERACITY_MULTIPLIER`** — gates the multiplier in the linear path's episodic + working loops AND the polyphonic engine's per-result composition.
- **`MNEMOSYNE_CROSS_TIER_DEDUP`** — gates `_dedup_cross_tier_summary_links` regardless of which engine called it.

The bonus toggles (`GRAPH_BONUS`, `FACT_BONUS`, `BINARY_BONUS`) are linear-only by design because the corresponding polyphonic signals come from different functions (`_graph_voice`, `_fact_voice`, `_vector_voice`) with different failure modes. To ablate the polyphonic equivalent, use the `MNEMOSYNE_VOICE_*` toggles.

## Example invocation

```bash
# Phase 3a — disable polyphonic fact voice, measure contribution
MNEMOSYNE_VOICE_FACT=0 \
MNEMOSYNE_POLYPHONIC_RECALL=1 \
MNEMOSYNE_BENCHMARK_PURE_RECALL=1 \
python tools/evaluate_beam_end_to_end.py --scales 100K --sample 3
```

PR #92's preflight will snapshot all `MNEMOSYNE_*` env vars into the results JSON under `metadata.config.env`, so the toggle state is recoverable post-run.

## Doc updates

- `docs/benchmarking.md` — "Future toggles needed" section moved to "A/B ablation toggles" with each documented as implemented + example invocation.
- `docs/experiments/2026-05-12-beam-recovery-arms-abc.md` — Gap B marked ✅ closed.

## What's now possible

With #92 + this PR merged, the experiment is fully runnable end-to-end per the plan. All 10 phases from the experiment plan can execute as one-variable-at-a-time ablations.

The two remaining gaps (E paired-outcome recording, G linear-path voice_scores) are post-execution analysis polish and not experiment-blocking.

## Test plan

- [x] 38 toggle tests pass
- [x] Full suite: 1024 passed, 10 skipped, 0 failed
- [x] No regressions to existing recall tests (linear or polyphonic)
- [x] Stacked on #92 — CI should be green from day one
- [ ] CI: full suite green on Python 3.9 / 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
