### PR TITLE
feat: per-question voice attribution + BEAM_OPTIMIZATIONS env-parser migration (pre-test gap closure)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Local-first, zero-cloud memory for AI agents. SQLite-backed. Sub-millisecond. Fu
 | [LLM Installation Guide](llm-installation-guide.md) | Installation instructions for AI agents/LLMs |
 | [Configuration](configuration.md) | Environment variables, data directory, vector compression |
 | [Benchmarking](benchmarking.md) | Maintainer guide: per-tool A/B benchmark env vars, diagnostics, pure-recall mode, test sequence template |
+| [Benchmark Results Analysis](benchmark-results-analysis.md) | Output-file schemas + analysis recipes (per-ability scores, paired bootstrap CIs, voice attribution). AI-assistant-friendly reference |
 | [Changelog](changelog.md) | Version history and release notes |
 
 ## Quick Links

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Local-first, zero-cloud memory for AI agents. SQLite-backed. Sub-millisecond. Fu
 | [Hermes Integration](hermes-integration.md) | Using Mnemosyne as a Hermes memory backend |
 | [LLM Installation Guide](llm-installation-guide.md) | Installation instructions for AI agents/LLMs |
 | [Configuration](configuration.md) | Environment variables, data directory, vector compression |
+| [Benchmarking](benchmarking.md) | Maintainer guide: per-tool A/B benchmark env vars, diagnostics, pure-recall mode, test sequence template |
 | [Changelog](changelog.md) | Version history and release notes |
 
 ## Quick Links

--- a/docs/beam-benchmark.md
+++ b/docs/beam-benchmark.md
@@ -3,6 +3,8 @@
 **Evaluated against ICLR 2026 BEAM dataset (Tavakoli et al.)**
 **Date:** 2026-05-06 | **Version:** Mnemosyne 2.5 | **Model:** Gemini 2.5 Flash via OpenRouter
 
+> **⚠ Results pre-date the May 2026 benchmark-infrastructure fixes.** Between this run and May 12, 2026, several silent-failure surfaces and harness-side oracles were corrected (see [benchmarking.md](benchmarking.md) for the full list). The numbers below were generated against a pipeline that had: cross-tier `(summary, source)` duplicate ranking under the linear scorer, veracity destroyed at consolidation, harness oracles answering TR/CR/IE/KU outside `BeamMemory.recall()`, and the last 12 raw conversation messages always prepended to every answer prompt. They are not credible evidence for any specific tool's contribution to total score. A re-run under the new infrastructure is tracked at [`experiments/2026-05-12-beam-recovery-arms-abc.md`](experiments/2026-05-12-beam-recovery-arms-abc.md).
+
 ---
 
 ## End-to-End Results (LLM-as-Judge, Rubric Scoring)

--- a/docs/benchmark-results-analysis.md
+++ b/docs/benchmark-results-analysis.md
@@ -1,0 +1,377 @@
+# BEAM Benchmark — Output Files and Analysis Guide
+
+**Audience:** anyone (human or AI assistant) reading the result files produced by `tools/evaluate_beam_end_to_end.py` and computing per-phase / per-arm comparisons.
+
+This doc is intentionally self-contained: file paths, schemas with field types, example records, and worked analyses. An AI assistant pointed at this doc plus the result files should be able to compute paired bootstrap CIs without external context.
+
+For the test-infrastructure overview (env vars, pure-recall mode, etc.) see [benchmarking.md](benchmarking.md). For the specific BEAM-recovery experiment plan see [experiments/2026-05-12-beam-recovery-arms-abc.md](experiments/2026-05-12-beam-recovery-arms-abc.md).
+
+---
+
+## Where the files live
+
+After `tools/evaluate_beam_end_to_end.py` runs to completion, three files exist under `results/`:
+
+```
+results/
+├── beam_e2e_results.json     # per-question results with full metadata + diagnostics
+├── beam_e2e_summary.json     # aggregate ability scores per scale
+└── paired_outcomes.jsonl     # one row per question, append-only across runs
+```
+
+The first two are overwritten per run. `paired_outcomes.jsonl` is **append-only** so multiple A/B runs accumulate. Filter by `config_id` to isolate a single phase.
+
+---
+
+## File 1: `beam_e2e_results.json`
+
+Top-level JSON object: `{metadata, results}`. Schema:
+
+```jsonc
+{
+  "metadata": {
+    "date": "2026-05-12T14:30:00+00:00",        // run completion timestamp (UTC ISO 8601)
+    "run_started_at": "2026-05-12T14:00:00+00:00", // run start timestamp
+    "config_id": "phase3a-no-fact-voice",       // either --config-id arg or auto-hash
+    "model": "deepseek-v4-pro",                 // answer LLM
+    "judge_model": "deepseek-v4-pro",           // judge LLM (may differ from model)
+    "top_k": 10,                                // recall top-k per question
+    "sample_size": 3,                           // conversations per scale (or "ALL")
+    "scales": ["100K", "500K"],                 // BEAM scales evaluated
+    "total_conversations": 6,                   // count of conversations actually evaluated
+    "config": {
+      "env": {                                  // snapshot of MNEMOSYNE_* + FULL_CONTEXT_MODE at run start
+        "MNEMOSYNE_POLYPHONIC_RECALL": "1",
+        "MNEMOSYNE_VOICE_FACT": "0",
+        "MNEMOSYNE_BENCHMARK_PURE_RECALL": "1"
+        // API keys are redacted ("***redacted***")
+      },
+      "pure_recall": true,                      // pure-recall mode active
+      "allow_harness_oracles": false,
+      "full_context": false,
+      "use_cloud": false
+    },
+    "diagnostics": {
+      "recall": { /* see "recall diagnostics" below */ },
+      "extraction": { /* see "extraction diagnostics" below */ }
+    }
+  },
+  "results": [
+    {
+      "conversation_id": "conv_abc",
+      "scale": "100K",
+      "num_questions": 50,
+      "num_evaluated": 50,
+      "results": [
+        {
+          "qid": "q_001",
+          "ability": "IE",                       // one of: IE, MR, KU, TR, ABS, CR, EO, IF, PF, SUM
+          "question": "what is the user's favorite color?",
+          "ideal_answer": "blue",
+          "ai_answer": "The user's favorite color is blue.",
+          "score": 1.0,                          // rubric score: 0.0, 0.5, or 1.0
+          "nuggets": [...],                      // judge's nugget breakdown (may be empty)
+          "assessment": "Correctly identifies blue from context.",
+          "answer_time_ms": 1234.5,              // LLM answer latency
+          "judge_time_ms": 567.8                 // judge latency
+        }
+        // ... one entry per question evaluated
+      ]
+    }
+    // ... one entry per conversation evaluated
+  ]
+}
+```
+
+### `metadata.diagnostics.recall`
+
+Recall pipeline provenance (`get_recall_diagnostics()` snapshot at run end). Tells you which recall tier produced each kept row — critical for sanity-checking that recall isn't dominated by the weak-signal substring-fallback path.
+
+```jsonc
+{
+  "created_at": "2026-05-12T14:00:00+00:00",
+  "snapshot_at": "2026-05-12T14:30:00+00:00",
+  "totals": {
+    "calls": 300,                       // total recall() invocations across the run
+    "calls_using_wm_fallback": 12,      // calls that fell back to WM substring scan
+    "calls_using_em_fallback": 5,
+    "calls_truly_empty": 0,             // calls where every tier produced zero kept rows
+    "wm_fallback_rate": 0.04,           // 0.0-1.0 — high (>0.2) = signal-poor, treat results skeptically
+    "em_fallback_rate": 0.017
+  },
+  "by_tier": {
+    "wm_fts": {"calls_with_hits": 280, "total_hits": 920},
+    "wm_vec": {"calls_with_hits": 295, "total_hits": 1100},
+    "wm_fallback": {"calls_with_hits": 12, "total_hits": 35},
+    "em_fts": {"calls_with_hits": 250, "total_hits": 700},
+    "em_vec": {"calls_with_hits": 290, "total_hits": 940},
+    "em_fallback": {"calls_with_hits": 5, "total_hits": 12}
+  }
+}
+```
+
+### `metadata.diagnostics.extraction`
+
+Fact-extraction pipeline provenance (`get_extraction_stats()` snapshot). Surfaces silent failures in the per-row LLM extraction tiers.
+
+```jsonc
+{
+  "created_at": "...",
+  "snapshot_at": "...",
+  "totals": {
+    "calls": 100,
+    "successes": 95,
+    "failures": 3,
+    "empty": 2,
+    "success_rate": 0.95
+  },
+  "by_tier": {
+    "host": {"attempts": 0, "successes": 0, "no_output": 0, "failures": 0, "error_samples": []},
+    "remote": {"attempts": 100, "successes": 95, "no_output": 2, "failures": 3,
+               "error_samples": [{"timestamp": "...", "message": "rate limit", "exc_type": "HTTPError"}]},
+    "local": {"attempts": 0, "successes": 0, "no_output": 0, "failures": 0, "error_samples": []},
+    "cloud": {"attempts": 0, "successes": 0, "no_output": 0, "failures": 0, "error_samples": []},
+    "wrapper": {"attempts": 0, "successes": 0, "no_output": 0, "failures": 0, "error_samples": []}
+  }
+}
+```
+
+---
+
+## File 2: `beam_e2e_summary.json`
+
+Aggregate ability scores per scale — small, summary-only.
+
+```jsonc
+{
+  "date": "2026-05-12T14:30:00+00:00",
+  "metadata": {
+    "model": "deepseek-v4-pro",
+    "sample_size": 3,
+    "judge_model": "deepseek-v4-pro"
+  },
+  "ability_summary": {
+    "100K": {
+      "IE":  {"avg_score": 0.80, "count": 24},
+      "MR":  {"avg_score": 0.16, "count": 12},
+      "KU":  {"avg_score": 0.16, "count": 12},
+      "TR":  {"avg_score": 0.29, "count": 24},
+      "ABS": {"avg_score": 0.50, "count": 12},
+      "CR":  {"avg_score": 0.35, "count": 24},
+      "EO":  {"avg_score": 0.13, "count": 18},
+      "SUM": {"avg_score": 0.42, "count": 12},
+      "OVERALL": {"avg_score": 0.35, "count": 138}
+    },
+    "500K": { /* same shape */ }
+  }
+}
+```
+
+Use this for a quick at-a-glance scoreboard. For paired analysis, use `paired_outcomes.jsonl` instead.
+
+---
+
+## File 3: `paired_outcomes.jsonl`
+
+One JSON object per line. **Append-only across runs.** Filter by `config_id` to isolate a phase.
+
+```jsonc
+{
+  "config_id": "phase3a-no-fact-voice",       // string, equals --config-id or auto-hash
+  "run_started_at": "2026-05-12T14:00:00+00:00", // UTC ISO 8601
+  "scale": "100K",                             // BEAM scale tier
+  "conversation_id": "conv_abc",               // BEAM conversation id
+  "qid": "q_001",                              // BEAM question id (stable across runs)
+  "ability": "IE",                             // ability code (see "ability codes" below)
+  "score": 1.0,                                // raw rubric score: float 0.0–1.0
+  "correct": true                              // bool: score >= 0.5 (partial credit counts)
+}
+```
+
+Field meanings:
+
+- `config_id` — every row in a single run shares this. Use for paired-arm comparisons. If `--config-id` not given, auto-derived as `"cfg-" + sha256(canonical_env)[:10]`.
+- `qid` — stable across runs. Lets you pair "config A's score on Q" with "config B's score on Q".
+- `score` — raw rubric. Use for continuous deltas + CIs.
+- `correct` — bool threshold (`score >= 0.5`). Use for accuracy-style metrics. Analysts wanting stricter (e.g., only 1.0 = correct) can re-threshold off `score`.
+
+---
+
+## Ability codes reference
+
+The BEAM benchmark scores 10 ability dimensions. Codes used in result files:
+
+| Code | Name | What it measures |
+|---|---|---|
+| `IE` | Information Extraction | retrieve specific facts from context |
+| `MR` | Multi-session Reasoning (a.k.a. Multi-hop) | connect facts across distant messages |
+| `KU` | Knowledge Update | track value changes over time |
+| `TR` | Temporal Reasoning | date math, ordering by time |
+| `ABS` | Abstention | identify unanswerable questions |
+| `CR` | Contradiction Resolution | flag conflicting info |
+| `EO` | Event Ordering | sequence events chronologically |
+| `IF` | Instruction Following | apply implicit instructions |
+| `PF` | Preference Following | adhere to stated preferences |
+| `SUM` | Summarization | synthesize across windows |
+
+---
+
+## Worked analyses
+
+### A. Per-ability scores for a single run
+
+Read `beam_e2e_summary.json.ability_summary[scale][ability].avg_score`. Done. Or:
+
+```python
+import json
+data = json.load(open("results/beam_e2e_summary.json"))
+for scale, abilities in data["ability_summary"].items():
+    print(f"\n{scale}:")
+    for ability, stats in abilities.items():
+        print(f"  {ability}: {stats['avg_score']:.3f} ({stats['count']} questions)")
+```
+
+### B. Δ between two A/B configs on a single ability
+
+Two runs were performed: one with `config_id=phase2-baseline-polyphonic`, one with `config_id=phase3a-no-fact-voice`. Compute the score delta on TR questions:
+
+```python
+import json
+from statistics import mean
+
+rows = [json.loads(line) for line in open("results/paired_outcomes.jsonl")]
+
+def avg_for(config_id, ability):
+    matching = [r["score"] for r in rows
+                if r["config_id"] == config_id and r["ability"] == ability]
+    return mean(matching) if matching else None
+
+baseline = avg_for("phase2-baseline-polyphonic", "TR")
+ablation = avg_for("phase3a-no-fact-voice", "TR")
+print(f"Δ on TR = {ablation - baseline:+.3f}  ({len(matching)} questions)")
+```
+
+### C. Paired bootstrap CI on Δ total score
+
+Bootstrap 5000 paired-resamples to get a 95% CI on the Δ between two configs across all questions:
+
+```python
+import json
+import random
+from statistics import mean
+
+rows = [json.loads(line) for line in open("results/paired_outcomes.jsonl")]
+
+# Group by config_id, then by qid → score
+def scores_by_qid(config_id):
+    return {r["qid"]: r["score"] for r in rows if r["config_id"] == config_id}
+
+base = scores_by_qid("phase2-baseline-polyphonic")
+abl = scores_by_qid("phase3a-no-fact-voice")
+paired_qids = sorted(set(base) & set(abl))   # questions present in BOTH runs
+paired_diffs = [abl[q] - base[q] for q in paired_qids]
+
+n = len(paired_diffs)
+print(f"Paired Δ: n={n}, point estimate={mean(paired_diffs):+.3f}")
+
+# Bootstrap CI
+rng = random.Random(42)
+B = 5000
+boot_means = []
+for _ in range(B):
+    resample = [rng.choice(paired_diffs) for _ in range(n)]
+    boot_means.append(mean(resample))
+boot_means.sort()
+ci_lo, ci_hi = boot_means[int(0.025 * B)], boot_means[int(0.975 * B)]
+print(f"  95% CI: [{ci_lo:+.3f}, {ci_hi:+.3f}]")
+print(f"  Falsifiable: {'yes (CI excludes 0)' if ci_lo > 0 or ci_hi < 0 else 'no (CI spans 0)'}")
+```
+
+### D. Fallback-rate sanity check
+
+If `wm_fallback_rate` or `em_fallback_rate` is high (>0.2), recall is dominated by the weak-signal substring fallback and arm-vs-arm comparisons aren't credible — both arms are mostly hitting the same fallback path.
+
+```python
+import json
+data = json.load(open("results/beam_e2e_results.json"))
+diag = data["metadata"]["diagnostics"]["recall"]["totals"]
+print(f"WM fallback rate: {diag['wm_fallback_rate']:.1%}")
+print(f"EM fallback rate: {diag['em_fallback_rate']:.1%}")
+if diag["wm_fallback_rate"] > 0.2 or diag["em_fallback_rate"] > 0.2:
+    print("⚠ High fallback rate — arm-vs-arm comparisons may not be credible")
+```
+
+### E. Per-voice attribution (polyphonic runs)
+
+Each result dict in `beam_e2e_results.json` carries a `voice_scores: dict`. On polyphonic runs, keys are `vector`, `graph`, `fact`, `temporal`. On linear runs, keys are `vec`, `fts`, `keyword`, `importance`, `recency_decay`. Engine identity is the dict's keyset.
+
+To find what fraction of polyphonic results were vector-voice-led:
+
+```python
+import json
+data = json.load(open("results/beam_e2e_results.json"))
+top_voice_counts = {}
+for conv in data["results"]:
+    for q in conv["results"]:
+        # Need the underlying recall result; the harness currently
+        # captures voice_scores in BeamMemory.recall() output but
+        # doesn't (yet) thread that into the per-question result.
+        # See Gap E follow-ups; for now query the DB directly or
+        # add a hook in the harness.
+        pass
+```
+
+Note: at present the harness does NOT include per-question recall voice_scores in `beam_e2e_results.json` (only the final answer + judge score). Per-question voice provenance would require an additional hook in `evaluate_conversation()`. Tracked as a follow-up.
+
+### F. Detect a run that ran without pure-recall mode
+
+A run without `--pure-recall` would have its results contaminated by harness oracles (see [benchmarking.md#pure-recall-mode](benchmarking.md#pure-recall-mode)). Check the metadata:
+
+```python
+import json
+data = json.load(open("results/beam_e2e_results.json"))
+if not data["metadata"]["config"]["pure_recall"]:
+    if data["metadata"]["config"]["allow_harness_oracles"]:
+        print("⚠ Run intentionally used harness oracles — not comparable to other arms")
+    else:
+        print("⚠ Run was not in pure-recall mode — results compromised")
+```
+
+The harness preflight refuses to start without pure-recall OR explicit `--allow-harness-oracles`, but the metadata is the post-hoc verification.
+
+---
+
+## For AI assistants
+
+If you're an AI assistant reading these result files to help an operator interpret a BEAM benchmark run, here's what to know in compressed form:
+
+1. **Three files matter.** `beam_e2e_results.json` (rich, per-question + metadata + diagnostics), `beam_e2e_summary.json` (per-ability averages, summary-only), `paired_outcomes.jsonl` (one row per question, append-only across multiple runs — filter by `config_id`).
+
+2. **Scores are rubric, not binary.** `score` is `0.0` / `0.5` / `1.0` per question. `correct` (in the JSONL) is `score >= 0.5`. Two ways to compute "accuracy": mean of `score` (continuous), or mean of `correct` (binary at 0.5 threshold).
+
+3. **A/B comparisons require paired questions.** Two A/B runs share `qid` values across `config_id`s. To compute Δ between configs, group by `config_id`, then inner-join on `qid`. Drop unpaired questions. Bootstrap CI on the paired differences (see Section C above).
+
+4. **Verify the run was credible BEFORE trusting deltas.** Check three things:
+   - `metadata.config.pure_recall == true` (no harness oracles)
+   - `metadata.diagnostics.recall.totals.{wm,em}_fallback_rate < 0.2` (recall not dominated by weak-signal fallback)
+   - `metadata.diagnostics.extraction.totals.success_rate > 0.9` (fact extraction working)
+
+   If any of these fail, surface that to the operator before reporting score deltas.
+
+5. **Treat 2pp as the noise floor.** With ~50 questions per conversation, only deltas with 95% CIs excluding ±2pp are credible. Sub-3pp deltas without overlapping CIs are inconclusive.
+
+6. **The experiment plan is the authority on what each `config_id` means.** If `config_id == "phase3a-no-fact-voice"` you can look up Phase 3a in [`docs/experiments/2026-05-12-beam-recovery-arms-abc.md`](experiments/2026-05-12-beam-recovery-arms-abc.md) to find the prediction being tested. Always cross-reference; the plan documents the *intent* of each ablation.
+
+7. **Per-ability deltas often tell a richer story than total deltas.** A toggle that drops total score by 0.5pp might drop TR by 8pp and lift IE by 7pp. Always report per-ability breakdowns alongside total.
+
+8. **Two engines, two voice_score schemas.** If you're processing per-result voice_scores, engine-identify by the dict's keyset: polyphonic uses `{vector, graph, fact, temporal}`, linear uses `{vec, fts, keyword, importance, recency_decay}`.
+
+---
+
+## Where to look when a result surprises you
+
+- **"This number looks too high."** Check `metadata.config.pure_recall`. If false, the harness oracles (TR timeline / CR injection / IE-KU `_context_facts` / RECENT CONVERSATION) likely produced answers without going through Mnemosyne recall.
+- **"This number looks too low."** Check `metadata.diagnostics.recall.totals.fallback_rate`. If high, recall returned mostly fallback noise.
+- **"Two runs that should be identical aren't."** Check `metadata.config.env` for both. The env snapshot includes every `MNEMOSYNE_*` env var at run start. A toggle the operator forgot to set is a silent confound.
+- **"The polyphonic run scored lower than linear."** Check `voice_scores` on per-result level — possibly only 2 of 4 voices contributed because the others returned empty (e.g., temporal voice ignored a non-temporal query).
+- **"My CI is huge."** Probably small sample size. Either increase `--sample` or report median+IQR alongside mean.

--- a/docs/benchmark-results-analysis.md
+++ b/docs/benchmark-results-analysis.md
@@ -69,6 +69,13 @@ Top-level JSON object: `{metadata, results}`. Schema:
           "question": "what is the user's favorite color?",
           "ideal_answer": "blue",
           "ai_answer": "The user's favorite color is blue.",
+          "recall_provenance": {                 // see Recipe E for analysis usage
+            "engine": "polyphonic",              // "polyphonic" / "linear" / "unknown"
+            "kept_count": 10,
+            "voice_sums": {"vector": 4.2, "graph": 1.1, "fact": 0.0, "temporal": 0.3},
+            "top_result_voices": {"vector": 0.7, "graph": 0.2, "fact": 0.0, "temporal": 0.1},
+            "top_result_tier": "episodic"        // tier of the top-ranked memory
+          },
           "score": 1.0,                          // rubric score: 0.0, 0.5, or 1.0
           "nuggets": [...],                      // judge's nugget breakdown (may be empty)
           "assessment": "Correctly identifies blue from context.",
@@ -301,27 +308,76 @@ if diag["wm_fallback_rate"] > 0.2 or diag["em_fallback_rate"] > 0.2:
     print("⚠ High fallback rate — arm-vs-arm comparisons may not be credible")
 ```
 
-### E. Per-voice attribution (polyphonic runs)
+### E. Per-voice attribution (per question)
 
-Each result dict in `beam_e2e_results.json` carries a `voice_scores: dict`. On polyphonic runs, keys are `vector`, `graph`, `fact`, `temporal`. On linear runs, keys are `vec`, `fts`, `keyword`, `importance`, `recency_decay`. Engine identity is the dict's keyset.
+Each per-question result dict in `beam_e2e_results.json.results[i].results[j]` carries `recall_provenance` with a summary of which voices contributed. Shape:
 
-To find what fraction of polyphonic results were vector-voice-led:
+```jsonc
+{
+  "recall_provenance": {
+    "engine": "polyphonic",                  // or "linear" or "unknown"
+    "kept_count": 10,                        // memories the LLM saw
+    "voice_sums": {                          // per-voice score totals across kept results
+      "vector": 4.2,
+      "graph": 1.1,
+      "fact": 0.0,
+      "temporal": 0.3
+    },
+    "top_result_voices": {                   // voice_scores for the top-ranked memory
+      "vector": 0.7,
+      "graph": 0.2,
+      "fact": 0.0,
+      "temporal": 0.1
+    },
+    "top_result_tier": "episodic"
+  }
+}
+```
+
+To find what fraction of polyphonic-engine answers were vector-voice-led across a run:
 
 ```python
 import json
+from collections import Counter
+
 data = json.load(open("results/beam_e2e_results.json"))
-top_voice_counts = {}
+top_voice_counts = Counter()
 for conv in data["results"]:
     for q in conv["results"]:
-        # Need the underlying recall result; the harness currently
-        # captures voice_scores in BeamMemory.recall() output but
-        # doesn't (yet) thread that into the per-question result.
-        # See Gap E follow-ups; for now query the DB directly or
-        # add a hook in the harness.
-        pass
+        prov = q.get("recall_provenance", {})
+        if prov.get("engine") != "polyphonic":
+            continue
+        top_voices = prov.get("top_result_voices", {})
+        if not top_voices:
+            continue
+        # Voice with the highest score on the top-ranked result
+        leader = max(top_voices.items(), key=lambda kv: kv[1])[0]
+        top_voice_counts[leader] += 1
+
+print("Top-voice leader distribution (polyphonic engine):")
+for voice, n in top_voice_counts.most_common():
+    print(f"  {voice}: {n}")
 ```
 
-Note: at present the harness does NOT include per-question recall voice_scores in `beam_e2e_results.json` (only the final answer + judge score). Per-question voice provenance would require an additional hook in `evaluate_conversation()`. Tracked as a follow-up.
+To compute per-voice contribution by ability — e.g., "how much did the fact voice contribute to TR vs IE questions?":
+
+```python
+fact_contrib_by_ability = {}  # ability → list of fact voice_sums
+for conv in data["results"]:
+    for q in conv["results"]:
+        prov = q.get("recall_provenance", {})
+        if prov.get("engine") != "polyphonic":
+            continue
+        ability = q.get("ability")
+        fact_contrib = prov.get("voice_sums", {}).get("fact", 0.0)
+        fact_contrib_by_ability.setdefault(ability, []).append(fact_contrib)
+
+for ability, vals in fact_contrib_by_ability.items():
+    avg = sum(vals) / max(len(vals), 1)
+    print(f"  {ability}: avg fact-voice sum = {avg:.3f} across {len(vals)} questions")
+```
+
+`recall_provenance.engine == "unknown"` and `kept_count == 0` indicates a bypass path (TR oracle / IE-KU context-fact match) returned the answer without going through `BeamMemory.recall()`. With `--pure-recall` active, this should only happen on full-context-mode runs.
 
 ### F. Detect a run that ran without pure-recall mode
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -108,7 +108,7 @@ Applied in both linear (post-FTS+vec scoring) and polyphonic (post-RRF) paths. A
 
 **Drift caveat:** these env vars override the recall multiplier in `beam.py`, but the consolidator's Bayesian compounding in `veracity_consolidation.py` does NOT honor env overrides — it reads `VERACITY_WEIGHTS` directly. Setting `MNEMOSYNE_STATED_WEIGHT=0.9` breaks the invariant "consolidated-as-N also ranks at N." `beam.py` module-load emits a single WARNING when any of these env vars are set, surfacing the drift risk.
 
-If you want to disable the multiplier entirely for an A/B baseline, setting all five to `1.0` makes the multiplier a constant — see [Future toggles](#future-toggles-needed) for the proposed cleaner `MNEMOSYNE_VERACITY_MULTIPLIER=0` flag.
+If you want to disable the multiplier entirely for an A/B baseline, set `MNEMOSYNE_VERACITY_MULTIPLIER=0` — see [A/B ablation toggles](#ab-ablation-toggles).
 
 ### Episodic tier degradation
 
@@ -250,23 +250,35 @@ The current harness does not yet emit the diagnostic snapshots or paired outcome
 
 ---
 
-## Future toggles needed
+## A/B ablation toggles
 
-The following A/B isolation knobs do **not** yet exist in code. They are tracked here so future contributors can add them or use them once added.
+Nine env-var toggles allow disabling specific components for experimental ablation. **Each defaults to ON** (production behavior preserved); set the env var to `0`/`false`/`no`/`off` (case-insensitive, whitespace-stripped) to disable. Truthy/garbage/unset values keep the feature enabled — these are opt-out flags, not opt-in.
 
-| Proposed env var | Purpose | Affects |
+The toggle helper is `mnemosyne.core.beam._env_disabled(name)` (and a mirror in `polyphonic_recall.py`). For the experiment plan's phase-by-phase usage of each toggle, see [`experiments/2026-05-12-beam-recovery-arms-abc.md`](experiments/2026-05-12-beam-recovery-arms-abc.md).
+
+| Env var | Disables when set falsy | Affects |
 |---|---|---|
-| `MNEMOSYNE_VOICE_VECTOR=0/1` | Disable polyphonic vector voice for ablation | `polyphonic_recall._vector_voice` |
-| `MNEMOSYNE_VOICE_GRAPH=0/1` | Disable polyphonic graph voice | `polyphonic_recall._graph_voice` |
-| `MNEMOSYNE_VOICE_FACT=0/1` | Disable polyphonic fact voice | `polyphonic_recall._fact_voice` |
-| `MNEMOSYNE_VOICE_TEMPORAL=0/1` | Disable polyphonic temporal voice | `polyphonic_recall._temporal_voice` |
-| `MNEMOSYNE_GRAPH_BONUS=0/1` | Disable linear-path graph-edge bonus | `beam.py` linear ep loop |
-| `MNEMOSYNE_FACT_BONUS=0/1` | Disable linear-path fact-table bonus | `beam.py` linear ep loop |
-| `MNEMOSYNE_BINARY_BONUS=0/1` | Disable linear-path binary-vector Hamming bonus | `beam.py` linear ep loop |
-| `MNEMOSYNE_VERACITY_MULTIPLIER=0/1` | Short-circuit veracity multiplier to 1.0 in both engines | `beam.py` linear + polyphonic |
-| `MNEMOSYNE_CROSS_TIER_DEDUP=0/1` | Disable `_dedup_cross_tier_summary_links` for ablation | `beam.py` linear + polyphonic |
+| `MNEMOSYNE_VOICE_VECTOR` | Polyphonic vector voice (Phase 3d ablation) | `polyphonic_recall._vector_voice` early-return |
+| `MNEMOSYNE_VOICE_GRAPH` | Polyphonic graph voice (Phase 3b) | `polyphonic_recall._graph_voice` early-return |
+| `MNEMOSYNE_VOICE_FACT` | Polyphonic fact voice (Phase 3a) | `polyphonic_recall._fact_voice` early-return |
+| `MNEMOSYNE_VOICE_TEMPORAL` | Polyphonic temporal voice (Phase 3c) | `polyphonic_recall._temporal_voice` early-return |
+| `MNEMOSYNE_GRAPH_BONUS` | Linear-path graph-edge bonus | `beam.py` ep main loop + fallback |
+| `MNEMOSYNE_FACT_BONUS` | Linear-path fact-table bonus | `beam.py` ep main loop + fallback |
+| `MNEMOSYNE_BINARY_BONUS` | Linear-path binary-vector Hamming bonus | `beam.py` ep main loop |
+| `MNEMOSYNE_VERACITY_MULTIPLIER` | Veracity multiplier (Phase 0/1) | `beam.py` linear + polyphonic |
+| `MNEMOSYNE_CROSS_TIER_DEDUP` | `_dedup_cross_tier_summary_links` (Phase 4) | `beam.py` linear + polyphonic |
 
-Each is a small implementation (~20–30 LOC plus tests). Total ~225 LOC if all nine ship as one PR. Without them, several phases of the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md) cannot be executed cleanly because the alternative (modifying veracity values, deleting code paths, manipulating fixture data) introduces multiple confounded variables.
+Example:
+
+```bash
+# Phase 3a: disable the polyphonic fact voice to measure its contribution
+MNEMOSYNE_VOICE_FACT=0 \
+MNEMOSYNE_POLYPHONIC_RECALL=1 \
+MNEMOSYNE_BENCHMARK_PURE_RECALL=1 \
+python tools/evaluate_beam_end_to_end.py --scales 100K --sample 3
+```
+
+Pin each toggle in your `.env` or shell environment across an A/B run. The harness preflight snapshots all `MNEMOSYNE_*` env vars into the results JSON under `metadata.config.env` so you can verify the configuration retroactively.
 
 ---
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,279 @@
+# Benchmarking and Testing Infrastructure
+
+**Audience:** maintainers and contributors running benchmarks against the Mnemosyne recall stack. This is not part of the normal user-facing setup — see [getting-started.md](getting-started.md) and [configuration.md](configuration.md) for those.
+
+This document is the single source of truth for the levers that affect benchmark results: env vars, recall modes, diagnostic instrumentation, and the methodology for running rigorous A/B tests. It exists because Mnemosyne has multiple recall paths (linear + polyphonic), per-tool toggles, and harness modes that aren't relevant to normal usage but matter a great deal when measuring per-component contribution to scores.
+
+---
+
+## Why a separate doc
+
+Past benchmark results (see [beam-benchmark.md](beam-benchmark.md)) were collected before several silent-failure surfaces were closed (May 2026, PRs #80–#91). Those results are not credible evidence for any specific tool's contribution to total score, because the prior pipeline had:
+
+- Harness-side oracles that answered TR/CR/IE/KU questions without going through `BeamMemory.recall()` (PR #90).
+- Last 12 raw conversation messages always prepended to every answer prompt — recency-anchored answers succeeded regardless of recall quality (PR #90).
+- Cross-tier `(summary, source)` duplicates ranked side-by-side under the linear scorer but collapsed under polyphonic's diversity rerank, confounding arm-vs-arm comparison (PR #88).
+- Veracity destroyed at consolidation — every post-`sleep()` episodic row scored at the 0.8 `unknown` multiplier regardless of source-row veracity (PR #89).
+- `remember_batch` silently swallowing partial embedding failures, biasing the vector voice toward early-ingested rows (PR #89).
+- Benchmark adapter writing template summaries and destroying source rows; the corpus recall actually saw was ~500 rows of "Batch N: …" stubs (PR #75 → E1).
+
+This doc encodes what those fixes opened up: the ability to run **per-tool A/B tests** with a single variable changed per run. Use this document as the reference when designing or executing a benchmark; the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md) is a concrete application.
+
+---
+
+## Setup
+
+These prerequisites are benchmark-only. They are **not** required to run Mnemosyne under normal use.
+
+### Python dependencies
+
+```bash
+# Already in pyproject as optional groups:
+pip install 'mnemosyne-memory[embeddings]'    # fastembed — vector voice + dense recall
+pip install 'mnemosyne-memory[llm]'           # llama-cpp-python — sleep summarization (else AAAK fallback)
+
+# Benchmark-only — NOT in pyproject:
+pip install datasets                           # HuggingFace BEAM dataset loader
+pip install sqlite-vec                         # ANN backend for vec_episodes virtual table
+pip install numpy                              # benchmark harness requires it unconditionally
+```
+
+The benchmark harness (`tools/evaluate_beam_end_to_end.py`) imports `numpy` and `datasets` unconditionally. Neither is declared as an installable extra of the package. Track these in your local venv setup or via `requirements-benchmark.txt`.
+
+### Environment variables required for any benchmark run
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `OPENROUTER_API_KEY` | yes | LLM that answers benchmark questions (or read from `/tmp/openrouter_key.txt`) |
+| `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` | yes (recommended) | Disables harness-side oracles; forces every answer through Mnemosyne recall. See [Pure-recall mode](#pure-recall-mode). |
+| `HF_TOKEN` | only if BEAM gets gated | Currently public at `Mohammadta/BEAM`; HF token only needed if access changes |
+| `OPENROUTER_BASE_URL` | optional | Defaults to `https://openrouter.ai/api/v1` |
+
+### Resource budget (per phase)
+
+| Resource | 100K scale (3 conversations) | 250K scale (3 conversations) |
+|---|---|---|
+| Wall clock | ~20–30 min | ~60–90 min |
+| Peak RSS | ~2–4 GB | ~4–8 GB |
+| Disk for DB | ~500 MB | ~2–4 GB |
+| LLM API spend | ~$0.50–$2 | ~$5–$15 |
+
+API spend is dominated by per-question answer LLM calls. Caching identical queries can lower this; quantify on the first phase before committing to a long run.
+
+---
+
+## Environment variable reference
+
+Every env var that affects recall ranking or benchmark behavior. Pin them across phases of an A/B run or the comparisons are meaningless. The harness should snapshot all of these into the results JSON (see [Recording](#recording-per-run)).
+
+### Test mode / harness
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_BENCHMARK_PURE_RECALL` | unset (`0`) | When truthy (`1`/`true`/`yes`/`on`), disables four harness bypass paths: TR timeline oracle, CR contradiction injection, IE/KU `_context_facts` side-index, "RECENT CONVERSATION" raw-message prompt section. Forces every answer through `BeamMemory.recall()`. **Required for credible arm-vs-arm comparison.** Also exposed as `--pure-recall` CLI flag. |
+| `FULL_CONTEXT_MODE` | unset (`0`) | Sends the entire conversation to the answer LLM, bypassing retrieval. Useful for measuring the "LLM ceiling without recall" upper bound. Overridden by `MNEMOSYNE_BENCHMARK_PURE_RECALL` if both are set. Also exposed as `--full-context`. |
+
+Both parsers accept `1`/`true`/`yes`/`on` (case-insensitive, whitespace-stripped). Anything else is falsy.
+
+### Recall path selection
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_POLYPHONIC_RECALL` | unset (`0`) | When truthy, routes `BeamMemory.recall()` through `PolyphonicRecallEngine` (RRF fusion across vector / graph / fact / temporal voices + diversity rerank). When unset, uses the linear scorer with inline `graph_bonus` / `fact_bonus` / `binary_bonus` terms. Read at recall time, not init time — can be toggled per-call by changing the env. |
+
+**Linear vs polyphonic implement related signals via DIFFERENT mechanisms.** The linear path's `graph_bonus` is an edge-count LIKE-match on `graph_edges`. The polyphonic engine's `_graph_voice` does entity extraction + `find_facts_by_subject`. They have different failure modes; do not assume an ablation on one engine carries over to the other.
+
+### Linear-path scoring weights
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_VEC_WEIGHT` | `0.5` | Weight of vector similarity in the linear hybrid score. Normalized to sum to 1.0 with FTS + importance. |
+| `MNEMOSYNE_FTS_WEIGHT` | `0.4` | Weight of FTS5 score in the linear hybrid score. |
+| `MNEMOSYNE_IMPORTANCE_WEIGHT` | `0.1` | Weight of stored `importance` in the linear hybrid score. |
+| `MNEMOSYNE_TEMPORAL_HALFLIFE_HOURS` | (caller arg) | Temporal-boost half-life for the linear path's `_temporal_boost`. Only active when caller passes `temporal_weight > 0`. |
+
+These three (`VEC` / `FTS` / `IMPORTANCE`) interact — changing one alters the relative weight of the others. Treat as a triple to pin together.
+
+### Veracity multipliers
+
+Applied in both linear (post-FTS+vec scoring) and polyphonic (post-RRF) paths. Affect ranking; do not affect ingest.
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_STATED_WEIGHT` | `1.0` | Multiplier for rows tagged `veracity='stated'` |
+| `MNEMOSYNE_INFERRED_WEIGHT` | `0.7` | Multiplier for `veracity='inferred'` |
+| `MNEMOSYNE_TOOL_WEIGHT` | `0.5` | Multiplier for `veracity='tool'` |
+| `MNEMOSYNE_IMPORTED_WEIGHT` | `0.6` | Multiplier for `veracity='imported'` |
+| `MNEMOSYNE_UNKNOWN_WEIGHT` | `0.8` | Multiplier for `veracity='unknown'` (the schema default) |
+
+**Drift caveat:** these env vars override the recall multiplier in `beam.py`, but the consolidator's Bayesian compounding in `veracity_consolidation.py` does NOT honor env overrides — it reads `VERACITY_WEIGHTS` directly. Setting `MNEMOSYNE_STATED_WEIGHT=0.9` breaks the invariant "consolidated-as-N also ranks at N." `beam.py` module-load emits a single WARNING when any of these env vars are set, surfacing the drift risk.
+
+If you want to disable the multiplier entirely for an A/B baseline, setting all five to `1.0` makes the multiplier a constant — see [Future toggles](#future-toggles-needed) for the proposed cleaner `MNEMOSYNE_VERACITY_MULTIPLIER=0` flag.
+
+### Episodic tier degradation
+
+Applied to episodic results based on their `tier` column (1, 2, 3 — set by `degrade_episodic`).
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_TIER1_WEIGHT` | `1.0` | Hot tier multiplier (rows < `TIER2_DAYS` old) |
+| `MNEMOSYNE_TIER2_WEIGHT` | `0.5` | Mid tier multiplier |
+| `MNEMOSYNE_TIER3_WEIGHT` | `0.25` | Cold tier multiplier (rows > `TIER3_DAYS` old) |
+| `MNEMOSYNE_TIER2_DAYS` | `30` | Threshold for tier 1→2 transition |
+| `MNEMOSYNE_TIER3_DAYS` | `180` | Threshold for tier 2→3 transition |
+
+For benchmark runs on synthetic short-time-span data, tier degradation typically doesn't fire and all weights collapse to `TIER1_WEIGHT`. Pin them to `1.0` if you want zero tier effect.
+
+### Vector backend
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_VEC_TYPE` | `int8` | Storage format for vector embeddings: `float32` (full precision, 1536 bytes/vec), `int8` (384 bytes/vec, default), `bit` (48 bytes/vec, binary-quantized). Changes candidate set for `_vec_search` and ranking quality. |
+
+`bit` mode trades recall quality for storage; expect lower scores on semantic-heavy questions.
+
+### Scan breadth / FTS semantics
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_BEAM_OPTIMIZATIONS` | unset (`0`) | When truthy, switches FTS5 to OR-semantics, raises vector-scan limit, and always includes vector results. Designed for benchmark-scale recall over large corpora. Distinct from `MNEMOSYNE_BENCHMARK_PURE_RECALL` — the latter is harness-side, this is recall-side. |
+
+If you don't enable this for benchmarks ≥100K, expect FTS-driven recall to miss substring partial matches that the benchmark questions expect.
+
+### Working memory / sleep
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_WM_TTL_HOURS` | `24` | Working memory rows older than this get pulled into `sleep()`. The benchmark harness backdates timestamps to ensure rows are eligible. |
+| `MNEMOSYNE_SLEEP_BATCH` | `5000` | Max rows pulled per `sleep()` invocation. Larger batches reduce sleep overhead; smaller batches reduce peak memory during summarization. |
+| `MNEMOSYNE_LLM_ENABLED` | `true` | When `false`, `sleep()` skips local LLM summarization and falls back to AAAK encoding. Useful for benchmark runs that want deterministic summaries without per-row LLM latency. |
+
+---
+
+## Pure-recall mode
+
+`MNEMOSYNE_BENCHMARK_PURE_RECALL=1` (or `--pure-recall`) is the single most important flag for any A/B benchmark. It disables four hardcoded paths in the harness that produce answers *without* going through `BeamMemory.recall()`:
+
+1. **TR (Temporal Reasoning) oracle** — pre-fix, TR questions extracted a timeline from raw `conversation_messages` and answered via an LLM-with-dates prompt, returning before any recall. Pure-recall lets TR questions flow through normal recall.
+2. **CR (Contradiction Resolution) injection** — pre-fix, raw-message contradiction detection injected a "you mentioned contradictory things" hint into the answer prompt. Pure-recall disables this hint; the arm must surface the contradiction via recall.
+3. **IE/KU `_context_facts` side-index** — pre-fix, the harness built a regex-keyed phrase-to-value index at ingest from raw messages, then matched questions against it and returned the value directly. Pure-recall disables the lookup.
+4. **"RECENT CONVERSATION" injection** — pre-fix, the last 12 raw conversation messages were always prepended to every answer prompt. Recency-anchored answers succeeded regardless of recall quality. Pure-recall strips the section; only retrieved memories reach the LLM.
+
+Without these gates, any "Arm B beats Arm A by 5pp" claim is suspect — the harness might have produced identical answers across arms for the questions hitting the bypass paths.
+
+The flag was added in May 2026. Default behavior (env unset) preserves the legacy benchmark mode for backward compatibility, but new runs targeting per-tool A/B claims should always set it.
+
+---
+
+## Diagnostic instrumentation
+
+Two diagnostic modules emit per-run snapshots that should be captured into results JSON.
+
+### Recall diagnostics
+
+```python
+from mnemosyne.core.recall_diagnostics import (
+    get_recall_diagnostics,      # returns Dict snapshot
+    reset_recall_diagnostics,    # clears process-global counters
+)
+```
+
+`get_recall_diagnostics()` returns a JSON-serializable dict with:
+
+| Field | Meaning |
+|---|---|
+| `wm_fts_kept` | Working-memory rows kept via FTS5 |
+| `wm_vec_kept` | Working-memory rows kept via vector search |
+| `wm_fallback_kept` | Working-memory rows kept via substring fallback |
+| `em_fts_kept` | Episodic rows kept via FTS5 |
+| `em_vec_kept` | Episodic rows kept via vector search |
+| `em_fallback_kept` | Episodic rows kept via substring fallback |
+| `total_kept` | Sum across all tiers |
+| `truly_empty_calls` | Calls where every tier produced zero kept rows |
+| `fallback_rate` | `(wm_fallback + em_fallback) / total_kept` |
+
+High `fallback_rate` (>30%) on a benchmark run is a red flag — it means most recall is coming from the weak-signal substring scan, not FTS or vector. Investigate before trusting the score.
+
+Call `reset_recall_diagnostics()` at the start of each phase to keep counters clean per-run.
+
+### Extraction diagnostics
+
+```python
+from mnemosyne.extraction.diagnostics import get_extraction_stats
+```
+
+Returns per-tier (host / remote / local / cloud / wrapper) extraction call counts plus bounded error samples (10 samples per tier, 200 chars per message). Surfaces silent failures in the fact-extraction pipeline.
+
+---
+
+## Test sequence template
+
+The general shape of a credible A/B benchmark:
+
+1. **Preflight** — assert pure-recall is active, snapshot every `MNEMOSYNE_*` env var, log recall path per call.
+2. **Phase 0 (baseline floor)** — minimum configuration: linear scorer, all veracity weights = 1.0, no enrichment.
+3. **+ one variable** per subsequent phase. Run on a 100K-message slice (~20 min); save full 250K runs for confirming the top two configurations from the small-scale screen.
+4. **Record** per-question paired outcomes plus the diagnostic snapshots. Compute bootstrap CIs on per-ability score deltas.
+5. **Falsification criterion:** for "tool X contributes near-zero" claims, the 95% CI must exclude ±2pp before treating the prediction as confirmed.
+
+See the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md) for a concrete instantiation with 10 phases and 8 theses.
+
+### Preflight checklist
+
+Every benchmark run should:
+
+- [ ] Confirm pure-recall mode is active (`MNEMOSYNE_BENCHMARK_PURE_RECALL=1` or `--pure-recall`).
+- [ ] Set `OPENROUTER_API_KEY` (or its fallback file).
+- [ ] Pin all ranking weights (`MNEMOSYNE_VEC_WEIGHT`, `FTS_WEIGHT`, `IMPORTANCE_WEIGHT`, `TEMPORAL_HALFLIFE_HOURS`, `VEC_TYPE`, `BEAM_OPTIMIZATIONS`) identically across phases.
+- [ ] Reset diagnostics before each phase.
+- [ ] Verify the recall path (linear vs polyphonic) matches what the phase intends.
+
+A small Python helper or shell wrapper that asserts all of these and refuses to run if any are missing is cheap insurance against accidentally-invalid runs.
+
+---
+
+## Recording per run
+
+Capture into `results/beam_e2e_results.json` (or equivalent):
+
+- **Per-ability score** — TR / CR / IE / KU / MR / ABS / EO / SUM, plus total.
+- **Run config** — phase name, sample size, scale, all `MNEMOSYNE_*` + `FULL_CONTEXT_MODE` env vars at start.
+- **Recall diagnostics** — full `get_recall_diagnostics()` snapshot at run end (or aggregated per-call).
+- **Extraction diagnostics** — full `get_extraction_stats()` snapshot.
+- **Latency** — p50 / p95 / p99 per-question recall + answer roundtrip.
+- **Storage** — final row counts in `working_memory`, `episodic_memory`, `memory_embeddings`, `vec_episodes`, `annotations`, `consolidated_facts`.
+- **Peak RSS** during ingest and recall phases separately.
+
+For statistical reporting, also output a flat `paired_outcomes.jsonl` with `{config_id, question_id, ability, correct}` rows so bootstrap CIs on paired deltas can be computed without re-parsing the main results.
+
+The current harness does not yet emit the diagnostic snapshots or paired outcomes; wiring them in is tracked as Gap D + Gap E in the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md#implementation-gaps).
+
+---
+
+## Future toggles needed
+
+The following A/B isolation knobs do **not** yet exist in code. They are tracked here so future contributors can add them or use them once added.
+
+| Proposed env var | Purpose | Affects |
+|---|---|---|
+| `MNEMOSYNE_VOICE_VECTOR=0/1` | Disable polyphonic vector voice for ablation | `polyphonic_recall._vector_voice` |
+| `MNEMOSYNE_VOICE_GRAPH=0/1` | Disable polyphonic graph voice | `polyphonic_recall._graph_voice` |
+| `MNEMOSYNE_VOICE_FACT=0/1` | Disable polyphonic fact voice | `polyphonic_recall._fact_voice` |
+| `MNEMOSYNE_VOICE_TEMPORAL=0/1` | Disable polyphonic temporal voice | `polyphonic_recall._temporal_voice` |
+| `MNEMOSYNE_GRAPH_BONUS=0/1` | Disable linear-path graph-edge bonus | `beam.py` linear ep loop |
+| `MNEMOSYNE_FACT_BONUS=0/1` | Disable linear-path fact-table bonus | `beam.py` linear ep loop |
+| `MNEMOSYNE_BINARY_BONUS=0/1` | Disable linear-path binary-vector Hamming bonus | `beam.py` linear ep loop |
+| `MNEMOSYNE_VERACITY_MULTIPLIER=0/1` | Short-circuit veracity multiplier to 1.0 in both engines | `beam.py` linear + polyphonic |
+| `MNEMOSYNE_CROSS_TIER_DEDUP=0/1` | Disable `_dedup_cross_tier_summary_links` for ablation | `beam.py` linear + polyphonic |
+
+Each is a small implementation (~20–30 LOC plus tests). Total ~225 LOC if all nine ship as one PR. Without them, several phases of the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md) cannot be executed cleanly because the alternative (modifying veracity values, deleting code paths, manipulating fixture data) introduces multiple confounded variables.
+
+---
+
+## How this doc evolves
+
+When a new env var is added that affects recall ranking or benchmark behavior, update the [Environment variable reference](#environment-variable-reference) table here. When a new diagnostic counter ships, add it to [Diagnostic instrumentation](#diagnostic-instrumentation). When a new experiment runs, add a dated artifact under `docs/experiments/`.
+
+Past experiment artifacts:
+- [2026-05-12 — BEAM-recovery Arms A/B/C](experiments/2026-05-12-beam-recovery-arms-abc.md)
+- (older runs documented in [beam-benchmark.md](beam-benchmark.md) — note that those pre-date the May 2026 fix bundle and aren't credible for per-tool claims)

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -244,9 +244,11 @@ Capture into `results/beam_e2e_results.json` (or equivalent):
 - **Storage** — final row counts in `working_memory`, `episodic_memory`, `memory_embeddings`, `vec_episodes`, `annotations`, `consolidated_facts`.
 - **Peak RSS** during ingest and recall phases separately.
 
-For statistical reporting, also output a flat `paired_outcomes.jsonl` with `{config_id, question_id, ability, correct}` rows so bootstrap CIs on paired deltas can be computed without re-parsing the main results.
+For statistical reporting, the harness emits a flat `paired_outcomes.jsonl` alongside `beam_e2e_results.json`. Each row carries `{config_id, run_started_at, scale, conversation_id, qid, ability, score, correct}`. `config_id` is either supplied via `--config-id` (recommended for human-readable phase labels like `phase3a-no-fact-voice`) or auto-derived as a SHA-256 hash of the `MNEMOSYNE_*` env snapshot. `correct` is `score >= 0.5` (treating partial-credit as correct; analyst can re-threshold off raw `score`).
 
-The current harness does not yet emit the diagnostic snapshots or paired outcomes; wiring them in is tracked as Gap D + Gap E in the [BEAM-recovery experiment plan](experiments/2026-05-12-beam-recovery-arms-abc.md#implementation-gaps).
+Append-only: multiple A/B-phase runs accumulate in one file. Filter by `config_id` to isolate a single phase. The diagnostic snapshots are also emitted into `beam_e2e_results.json` under `metadata.diagnostics`.
+
+**Voice-score parity:** post-recall result dicts from both engines now carry a `voice_scores: dict` field for uniform analysis. Keys differ between engines (linear uses `{vec, fts, keyword, importance, recency_decay}`; polyphonic uses `{vector, graph, fact, temporal}`), so engine identity is the dict's keyset, not the field's presence.
 
 ---
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -234,6 +234,8 @@ A small Python helper or shell wrapper that asserts all of these and refuses to 
 
 ## Recording per run
 
+For the **output-file schemas, analysis recipes (paired bootstrap CIs, per-voice attribution, fallback-rate sanity checks), and an AI-assistant-friendly summary**, see [benchmark-results-analysis.md](benchmark-results-analysis.md). Quick reference:
+
 Capture into `results/beam_e2e_results.json` (or equivalent):
 
 - **Per-ability score** — TR / CR / IE / KU / MR / ABS / EO / SUM, plus total.

--- a/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
+++ b/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
@@ -206,7 +206,7 @@ This is the complete list of functionality the plan assumes exists but doesn't (
 
 Merging PRs #80, #82, #88, #89, #90, #91 closes most of the prerequisite footprint. PRs #83, #85, #86, #87 are also open but not strictly required for the experiment to run — they harden surrounding paths against silent failure but don't gate the test sequence itself.
 
-### Gap B — Nine A/B toggles (the big one — ~225 LOC) — ⏳ in PR A (separate)
+### Gap B — Nine A/B toggles (the big one — ~225 LOC) — ✅ closed in PR A
 
 See §6 above. Without these, phases 0, 1, 3a–3d, 3-LIN-*, and 4 cannot be run cleanly — they either change multiple variables at once or have no working knob. **Required to execute phases 0–5 as designed.**
 

--- a/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
+++ b/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
@@ -223,7 +223,7 @@ Add to `tools/evaluate_beam_end_to_end.py:main()` near argument parsing:
 
 Wire the harness to call `get_recall_diagnostics()` and `get_extraction_stats()` and write their JSON snapshots into `results/beam_e2e_results.json` per-conversation per-phase. Also call `reset_recall_diagnostics()` at the start of each phase to keep counters clean. The functions exist (PR #78 + #79); the harness simply doesn't use them.
 
-### Gap E — Per-question paired-outcome recording for CIs (~40 LOC)
+### Gap E — Per-question paired-outcome recording for CIs (~40 LOC) — ✅ closed
 
 Currently the harness writes per-question scores but doesn't structure them for paired statistical analysis. Add: for each (config, question) pair, record whether the answer was correct. Output a flat `paired_outcomes.jsonl` with `{config_id, question_id, ability, correct}` rows so a downstream notebook can bootstrap CIs without re-parsing the main results.
 
@@ -231,7 +231,7 @@ Currently the harness writes per-question scores but doesn't structure them for 
 
 Add a top-level file listing `numpy`, `datasets`, `sqlite-vec`, `fastembed`, optionally `llama-cpp-python` and `huggingface-hub`. Reference it from the README under "Running the BEAM benchmark." The current pyproject `[project.optional-dependencies]` groups (`llm`, `embeddings`, `mcp`, `all`) don't cover the benchmark-only deps (`numpy`, `datasets`, `sqlite-vec`).
 
-### Gap G — Voice-score capture in linear-path results (~20 LOC)
+### Gap G — Voice-score capture in linear-path results (~20 LOC) — ✅ closed
 
 The polyphonic results already carry `voice_scores: dict` per result dict (`beam.py:~2969`). Linear-path results don't — they have `dense_score`, `keyword_score`, `fts_score` separately but no unified provenance dict. For uniform post-hoc analysis ("which signal drove this row?"), add a similarly-shaped provenance dict to linear results too. Not strictly required to run the plan, but materially eases analysis. Defer if scope is tight.
 

--- a/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
+++ b/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
@@ -1,0 +1,305 @@
+# BEAM-Recovery Experiment — Test Sequence and Theses
+
+**Date:** 2026-05-12 | **Status:** Plan, pre-execution. References [docs/benchmarking.md](../benchmarking.md) for env-var definitions and methodology.
+
+This is a dated experiment artifact. For the reusable test-infrastructure reference (env vars, diagnostic instrumentation, pure-recall mode, recording template), see [benchmarking.md](../benchmarking.md). This file describes the specific 10-phase ablation sequence planned for the post-May-2026 fix bundle and the theses each phase tests.
+
+---
+
+## Why this exists
+
+The goal is to measure, per tool, what each component of the Mnemosyne recall stack contributes to BEAM scores — not to demonstrate Mnemosyne wins. PRs #80–#91 were filed specifically to enable that per-tool isolation, and **stats collected before those land are not credible evidence for or against any specific tool**, because the prior pipeline had silent failure modes and harness-side oracles that made it impossible to attribute deltas to a single change.
+
+The proposed sequence below is designed to commit each tool to a measurable A/B test rather than a "polyphonic vs linear" bundle comparison.
+
+---
+
+## Hard prerequisites before any phase runs
+
+### Code prerequisites — PRs to merge first
+
+**This plan is only valid against a checkout that has these PRs merged:** #80 (polyphonic vector voice rewire to `memory_embeddings` + sqlite-vec), #82 (`remember_batch` enrichment parity), #88 (cross-tier dedup), #89 (veracity preservation through consolidation), #90 (pure-recall harness gate), #91 (env-parser + telemetry). On current `main` (pre-merge) several plan claims are factually wrong — `_dedup_cross_tier_summary_links` doesn't exist, `_recall_polyphonic` still uses `BinaryVectorStore`, the harness has no `--pure-recall` flag. If those PRs haven't merged when you run this, stop and merge them first.
+
+### Python / system dependencies
+
+```bash
+# Core (already in pyproject as optional groups):
+pip install 'mnemosyne-memory[embeddings]'   # fastembed (≥0.3.0) — recall vector voice
+pip install 'mnemosyne-memory[llm]'          # llama-cpp-python — sleep summarization (else AAAK fallback)
+
+# Benchmark-only — NOT in pyproject yet:
+pip install datasets                          # HuggingFace BEAM dataset loader (tools/evaluate_beam_end_to_end.py:183)
+pip install sqlite-vec                        # vec_episodes ANN backend (linear path + polyphonic post-#80)
+pip install numpy                             # tools/evaluate_beam_end_to_end.py:54 import is unconditional
+```
+
+`numpy` and `datasets` are runtime requirements of the benchmark harness but not declared as installable extras of the package — install them in the same venv. Recommend tracking these in a `requirements-benchmark.txt` (see Implementation Gaps §6 below).
+
+### External services / API keys
+
+| Variable | Required for | Source |
+|---|---|---|
+| `OPENROUTER_API_KEY` | LLM that answers benchmark questions | OpenRouter account |
+| `HF_TOKEN` (optional) | If BEAM dataset turns gated; currently public at `Mohammadta/BEAM` | HuggingFace |
+| `OPENROUTER_BASE_URL` (optional) | API base URL override; default `https://openrouter.ai/api/v1` | env-only |
+
+The harness falls back to reading `OPENROUTER_API_KEY` from `/tmp/opencode_key.txt` or `/tmp/openrouter_key.txt` if the env isn't set (`tools/evaluate_beam_end_to_end.py:60-71`).
+
+### Compute / resource budget
+
+| Resource | 100K phase | 250K phase |
+|---|---|---|
+| Wall clock | ~20–30 min per run | ~60–90 min per run |
+| Peak RSS | ~2–4 GB (fastembed + LLM) | ~4–8 GB |
+| Disk for DB | ~500 MB per conversation | ~2–4 GB per conversation |
+| LLM API spend | ~$0.50–$2 per phase | ~$5–$15 per phase |
+
+API spend is dominated by per-question answer LLM calls (BEAM has up to 50 questions per conversation per scale). Cache hits via deduplication of identical queries can lower this; quantify on first phase before committing to all 10.
+
+**Preflight (run once per session, then per phase):**
+
+1. **Assert pure-recall mode is active.** The harness should refuse to run if `MNEMOSYNE_BENCHMARK_PURE_RECALL` is unset. The bypasses don't produce identical answers across arms; running without the gate silently invalidates every comparison.
+2. **Dump every `MNEMOSYNE_*` env var into results JSON.** A toggle the operator forgot is a confound in disguise.
+3. **Pin all ranking knobs.** `MNEMOSYNE_VEC_WEIGHT`, `MNEMOSYNE_FTS_WEIGHT`, `MNEMOSYNE_IMPORTANCE_WEIGHT`, `MNEMOSYNE_TEMPORAL_HALFLIFE_HOURS`, `MNEMOSYNE_VEC_TYPE`, `MNEMOSYNE_BEAM_OPTIMIZATIONS`, `MNEMOSYNE_TIER{1,2,3}_WEIGHT`, `MNEMOSYNE_*_WEIGHT` veracity values must be set identically across phases — pin them in a `.env` file or assert in the runner.
+4. **Sanity-check the active recall path.** Log whether each call went through linear or polyphonic; the env var is read at call time, not init time, so accidental flips mid-run are possible.
+5. **Record per-result `voice_scores` and tier provenance** (from C4 + C13.b diagnostics). Without these, a "tool contributes nothing" finding is unfalsifiable.
+
+---
+
+## Why prior stats are suspect
+
+- The benchmark harness answered TR/CR/IE/KU questions from a regex-extracted timeline, raw-message contradiction detection, and a `_context_facts` side-index — bypassing `BeamMemory.recall()` entirely on those ability dimensions (PR #90).
+- Every answer prompt was always prepended with the last 12 raw conversation messages, so any recency-anchored answer could succeed regardless of recall quality and arm choice (PR #90).
+- Post-E3 additive sleep left both the source `working_memory` row and the episodic summary discoverable by recall, double-incrementing `recall_count` and ranking duplicates side-by-side under the linear scorer while polyphonic's diversity rerank silently collapsed them — asymmetric dedup confounded any arm-vs-arm comparison (PR #88).
+- `consolidate_to_episodic` never populated the `veracity` column on the summary row, so post-E4 per-row veracity got destroyed the moment sleep ran — every episodic row scored at the 0.8 `unknown` multiplier (PR #89).
+- `remember_batch` swallowed partial embedding failures via a bare `except Exception: pass`, silently losing entire batches of vectors at scale (PR #89).
+- Pre-E1 the benchmark adapter wrote template summaries and destroyed source rows; the corpus most prior runs actually recalled against was ~500 episodic rows of "Batch N: first_3_msg_contents[:100chars]" stubs, not the 250K-message dataset (PR #75).
+
+Each is fixed; their combined effect on prior numbers is unknowable.
+
+---
+
+## What's now controllable for A/B
+
+**Key disambiguation up front:** the linear path and the polyphonic engine implement related signals through DIFFERENT mechanisms. The linear scorer applies `graph_bonus` / `fact_bonus` / `binary_bonus` as inline additions (`beam.py:~2497-2545`); the polyphonic engine runs separate voices (`polyphonic_recall.py:_graph_voice`, `_fact_voice`, `_vector_voice` which is binary-vector-driven). They have different failure modes and different ablation surfaces. Toggles must specify which engine they gate.
+
+| Tool / axis | Engine | On/off mechanism | Landed in |
+|---|---|---|---|
+| Polyphonic engine vs linear scorer | both | `MNEMOSYNE_POLYPHONIC_RECALL=1` selects polyphonic | E5 (#76) |
+| Polyphonic vector voice (post-#80: `memory_embeddings` + sqlite-vec ANN; pre-#80: `BinaryVectorStore`) | polyphonic | Implicit when polyphonic on; ANN gated by `_vec_available`. **Proposed:** `MNEMOSYNE_VOICE_VECTOR=0` for ablation | E5.a (#80) |
+| Polyphonic graph voice (`find_gists_by_participant` / `find_facts_by_subject`) | polyphonic | **Proposed:** `MNEMOSYNE_VOICE_GRAPH=0` |  |
+| Linear graph bonus (edge-count LIKE-match on `graph_edges`) | linear | **Proposed:** `MNEMOSYNE_GRAPH_BONUS=0`; **separate toggle from polyphonic graph voice** |  |
+| Polyphonic fact voice (synthetic `cf_*` IDs from `consolidated_facts`) | polyphonic | **Proposed:** `MNEMOSYNE_VOICE_FACT=0` |  |
+| Linear fact bonus (per-row `facts` table query) | linear | **Proposed:** `MNEMOSYNE_FACT_BONUS=0` |  |
+| Polyphonic temporal voice | polyphonic | **Proposed:** `MNEMOSYNE_VOICE_TEMPORAL=0` |  |
+| Linear temporal boost (`_temporal_boost` × `temporal_weight`) | linear | `temporal_weight=0` per-call arg (already exposed); needs harness flag |  |
+| Linear binary-vector bonus (capped at 0.08) | linear | **Proposed:** `MNEMOSYNE_BINARY_BONUS=0` |  |
+| Veracity multiplier | both | **Proposed:** `MNEMOSYNE_VERACITY_MULTIPLIER=0` — gates the multiplier in linear + polyphonic |  |
+| Tier-degradation multiplier | both | `MNEMOSYNE_TIER{1,2,3}_WEIGHT=1.0` neutralizes (existing env vars) |  |
+| Cross-tier (summary, source) dedup | both | **Proposed:** `MNEMOSYNE_CROSS_TIER_DEDUP=0` (requires #88 merged) | E3.a.3 (#88) |
+| Algorithmic enrichment in `remember_batch` | ingest | `extract_entities=False`, `extract=False` kwargs (rule-based always-on post-E2 is not separately toggled) | E2 (#82) |
+| LLM extraction | ingest | `extract=True` kwarg (per-row cost); out of scope for Arms A–C |  |
+| Pure-recall mode (no harness oracles) | harness | `--pure-recall` or `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` (requires #90/#91) | #90, #91 |
+| Veracity tagging at ingest | ingest | `remember_batch(items, veracity=...)` per-item or default | E4 (#74), E4.a.1 (#89) |
+| Score-component weights | linear | `MNEMOSYNE_VEC_WEIGHT`, `MNEMOSYNE_FTS_WEIGHT`, `MNEMOSYNE_IMPORTANCE_WEIGHT` (existing; normalized to 1.0) |  |
+| FTS5 / vec scan breadth | both | `MNEMOSYNE_BEAM_OPTIMIZATIONS=1` widens FTS OR-semantics + raises vec scan limits |  |
+| Vector storage backend | both | `MNEMOSYNE_VEC_TYPE` ∈ {`float32`, `int8`, `bit`} |  |
+| Recall diagnostics (per-tier hits, fallback rate) | observability | `mnemosyne.core.recall_diagnostics.get_recall_diagnostics()` | C4 (#79) |
+| Extraction diagnostics (per-tier extract counts) | observability | `mnemosyne.extraction.diagnostics.get_extraction_stats()` | C13.b (#78) |
+
+The "proposed" rows are the gap between today's code (assuming #80–#91 merged) and a clean A/B matrix. Scope is in §6.
+
+---
+
+## Proposed test sequence
+
+Each phase changes exactly one variable from the prior. Run on the 100K slice unless noted; budget ~20–30 minutes per phase on a single conversation. Use `--pure-recall` on every phase — running without it reintroduces the harness oracles and invalidates per-tool deltas.
+
+Phases 3a–3d ablate components of the polyphonic engine specifically. They can run in parallel from a frozen DB snapshot taken at Phase 2 ingest completion, since each toggle is independent of the others. Phase 3-LIN-* exercises the analogous LINEAR-path bonus blocks separately — those aren't redundant with 3a–3d because the linear graph/fact mechanisms are different functions on different data.
+
+**Every phase requires:** `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` (or `--pure-recall`), `OPENROUTER_API_KEY` set, and the Python deps from §1 installed. The per-phase table below lists only the variables that change from defaults.
+
+| Phase | Name | Setup (delta from prior) | What to measure | Expectation |
+|---|---|---|---|---|
+| 0 | Baseline floor | Linear scorer, pure-recall, `MNEMOSYNE_VERACITY_MULTIPLIER=0` (explicit toggle, NOT data labeling — uniform `unknown` rows still get the 0.8 multiplier), no enrichment | Per-ability score + total | The "raw working_memory + episodic via FTS + numpy-vec, no multipliers" floor |
+| 1 | + veracity | Phase 0 + `MNEMOSYNE_VERACITY_MULTIPLIER=1`, rows tagged via `remember_batch` defaults | Δ vs phase 0 | Test Thesis 5 (prior: small Δ on uniform corpora; report CIs) |
+| 2 | + polyphonic engine | Phase 1 + `MNEMOSYNE_POLYPHONIC_RECALL=1`, all voices on | Δ vs phase 1 | Net engine contribution — RRF + diversity rerank vs linear scorer |
+| 3a | − fact voice (polyphonic) | Phase 2 + `MNEMOSYNE_VOICE_FACT=0` | Δ vs phase 2 | Test Thesis 1: predict near-zero — see thesis details below |
+| 3b | − graph voice (polyphonic) | Phase 2 + `MNEMOSYNE_VOICE_GRAPH=0` | Δ vs phase 2 | Test Thesis 2a (polyphonic graph voice contribution) |
+| 3c | − temporal voice (polyphonic) | Phase 2 + `MNEMOSYNE_VOICE_TEMPORAL=0` | Δ vs phase 2 | Question-mix dependent |
+| 3d | − polyphonic vector voice | Phase 2 + `MNEMOSYNE_VOICE_VECTOR=0` | Δ vs phase 2 | **This is the polyphonic-engine analog of "no vector signal" — gates `_vector_voice()` in `polyphonic_recall.py:113-151`, NOT the linear binary_bonus block. Vector voice is the heaviest contributor; predict large Δ.** |
+| 3-LIN-bin | − linear binary bonus | Phase 1 (linear) + `MNEMOSYNE_BINARY_BONUS=0` (gates `beam.py:2527-2545`) | Δ vs phase 1 | Test Thesis 3a (linear-only binary bonus deprecation) — predict near-zero |
+| 3-LIN-graph | − linear graph bonus | Phase 1 + `MNEMOSYNE_GRAPH_BONUS=0` (gates `beam.py:2497-2521`, 2632-2656) | Δ vs phase 1 | Test Thesis 2b (linear graph-bonus contribution) |
+| 3-LIN-fact | − linear fact bonus | Phase 1 + `MNEMOSYNE_FACT_BONUS=0` (gates `beam.py:2508-2521`, 2640-2655) | Δ vs phase 1 | Test Thesis 1b (linear fact-bonus contribution) |
+| 4 | + cross-tier dedup off | Phase 2 + `MNEMOSYNE_CROSS_TIER_DEDUP=0` | Δ vs phase 2 | Test Thesis 4 |
+| 5 | + algorithmic enrichment | Phase 2 + `extract_entities=True` at ingest | Δ vs phase 2 | Graph+fact data populated → voices have substance |
+| 6 | Full 250K confirmation | Top-2 configurations from phases 0–5 + Phase 0 floor | Per-ability + total + latency | Confirms 100K findings hold at scale |
+
+A full 2^N factorial across the voices is more rigorous but costs N²-ish runs; the single-variable ablations capture the dominant per-component contributions cheaply. If any 3a–3d delta surprises (e.g., voice X looks important when predicted dead), follow up with a paired-voice ablation (X + Y both off).
+
+---
+
+## Theses
+
+Each is a **prior** with code grounding, plus the test that would prove or disprove it. **The quantitative predictions are priors, not measurement-backed claims** — there are no pilot runs with confidence intervals behind them. Report bootstrap CIs or per-question paired deltas during execution; a "prediction confirmed" with overlapping CIs is not confirmation.
+
+**Thesis 1a — The polyphonic fact voice contributes effectively zero to final recall.**
+`_fact_voice` (`polyphonic_recall.py:~200-217`) emits synthetic `cf_{subject}_{predicate}_{object}` IDs. `_recall_polyphonic` (`beam.py:~2935-2938`) skips any ID starting with `cf_` because `_fetch_polyphonic_row` can't map them to a real row. `_combine_voices` (`polyphonic_recall.py:~295-336`) does not join `cf_*` IDs to source memory rows — the consolidator's `sources` list isn't threaded through. So when the fact voice "fires," its rows are filtered out before composition. Indirect contribution via RRF on memory_ids surfaced by other voices is also zero in this code, because the fact voice doesn't surface those IDs. **Prior:** Δ ≤ 0.5pp on total score, indistinguishable from noise. **Test:** Phase 3a. If true, the polyphonic fact voice is currently dead code in the recall path — the cost is the consolidator's ingest-time Bayesian compounding, which has separate value but isn't tested here.
+
+**Thesis 1b — The LINEAR fact bonus is on a different mechanism and should be tested separately.**
+The linear path at `beam.py:~2508-2521` per-row queries the `facts` table by `source_msg_id` and adds a capped bonus (max 0.1) when query tokens overlap with extracted fact tokens. This is NOT the same code path as the polyphonic fact voice — it operates on `facts`, not `consolidated_facts`. **Prior:** Δ small-but-positive (1–3pp) on questions whose answer involves an extracted fact; zero on others. **Test:** Phase 3-LIN-fact.
+
+**Thesis 2a — The polyphonic graph voice's contribution depends heavily on entity-extraction quality.**
+`_graph_voice` (`polyphonic_recall.py:~160-183`) extracts capitalized tokens from the query and calls `find_gists_by_participant` / `find_facts_by_subject`. Failure modes: case-sensitivity (lowercase entities ignored), brittle entity extraction, and the suspect `fact.id.split("_")[-1]` mapping that assumes a particular ID schema. **Prior:** uneven Δ — 2–4pp on questions with clearly-capitalized proper-noun entities, near-zero otherwise. **Test:** Phase 3b. Stratify the analysis by whether the question contains capitalized tokens.
+
+**Thesis 2b — The LINEAR graph bonus rewards connectivity, not query relevance.**
+`beam.py:~2497-2505` counts edges in `graph_edges` via `subject LIKE %memory_id% OR target LIKE %memory_id%`, capped at 0.08. Densely-connected rows get the bonus regardless of whether they're actually relevant to the query — well-connected rows are surfaced more often than they should be. **Prior:** Δ near-zero on total score (the cap is small), possibly negative on questions where the densely-connected rows aren't the answer. **Test:** Phase 3-LIN-graph.
+
+**Thesis 3a — The LINEAR binary-vector bonus block is deprecation-eligible.**
+`beam.py:~2527-2545` adds a tanh-normalized Hamming-distance bonus capped at 0.08 from the `binary_vector` column when both query and row vectors are present. The float-vector signal in `vec_results` already drives most of the ranking through `vec_sim * vw`. **Prior:** Δ < 1pp. **Test:** Phase 3-LIN-bin.
+
+**Thesis 3b — The POLYPHONIC vector voice is the heaviest contributor and should NOT be conflated with 3a.**
+`_vector_voice` (`polyphonic_recall.py:113-151`) runs `BinaryVectorStore.search` (pre-#80) or sqlite-vec ANN over `memory_embeddings` (post-#80). Either way it's the highest-RRF-rank-weight voice and dominates the polyphonic engine's signal. Deprecating it via Phase 3d would tank polyphonic recall scores. **Prior:** Δ large-negative (5–20pp) when disabled. **Test:** Phase 3d. **Do not conclude binary-vector deprecation from Phase 3d** — that decision is Phase 3-LIN-bin's territory, not 3d's.
+
+**Thesis 4 — Cross-tier dedup matters more for linear than polyphonic.**
+Pre-#88 the linear path returned (summary, source) pairs ranked side-by-side. Polyphonic's diversity rerank handles this approximately via embedding similarity. **Prior:** linear regresses 3–8pp without dedup; polyphonic regresses <2pp. **Test:** Phase 4 × {Phase 0 baseline, Phase 2}. Requires #88 merged (`_dedup_cross_tier_summary_links` doesn't exist pre-merge).
+
+**Thesis 5 — Veracity multiplier is near-noise on uniform-veracity BEAM data.**
+If every WM and EP row has the same veracity label, the multiplier becomes a global scalar that doesn't change ranking. Post-#89 the consolidator now aggregates source veracity, so summary rows can have different veracity from sources — slightly breaking uniformity. **Prior:** Δ < 1pp on total score, possibly larger on questions answered from consolidated summaries vs raw sources. **Test:** Phase 1 vs Phase 0 with explicit multiplier toggle (NOT data labeling — uniform rows still get the multiplier applied; only the toggle short-circuits it).
+
+**Thesis 6 — The RECENT CONVERSATION leak was the dominant prior driver of arm-vs-arm equivalence.**
+Pre-#90 every answer prompt included the last 12 raw messages. Recency-anchored answers succeeded without needing recall — arm choice was invisible. **Prior:** pure-recall mode shows arm-vs-arm deltas 2–5× larger than legacy mode. **Test:** Phase 2 with `--pure-recall` vs without (legacy harness behavior). Also serves as a sanity check that #90's gate is actually firing.
+
+**Thesis 7 — sqlite-vec ANN vs numpy exact-vec affects latency, not score (post-#80).**
+The polyphonic engine over-fetches `top_k * 2`; the final RRF + multiplier + dedup pipeline returns top_k. ANN-vs-exact differences in the long tail past position ~60 get truncated. **Prior:** Δ score < 0.5pp; p95 latency divergence 5–20×. **Test:** Phase 2 with `sqlite-vec` importable vs mocked-unavailable (numpy fallback). Requires #80 merged.
+
+**Thesis 8 — Algorithmic enrichment captures most of what LLM extraction would.**
+BEAM facts are predominantly subject-verb-object patterns the regex extractor handles. LLM extraction catches more nuance at $25–$2500 + 35–138h per 250K pass (E2.a.3 ledger note). **Prior:** ≤5pp gap between Phase 5 (algorithmic) and a separate `extract=True` LLM-extraction run. **Test:** Phase 5 vs a separate Arm D run. If gap ≤5pp, LLM extraction is cost overhead; if gap >10pp, it's a real capability.
+
+---
+
+## Toggles needed before full A/B
+
+Each toggle is its own scope (not 5 LOC). LOC estimates include the env-parse code, the gate site(s), invalidation of cached `PolyphonicRecallEngine` if the toggle affects voice construction, and 2–3 regression tests per toggle.
+
+| Toggle | Purpose | Sites | LOC (incl. tests) |
+|---|---|---|---|
+| `MNEMOSYNE_VOICE_VECTOR=0/1` | Phase 3d — polyphonic vector voice | `polyphonic_recall.py:_vector_voice` early-return when off | ~25 |
+| `MNEMOSYNE_VOICE_GRAPH=0/1` | Phase 3b — polyphonic graph voice | `polyphonic_recall.py:_graph_voice` early-return | ~25 |
+| `MNEMOSYNE_VOICE_FACT=0/1` | Phase 3a — polyphonic fact voice | `polyphonic_recall.py:_fact_voice` early-return | ~25 |
+| `MNEMOSYNE_VOICE_TEMPORAL=0/1` | Phase 3c — polyphonic temporal voice | `polyphonic_recall.py:_temporal_voice` early-return | ~25 |
+| `MNEMOSYNE_GRAPH_BONUS=0/1` | Phase 3-LIN-graph — linear graph bonus | Gate `beam.py:~2497-2521` (main ep loop) AND `:~2632-2645` (fallback) | ~30 |
+| `MNEMOSYNE_FACT_BONUS=0/1` | Phase 3-LIN-fact — linear fact bonus | Gate `beam.py:~2508-2521` AND `:~2640-2655` | ~30 |
+| `MNEMOSYNE_BINARY_BONUS=0/1` | Phase 3-LIN-bin — linear binary-vector bonus | Gate `beam.py:~2527-2545` | ~20 |
+| `MNEMOSYNE_VERACITY_MULTIPLIER=0/1` | Phase 0/1 — disable veracity multiplier in both engines | Short-circuit to 1.0 in linear (`beam.py:~2700-2719`) + polyphonic (`beam.py:~3015-3017`) | ~25 |
+| `MNEMOSYNE_CROSS_TIER_DEDUP=0/1` | Phase 4 — disable E3.a.3 dedup | Short-circuit `_dedup_cross_tier_summary_links` to return input list unchanged | ~20 |
+
+Total ~225 LOC across ~30 tests if all nine are implemented in one PR. A subset is fine if you want to prioritize: vector-voice toggle (3d) + veracity toggle (0/1) + cross-tier toggle (4) are the three most important for the experiment's central claims. The linear-bonus toggles (3-LIN-*) matter only if you want to deprecate components of the linear scorer; they're independent of the polyphonic-vs-linear comparison.
+
+---
+
+## Implementation gaps — what the plan needs that does NOT yet exist
+
+This is the complete list of functionality the plan assumes exists but doesn't (as of 2026-05-12, prior to PRs #80–#91 merging). The plan can't be executed cleanly until these gaps close. Each item is callable as its own small PR; estimates include tests.
+
+### Gap A — PR merges (no new code; just merge what's open) — ✅ closed 2026-05-12
+
+Merging PRs #80, #82, #88, #89, #90, #91 closes most of the prerequisite footprint. PRs #83, #85, #86, #87 are also open but not strictly required for the experiment to run — they harden surrounding paths against silent failure but don't gate the test sequence itself.
+
+### Gap B — Nine A/B toggles (the big one — ~225 LOC) — ⏳ in PR A (separate)
+
+See §6 above. Without these, phases 0, 1, 3a–3d, 3-LIN-*, and 4 cannot be run cleanly — they either change multiple variables at once or have no working knob. **Required to execute phases 0–5 as designed.**
+
+### Gap C — Harness preflight assertions (~80 LOC) — ✅ closed in this PR
+
+Add to `tools/evaluate_beam_end_to_end.py:main()` near argument parsing:
+
+1. **Pure-recall guard:** `sys.exit(1)` with explanatory message if `MNEMOSYNE_BENCHMARK_PURE_RECALL` is not truthy AND `--pure-recall` was not passed AND a new `--allow-harness-oracles` opt-out wasn't passed (existing benchmark workflows might legitimately want the legacy mode for ceiling tests; require explicit opt-in to be sure).
+2. **Env-var dump:** at run start, snapshot every env var matching `^MNEMOSYNE_|^FULL_CONTEXT_MODE$|^OPENROUTER_BASE_URL$` into the results JSON under `config.env`.
+3. **Active recall path logger:** wrap `BeamMemory.recall` to record whether each call took the linear or polyphonic branch; emit a count in the per-conversation summary so an accidental mid-run mode flip is visible.
+4. **Sentinel feature checks:** assert importable: `_dedup_cross_tier_summary_links` from `beam.py` (proves #88 merged), `aggregate_veracity` from `veracity_consolidation.py` (proves #89 merged), `_env_truthy` from the harness module itself (proves #91 merged). Fail fast with the missing-PR name.
+
+### Gap D — Harness diagnostic capture (~60 LOC) — ✅ closed in this PR
+
+Wire the harness to call `get_recall_diagnostics()` and `get_extraction_stats()` and write their JSON snapshots into `results/beam_e2e_results.json` per-conversation per-phase. Also call `reset_recall_diagnostics()` at the start of each phase to keep counters clean. The functions exist (PR #78 + #79); the harness simply doesn't use them.
+
+### Gap E — Per-question paired-outcome recording for CIs (~40 LOC)
+
+Currently the harness writes per-question scores but doesn't structure them for paired statistical analysis. Add: for each (config, question) pair, record whether the answer was correct. Output a flat `paired_outcomes.jsonl` with `{config_id, question_id, ability, correct}` rows so a downstream notebook can bootstrap CIs without re-parsing the main results.
+
+### Gap F — `requirements-benchmark.txt` (~5 LOC) — ✅ closed in this PR
+
+Add a top-level file listing `numpy`, `datasets`, `sqlite-vec`, `fastembed`, optionally `llama-cpp-python` and `huggingface-hub`. Reference it from the README under "Running the BEAM benchmark." The current pyproject `[project.optional-dependencies]` groups (`llm`, `embeddings`, `mcp`, `all`) don't cover the benchmark-only deps (`numpy`, `datasets`, `sqlite-vec`).
+
+### Gap G — Voice-score capture in linear-path results (~20 LOC)
+
+The polyphonic results already carry `voice_scores: dict` per result dict (`beam.py:~2969`). Linear-path results don't — they have `dense_score`, `keyword_score`, `fts_score` separately but no unified provenance dict. For uniform post-hoc analysis ("which signal drove this row?"), add a similarly-shaped provenance dict to linear results too. Not strictly required to run the plan, but materially eases analysis. Defer if scope is tight.
+
+### Total effort to close all gaps
+
+- Required for plan execution (A + B + C + D): ~365 LOC + 40 tests + 6 PR merges
+- Highly recommended (E + F): ~45 LOC + 1 doc file
+- Nice-to-have (G): ~20 LOC
+
+A single "experiment-readiness" PR bundling B + C + D + E + F is ~510 LOC and one /review pass. Or split into three smaller PRs:
+1. Toggles (B) — biggest, most reviewable on its own
+2. Preflight + diagnostic capture (C + D + F) — harness-only, no recall-path changes
+3. Paired-outcome recording (E) — orthogonal, easy
+
+Tell me which order you want them in.
+
+---
+
+## What to record per run
+
+Capture into `results/beam_e2e_results.json`:
+
+- **Per-ability score** — TR / CR / IE / KU / MR / ABS / EO / SUM, plus total.
+- **Run config** — phase number, all toggle states, polyphonic flag, sample size, scale.
+- **Recall diagnostics** (`mnemosyne.core.recall_diagnostics.get_recall_diagnostics()` returns a JSON-serializable Dict snapshot; call once per recall and aggregate, OR once at run end): per-tier kept counts (`wm_fts`, `wm_vec`, `wm_fallback`, `em_fts`, `em_vec`, `em_fallback`), `fallback_rate`, `truly_empty` count. Use `reset_recall_diagnostics()` from the same module to clear counters before each phase. **The harness currently does NOT call these — wiring this in is part of the implementation-gaps list below.**
+- **Extraction diagnostics** (`mnemosyne.extraction.diagnostics.get_extraction_stats()`): per-tier extract counts + bounded error samples. Also not currently called by the harness.
+- **Latency** — p50 / p95 / p99 per-question recall + answer roundtrip.
+- **Storage** — final row counts in `working_memory`, `episodic_memory`, `memory_embeddings`, `vec_episodes`, `annotations`, `consolidated_facts`.
+- **Peak RSS** during ingest phase and recall phase separately.
+
+The diagnostics fields are the single biggest improvement to post-hoc analysis — they tell you WHICH tier produced each kept row, which lets you attribute score deltas to specific code paths instead of guessing.
+
+**Statistical reporting:** record per-question paired outcomes (was the answer correct in config A and config B for the same question?) and compute bootstrap CIs on the per-ability score deltas. With ~50 questions per conversation and 1–3 conversations per scale, a 2pp delta on total score is likely within noise; treat sub-3pp deltas as inconclusive until CIs separate. Where a thesis predicts "near-zero Δ," the right falsification criterion is "95% CI excludes ±2pp," not point-estimate equality.
+
+---
+
+## Recommended sequence of runs
+
+Minimum credible A/B requires ~10–12 runs:
+
+1. Phase 0 — 100K (baseline floor, all multipliers off)
+2. Phase 1 — 100K (+ veracity multiplier)
+3. Phase 2 — 100K (+ polyphonic engine)
+4. Phase 3a — 100K (− polyphonic fact voice)
+5. Phase 3b — 100K (− polyphonic graph voice)
+6. Phase 3c — 100K (− polyphonic temporal voice)
+7. Phase 3d — 100K (− polyphonic vector voice — expected large negative Δ; this is the polyphonic-engine analog of "no vector signal")
+8. Phase 4 — 100K (− cross-tier dedup)
+9. Phase 5 — 100K (+ algorithmic enrichment, populates entity/fact data)
+10. Phase 6 — 250K confirmation on the top-2 configs + Phase-0 floor
+
+Phases 3a–3d can run in parallel from a Phase-2 DB snapshot since each toggle is independent of the others.
+
+Approximate wall-clock budget: 5–6 hours total if 100K phases land in ~20 min each and the 250K run takes 60–90 min. Run a sample-1 conversation dry-run first to confirm corpus loaded, embeddings populated, and the preflight assertions fire.
+
+**Optional linear-scorer ablations** (only if you want to deprecate components of the linear path; not required for the polyphonic-vs-linear comparison):
+
+- Phase 3-LIN-bin — linear binary-vector bonus off
+- Phase 3-LIN-graph — linear graph bonus off
+- Phase 3-LIN-fact — linear fact bonus off
+
+**Optional ceiling and lower-bound bookends:**
+
+- Phase 7 — `--full-context` (LLM ceiling without recall). Sets the upper bound.
+- Phase 8 — Phase 6 with `MNEMOSYNE_VERACITY_MULTIPLIER=0`. Cleanest possible linear-vs-polyphonic A/B at scale.
+
+If any thesis turns out wildly wrong (e.g., fact voice contributes 5+pp on Thesis 1a), pause and investigate before continuing — the surprise likely indicates a code path the plan doesn't account for. The PRs ship the harness changes; the testing remains yours.
+
+---
+
+**Open PRs at handoff:** #80, #82, #83, #85, #86, #87, #88, #89, #90, #91. None are experiment-blocking individually, but the experiment can't run cleanly until at least #82, #88, #89, and #90 are merged. The rest improve specific tools' measurability and observability.

--- a/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
+++ b/docs/experiments/2026-05-12-beam-recovery-arms-abc.md
@@ -252,6 +252,8 @@ Tell me which order you want them in.
 
 ## What to record per run
 
+For full output-file schemas + analysis recipes (paired bootstrap CIs, ability deltas, fallback-rate sanity checks), see [`../benchmark-results-analysis.md`](../benchmark-results-analysis.md). Quick reference:
+
 Capture into `results/beam_e2e_results.json`:
 
 - **Per-ability score** — TR / CR / IE / KU / MR / ABS / EO / SUM, plus total.

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -141,10 +141,28 @@ DEFAULT_DB_PATH = DEFAULT_DATA_DIR / "mnemosyne.db"
 
 import os
 
+def _env_truthy(name: str) -> bool:
+    """Parse an env var as truthy. Accepts `1`/`true`/`yes`/`on`
+    (case-insensitive, whitespace-stripped). Everything else
+    (including unset, empty, garbage) is False.
+
+    Complement of `_env_disabled` (defined below) — they exist for
+    different default-state use cases. Use `_env_truthy` when the
+    feature is default-OFF and an env var opts it on; use
+    `_env_disabled` when the feature is default-ON and an env var
+    opts it off.
+
+    Mirrors the helper of the same name in `tools/evaluate_beam_end_to_end.py`
+    for env-parsing consistency across the codebase.
+    """
+    val = os.environ.get(name, "").strip().lower()
+    return val in ("1", "true", "yes", "on")
+
+
 # BEAM benchmark optimizations (opt-in via env var, zero impact on production)
 # When enabled: broader FTS5 OR semantics, larger vector scan limits, always-include vectors.
 # Set MNEMOSYNE_BEAM_OPTIMIZATIONS=1 to activate for BEAM benchmarking only.
-_BEAM_MODE = os.environ.get("MNEMOSYNE_BEAM_OPTIMIZATIONS", "").lower() in ("1", "true", "yes")
+_BEAM_MODE = _env_truthy("MNEMOSYNE_BEAM_OPTIMIZATIONS")
 
 if os.environ.get("MNEMOSYNE_DATA_DIR"):
     DEFAULT_DATA_DIR = Path(os.environ.get("MNEMOSYNE_DATA_DIR"))

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -181,6 +181,23 @@ DEGRADE_BATCH_SIZE = int(os.environ.get("MNEMOSYNE_DEGRADE_BATCH", "100"))
 SMART_COMPRESS = os.environ.get("MNEMOSYNE_SMART_COMPRESS", "1") not in ("0", "false", "no")
 TIER3_MAX_CHARS = int(os.environ.get("MNEMOSYNE_TIER3_MAX_CHARS", "300"))
 
+
+def _env_disabled(name: str) -> bool:
+    """A/B toggle helper: return True iff the env var is explicitly
+    set to a falsy value (`0`/`false`/`no`/`off`, case-insensitive,
+    whitespace-stripped).
+
+    Used by experiment ablation toggles where the feature is ON by
+    default (production behavior) and operators can disable it
+    explicitly via env var. Distinct from `_env_truthy` from the
+    benchmark harness — that one defaults to OFF, this one defaults
+    to ON. See `docs/benchmarking.md` for the full toggle reference.
+
+    Unset / empty / non-falsy → False (feature enabled).
+    """
+    val = os.environ.get(name, "").strip().lower()
+    return val in ("0", "false", "no", "off")
+
 # Veracity weighting (memory confidence). C29: defaults come from
 # `_VW_DEFAULTS` which mirrors `veracity_consolidation.VERACITY_WEIGHTS`
 # in normal mode and falls back to a hardcoded literal in degraded-import
@@ -2871,14 +2888,18 @@ class BeamMemory:
             # vec_weight + fts_weight + importance_weight are normalized to sum to 1.0
             base_score = sim * vw + fts * fw + row["importance"] * iw
 
-            # Phase 5: Graph + fact voices (polyphonic recall bonus)
+            # Phase 5: Graph + fact voices (polyphonic recall bonus).
+            # Each block gated by an A/B toggle: `MNEMOSYNE_GRAPH_BONUS=0`,
+            # `MNEMOSYNE_FACT_BONUS=0`, `MNEMOSYNE_BINARY_BONUS=0` to
+            # disable individually for ablation. Default ON — production
+            # behavior unchanged.
             graph_bonus = 0.0
             fact_bonus = 0.0
             binary_bonus = 0.0
             memory_id = row["id"]
             content_lower = row["content"].lower()
             bv = row["binary_vector"]
-            if self.episodic_graph is not None:
+            if self.episodic_graph is not None and not _env_disabled("MNEMOSYNE_GRAPH_BONUS"):
                 try:
                     # Count graph edges for this memory (well-connected = more relevant)
                     cursor2 = self.conn.cursor()
@@ -2889,7 +2910,7 @@ class BeamMemory:
                     graph_bonus = min(edge_count * 0.02, 0.08)
                 except Exception:
                     pass
-            if self.episodic_graph is not None:
+            if self.episodic_graph is not None and not _env_disabled("MNEMOSYNE_FACT_BONUS"):
                 try:
                     # Check if facts from graph match query terms via set-overlap
                     cursor2 = self.conn.cursor()
@@ -2908,7 +2929,7 @@ class BeamMemory:
             # Binary vector voice (Phase 5): re-enabled — binary vectors are now
             # backfilled for all episodic entries. ITS discriminability improves at
             # scale (1033 entries); clustering concern was for small synthetic sets.
-            if query_bv is not None and bv is not None:
+            if query_bv is not None and bv is not None and not _env_disabled("MNEMOSYNE_BINARY_BONUS"):
                 try:
                     # Compute hamming distance via XOR + popcount
                     q_arr = np.frombuffer(query_bv, dtype=np.uint8)
@@ -3009,32 +3030,37 @@ class BeamMemory:
                     base_score = relevance * kw_share + row["importance"] * iw
                     score = base_score * (rc_share + (1.0 - rc_share) * decay)
 
-                    # Phase 5: Graph + fact + binary bonuses for fallback
+                    # Phase 5: Graph + fact + binary bonuses for fallback.
+                    # Gated by the same toggles as the main loop above
+                    # so ablation behavior is consistent across both
+                    # episodic paths.
                     graph_b = 0.0
                     fact_b = 0.0
                     binary_b = 0.0
-                    try:
-                        cursor2 = self.conn.cursor()
-                        cursor2.execute(
-                            "SELECT COUNT(*) FROM graph_edges WHERE source LIKE ? OR target LIKE ?",
-                            (f"%{row['id']}%", f"%{row['id']}%"))
-                        graph_b = min(cursor2.fetchone()[0] * 0.02, 0.08)
-                    except Exception:
-                        pass
-                    try:
-                        cursor2 = self.conn.cursor()
-                        cursor2.execute(
-                            "SELECT subject, predicate, object FROM facts WHERE source_msg_id = ?",
-                            (row["id"],))
-                        q_word_set = {w for w in query.lower().split() if len(w) > 2}
-                        mc = 0
-                        for frow in cursor2.fetchall():
-                            f_tokens = {t.lower() for t in (f"{frow['subject']} {frow['predicate']} {frow['object']}").split() if len(t) > 2}
-                            if q_word_set & f_tokens:
-                                mc += 1
-                        fact_b = min(mc * 0.04, 0.1)
-                    except Exception:
-                        pass
+                    if not _env_disabled("MNEMOSYNE_GRAPH_BONUS"):
+                        try:
+                            cursor2 = self.conn.cursor()
+                            cursor2.execute(
+                                "SELECT COUNT(*) FROM graph_edges WHERE source LIKE ? OR target LIKE ?",
+                                (f"%{row['id']}%", f"%{row['id']}%"))
+                            graph_b = min(cursor2.fetchone()[0] * 0.02, 0.08)
+                        except Exception:
+                            pass
+                    if not _env_disabled("MNEMOSYNE_FACT_BONUS"):
+                        try:
+                            cursor2 = self.conn.cursor()
+                            cursor2.execute(
+                                "SELECT subject, predicate, object FROM facts WHERE source_msg_id = ?",
+                                (row["id"],))
+                            q_word_set = {w for w in query.lower().split() if len(w) > 2}
+                            mc = 0
+                            for frow in cursor2.fetchall():
+                                f_tokens = {t.lower() for t in (f"{frow['subject']} {frow['predicate']} {frow['object']}").split() if len(t) > 2}
+                                if q_word_set & f_tokens:
+                                    mc += 1
+                            fact_b = min(mc * 0.04, 0.1)
+                        except Exception:
+                            pass
                     # Binary vector bonus disabled (same reason as main path — ITS clustering)
                     binary_b = 0.0
                     score += graph_b + fact_b + binary_b
@@ -3095,6 +3121,11 @@ class BeamMemory:
             tier_lookup = {r["id"]: (r["tier"] or 1) for r in tier_rows}
             veracity_lookup = {r["id"]: (r["veracity"] or "unknown") for r in tier_rows}
             ep_summary_of_map = {r["id"]: (r["summary_of"] or "") for r in tier_rows}
+            # A/B toggle: `MNEMOSYNE_VERACITY_MULTIPLIER=0` short-circuits
+            # the multiplier so ranking depends on hybrid score alone.
+            # Useful for Phase 0/1 ablation in the BEAM-recovery
+            # experiment. Default ON.
+            apply_veracity = not _env_disabled("MNEMOSYNE_VERACITY_MULTIPLIER")
             for r in results:
                 if r.get("tier") == "episodic":
                     ep_tier = tier_lookup.get(r["id"], 1)
@@ -3102,7 +3133,8 @@ class BeamMemory:
                     r["degradation_tier"] = ep_tier
                     r["veracity"] = ep_veracity
                     r["score"] *= weight_map.get(ep_tier, 1.0)
-                    r["score"] *= veracity_map.get(ep_veracity, UNKNOWN_WEIGHT)
+                    if apply_veracity:
+                        r["score"] *= veracity_map.get(ep_veracity, UNKNOWN_WEIGHT)
 
         # [E4] Apply the veracity multiplier to working_memory results
         # too. Pre-E4 the multiplier was episodic-only, so per-row
@@ -3111,10 +3143,11 @@ class BeamMemory:
         # batch-ingested 'stated' content didn't rank above 'unknown'.
         # The row dicts already carry "veracity" from the SELECT
         # populated earlier in this function, so no second query needed.
-        for r in results:
-            if r.get("tier") == "working":
-                wm_veracity = r.get("veracity") or "unknown"
-                r["score"] *= veracity_map.get(wm_veracity, UNKNOWN_WEIGHT)
+        if not _env_disabled("MNEMOSYNE_VERACITY_MULTIPLIER"):
+            for r in results:
+                if r.get("tier") == "working":
+                    wm_veracity = r.get("veracity") or "unknown"
+                    r["score"] *= veracity_map.get(wm_veracity, UNKNOWN_WEIGHT)
 
         results.sort(key=lambda x: x["score"], reverse=True)
         # E3.a.3: collapse (episodic_summary, working_memory_source)
@@ -3261,7 +3294,13 @@ class BeamMemory:
             `sleep()` / `forget()` between them could yield stale linkage
             data. Acceptable under SQLite WAL + busy_timeout: the worst
             case is a one-call dedup miss, not data loss.
+
+        A/B toggle: `MNEMOSYNE_CROSS_TIER_DEDUP=0` disables the dedup,
+        returning the input list unchanged. Used by the BEAM-recovery
+        Phase 4 ablation to isolate the dedup's contribution.
         """
+        if _env_disabled("MNEMOSYNE_CROSS_TIER_DEDUP"):
+            return results
         ep_ids = [r["id"] for r in results if r.get("tier") == "episodic"]
         if not ep_ids:
             return results
@@ -3490,9 +3529,13 @@ class BeamMemory:
             # flag=ON callers don't silently lose the veracity rank
             # signal or tier degradation. Veracity multiplier applies
             # to both tiers (matching the post-E4 linear behavior).
+            # A/B toggle: `MNEMOSYNE_VERACITY_MULTIPLIER=0` disables
+            # veracity scaling here too — mirroring the linear path so
+            # both arms ablate identically.
             score = r.combined_score
             row_veracity = row_dict.get("veracity") or "unknown"
-            score *= weight_map.get(row_veracity, UNKNOWN_WEIGHT)
+            if not _env_disabled("MNEMOSYNE_VERACITY_MULTIPLIER"):
+                score *= weight_map.get(row_veracity, UNKNOWN_WEIGHT)
             if row_dict.get("tier") == "episodic":
                 ep_tier = row_dict.get("degradation_tier") or 1
                 score *= tier_weight_map.get(ep_tier, 1.0)

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -3149,6 +3149,24 @@ class BeamMemory:
                     wm_veracity = r.get("veracity") or "unknown"
                     r["score"] *= veracity_map.get(wm_veracity, UNKNOWN_WEIGHT)
 
+        # Gap G: linear-path voice_scores parity with the polyphonic
+        # engine. Each result already carries per-signal fields
+        # (dense_score, fts_score, keyword_score) and ranking inputs
+        # (importance, recency_decay). Collapse them into a
+        # `voice_scores` dict so downstream analysis can treat linear
+        # + polyphonic results uniformly when computing per-signal
+        # contributions across arms. The polyphonic engine sets the
+        # same field at beam.py:~3544 — same contract, different keys
+        # because the engines have different signal sources.
+        for r in results:
+            r.setdefault("voice_scores", {
+                "vec": r.get("dense_score", 0.0),
+                "fts": r.get("fts_score", 0.0),
+                "keyword": r.get("keyword_score", 0.0),
+                "importance": r.get("importance", 0.0),
+                "recency_decay": r.get("recency_decay", 0.0),
+            })
+
         results.sort(key=lambda x: x["score"], reverse=True)
         # E3.a.3: collapse (episodic_summary, working_memory_source)
         # duplicates before top-K truncation and recall_count attribution.

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -189,11 +189,88 @@ TIER3_MAX_CHARS = int(os.environ.get("MNEMOSYNE_TIER3_MAX_CHARS", "300"))
 # Env-var overrides remain so operators can tune ranking; documented
 # drift risk: if `MNEMOSYNE_*_WEIGHT` is set, recall scoring diverges
 # from consolidation confidence math (consolidator doesn't honor env).
-STATED_WEIGHT = float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", str(_VW_DEFAULTS["stated"])))
-INFERRED_WEIGHT = float(os.environ.get("MNEMOSYNE_INFERRED_WEIGHT", str(_VW_DEFAULTS["inferred"])))
-TOOL_WEIGHT = float(os.environ.get("MNEMOSYNE_TOOL_WEIGHT", str(_VW_DEFAULTS["tool"])))
-IMPORTED_WEIGHT = float(os.environ.get("MNEMOSYNE_IMPORTED_WEIGHT", str(_VW_DEFAULTS["imported"])))
-UNKNOWN_WEIGHT = float(os.environ.get("MNEMOSYNE_UNKNOWN_WEIGHT", str(_VW_DEFAULTS["unknown"])))
+def _env_float(name: str, default: float) -> float:
+    """Parse an env var as float; fall back to `default` on empty or
+    invalid values rather than crashing at module load.
+
+    Pre-fix `float(os.environ.get("MNEMOSYNE_STATED_WEIGHT", "1.0"))`
+    raised ValueError when the env var was set to empty (`export
+    MNEMOSYNE_STATED_WEIGHT=`) because `os.environ.get` returns `""`
+    (the value), not the default — `float("")` then crashed import
+    BEFORE the C32 override-WARN could fire. Restored from PR #91
+    after the merge stripped it.
+    """
+    raw = os.environ.get(name, "")
+    raw = raw.strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a valid float; falling back to default %s",
+            name, raw[:80], default,
+        )
+        return default
+
+
+# Veracity weighting (memory confidence)
+STATED_WEIGHT = _env_float("MNEMOSYNE_STATED_WEIGHT", _VW_DEFAULTS["stated"])
+INFERRED_WEIGHT = _env_float("MNEMOSYNE_INFERRED_WEIGHT", _VW_DEFAULTS["inferred"])
+TOOL_WEIGHT = _env_float("MNEMOSYNE_TOOL_WEIGHT", _VW_DEFAULTS["tool"])
+IMPORTED_WEIGHT = _env_float("MNEMOSYNE_IMPORTED_WEIGHT", _VW_DEFAULTS["imported"])
+UNKNOWN_WEIGHT = _env_float("MNEMOSYNE_UNKNOWN_WEIGHT", _VW_DEFAULTS["unknown"])
+
+
+def _detect_veracity_weight_overrides() -> List[str]:
+    """C32: return a list of `MNEMOSYNE_*_WEIGHT` env vars set to a
+    non-empty value. Filters out empty-string values (`export
+    MNEMOSYNE_STATED_WEIGHT=`) since `_env_float` falls back to default
+    on empties — counting them would confuse the WARN message.
+    """
+    return [
+        name for name in (
+            "MNEMOSYNE_STATED_WEIGHT",
+            "MNEMOSYNE_INFERRED_WEIGHT",
+            "MNEMOSYNE_TOOL_WEIGHT",
+            "MNEMOSYNE_IMPORTED_WEIGHT",
+            "MNEMOSYNE_UNKNOWN_WEIGHT",
+        )
+        if os.environ.get(name, "").strip()
+    ]
+
+
+_VERACITY_WARN_EMITTED = False
+
+
+def _warn_about_veracity_weight_overrides(force: bool = False) -> bool:
+    """Log a WARNING if any `MNEMOSYNE_*_WEIGHT` env var is overridden.
+
+    Idempotent per-process: subsequent calls return False without
+    re-emitting unless `force=True` (tests use this to verify the WARN
+    fires per call). Multi-worker setups (uvicorn `--workers`,
+    pytest-xdist) get one WARN per process instead of N per startup.
+    """
+    global _VERACITY_WARN_EMITTED
+    if _VERACITY_WARN_EMITTED and not force:
+        return False
+    overrides = _detect_veracity_weight_overrides()
+    if not overrides:
+        return False
+    logger.warning(
+        "Veracity weight env overrides detected: %s. Recall scoring will "
+        "honor the override, but consolidation Bayesian compounding "
+        "(veracity_consolidation.VERACITY_WEIGHTS) does NOT — the two "
+        "will drift. Set matching values in veracity_consolidation.py "
+        "OR accept that 'consolidated-as-N also ranks at N' invariant "
+        "is broken until the consolidator is taught the same overrides.",
+        ", ".join(overrides),
+    )
+    _VERACITY_WARN_EMITTED = True
+    return True
+
+
+_warn_about_veracity_weight_overrides()
 
 # Vector compression: float32 | int8 | bit
 VEC_TYPE = os.environ.get("MNEMOSYNE_VEC_TYPE", "int8").lower()
@@ -1755,7 +1832,60 @@ class BeamMemory:
                     "%d items (vector voice will miss these rows) (%s): %s",
                     len(items), type(exc).__name__, exc,
                 )
-        
+
+        # E2 — enrichment parity with `remember()`. The merge of PR #82
+        # accidentally stripped these calls during conflict resolution;
+        # `_add_temporal_triple` and `_ingest_graph_and_veracity` exist
+        # but were not being called per row. Without them the polyphonic
+        # engine's graph + fact voices have no data to fuse and recall's
+        # multi-voice RRF collapses. Each call is non-blocking
+        # (try/except around per-row metadata access prevents one bad
+        # row from killing the rest of the batch). Runs after the bulk
+        # working_memory + embedding writes so a failure here doesn't
+        # poison the per-row source / veracity bookkeeping.
+        for memory_id in ids:
+            item_source, item_veracity = meta_by_id.get(
+                memory_id, ("conversation", "unknown")
+            )
+            try:
+                # Look up the just-written row to find its content +
+                # timestamp; cheap (PK lookup).
+                row = cursor.execute(
+                    "SELECT content, timestamp FROM working_memory WHERE id = ?",
+                    (memory_id,),
+                ).fetchone()
+                if row is None:
+                    continue
+                row_content = row["content"] if hasattr(row, "keys") else row[0]
+                row_timestamp = row["timestamp"] if hasattr(row, "keys") else row[1]
+                self._add_temporal_triple(
+                    memory_id, row_timestamp, item_source, row_content
+                )
+                self._ingest_graph_and_veracity(
+                    memory_id, row_content, item_source, item_veracity
+                )
+                if extract_entities:
+                    _extract_and_store_entities(self, memory_id, row_content)
+                if extract:
+                    _extract_and_store_facts(self, memory_id, row_content, item_source)
+                # MEMORY_ADDED parity with remember() — streaming
+                # observers + DeltaSync see batch rows the same way
+                # they see single-row writes.
+                self._emit_event(
+                    "MEMORY_ADDED", memory_id,
+                    content=row_content,
+                    source=item_source,
+                    importance=0.5,
+                    metadata=None,
+                )
+            except Exception as exc:
+                # Defensive: a single row's enrichment failure must not
+                # poison the rest of the batch. Log + continue.
+                logger.warning(
+                    "remember_batch: per-row enrichment failed for %s (%s): %s",
+                    memory_id, type(exc).__name__, exc,
+                )
+
         self._trim_working_memory()
         return ids
 

--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -48,6 +48,17 @@ from mnemosyne.core.veracity_consolidation import (
 )
 
 
+def _env_disabled(name: str) -> bool:
+    """A/B toggle helper: return True iff env var is set to a falsy
+    value (`0`/`false`/`no`/`off`). Used by the per-voice ablation
+    toggles. Mirrors the helper in `beam.py` so each module is
+    self-contained — duplicated rather than imported to avoid a
+    cross-module dependency for a 4-line helper.
+    """
+    val = os.environ.get(name, "").strip().lower()
+    return val in ("0", "false", "no", "off")
+
+
 @dataclass
 class RecallResult:
     """Result from a single recall voice."""
@@ -179,7 +190,13 @@ class PolyphonicRecallEngine:
         higher-similarity occurrence — without this, a memory that
         exists in both tiers post-E3 would be double-counted in RRF
         and silently cap unique candidates below `top_k=20`.
+
+        A/B toggle: `MNEMOSYNE_VOICE_VECTOR=0` disables this voice for
+        ablation experiments. Returns empty so RRF fusion sees no
+        vector contribution.
         """
+        if _env_disabled("MNEMOSYNE_VOICE_VECTOR"):
+            return []
         if query_embedding is None or np is None:
             return []
 
@@ -471,10 +488,14 @@ class PolyphonicRecallEngine:
     def _graph_voice(self, query: str) -> List[RecallResult]:
         """
         Voice 2: Episodic graph traversal.
-        
+
         Extracts entities from query, finds related memories
         through graph edges.
+
+        A/B toggle: `MNEMOSYNE_VOICE_GRAPH=0` disables this voice.
         """
+        if _env_disabled("MNEMOSYNE_VOICE_GRAPH"):
+            return []
         # Extract entities (simple noun extraction)
         entities = self._extract_entities(query)
         
@@ -505,9 +526,13 @@ class PolyphonicRecallEngine:
     def _fact_voice(self, query: str) -> List[RecallResult]:
         """
         Voice 3: Structured fact matching.
-        
+
         Matches query against consolidated facts.
+
+        A/B toggle: `MNEMOSYNE_VOICE_FACT=0` disables this voice.
         """
+        if _env_disabled("MNEMOSYNE_VOICE_FACT"):
+            return []
         # Extract potential subject from query
         words = query.lower().split()
         
@@ -553,7 +578,11 @@ class PolyphonicRecallEngine:
 
         Boosts recent memories, penalizes old ones.
         Uses exponential decay based on age.
+
+        A/B toggle: `MNEMOSYNE_VOICE_TEMPORAL=0` disables this voice.
         """
+        if _env_disabled("MNEMOSYNE_VOICE_TEMPORAL"):
+            return []
         # Check for temporal keywords
         temporal_keywords = [
             "yesterday", "today", "recent", "last", "latest",

--- a/mnemosyne/core/veracity_consolidation.py
+++ b/mnemosyne/core/veracity_consolidation.py
@@ -525,8 +525,14 @@ class VeracityConsolidator:
 
                 conflicts = cursor.fetchall()
 
-                # Insert new fact
-                fact_id = f"cf_{subject}_{predicate}_{object}".replace(" ", "_")[:100]
+                # Insert new fact. E2.a.4 (PR #83): use `compute_fact_id`
+                # (SHA-256 of NFC-normalized SPO + length-prefix framing)
+                # for collision-free deterministic IDs. The merge of
+                # PR #83 accidentally left the OLD truncating f-string
+                # pattern at this call site even though `compute_fact_id`
+                # exists at line 38; same hunk that dropped the new logic
+                # also dropped the call.
+                fact_id = compute_fact_id(subject, predicate, object)
                 base_confidence = VERACITY_WEIGHTS.get(veracity, 0.8) * 0.5
 
                 sources = [source] if source else []

--- a/requirements-benchmark.txt
+++ b/requirements-benchmark.txt
@@ -1,0 +1,18 @@
+# Benchmark-only dependencies for `tools/evaluate_beam_end_to_end.py`.
+#
+# These are NOT required for normal Mnemosyne use — install them only when
+# running BEAM benchmarks or comparing recall configurations. The package
+# proper declares `embeddings`, `llm`, `mcp`, `all`, and `dev` extras in
+# pyproject.toml; the harness needs `numpy` + `datasets` + `sqlite-vec` on
+# top of those.
+#
+# Install: pip install -r requirements-benchmark.txt
+# See docs/benchmarking.md for the full benchmark setup guide.
+
+datasets>=2.0      # HuggingFace BEAM dataset loader
+numpy>=1.20        # Required unconditionally by the harness
+sqlite-vec>=0.1    # ANN backend for vec_episodes virtual table
+
+# Plus the package's own extras — install separately:
+#   pip install 'mnemosyne-memory[embeddings,llm]'
+# (fastembed for the vector voice + optional llama-cpp for sleep summarization)

--- a/tests/test_ab_toggles.py
+++ b/tests/test_ab_toggles.py
@@ -1,0 +1,447 @@
+"""Regression tests for the BEAM-recovery experiment A/B toggles.
+
+Each toggle is default-ON (production behavior unchanged) and disables
+the corresponding feature when set to a falsy value (`0`/`false`/`no`/
+`off`, case-insensitive, whitespace-stripped). See
+`docs/benchmarking.md` for the full toggle catalog.
+
+These tests pin three properties per toggle:
+  1. Default behavior (env unset) — feature ENABLED.
+  2. Falsy values disable the feature.
+  3. The disable surfaces in actual recall results (when feasible) —
+     not just an internal flag — so a future refactor that strips the
+     gate from the code path fails this test instead of silently
+     reverting the experiment's ability to ablate.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from mnemosyne.core.beam import BeamMemory, _env_disabled
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+@pytest.fixture(autouse=True)
+def _clean_toggle_env(monkeypatch):
+    """Each test starts from a clean env. Clears every toggle so
+    test order can't affect outcomes."""
+    for name in (
+        "MNEMOSYNE_VOICE_VECTOR", "MNEMOSYNE_VOICE_GRAPH",
+        "MNEMOSYNE_VOICE_FACT", "MNEMOSYNE_VOICE_TEMPORAL",
+        "MNEMOSYNE_GRAPH_BONUS", "MNEMOSYNE_FACT_BONUS",
+        "MNEMOSYNE_BINARY_BONUS", "MNEMOSYNE_VERACITY_MULTIPLIER",
+        "MNEMOSYNE_CROSS_TIER_DEDUP",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+# ─────────────────────────────────────────────────────────────────
+# _env_disabled helper itself
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestEnvDisabledHelper:
+    """Pins the default-ON-with-opt-out semantics so future toggles
+    that use this helper inherit the same falsy-value parsing."""
+
+    @pytest.mark.parametrize("value", [
+        "0", "false", "no", "off",
+        "FALSE", "OFF", "False", "No",
+        " 0 ", "  false  ", "\toff\t",
+    ])
+    def test_falsy_values_disable(self, value, monkeypatch):
+        monkeypatch.setenv("X_TEST_TOGGLE", value)
+        assert _env_disabled("X_TEST_TOGGLE") is True
+
+    @pytest.mark.parametrize("value", [
+        "1", "true", "yes", "on",
+        "TRUE", "ON",
+        "", " ", "anything-else", "maybe",
+    ])
+    def test_truthy_or_garbage_enable(self, value, monkeypatch):
+        """Unset / empty / truthy / unrecognized → feature stays ON."""
+        monkeypatch.setenv("X_TEST_TOGGLE", value)
+        assert _env_disabled("X_TEST_TOGGLE") is False
+
+    def test_unset_returns_false(self, monkeypatch):
+        monkeypatch.delenv("X_TEST_TOGGLE", raising=False)
+        assert _env_disabled("X_TEST_TOGGLE") is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# Polyphonic voice toggles (4)
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPolyphonicVoiceToggles:
+    """Each polyphonic voice has a toggle. When disabled, the voice
+    returns `[]`, contributing nothing to the engine's RRF fusion."""
+
+    @pytest.fixture
+    def engine(self, temp_db):
+        from mnemosyne.core.polyphonic_recall import PolyphonicRecallEngine
+        # Construct with default args; uses temp_db for any state.
+        eng = PolyphonicRecallEngine(db_path=temp_db)
+        yield eng
+        eng.close()
+
+    def test_vector_voice_disabled_returns_empty(self, engine, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_VOICE_VECTOR", "0")
+        # Pass a dummy embedding; with toggle off we should short-circuit
+        # before any DB work.
+        import numpy as np
+        result = engine._vector_voice(np.zeros(384, dtype=np.float32))
+        assert result == []
+
+    def test_vector_voice_enabled_runs(self, engine, monkeypatch):
+        """With toggle unset (default), the voice attempts to run.
+        We don't assert specific results — only that we got past the
+        early-return guard (returns a list, even if empty)."""
+        monkeypatch.delenv("MNEMOSYNE_VOICE_VECTOR", raising=False)
+        import numpy as np
+        result = engine._vector_voice(np.zeros(384, dtype=np.float32))
+        assert isinstance(result, list)
+        # No memories in fresh DB → empty list, but we got past the gate.
+
+    def test_graph_voice_disabled_returns_empty(self, engine, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_VOICE_GRAPH", "false")
+        result = engine._graph_voice("any query here")
+        assert result == []
+
+    def test_graph_voice_enabled_runs(self, engine, monkeypatch):
+        monkeypatch.delenv("MNEMOSYNE_VOICE_GRAPH", raising=False)
+        result = engine._graph_voice("any query here")
+        assert isinstance(result, list)
+
+    def test_fact_voice_disabled_returns_empty(self, engine, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_VOICE_FACT", "off")
+        result = engine._fact_voice("any query here")
+        assert result == []
+
+    def test_fact_voice_enabled_runs(self, engine, monkeypatch):
+        monkeypatch.delenv("MNEMOSYNE_VOICE_FACT", raising=False)
+        result = engine._fact_voice("any query here")
+        assert isinstance(result, list)
+
+    def test_temporal_voice_disabled_returns_empty(self, engine, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_VOICE_TEMPORAL", "no")
+        result = engine._temporal_voice("recent activity yesterday")
+        assert result == []
+
+    def test_temporal_voice_enabled_runs(self, engine, monkeypatch):
+        monkeypatch.delenv("MNEMOSYNE_VOICE_TEMPORAL", raising=False)
+        result = engine._temporal_voice("recent activity yesterday")
+        assert isinstance(result, list)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Linear-path bonus toggles (3)
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLinearBonusToggles:
+    """Linear path's `graph_bonus` / `fact_bonus` / `binary_bonus` add
+    capped (0.08, 0.1, 0.08) score lifts to episodic rows. With the
+    toggles disabled, those lifts must not be applied.
+
+    Direct assertion: with toggle OFF, the score is what hybrid scoring
+    produces WITHOUT the bonus block running. We check this by
+    structural test of beam.py — the toggles short-circuit the entire
+    bonus-computation block, not just the final addition, so any rows
+    that would have received a bonus get a strictly lower score.
+    """
+
+    def _seed_episodic_with_graph_data(self, beam: BeamMemory):
+        """Seed one episodic row + corresponding graph_edges + facts
+        rows so a recall query has bonuses available to claim."""
+        ts = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("ep-bonus", "deploy production rollout plan", "consolidation",
+             ts, "s1", 0.5),
+        )
+        # graph_edges: this memory_id has connections
+        beam.conn.execute(
+            "INSERT INTO graph_edges (source, target, edge_type) "
+            "VALUES (?, ?, ?)",
+            ("ep-bonus", "ep-other", "related"),
+        )
+        beam.conn.execute(
+            "INSERT INTO graph_edges (source, target, edge_type) "
+            "VALUES (?, ?, ?)",
+            ("ep-other", "ep-bonus", "related"),
+        )
+        # facts: this memory has extracted facts that match a query word
+        beam.conn.execute(
+            "INSERT INTO facts (fact_id, session_id, source_msg_id, subject, predicate, object) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("fact-1", "s1", "ep-bonus", "team", "deploys", "production"),
+        )
+        beam.conn.commit()
+
+    def test_graph_bonus_disabled_does_not_apply(self, temp_db, monkeypatch):
+        """With `MNEMOSYNE_GRAPH_BONUS=0`, the graph-edge bonus block is
+        skipped. We construct the same scenario twice and assert the
+        scores differ by the expected bonus amount."""
+        # Run 1: default ON — score includes graph bonus.
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        self._seed_episodic_with_graph_data(beam)
+        # Defang downstream multipliers we don't care about.
+        monkeypatch.setenv("MNEMOSYNE_VERACITY_MULTIPLIER", "0")
+        monkeypatch.delenv("MNEMOSYNE_GRAPH_BONUS", raising=False)
+        on_results = beam.recall("deploy production rollout", top_k=5)
+        beam.conn.close()
+
+        # Run 2: bonus OFF, otherwise identical.
+        with tempfile.TemporaryDirectory() as tmpdir2:
+            db2 = Path(tmpdir2) / "test.db"
+            beam2 = BeamMemory(session_id="s1", db_path=db2)
+            self._seed_episodic_with_graph_data(beam2)
+            monkeypatch.setenv("MNEMOSYNE_GRAPH_BONUS", "0")
+            off_results = beam2.recall("deploy production rollout", top_k=5)
+            beam2.conn.close()
+
+        on_hit = next((r for r in on_results if r["id"] == "ep-bonus"), None)
+        off_hit = next((r for r in off_results if r["id"] == "ep-bonus"), None)
+        assert on_hit is not None and off_hit is not None
+        # When bonus is enabled, score is strictly higher (bonus is
+        # additive on the linear ep path). Allow for floating-point
+        # noise.
+        assert on_hit["score"] > off_hit["score"], (
+            f"graph_bonus toggle had no effect on score: "
+            f"on={on_hit['score']} off={off_hit['score']}"
+        )
+
+    def test_fact_bonus_disabled_does_not_apply(self, temp_db, monkeypatch):
+        """Same shape for fact_bonus: with toggle off, score is strictly
+        lower than with toggle on."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        self._seed_episodic_with_graph_data(beam)
+        # Defang other lifts so the only difference is fact_bonus.
+        monkeypatch.setenv("MNEMOSYNE_VERACITY_MULTIPLIER", "0")
+        monkeypatch.setenv("MNEMOSYNE_GRAPH_BONUS", "0")
+        monkeypatch.delenv("MNEMOSYNE_FACT_BONUS", raising=False)
+        on_results = beam.recall("deploys production", top_k=5)
+        beam.conn.close()
+
+        with tempfile.TemporaryDirectory() as tmpdir2:
+            db2 = Path(tmpdir2) / "test.db"
+            beam2 = BeamMemory(session_id="s1", db_path=db2)
+            self._seed_episodic_with_graph_data(beam2)
+            monkeypatch.setenv("MNEMOSYNE_FACT_BONUS", "0")
+            off_results = beam2.recall("deploys production", top_k=5)
+            beam2.conn.close()
+
+        on_hit = next((r for r in on_results if r["id"] == "ep-bonus"), None)
+        off_hit = next((r for r in off_results if r["id"] == "ep-bonus"), None)
+        assert on_hit is not None and off_hit is not None
+        assert on_hit["score"] > off_hit["score"], (
+            f"fact_bonus toggle had no effect: "
+            f"on={on_hit['score']} off={off_hit['score']}"
+        )
+
+    def test_binary_bonus_toggle_structural(self):
+        """Source-level check: `MNEMOSYNE_BINARY_BONUS` is referenced
+        in both linear main loop and fallback (so disabling it gates
+        both branches). End-to-end test would require a query embedding
+        + binary vector setup that's brittle; this catches the regression
+        where someone strips the gate."""
+        src = (Path(__file__).resolve().parents[1] / "mnemosyne" / "core" / "beam.py").read_text()
+        # Should be referenced in the binary_bonus gate site
+        assert src.count("MNEMOSYNE_BINARY_BONUS") >= 1, (
+            "MNEMOSYNE_BINARY_BONUS gate missing from beam.py — "
+            "ablation toggle stripped"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# Veracity multiplier toggle
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestVeracityMultiplierToggle:
+    """`MNEMOSYNE_VERACITY_MULTIPLIER=0` short-circuits the multiplier
+    in BOTH the linear and polyphonic paths so Phase 0/1 ablation works
+    identically across engines."""
+
+    def test_disabled_makes_stated_unknown_score_equal(self, temp_db, monkeypatch):
+        """Two episodic rows with identical content but different
+        veracity ('stated' vs 'unknown') should score IDENTICALLY when
+        the multiplier is disabled, regardless of their veracity."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ts = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-stated", "the user prefers dark mode", "consolidation",
+             ts, "s1", 0.5, "stated"),
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-unknown", "the user prefers dark mode", "consolidation",
+             ts, "s1", 0.5, "unknown"),
+        )
+        beam.conn.commit()
+
+        monkeypatch.setenv("MNEMOSYNE_VERACITY_MULTIPLIER", "0")
+        # Defang other bonuses
+        monkeypatch.setenv("MNEMOSYNE_GRAPH_BONUS", "0")
+        monkeypatch.setenv("MNEMOSYNE_FACT_BONUS", "0")
+        monkeypatch.setenv("MNEMOSYNE_BINARY_BONUS", "0")
+        results = beam.recall("dark mode", top_k=10)
+        by_id = {r["id"]: r for r in results}
+        if "ep-stated" in by_id and "ep-unknown" in by_id:
+            assert by_id["ep-stated"]["score"] == by_id["ep-unknown"]["score"], (
+                "Veracity multiplier toggle OFF, but stated/unknown rows "
+                f"scored differently: {by_id['ep-stated']['score']} vs "
+                f"{by_id['ep-unknown']['score']}"
+            )
+
+    def test_enabled_makes_stated_outrank_unknown(self, temp_db, monkeypatch):
+        """Sanity / positive control: with toggle ON (default), the
+        stated row should rank above the unknown one (1.0 > 0.8
+        multiplier)."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        ts = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-stated", "the user prefers dark mode", "consolidation",
+             ts, "s1", 0.5, "stated"),
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, veracity) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-unknown", "the user prefers dark mode", "consolidation",
+             ts, "s1", 0.5, "unknown"),
+        )
+        beam.conn.commit()
+
+        monkeypatch.delenv("MNEMOSYNE_VERACITY_MULTIPLIER", raising=False)
+        monkeypatch.setenv("MNEMOSYNE_GRAPH_BONUS", "0")
+        monkeypatch.setenv("MNEMOSYNE_FACT_BONUS", "0")
+        monkeypatch.setenv("MNEMOSYNE_BINARY_BONUS", "0")
+        results = beam.recall("dark mode", top_k=10)
+        by_id = {r["id"]: r for r in results}
+        if "ep-stated" in by_id and "ep-unknown" in by_id:
+            assert by_id["ep-stated"]["score"] > by_id["ep-unknown"]["score"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Cross-tier dedup toggle
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCrossTierDedupToggle:
+    """`MNEMOSYNE_CROSS_TIER_DEDUP=0` short-circuits
+    `_dedup_cross_tier_summary_links` to return the input list unchanged."""
+
+    def test_disabled_returns_input_unchanged(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        monkeypatch.setenv("MNEMOSYNE_CROSS_TIER_DEDUP", "0")
+
+        # Construct a (summary, source) pair that WOULD normally dedup.
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, "
+            "session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("wm-src", "raw text content", "conversation",
+             datetime.now().isoformat(), "s1", 0.5),
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, summary_of) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-sum", "summary of raw text content", "consolidation",
+             datetime.now().isoformat(), "s1", 0.5, "wm-src"),
+        )
+        beam.conn.commit()
+
+        # Synthetic results — both should survive when dedup is off.
+        results = [
+            {"id": "wm-src", "tier": "working", "score": 0.9, "content": "raw"},
+            {"id": "ep-sum", "tier": "episodic", "score": 0.5, "content": "sum"},
+        ]
+        out = beam._dedup_cross_tier_summary_links(results)
+        assert len(out) == 2
+        assert out is results, "Toggle-off path must short-circuit to identity"
+
+    def test_enabled_dedups_normally(self, temp_db, monkeypatch):
+        """Positive control: with toggle ON, the lower-scored side gets
+        dropped per E3.a.3 logic."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        monkeypatch.delenv("MNEMOSYNE_CROSS_TIER_DEDUP", raising=False)
+
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, "
+            "session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("wm-src", "raw text", "conversation",
+             datetime.now().isoformat(), "s1", 0.5),
+        )
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance, summary_of) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ep-sum", "summary", "consolidation",
+             datetime.now().isoformat(), "s1", 0.5, "wm-src"),
+        )
+        beam.conn.commit()
+
+        results = [
+            {"id": "wm-src", "tier": "working", "score": 0.9, "content": "raw"},
+            {"id": "ep-sum", "tier": "episodic", "score": 0.5, "content": "sum"},
+        ]
+        out = beam._dedup_cross_tier_summary_links(results)
+        # Dedup should drop the lower-scored ep
+        assert len(out) == 1
+        assert out[0]["id"] == "wm-src"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Coverage map: every toggle has at least one disabled-path test
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestToggleCoverageMap:
+    """Pin that the 9 documented toggles are each present in the code.
+    A future refactor that strips one of them fails this test even if
+    no specific functional test was written for that one."""
+
+    REQUIRED_TOGGLES = [
+        "MNEMOSYNE_VOICE_VECTOR",
+        "MNEMOSYNE_VOICE_GRAPH",
+        "MNEMOSYNE_VOICE_FACT",
+        "MNEMOSYNE_VOICE_TEMPORAL",
+        "MNEMOSYNE_GRAPH_BONUS",
+        "MNEMOSYNE_FACT_BONUS",
+        "MNEMOSYNE_BINARY_BONUS",
+        "MNEMOSYNE_VERACITY_MULTIPLIER",
+        "MNEMOSYNE_CROSS_TIER_DEDUP",
+    ]
+
+    def test_all_toggles_present_in_source(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        sources = (
+            (repo_root / "mnemosyne" / "core" / "beam.py").read_text()
+            + (repo_root / "mnemosyne" / "core" / "polyphonic_recall.py").read_text()
+        )
+        missing = [t for t in self.REQUIRED_TOGGLES if t not in sources]
+        assert not missing, (
+            f"Required A/B toggles missing from source: {missing}. "
+            f"docs/benchmarking.md promises these toggles exist."
+        )

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -65,9 +65,12 @@ class TestE5FeatureFlag:
         """[E5] When MNEMOSYNE_POLYPHONIC_RECALL is unset or '0', recall
         runs the existing linear scorer. Production behavior unchanged.
 
-        The signal that we're on the linear path: result dicts do NOT
-        carry a `voice_scores` field (that's only populated by the
-        polyphonic engine)."""
+        Post-Gap-G (May 2026): both engines now populate `voice_scores`
+        for analysis parity, but with different keys. Linear keys are
+        {vec, fts, keyword, importance, recency_decay}; polyphonic keys
+        are {vector, graph, fact, temporal}. The signal that linear ran
+        is the absence of polyphonic-specific keys, not the absence of
+        the dict itself."""
         monkeypatch.delenv("MNEMOSYNE_POLYPHONIC_RECALL", raising=False)
 
         beam = BeamMemory(session_id="e5-off", db_path=temp_db)
@@ -78,9 +81,11 @@ class TestE5FeatureFlag:
 
         results = beam.recall("deploy", top_k=10)
         assert results, "recall returned 0 — sanity check"
+        _POLYPHONIC_KEYS = {"vector", "graph", "fact", "temporal"}
         for r in results:
-            assert "voice_scores" not in r, (
-                f"linear scorer leaked voice_scores into result: {r}"
+            vs = r.get("voice_scores", {})
+            assert not (set(vs.keys()) & _POLYPHONIC_KEYS), (
+                f"linear path leaked polyphonic voice keys: {set(vs.keys())}"
             )
 
     def test_flag_off_explicit_zero(self, temp_db, monkeypatch, disable_llm):
@@ -94,8 +99,10 @@ class TestE5FeatureFlag:
         ])
 
         results = beam.recall("explicit-zero", top_k=10)
+        _POLYPHONIC_KEYS = {"vector", "graph", "fact", "temporal"}
         for r in results:
-            assert "voice_scores" not in r
+            vs = r.get("voice_scores", {})
+            assert not (set(vs.keys()) & _POLYPHONIC_KEYS)
 
     def test_flag_on_uses_polyphonic_engine(
         self, temp_db, monkeypatch, disable_llm
@@ -148,13 +155,22 @@ class TestE5FeatureFlag:
         monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
         off_results = beam.recall("Alice toggle", top_k=10)
 
-        # ON path produces voice_scores; OFF path doesn't.
-        on_has_voices = any(r.get("voice_scores") for r in on_results)
-        off_has_voices = any("voice_scores" in r for r in off_results)
-        assert on_has_voices, (
+        # Post-Gap-G: both engines populate voice_scores with different
+        # keys. Engine identity is the polyphonic-specific keys
+        # (vector/graph/fact/temporal), not the field's mere presence.
+        _POLYPHONIC_KEYS = {"vector", "graph", "fact", "temporal"}
+        on_has_polyphonic_keys = any(
+            (set(r.get("voice_scores", {}).keys()) & _POLYPHONIC_KEYS)
+            for r in on_results
+        )
+        off_has_polyphonic_keys = any(
+            (set(r.get("voice_scores", {}).keys()) & _POLYPHONIC_KEYS)
+            for r in off_results
+        )
+        assert on_has_polyphonic_keys, (
             f"flag=ON didn't engage the engine. on_results={on_results}"
         )
-        assert not off_has_voices, "flag=OFF still ran the engine"
+        assert not off_has_polyphonic_keys, "flag=OFF still ran the engine"
 
 
 class TestE5EnginePlumbing:

--- a/tests/test_benchmark_preflight.py
+++ b/tests/test_benchmark_preflight.py
@@ -1,0 +1,120 @@
+"""Preflight regression tests for the BEAM benchmark harness.
+
+Pre-fix, `tools/evaluate_beam_end_to_end.py` ran with harness oracles
+(TR timeline, CR injection, IE/KU `_context_facts`, RECENT CONVERSATION
+raw-message injection) by default — without pure-recall mode the
+oracles produce answers that bypass `BeamMemory.recall()`, contaminating
+arm-vs-arm comparisons.
+
+Post-fix the harness refuses to run unless either:
+  - `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` (or `--pure-recall`), or
+  - `--allow-harness-oracles` (explicit opt-in for ceiling tests / legacy
+    reproduction)
+
+These tests pin the preflight gate. They subprocess the harness in
+`--help` / argument-parsing mode rather than running a full benchmark.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_HARNESS = _REPO_ROOT / "tools" / "evaluate_beam_end_to_end.py"
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Clear all benchmark-mode env vars so each test starts from a
+    known state."""
+    monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+    monkeypatch.delenv("FULL_CONTEXT_MODE", raising=False)
+    return monkeypatch
+
+
+def _run_harness(*args, env_overrides=None):
+    """Invoke the harness with the given CLI args + env overrides.
+    Returns CompletedProcess. Uses --dry-run when possible to avoid
+    actually loading the BEAM dataset."""
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+    # Always include --sample 0 + --scales (a single small scale) so we
+    # don't accidentally hit the full pipeline if dry-run isn't enough.
+    return subprocess.run(
+        [sys.executable, str(_HARNESS), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+class TestPreflightRefusesWithoutPureRecall:
+    """When neither pure-recall nor --allow-harness-oracles is set,
+    the harness must exit with a non-zero status BEFORE doing any work
+    (no dataset load, no LLM calls)."""
+
+    def test_no_flags_no_env_exits_with_error(self, clean_env):
+        """Default invocation — should refuse."""
+        result = _run_harness("--sample", "1", "--scales", "100K")
+        assert result.returncode == 2, (
+            f"Expected exit code 2 (preflight refusal); got {result.returncode}.\n"
+            f"stdout: {result.stdout[:400]}\nstderr: {result.stderr[:400]}"
+        )
+        assert "harness oracles are active" in result.stderr, (
+            f"Expected preflight error message in stderr; got: {result.stderr[:400]}"
+        )
+
+    def test_full_context_alone_is_not_enough(self, clean_env):
+        """`FULL_CONTEXT_MODE=1` doesn't disable the oracles — it adds
+        a different bypass. Should still refuse without pure-recall."""
+        result = _run_harness(
+            "--sample", "1", "--scales", "100K",
+            env_overrides={"FULL_CONTEXT_MODE": "1"},
+        )
+        assert result.returncode == 2
+
+    def test_pure_recall_flag_satisfies_preflight(self, clean_env):
+        """`--pure-recall` enables the bypass-disabling mode; preflight
+        should let the run proceed (it may fail later for unrelated
+        reasons like missing API key, but not at preflight)."""
+        result = _run_harness("--pure-recall", "--dry-run")
+        # Either it proceeded past preflight (returncode != 2) or it
+        # failed for some OTHER reason (dataset / network). The
+        # preflight-error string is what we're checking is absent.
+        assert "harness oracles are active" not in result.stderr
+
+    def test_pure_recall_env_satisfies_preflight(self, clean_env):
+        result = _run_harness(
+            "--dry-run",
+            env_overrides={"MNEMOSYNE_BENCHMARK_PURE_RECALL": "1"},
+        )
+        assert "harness oracles are active" not in result.stderr
+
+    def test_pure_recall_env_accepts_on(self, clean_env):
+        """C31 helper accepts `on`; preflight should honor that."""
+        result = _run_harness(
+            "--dry-run",
+            env_overrides={"MNEMOSYNE_BENCHMARK_PURE_RECALL": "on"},
+        )
+        assert "harness oracles are active" not in result.stderr
+
+    def test_allow_harness_oracles_explicit_opt_in(self, clean_env):
+        """Operators that explicitly want the legacy bypass behavior
+        (ceiling tests, pre-fix reproduction) can opt in."""
+        result = _run_harness("--allow-harness-oracles", "--dry-run")
+        assert "harness oracles are active" not in result.stderr
+
+    def test_preflight_runs_before_dataset_load(self, clean_env):
+        """The preflight should fail BEFORE attempting to load the
+        BEAM dataset, so operators with no HuggingFace access still
+        get a clean error message."""
+        result = _run_harness("--sample", "1", "--scales", "100K")
+        # If we got past preflight to dataset loading, we'd see
+        # 'Loading BEAM dataset' in stdout. Should not be there.
+        assert "Loading BEAM dataset" not in result.stdout

--- a/tests/test_gap_e_g_analysis.py
+++ b/tests/test_gap_e_g_analysis.py
@@ -1,0 +1,236 @@
+"""Regression tests for Gap E (paired-outcomes JSONL) and Gap G
+(linear-path voice_scores parity).
+
+Both gaps were filed in the BEAM-recovery experiment plan as
+post-execution analysis polish — they don't block the experiment
+running, but they make post-hoc per-tool attribution credible.
+
+- **Gap G:** `BeamMemory.recall()` linear-path result dicts now carry
+  a `voice_scores: dict` field with the same JSON shape contract as
+  polyphonic results (different keys per engine since the signal
+  sources differ). Lets downstream analysis treat both arms uniformly
+  when computing per-signal contributions across phases.
+
+- **Gap E:** the harness writes `paired_outcomes.jsonl` alongside the
+  main results JSON. Each line is one (config_id, question_id,
+  ability, score, correct) row. Append-only with config_id so
+  multiple A/B runs accumulate in one file; analyst filters by
+  config_id when computing bootstrap CIs on paired deltas.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Gap G — Linear-path voice_scores parity
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLinearVoiceScores:
+    """Linear-path result dicts must carry a `voice_scores: dict` field
+    so downstream analysis can treat linear + polyphonic results
+    uniformly when computing per-signal contributions."""
+
+    def _seed_episodic(self, beam: BeamMemory, ep_id: str, content: str):
+        ts = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            (ep_id, content, "consolidation", ts, "s1", 0.5),
+        )
+        beam.conn.commit()
+
+    def test_every_linear_result_has_voice_scores(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Seed enough content that recall returns results across both
+        # tiers + via different paths (main + fallback).
+        self._seed_episodic(beam, "ep-1", "the deployment runbook explains rollout")
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, "
+            "session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("wm-1", "the deployment plan is approved", "conversation",
+             datetime.now().isoformat(), "s1", 0.5),
+        )
+        beam.conn.commit()
+
+        results = beam.recall("deployment", top_k=10)
+        assert results, "Expected at least one recall hit"
+        for r in results:
+            assert "voice_scores" in r, (
+                f"Linear result missing voice_scores: "
+                f"{list(r.keys())}"
+            )
+            assert isinstance(r["voice_scores"], dict)
+
+    def test_voice_scores_contains_expected_signal_keys(self, temp_db):
+        """The linear engine's voice_scores dict should include the
+        per-signal raw scores the linear scorer composed."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        self._seed_episodic(beam, "ep-1", "deployment notes about prod release")
+
+        results = beam.recall("deployment", top_k=5)
+        if not results:
+            pytest.skip("recall returned empty — environment-dependent")
+        vs = results[0]["voice_scores"]
+        # Linear-side keys (different from polyphonic's vec/graph/fact/temporal).
+        expected_keys = {"vec", "fts", "keyword", "importance", "recency_decay"}
+        assert expected_keys.issubset(set(vs.keys())), (
+            f"voice_scores keys missing expected linear signals: "
+            f"got {set(vs.keys())}, want superset of {expected_keys}"
+        )
+
+    def test_voice_scores_values_are_numeric(self, temp_db):
+        """All entries should be floats so downstream summing /
+        comparison works without coercion."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        self._seed_episodic(beam, "ep-1", "config change for the api gateway")
+
+        results = beam.recall("api gateway", top_k=5)
+        if not results:
+            pytest.skip("recall returned empty")
+        for k, v in results[0]["voice_scores"].items():
+            assert isinstance(v, (int, float)), (
+                f"voice_scores[{k!r}] = {v!r} is not numeric"
+            )
+
+    def test_voice_scores_in_both_main_and_fallback_paths(self, temp_db, monkeypatch):
+        """Both the main vec/FTS-driven loop and the fallback substring
+        scan should attach voice_scores. Force fallback by inserting an
+        ep row WITHOUT embeddings (so vec returns no candidates)."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Insert directly so no embedding gets generated → triggers fallback
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, "
+            "session_id, importance) VALUES (?, ?, ?, ?, ?, ?)",
+            ("ep-fallback", "unique-marker for the fallback path",
+             "consolidation", datetime.now().isoformat(), "s1", 0.5),
+        )
+        beam.conn.commit()
+
+        results = beam.recall("unique-marker", top_k=5)
+        fallback_hits = [r for r in results if r["id"] == "ep-fallback"]
+        if not fallback_hits:
+            pytest.skip("recall didn't surface fallback row in this env")
+        assert "voice_scores" in fallback_hits[0]
+        assert isinstance(fallback_hits[0]["voice_scores"], dict)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Gap E — Paired-outcomes JSONL
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPairedOutcomesJSONL:
+    """The harness writes `paired_outcomes.jsonl` alongside the main
+    results JSON. Each row is one (config_id, qid, ability, score,
+    correct) so a downstream notebook can paired-bootstrap CIs across
+    multiple A/B runs without re-parsing the main JSON."""
+
+    def test_harness_help_shows_config_id_flag(self):
+        """`--config-id` flag is exposed."""
+        harness = _REPO_ROOT / "tools" / "evaluate_beam_end_to_end.py"
+        result = subprocess.run(
+            [sys.executable, str(harness), "--help"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert "--config-id" in result.stdout, (
+            f"Expected --config-id in help; got:\n{result.stdout[-500:]}"
+        )
+
+    def test_config_id_derived_from_env_when_unset(self, monkeypatch):
+        """Without --config-id, the harness derives one from the env
+        snapshot. Two runs with identical env should produce identical
+        config_ids; two runs with different env should differ.
+
+        We test this by verifying the helper logic: SHA-256 of the
+        canonical env serialization, first 10 hex chars, prefixed
+        with 'cfg-'.
+        """
+        import hashlib
+        env_a = {"MNEMOSYNE_VOICE_FACT": "0", "MNEMOSYNE_POLYPHONIC_RECALL": "1"}
+        env_b = {"MNEMOSYNE_VOICE_GRAPH": "0", "MNEMOSYNE_POLYPHONIC_RECALL": "1"}
+        # Mirror the harness's canonicalization (filtered + sorted).
+        def _id(env: Dict[str, str]) -> str:
+            canon = "\n".join(f"{k}={v}" for k, v in sorted(env.items()))
+            return "cfg-" + hashlib.sha256(canon.encode("utf-8")).hexdigest()[:10]
+        a1 = _id(env_a)
+        a2 = _id(env_a)
+        b = _id(env_b)
+        assert a1 == a2, "identical env should produce identical config_id"
+        assert a1 != b, "different env should produce different config_id"
+        assert a1.startswith("cfg-")
+        assert len(a1) == len("cfg-") + 10
+
+    def test_paired_outcomes_file_constant_defined(self):
+        """The harness module exposes PAIRED_OUTCOMES_FILE so tests
+        and downstream tools have a stable reference."""
+        import tools.evaluate_beam_end_to_end as harness
+        assert hasattr(harness, "PAIRED_OUTCOMES_FILE")
+        assert str(harness.PAIRED_OUTCOMES_FILE).endswith("paired_outcomes.jsonl")
+
+    def test_paired_outcomes_jsonl_row_shape(self, tmp_path):
+        """Direct test: simulate writing a row in the format the
+        harness writes, then read it back. This pins the JSONL schema
+        without subprocess-running the full pipeline."""
+        outfile = tmp_path / "paired_outcomes.jsonl"
+        row = {
+            "config_id": "cfg-abc1234567",
+            "run_started_at": "2026-05-12T15:00:00+00:00",
+            "scale": "100K",
+            "conversation_id": "conv-001",
+            "qid": "q-042",
+            "ability": "IE",
+            "score": 0.75,
+            "correct": True,
+        }
+        with open(outfile, "a") as f:
+            f.write(json.dumps(row) + "\n")
+        with open(outfile) as f:
+            line = f.readline()
+        parsed = json.loads(line)
+        # Required fields for paired-bootstrap analysis:
+        for required in ("config_id", "qid", "ability", "score", "correct"):
+            assert required in parsed, f"missing field {required!r}"
+        # Score is a float, correct is a bool.
+        assert isinstance(parsed["score"], (int, float))
+        assert isinstance(parsed["correct"], bool)
+
+    def test_correct_threshold_at_half(self):
+        """Pin the threshold definition: score >= 0.5 → correct=True.
+        Matches the rubric: 1.0=correct, 0.5=partial, 0.0=wrong.
+        Treating partial as correct here errs on the side of charity;
+        analyst can rescore using raw `score` if they want stricter."""
+        # Direct comparison to the harness's expression
+        assert (0.5 >= 0.5) is True   # exactly partial → correct
+        assert (1.0 >= 0.5) is True   # fully correct
+        assert (0.0 >= 0.5) is False  # wrong
+        assert (0.49 >= 0.5) is False  # just below threshold
+
+    def test_paired_outcomes_constants_path_under_results(self):
+        """Paired outcomes file should live alongside the main results
+        JSON, both under `results/`. Pins the convention."""
+        import tools.evaluate_beam_end_to_end as harness
+        assert harness.PAIRED_OUTCOMES_FILE.parent == harness.RESULTS_FILE.parent

--- a/tests/test_voice_attribution_and_beam_opt.py
+++ b/tests/test_voice_attribution_and_beam_opt.py
@@ -1,0 +1,252 @@
+"""Regression tests for the two pre-test gap closures:
+
+1. **Per-question voice_scores threading** — `evaluate_conversation()`
+   now writes a `recall_provenance` summary into each per-question
+   result dict so post-hoc per-voice attribution analysis (Recipe E
+   in `docs/benchmark-results-analysis.md`) works from the result
+   file directly. Without this, Theses 1, 2, 3 in the experiment
+   plan can't be falsified — they require knowing which voice
+   contributed to which question.
+
+2. **`MNEMOSYNE_BEAM_OPTIMIZATIONS` parser migration** — was using
+   the brittle `.lower() in ("1","true","yes")` pattern that rejects
+   `on` and whitespace. Now goes through `_env_truthy()` in `beam.py`,
+   matching the convention from PR #91.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from mnemosyne.core.beam import BeamMemory, _env_truthy
+
+
+# ─────────────────────────────────────────────────────────────────
+# Item 2: MNEMOSYNE_BEAM_OPTIMIZATIONS parser migration
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestBeamOptimizationsEnvParser:
+    """The env var now goes through `_env_truthy` so the parsing
+    semantics match the rest of the codebase: accepts `on`, strips
+    whitespace, case-insensitive."""
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on",
+                                        "TRUE", "ON", "On",
+                                        " 1 ", "  true  ", "\ton\t"])
+    def test_truthy_values_accepted(self, value, monkeypatch):
+        """Pre-fix, `on` and whitespace-padded values were silently
+        treated as off. Post-fix they enable BEAM mode."""
+        monkeypatch.setenv("MNEMOSYNE_BEAM_OPTIMIZATIONS", value)
+        assert _env_truthy("MNEMOSYNE_BEAM_OPTIMIZATIONS") is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off",
+                                        "FALSE", "OFF",
+                                        "", " ", "garbage", "maybe"])
+    def test_falsy_or_garbage_rejected(self, value, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_BEAM_OPTIMIZATIONS", value)
+        assert _env_truthy("MNEMOSYNE_BEAM_OPTIMIZATIONS") is False
+
+    def test_unset_is_false(self, monkeypatch):
+        monkeypatch.delenv("MNEMOSYNE_BEAM_OPTIMIZATIONS", raising=False)
+        assert _env_truthy("MNEMOSYNE_BEAM_OPTIMIZATIONS") is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# Item 1: Voice-attribution threading
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestAnswerWithMemoryReturnMemoriesKwarg:
+    """The `return_memories=True` kwarg returns `(answer, memories)`;
+    the default `return_memories=False` returns the answer string
+    unchanged (back-compat for existing tests)."""
+
+    @pytest.fixture
+    def fake_llm(self):
+        llm = MagicMock()
+        llm.chat = MagicMock(return_value="LLM-FALLBACK-ANSWER")
+        return llm
+
+    @pytest.fixture
+    def temp_db(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir) / "test.db"
+
+    def test_default_returns_string(self, temp_db, fake_llm, monkeypatch):
+        """Default — back-compat with all existing callers."""
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        result = answer_with_memory(
+            llm=fake_llm, beam=beam,
+            question="anything",
+            conversation_messages=[{"role": "user", "content": "x"}],
+            top_k=5, ability="ABS",
+        )
+        assert isinstance(result, str)
+
+    def test_return_memories_true_returns_tuple(self, temp_db, fake_llm, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", "1")
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        result = answer_with_memory(
+            llm=fake_llm, beam=beam,
+            question="anything",
+            conversation_messages=[{"role": "user", "content": "x"}],
+            top_k=5, ability="ABS",
+            return_memories=True,
+        )
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        answer, memories = result
+        assert isinstance(answer, str)
+        assert isinstance(memories, list)
+
+    def test_bypass_path_returns_empty_memories(self, temp_db, fake_llm, monkeypatch):
+        """TR bypass short-circuits before recall — memories list
+        should be empty but the field still present (schema parity)."""
+        monkeypatch.delenv("MNEMOSYNE_BENCHMARK_PURE_RECALL", raising=False)
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        from tools.evaluate_beam_end_to_end import answer_with_memory
+
+        # TR-shaped fixture that triggers the bypass
+        msgs = [
+            {"role": "user", "content": "I started March 15, 2024."},
+            {"role": "user", "content": "Deployed June 30, 2024."},
+        ]
+        answer, memories = answer_with_memory(
+            llm=fake_llm, beam=beam,
+            question="how many days between?",
+            conversation_messages=msgs,
+            top_k=5, ability="TR",
+            return_memories=True,
+        )
+        assert memories == []
+
+
+# ─────────────────────────────────────────────────────────────────
+# Item 1: _summarize_recall_memories helper
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestSummarizeRecallMemories:
+    """The summary helper packs voice_scores from a list of memory
+    dicts into a compact provenance object."""
+
+    def test_empty_memories_returns_minimal_shape(self):
+        from tools.evaluate_beam_end_to_end import _summarize_recall_memories
+        out = _summarize_recall_memories([])
+        assert out == {
+            "engine": "unknown",
+            "kept_count": 0,
+            "voice_sums": {},
+            "top_result_voices": {},
+            "top_result_tier": None,
+        }
+
+    def test_polyphonic_engine_identified_by_keyset(self):
+        from tools.evaluate_beam_end_to_end import _summarize_recall_memories
+        memories = [
+            {"voice_scores": {"vector": 0.5, "graph": 0.2}, "tier": "episodic"},
+            {"voice_scores": {"vector": 0.4}, "tier": "working"},
+        ]
+        out = _summarize_recall_memories(memories)
+        assert out["engine"] == "polyphonic"
+        assert out["kept_count"] == 2
+        # Sums across kept results
+        assert out["voice_sums"]["vector"] == pytest.approx(0.9)
+        assert out["voice_sums"]["graph"] == pytest.approx(0.2)
+        # Top result is the first memory's voice_scores
+        assert out["top_result_voices"]["vector"] == 0.5
+        assert out["top_result_tier"] == "episodic"
+
+    def test_linear_engine_identified_by_keyset(self):
+        from tools.evaluate_beam_end_to_end import _summarize_recall_memories
+        memories = [
+            {"voice_scores": {"vec": 0.7, "fts": 0.3, "keyword": 0.0,
+                              "importance": 0.5, "recency_decay": 0.9},
+             "tier": "working"},
+        ]
+        out = _summarize_recall_memories(memories)
+        assert out["engine"] == "linear"
+        assert out["kept_count"] == 1
+        assert out["voice_sums"]["vec"] == pytest.approx(0.7)
+        assert out["top_result_tier"] == "working"
+
+    def test_unknown_engine_for_voice_keys_outside_known_sets(self):
+        from tools.evaluate_beam_end_to_end import _summarize_recall_memories
+        # All memories have voice_scores but with unrecognized keys
+        memories = [{"voice_scores": {"made_up_voice": 0.5}, "tier": "working"}]
+        out = _summarize_recall_memories(memories)
+        assert out["engine"] == "unknown"
+        # Voice sums still tracked for unknown keys
+        assert out["voice_sums"]["made_up_voice"] == 0.5
+
+    def test_handles_missing_voice_scores_field(self):
+        """Some memory dicts might not have voice_scores at all
+        (e.g., bypass-path placeholders). Helper should tolerate."""
+        from tools.evaluate_beam_end_to_end import _summarize_recall_memories
+        memories = [
+            {"tier": "working"},  # no voice_scores
+            {"voice_scores": {"vector": 0.5}, "tier": "episodic"},
+        ]
+        out = _summarize_recall_memories(memories)
+        assert out["kept_count"] == 2
+        assert out["engine"] == "polyphonic"
+        assert out["voice_sums"]["vector"] == 0.5
+
+    def test_handles_non_numeric_voice_value(self):
+        """Defensive: malformed voice_score values are skipped, not
+        crash."""
+        from tools.evaluate_beam_end_to_end import _summarize_recall_memories
+        memories = [
+            {"voice_scores": {"vector": 0.5, "graph": None}, "tier": "working"},
+            {"voice_scores": {"vector": "not-a-number"}, "tier": "working"},
+        ]
+        out = _summarize_recall_memories(memories)
+        # `None` and "not-a-number" silently skipped
+        assert out["voice_sums"]["vector"] == 0.5
+        assert "graph" not in out["voice_sums"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Integration: recall_provenance ends up in per-question result
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestRecallProvenanceInResultDict:
+    """End-to-end: a per-question result dict includes
+    `recall_provenance` (the summary). Pinned via source-grep since
+    running `evaluate_conversation()` end-to-end requires real LLM."""
+
+    def test_evaluate_conversation_writes_recall_provenance(self):
+        """The per-question result dict construction in
+        `evaluate_conversation()` includes `recall_provenance`. A
+        future refactor that drops the field would break post-hoc
+        attribution analysis."""
+        harness_src = (_REPO_ROOT / "tools" / "evaluate_beam_end_to_end.py").read_text()
+        # The field is added to the per-question result dict
+        assert '"recall_provenance": recall_provenance,' in harness_src, (
+            "evaluate_conversation no longer writes recall_provenance "
+            "into per-question result dict — Recipe E in "
+            "docs/benchmark-results-analysis.md broken"
+        )
+        # And `return_memories=True` is passed when calling answer_with_memory
+        assert "return_memories=True" in harness_src, (
+            "evaluate_conversation no longer requests memories for "
+            "provenance — recall_provenance will be empty"
+        )

--- a/tools/evaluate_beam_end_to_end.py
+++ b/tools/evaluate_beam_end_to_end.py
@@ -1659,10 +1659,63 @@ def main():
                         help="Download data and print stats, don't evaluate")
     parser.add_argument("--use-cloud", action="store_true",
                         help="Enable LLM fact extraction (cloud tier). Requires OPENROUTER_API_KEY.")
+    parser.add_argument("--allow-harness-oracles", action="store_true",
+                        help="Opt out of the pure-recall safety check that requires "
+                             "MNEMOSYNE_BENCHMARK_PURE_RECALL=1 (or --pure-recall). The "
+                             "harness's TR/CR/IE/KU bypasses and RECENT CONVERSATION raw-"
+                             "message injection produce answers without going through "
+                             "BeamMemory.recall(), which contaminates arm-vs-arm "
+                             "comparisons. Set this flag only for ceiling-test or legacy-"
+                             "reproduction runs where you explicitly want the bypasses.")
     args = parser.parse_args()
 
     scales = [s.strip() for s in args.scales.split(",")]
     sample_size = args.sample if args.sample > 0 else None
+
+    # ---- Preflight: refuse to run with harness oracles unless explicitly opted in.
+    # The TR/CR/IE/KU bypasses and the always-included RECENT CONVERSATION block
+    # produce answers WITHOUT going through BeamMemory.recall(), contaminating any
+    # arm-vs-arm comparison. Pure-recall mode disables all four. See
+    # docs/benchmarking.md for the full rationale.
+    _pr_active = args.pure_recall or _env_truthy("MNEMOSYNE_BENCHMARK_PURE_RECALL")
+    if not _pr_active and not args.allow_harness_oracles:
+        print(
+            "ERROR: harness oracles are active by default but contaminate arm-vs-arm "
+            "comparisons. Pass --pure-recall (recommended) or set "
+            "MNEMOSYNE_BENCHMARK_PURE_RECALL=1 to disable them. If you genuinely want "
+            "the legacy bypass behavior (e.g., for a ceiling test or reproducing pre-"
+            "fix results), pass --allow-harness-oracles explicitly.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    # Snapshot the full benchmark-relevant env-var surface so results JSON captures
+    # exactly which configuration the run executed under. A toggle the operator
+    # forgot to set is a silent confound otherwise.
+    _benchmark_env_snapshot = {
+        k: v for k, v in os.environ.items()
+        if k.startswith("MNEMOSYNE_") or k in ("FULL_CONTEXT_MODE", "OPENROUTER_BASE_URL")
+    }
+    print(f"\n  Env snapshot ({len(_benchmark_env_snapshot)} vars):")
+    for k in sorted(_benchmark_env_snapshot):
+        # Don't echo API keys even if they accidentally got the MNEMOSYNE_ prefix.
+        v = _benchmark_env_snapshot[k]
+        if "KEY" in k or "TOKEN" in k or "SECRET" in k:
+            v = "***redacted***"
+        print(f"    {k}={v}")
+
+    # Reset recall + extraction diagnostics so per-run counters are clean. The
+    # snapshots are captured at the end of main() and written into results JSON.
+    try:
+        from mnemosyne.core.recall_diagnostics import reset_recall_diagnostics
+        reset_recall_diagnostics()
+    except ImportError:
+        pass  # Diagnostics module is optional; older checkouts may lack it.
+    try:
+        from mnemosyne.extraction.diagnostics import reset_extraction_stats
+        reset_extraction_stats()
+    except ImportError:
+        pass
 
     print(f"{'='*80}")
     print(f"  BEAM End-to-End Evaluation Pipeline")
@@ -1755,8 +1808,23 @@ def main():
                 all_results.append(conv_result)
                 beam.conn.close()
 
-            # Save progress after each conversation
+            # Save progress after each conversation. Includes the env-var
+            # snapshot + diagnostic snapshots so post-hoc analysis can attribute
+            # score deltas to specific configurations without re-running.
             os.makedirs(RESULTS_FILE.parent, exist_ok=True)
+            _recall_diag = None
+            _extraction_diag = None
+            try:
+                from mnemosyne.core.recall_diagnostics import get_recall_diagnostics
+                _recall_diag = get_recall_diagnostics()
+            except ImportError:
+                pass
+            try:
+                from mnemosyne.extraction.diagnostics import get_extraction_stats
+                _extraction_diag = get_extraction_stats()
+            except ImportError:
+                pass
+
             metadata = {
                 "date": datetime.now(timezone.utc).isoformat(),
                 "model": args.model,
@@ -1765,6 +1833,17 @@ def main():
                 "sample_size": sample_size or "ALL",
                 "scales": scales,
                 "total_conversations": len(all_results),
+                "config": {
+                    "env": _benchmark_env_snapshot,
+                    "pure_recall": _pr_active,
+                    "allow_harness_oracles": args.allow_harness_oracles,
+                    "full_context": args.full_context,
+                    "use_cloud": args.use_cloud,
+                },
+                "diagnostics": {
+                    "recall": _recall_diag,
+                    "extraction": _extraction_diag,
+                },
             }
             with open(RESULTS_FILE, "w") as f:
                 json.dump({"metadata": metadata, "results": all_results}, f, indent=2)

--- a/tools/evaluate_beam_end_to_end.py
+++ b/tools/evaluate_beam_end_to_end.py
@@ -96,6 +96,7 @@ def _env_truthy(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in _ENV_TRUTHY_VALUES
 BENCHMARK_QUERIES_PER_CONV = 50  # Max probing questions per conversation
 RESULTS_FILE = PROJECT_ROOT / "results" / "beam_e2e_results.json"
+PAIRED_OUTCOMES_FILE = PROJECT_ROOT / "results" / "paired_outcomes.jsonl"
 
 # Memory abilities tested by BEAM (10 dimensions)
 BEAM_ABILITIES = [
@@ -1659,6 +1660,13 @@ def main():
                         help="Download data and print stats, don't evaluate")
     parser.add_argument("--use-cloud", action="store_true",
                         help="Enable LLM fact extraction (cloud tier). Requires OPENROUTER_API_KEY.")
+    parser.add_argument("--config-id", default=None,
+                        help="Run identifier written into the paired-outcomes "
+                             "JSONL alongside results JSON. Defaults to a "
+                             "short hash of the MNEMOSYNE_* env snapshot — "
+                             "useful for distinguishing back-to-back ablation "
+                             "phases. Override when you want a human-readable "
+                             "label (e.g. 'phase3a-no-fact-voice').")
     parser.add_argument("--allow-harness-oracles", action="store_true",
                         help="Opt out of the pure-recall safety check that requires "
                              "MNEMOSYNE_BENCHMARK_PURE_RECALL=1 (or --pure-recall). The "
@@ -1703,6 +1711,25 @@ def main():
         if "KEY" in k or "TOKEN" in k or "SECRET" in k:
             v = "***redacted***"
         print(f"    {k}={v}")
+
+    # Gap E: config_id labels each row in paired_outcomes.jsonl so a
+    # downstream notebook can paired-bootstrap CIs across multiple A/B
+    # runs without re-parsing the main results JSON. Default to a short
+    # hash of the env snapshot (deterministic for identical configs);
+    # override via `--config-id` for human-readable labels (e.g.,
+    # 'phase3a-no-fact-voice').
+    import hashlib
+    if args.config_id:
+        _config_id = args.config_id
+    else:
+        _env_canonical = "\n".join(
+            f"{k}={v}" for k, v in sorted(_benchmark_env_snapshot.items())
+            if "KEY" not in k and "TOKEN" not in k and "SECRET" not in k
+        )
+        _config_id = "cfg-" + hashlib.sha256(_env_canonical.encode("utf-8")).hexdigest()[:10]
+    _run_started_at = datetime.now(timezone.utc).isoformat()
+    print(f"  Config ID: {_config_id}")
+    print(f"  Run started: {_run_started_at}")
 
     # Reset recall + extraction diagnostics so per-run counters are clean. The
     # snapshots are captured at the end of main() and written into results JSON.
@@ -1812,6 +1839,28 @@ def main():
             # snapshot + diagnostic snapshots so post-hoc analysis can attribute
             # score deltas to specific configurations without re-running.
             os.makedirs(RESULTS_FILE.parent, exist_ok=True)
+
+            # Gap E: append per-question paired outcomes to a flat JSONL
+            # so downstream analysis can paired-bootstrap CIs across
+            # multiple A/B runs. Each line records (config_id, qid,
+            # ability, score, correct, scale, ts) — enough to compute
+            # paired deltas without re-parsing the main results JSON.
+            # Append-only with run_started_at + config_id means multiple
+            # phases accumulate in one file; analyst filters by config_id.
+            with open(PAIRED_OUTCOMES_FILE, "a") as paired_f:
+                for question in conv_result.get("results", []):
+                    qid = question.get("qid")
+                    score = question.get("score", 0.0)
+                    paired_f.write(json.dumps({
+                        "config_id": _config_id,
+                        "run_started_at": _run_started_at,
+                        "scale": conv_result.get("scale"),
+                        "conversation_id": conv_result.get("conversation_id"),
+                        "qid": qid,
+                        "ability": question.get("ability"),
+                        "score": score,  # raw rubric score 0.0-1.0
+                        "correct": score >= 0.5,  # boolean threshold for paired tests
+                    }) + "\n")
             _recall_diag = None
             _extraction_diag = None
             try:
@@ -1827,6 +1876,8 @@ def main():
 
             metadata = {
                 "date": datetime.now(timezone.utc).isoformat(),
+                "run_started_at": _run_started_at,
+                "config_id": _config_id,
                 "model": args.model,
                 "judge_model": args.judge_model or args.model,
                 "top_k": DEFAULT_TOP_K,
@@ -1880,6 +1931,9 @@ def main():
 
     print(f"\n  Results saved to: {RESULTS_FILE}")
     print(f"  Summary saved to: {summary_file}")
+    if PAIRED_OUTCOMES_FILE.exists():
+        print(f"  Paired outcomes appended to: {PAIRED_OUTCOMES_FILE}")
+        print(f"    (filter by config_id={_config_id!r} for this run's rows)")
 
 
 if __name__ == "__main__":

--- a/tools/evaluate_beam_end_to_end.py
+++ b/tools/evaluate_beam_end_to_end.py
@@ -1075,9 +1075,70 @@ def _detect_contradictions(messages: list, question: str) -> str | None:
     return None
 
 
+_POLYPHONIC_VOICE_KEYS = frozenset({"vector", "graph", "fact", "temporal"})
+_LINEAR_VOICE_KEYS = frozenset({"vec", "fts", "keyword", "importance", "recency_decay"})
+
+
+def _summarize_recall_memories(memories: list) -> dict:
+    """Compact per-question recall provenance for analysis.
+
+    Captures engine identity + per-voice score sums + top-1 voice
+    breakdown. Lets `docs/benchmark-results-analysis.md` Recipe E
+    (per-voice attribution) work from the result JSON directly.
+
+    Shape:
+        {
+          "engine": "polyphonic" | "linear" | "unknown",
+          "kept_count": N,
+          "voice_sums": {voice_key: total_score, ...},
+          "top_result_voices": {voice_key: score, ...} | {},
+          "top_result_tier": "working" | "episodic" | None,
+        }
+
+    Returns a minimal dict when memories is empty (bypass paths
+    short-circuit before recall so the field still exists for
+    schema consistency).
+    """
+    if not memories:
+        return {"engine": "unknown", "kept_count": 0, "voice_sums": {},
+                "top_result_voices": {}, "top_result_tier": None}
+
+    # Engine ID by the voice_scores keyset of any result that has one.
+    engine = "unknown"
+    voice_sums: dict = {}
+    for m in memories:
+        vs = m.get("voice_scores") or {}
+        if not vs:
+            continue
+        if engine == "unknown":
+            keys = set(vs.keys())
+            if keys & _POLYPHONIC_VOICE_KEYS:
+                engine = "polyphonic"
+            elif keys & _LINEAR_VOICE_KEYS:
+                engine = "linear"
+        for k, v in vs.items():
+            try:
+                voice_sums[k] = voice_sums.get(k, 0.0) + float(v)
+            except (TypeError, ValueError):
+                pass  # ignore non-numeric voice values
+
+    top = memories[0] if memories else {}
+    return {
+        "engine": engine,
+        "kept_count": len(memories),
+        "voice_sums": {k: round(v, 4) for k, v in voice_sums.items()},
+        "top_result_voices": {
+            k: (round(float(v), 4) if isinstance(v, (int, float)) else v)
+            for k, v in (top.get("voice_scores") or {}).items()
+        },
+        "top_result_tier": top.get("tier"),
+    }
+
+
 def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
                       conversation_messages: list = None, top_k: int = DEFAULT_TOP_K,
-                      ability: str = None) -> str:
+                      ability: str = None,
+                      return_memories: bool = False):
     """Retrieve memories and have LLM answer, with context strategy based on conversation size.
 
     Set `MNEMOSYNE_BENCHMARK_PURE_RECALL=1` to disable the per-ability
@@ -1088,7 +1149,21 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
     BEAM-recovery experiment can measure each arm's recall quality
     without contamination from harness-side oracles. Default behavior
     (env unset or '0') preserves the existing benchmark mode.
+
+    Returns:
+        str when `return_memories=False` (default — backward-compat).
+        tuple[str, list[dict]] when `return_memories=True` — the second
+        element is the retrieved memories list (post-multi-strategy,
+        pre-LLM-context-build). Each memory dict carries `voice_scores`
+        from Gap G — required for per-voice attribution analysis.
+        Bypass paths return `(answer, [])` since they short-circuit
+        before recall.
     """
+    def _ret(answer, memories=None):
+        """Pack return value uniformly across all exit points."""
+        if return_memories:
+            return answer, (memories or [])
+        return answer
     # E7/E8/E9 gate: when set, the harness disables every shortcut that
     # would let the LLM produce an answer without going through
     # BeamMemory.recall(). The bypasses were useful for measuring
@@ -1114,7 +1189,7 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
                 ]
                 answer = llm.chat(messages, temperature=0.0, max_tokens=4096)
                 print(f"    [TR-bypass] LLM answer: {answer[:150]}")
-                return answer
+                return _ret(answer)
             else:
                 print(f"    [TR-bypass] _compute_tr_answer returned None")
         else:
@@ -1171,7 +1246,7 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
                     best_score = score
                     best_match = values[0]
             if best_match:
-                return best_match  # Direct fact answer, zero LLM cost
+                return _ret(best_match)  # Direct fact answer, zero LLM cost
         
         # ---- Phase 2: Full-context LLM fallback ----
         full_parts = []
@@ -1197,8 +1272,8 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
             {"role": "system", "content": ANSWER_SYSTEM_PROMPT},
             {"role": "user", "content": f"{_cr_prefix}{context}\n\nQUESTION: {question}\n\nANSWER:"},
         ]
-        return llm.chat(messages, temperature=0.1, max_tokens=2048)
-    
+        return _ret(llm.chat(messages, temperature=0.1, max_tokens=2048))
+
     # ALWAYS use multi-strategy retrieval to test Mnemosyne's recall quality.
     # The previous <=500 bypass sent full raw conversations to the LLM,
     # completely bypassing Mnemosyne's retrieval pipeline.
@@ -1341,7 +1416,7 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
 
     # If we found a direct context→value match, return it immediately (zero LLM cost)
     if context_answer:
-        return context_answer
+        return _ret(context_answer, memories)
 
     # Inject CR contradiction context if detected
     _cr_prefix_ret = ""
@@ -1353,7 +1428,7 @@ def answer_with_memory(llm: LLMClient, beam: BeamMemory, question: str,
         {"role": "user", "content": f"{_cr_prefix_ret}{context}\n\nQUESTION: {question}\n\nANSWER:"},
     ]
 
-    return llm.chat(messages, temperature=0.1, max_tokens=2048)
+    return _ret(llm.chat(messages, temperature=0.1, max_tokens=2048), memories)
 
 
 # ============================================================
@@ -1471,11 +1546,15 @@ def evaluate_conversation(
         if not question or not ideal:
             continue
 
-        # Step 1: LLM answers using Mnemosyne memories + conversation context
+        # Step 1: LLM answers using Mnemosyne memories + conversation context.
+        # `return_memories=True` gives us the per-question retrieved memory
+        # list so we can summarize voice-attribution provenance below.
         t0 = time.perf_counter()
-        ai_answer = answer_with_memory(llm, beam, question, 
-                                       conversation_messages=conversation.get("messages", []),
-                                       ability=ability)
+        ai_answer, recall_memories = answer_with_memory(
+            llm, beam, question,
+            conversation_messages=conversation.get("messages", []),
+            ability=ability, return_memories=True,
+        )
         answer_time = time.perf_counter() - t0
 
         # Handle None answer (LLM timeout/error)
@@ -1489,12 +1568,20 @@ def evaluate_conversation(
 
         score = judgment.get("overall_score", 0.0)
 
+        # Compact recall-provenance summary so per-voice attribution
+        # analysis (docs/benchmark-results-analysis.md Recipe E) works
+        # from the result file directly — no DB re-query needed. Full
+        # memory dicts would be ~10× larger; this summary captures
+        # what an analyst actually needs.
+        recall_provenance = _summarize_recall_memories(recall_memories)
+
         result = {
             "qid": qid,
             "ability": ability,
             "question": question[:200],
             "ideal_answer": ideal[:200],
             "ai_answer": ai_answer[:500],
+            "recall_provenance": recall_provenance,
             "score": score,
             "nuggets": judgment.get("nuggets", []),
             "assessment": judgment.get("brief_assessment", ""),


### PR DESCRIPTION
## TL;DR

Closes the two pre-test parked items: per-question voice attribution (needed for Theses 1–3 falsifiability) + `MNEMOSYNE_BEAM_OPTIMIZATIONS` parser migration. Both are blocking for credible BEAM-recovery experiment runs.

Stacked on #96.

**Full suite: 1065 passed, 10 skipped, 0 failed.**

## Item 1: Per-question voice_scores threading

**Why before testing:** without this, Theses 1, 2, 3 in `docs/experiments/2026-05-12-beam-recovery-arms-abc.md` can't be falsified. They predict specific voices contribute near-zero — but the only way to verify is per-question voice attribution. Recipe E in `docs/benchmark-results-analysis.md` was documented as "future enhancement"; this closes the gap.

### What lands

- `answer_with_memory()` gains `return_memories: bool = False`. Default returns `str` (back-compat with 16 existing test callers); when `True` returns `(answer, memories)` tuple.
- New `_summarize_recall_memories()` helper builds a compact `recall_provenance` summary per question:

```jsonc
{
  "recall_provenance": {
    "engine": "polyphonic",         // identified by voice-key set
    "kept_count": 10,
    "voice_sums": {"vector": 4.2, "graph": 1.1, "fact": 0.0, "temporal": 0.3},
    "top_result_voices": {"vector": 0.7, ...},
    "top_result_tier": "episodic"
  }
}
```

- `evaluate_conversation()` requests memories via `return_memories=True` and writes the summary into each per-question result dict.

### Why summary not raw

Raw memories at ~50 questions × 6 conversations × 10 memories = 3000 dicts with full content. The compact summary captures engine ID + per-voice sums + top-result breakdown — what analysis actually needs.

## Item 2: `MNEMOSYNE_BEAM_OPTIMIZATIONS` parser migration

**Why before testing:** the env var used the brittle `.lower() in ("1","true","yes")` parser. Pre-fix `MNEMOSYNE_BEAM_OPTIMIZATIONS=on` was silently treated as off — a confused-operator hazard during the experiment.

### What lands

- New `_env_truthy(name)` helper added to `beam.py` (mirrors `tools/evaluate_beam_end_to_end.py`'s helper). Accepts `1`/`true`/`yes`/`on`, strips whitespace, case-insensitive.
- `_BEAM_MODE` routes through `_env_truthy("MNEMOSYNE_BEAM_OPTIMIZATIONS")` instead of the inline pattern.

## Tests (`tests/test_voice_attribution_and_beam_opt.py`, 31 new)

| Class | Count | What it pins |
|---|---|---|
| `TestBeamOptimizationsEnvParser` | 13 | truthy/falsy parsing including `on` + whitespace |
| `TestAnswerWithMemoryReturnMemoriesKwarg` | 3 | `return_memories=False` returns str; `=True` returns tuple; bypass returns `(str, [])` |
| `TestSummarizeRecallMemories` | 6 | empty/polyphonic/linear/unknown engine ID; missing voice_scores tolerance; non-numeric value tolerance |
| `TestRecallProvenanceInResultDict` | 1 | source-grep canary — `recall_provenance` actually written to per-question results |

## Doc updates

- `docs/benchmark-results-analysis.md` Recipe E rewritten with the full schema and a worked example using `recall_provenance`. Includes a per-ability fact-voice contribution analysis snippet for testing Thesis 1 ("fact voice is dead weight").
- `beam_e2e_results.json` schema example now shows the `recall_provenance` field.

## What this enables

A maintainer can now run Phase 3a (no fact voice) and Phase 3b (no graph voice), then compute per-voice contribution deltas from the result file directly:

```python
import json
data = json.load(open("results/beam_e2e_results.json"))

# How much did the fact voice contribute on TR questions?
tr_fact_sums = []
for conv in data["results"]:
    for q in conv["results"]:
        if q["ability"] != "TR":
            continue
        prov = q.get("recall_provenance", {})
        tr_fact_sums.append(prov.get("voice_sums", {}).get("fact", 0.0))
print(f"TR avg fact-voice sum: {sum(tr_fact_sums)/len(tr_fact_sums):.3f}")
```

That's the analysis Theses 1, 2, 3 need. Without this PR, only total-score deltas would be available.

## Items still parked (non-blocking)

- `local_llm.py` env-parse migration (3 sites) — out of scope; experiment doesn't go through that surface.
- A `tools/analyze_beam_results.py` script packaging the worked recipes into one CLI — copy-paste-runnable from the doc; can ship later.
- Empirical noise-floor measurement — would need a test-retest run; documented 2pp prior is sufficient for first-pass interpretation.

## Test plan

- [x] 31 new tests pass
- [x] Full suite: 1065 passed, 10 skipped, 0 failed
- [x] Existing 70 harness tests still pass (back-compat verified)
- [x] Stacked on #96 — CI green from day one
- [ ] CI: full suite green on Python 3.9 / 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
