### PR TITLE
security: harden MCP SSE transport, gitignore, action pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -32,10 +32,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -30,10 +30,10 @@ jobs:
         run: python -m build
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: dist/*
           generate_release_notes: true
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,11 @@ DEVOPS_PLAN_*
 # GSD planning — operational docs stay private
 .planning/
 
+# Local secrets (S3 — keep .env out of git)
+.env
+.env.local
+.env.*.local
+
+# Local-only tooling artifacts (S4 housekeeping — security reports stay local)
+.gstack/
+

--- a/mnemosyne/mcp_server.py
+++ b/mnemosyne/mcp_server.py
@@ -1,25 +1,42 @@
 """
-Mnemosyne MCP Server — stdio and SSE transports.
+Mnemosyne MCP Server -- stdio and SSE transports.
 
 Usage:
-    # stdio (default) — for Claude Desktop, etc.
+    # stdio (default) -- for Claude Desktop, etc.
     mnemosyne mcp
 
-    # SSE — for web clients
+    # SSE on loopback -- safe default, no auth required
     mnemosyne mcp --transport sse --port 8080
+
+    # SSE exposed on LAN -- REQUIRES bearer token via env var
+    MNEMOSYNE_MCP_TOKEN=my-secret-token mnemosyne mcp \\
+        --transport sse --host 0.0.0.0 --port 8080
 
     # Specific bank
     mnemosyne mcp --bank project_a
+
+Security note (S1, 2026-05-12):
+    The SSE transport defaults to host=127.0.0.1 (loopback only). Binding
+    to a non-loopback address (0.0.0.0, a LAN IP, etc.) requires the env
+    var MNEMOSYNE_MCP_TOKEN to be set; clients must then send
+    ``Authorization: Bearer <token>`` on every request. Without the token
+    the server refuses to start. This prevents a LAN attacker from
+    reading/writing/deleting the user's memory via an unauthenticated
+    MCP endpoint.
 """
 
+import hmac
 import os
 import sys
 import json
 import asyncio
-from typing import Optional
+import logging
+from typing import Optional, Tuple
 from pathlib import Path
 
-# Guarded import — MCP is optional
+logger = logging.getLogger(__name__)
+
+# Guarded import -- MCP is optional
 try:
     from mcp.server import Server
     from mcp.server.stdio import stdio_server
@@ -33,6 +50,42 @@ except ImportError:
     CallToolResult = None
 
 from mnemosyne.mcp_tools import get_tool_definitions, handle_tool_call
+
+# ---------------------------------------------------------------------------
+# Security helpers (S1)
+# ---------------------------------------------------------------------------
+
+# Hosts treated as loopback-only; safe to expose without auth.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "ip6-localhost"})
+
+_TOKEN_ENV = "MNEMOSYNE_MCP_TOKEN"
+
+
+def _is_loopback(host: str) -> bool:
+    """Return True if `host` is a loopback bind that needs no auth."""
+    return host.strip().lower() in _LOOPBACK_HOSTS
+
+
+def _resolve_sse_auth(host: str) -> Tuple[bool, Optional[str]]:
+    """Decide whether SSE needs bearer-token auth and what the token is.
+
+    Returns (require_auth, token). Raises RuntimeError when host is
+    non-loopback and the MNEMOSYNE_MCP_TOKEN env var is unset/empty --
+    refusing to start an unauthenticated network-exposed MCP server.
+    """
+    if _is_loopback(host):
+        return (False, None)
+    token = (os.environ.get(_TOKEN_ENV) or "").strip()
+    if not token:
+        raise RuntimeError(
+            f"Refusing to bind MCP SSE on non-loopback host {host!r} without "
+            f"authentication. Set the {_TOKEN_ENV} env var to a strong random "
+            f"secret and have clients send 'Authorization: Bearer <token>' on "
+            f"each request. Or bind to 127.0.0.1 (the default) for local-only "
+            f"use."
+        )
+    return (True, token)
+
 
 # ---------------------------------------------------------------------------
 # Server Setup
@@ -61,19 +114,32 @@ async def _run_stdio() -> None:
         await server.run(read_stream, write_stream, server.create_initialization_options())
 
 
-async def _run_sse(port: int = 8080) -> None:
-    """Run MCP server over SSE transport."""
+def _build_sse_app(host: str = "127.0.0.1"):
+    """Build the Starlette app for SSE transport.
+
+    Split out from `_run_sse` so the auth-gating + middleware-installation
+    logic is testable without spinning up uvicorn.
+
+    Returns the configured Starlette application. Raises RuntimeError if
+    host is non-loopback and MNEMOSYNE_MCP_TOKEN is unset.
+    """
     if not _MCP_AVAILABLE:
         raise RuntimeError("MCP not installed. Run: pip install mnemosyne-memory[mcp]")
 
-    # SSE transport requires additional imports
     try:
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
         from starlette.routing import Route
-        import uvicorn
+        from starlette.middleware import Middleware
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from starlette.responses import JSONResponse
     except ImportError:
-        raise RuntimeError("SSE transport requires starlette and uvicorn. Run: pip install starlette uvicorn")
+        raise RuntimeError(
+            "SSE transport requires starlette and uvicorn. "
+            "Run: pip install starlette uvicorn"
+        )
+
+    require_auth, token = _resolve_sse_auth(host)
 
     transport = SseServerTransport("/messages")
     server = Server("mnemosyne")
@@ -97,14 +163,66 @@ async def _run_sse(port: int = 8080) -> None:
     async def handle_messages(request):
         await transport.handle_post_message(request.scope, request.receive, request.send)
 
+    middleware = []
+    if require_auth:
+        expected = token
+
+        class _BearerTokenMiddleware(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                header = request.headers.get("authorization", "")
+                if not header.startswith("Bearer "):
+                    return JSONResponse(
+                        {"error": "missing bearer token"},
+                        status_code=401,
+                        headers={"WWW-Authenticate": "Bearer"},
+                    )
+                presented = header[len("Bearer "):].strip()
+                if not hmac.compare_digest(presented, expected):
+                    return JSONResponse(
+                        {"error": "invalid bearer token"},
+                        status_code=401,
+                        headers={"WWW-Authenticate": "Bearer"},
+                    )
+                return await call_next(request)
+
+        middleware.append(Middleware(_BearerTokenMiddleware))
+        logger.info(
+            "MCP SSE bearer-token auth enabled (host=%s). Clients must send "
+            "'Authorization: Bearer <token>' on every request.",
+            host,
+        )
+    else:
+        logger.info(
+            "MCP SSE running loopback-only (host=%s); no auth required.",
+            host,
+        )
+
     starlette_app = Starlette(
         routes=[
             Route("/sse", endpoint=handle_sse),
             Route("/messages", endpoint=handle_messages, methods=["POST"]),
-        ]
+        ],
+        middleware=middleware,
     )
+    return starlette_app
 
-    config = uvicorn.Config(starlette_app, host="0.0.0.0", port=port, log_level="info")
+
+async def _run_sse(port: int = 8080, host: str = "127.0.0.1") -> None:
+    """Run MCP server over SSE transport.
+
+    Default host is 127.0.0.1 (loopback only). Binding non-loopback
+    requires MNEMOSYNE_MCP_TOKEN -- see _resolve_sse_auth.
+    """
+    try:
+        import uvicorn
+    except ImportError:
+        raise RuntimeError(
+            "SSE transport requires starlette and uvicorn. "
+            "Run: pip install starlette uvicorn"
+        )
+
+    app = _build_sse_app(host=host)
+    config = uvicorn.Config(app, host=host, port=port, log_level="info")
     await uvicorn.Server(config).serve()
 
 
@@ -112,7 +230,12 @@ async def _run_sse(port: int = 8080) -> None:
 # CLI Entry Point
 # ---------------------------------------------------------------------------
 
-def run_mcp_server(transport: str = "stdio", port: int = 8080, bank: Optional[str] = None) -> None:
+def run_mcp_server(
+    transport: str = "stdio",
+    port: int = 8080,
+    bank: Optional[str] = None,
+    host: str = "127.0.0.1",
+) -> None:
     """
     Run the Mnemosyne MCP server.
 
@@ -120,6 +243,8 @@ def run_mcp_server(transport: str = "stdio", port: int = 8080, bank: Optional[st
         transport: "stdio" or "sse"
         port: Port for SSE transport (ignored for stdio)
         bank: Default bank for operations (optional)
+        host: Bind address for SSE transport (default: 127.0.0.1 -- loopback
+            only). Non-loopback hosts require MNEMOSYNE_MCP_TOKEN.
     """
     if bank:
         os.environ["MNEMOSYNE_MCP_BANK"] = bank
@@ -127,7 +252,7 @@ def run_mcp_server(transport: str = "stdio", port: int = 8080, bank: Optional[st
     if transport == "stdio":
         asyncio.run(_run_stdio())
     elif transport == "sse":
-        asyncio.run(_run_sse(port))
+        asyncio.run(_run_sse(port=port, host=host))
     else:
         raise ValueError(f"Unknown transport: {transport}. Use 'stdio' or 'sse'.")
 
@@ -144,6 +269,16 @@ def main(argv: Optional[list[str]] = None) -> None:
         help="Transport protocol (default: stdio)"
     )
     parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help=(
+            "Bind address for SSE transport (default: 127.0.0.1 -- loopback "
+            "only). Use 0.0.0.0 to expose on LAN; this requires the "
+            "MNEMOSYNE_MCP_TOKEN env var to be set."
+        ),
+    )
+    parser.add_argument(
         "--port",
         type=int,
         default=8080,
@@ -157,7 +292,7 @@ def main(argv: Optional[list[str]] = None) -> None:
     )
     args = parser.parse_args(argv)
 
-    run_mcp_server(transport=args.transport, port=args.port, bank=args.bank)
+    run_mcp_server(transport=args.transport, port=args.port, bank=args.bank, host=args.host)
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -322,7 +322,7 @@ run_cli()
             main(["--transport", "sse", "--port", "19090", "--bank", "work"])
 
         run_mcp_server.assert_called_once_with(
-            transport="sse", port=19090, bank="work"
+            transport="sse", port=19090, bank="work", host="127.0.0.1"
         )
 
 

--- a/tests/test_s1_mcp_sse_auth.py
+++ b/tests/test_s1_mcp_sse_auth.py
@@ -1,0 +1,255 @@
+"""
+Regression tests for S1 (security audit, 2026-05-12):
+
+    MCP SSE transport binds 127.0.0.1 by default; binding to a non-loopback
+    host requires MNEMOSYNE_MCP_TOKEN and installs a bearer-token middleware.
+
+Pre-fix: `mnemosyne mcp --transport sse` bound `0.0.0.0` with no auth, so
+anyone on the same LAN could call /sse and /messages and read/write/delete
+the user's memory store. This file locks the hardened defaults in.
+
+Run with: pytest tests/test_s1_mcp_sse_auth.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# Helpers under direct test
+# ---------------------------------------------------------------------------
+
+
+class TestIsLoopback:
+    """`_is_loopback` decides whether a host bind needs auth."""
+
+    @pytest.mark.parametrize(
+        "host",
+        ["127.0.0.1", "localhost", "::1", "ip6-localhost",
+         "LOCALHOST", "  127.0.0.1  ", "LocalHost"],
+    )
+    def test_loopback_aliases(self, host):
+        from mnemosyne.mcp_server import _is_loopback
+        assert _is_loopback(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        ["0.0.0.0", "192.168.1.10", "10.0.0.5", "::",
+         "example.com", "fd00::1"],
+    )
+    def test_non_loopback(self, host):
+        from mnemosyne.mcp_server import _is_loopback
+        assert _is_loopback(host) is False
+
+
+class TestResolveSseAuth:
+    """`_resolve_sse_auth` is the gate that enforces the hardened policy."""
+
+    def test_loopback_skips_auth(self, monkeypatch):
+        """Default 127.0.0.1 needs no token, no env var."""
+        monkeypatch.delenv("MNEMOSYNE_MCP_TOKEN", raising=False)
+        from mnemosyne.mcp_server import _resolve_sse_auth
+        require_auth, token = _resolve_sse_auth("127.0.0.1")
+        assert require_auth is False
+        assert token is None
+
+    def test_loopback_ignores_token_even_if_set(self, monkeypatch):
+        """Loopback bind never requires auth regardless of env state."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "some-token")
+        from mnemosyne.mcp_server import _resolve_sse_auth
+        require_auth, token = _resolve_sse_auth("localhost")
+        assert require_auth is False
+        assert token is None
+
+    def test_non_loopback_without_token_raises(self, monkeypatch):
+        """0.0.0.0 with no token must refuse to start. The error message
+        names the env var so operators can fix it without grepping."""
+        monkeypatch.delenv("MNEMOSYNE_MCP_TOKEN", raising=False)
+        from mnemosyne.mcp_server import _resolve_sse_auth
+        with pytest.raises(RuntimeError, match="MNEMOSYNE_MCP_TOKEN"):
+            _resolve_sse_auth("0.0.0.0")
+
+    def test_non_loopback_empty_token_raises(self, monkeypatch):
+        """Empty/whitespace token is treated as unset."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "   ")
+        from mnemosyne.mcp_server import _resolve_sse_auth
+        with pytest.raises(RuntimeError, match="MNEMOSYNE_MCP_TOKEN"):
+            _resolve_sse_auth("0.0.0.0")
+
+    def test_non_loopback_with_token_returns_pair(self, monkeypatch):
+        """Properly configured non-loopback returns (True, token)."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "real-secret-123")
+        from mnemosyne.mcp_server import _resolve_sse_auth
+        require_auth, token = _resolve_sse_auth("0.0.0.0")
+        assert require_auth is True
+        assert token == "real-secret-123"
+
+    def test_token_is_stripped(self, monkeypatch):
+        """Trailing whitespace in the env var doesn't break auth."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "  with-spaces  ")
+        from mnemosyne.mcp_server import _resolve_sse_auth
+        require_auth, token = _resolve_sse_auth("0.0.0.0")
+        assert token == "with-spaces"
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+class TestMainHostArg:
+    """`mnemosyne mcp` CLI: --host flag plumbs through, default is loopback."""
+
+    def test_default_host_is_loopback(self):
+        """Calling main() without --host should pass host='127.0.0.1'."""
+        from mnemosyne.mcp_server import main
+        with patch("mnemosyne.mcp_server.run_mcp_server") as runner:
+            main(["--transport", "sse", "--port", "9000"])
+        runner.assert_called_once_with(
+            transport="sse", port=9000, bank=None, host="127.0.0.1"
+        )
+
+    def test_explicit_host_arg(self):
+        """--host 0.0.0.0 must be threaded through."""
+        from mnemosyne.mcp_server import main
+        with patch("mnemosyne.mcp_server.run_mcp_server") as runner:
+            main(["--transport", "sse", "--host", "0.0.0.0", "--port", "9001"])
+        runner.assert_called_once_with(
+            transport="sse", port=9001, bank=None, host="0.0.0.0"
+        )
+
+    def test_run_mcp_server_default_host_is_loopback(self):
+        """run_mcp_server() default kwarg pins 127.0.0.1."""
+        import inspect
+        from mnemosyne.mcp_server import run_mcp_server
+        sig = inspect.signature(run_mcp_server)
+        assert sig.parameters["host"].default == "127.0.0.1"
+
+    def test_run_sse_default_host_is_loopback(self):
+        """_run_sse() default kwarg pins 127.0.0.1 as a second line of defense."""
+        import inspect
+        from mnemosyne.mcp_server import _run_sse
+        sig = inspect.signature(_run_sse)
+        assert sig.parameters["host"].default == "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# App building (Starlette + middleware)
+# ---------------------------------------------------------------------------
+
+
+def _starlette_available() -> bool:
+    try:
+        import starlette  # noqa: F401
+        import mcp  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(
+    not _starlette_available(),
+    reason="starlette/mcp not installed -- build_sse_app skipped",
+)
+class TestBuildSseApp:
+    """`_build_sse_app` is the integration point: auth gate + middleware install."""
+
+    def test_loopback_app_has_no_auth_middleware(self, monkeypatch):
+        """Loopback bind: app should not carry the bearer middleware."""
+        monkeypatch.delenv("MNEMOSYNE_MCP_TOKEN", raising=False)
+        from mnemosyne.mcp_server import _build_sse_app
+        app = _build_sse_app(host="127.0.0.1")
+        # Starlette stores user-supplied middleware on user_middleware.
+        # We just check that none of them is our bearer-token class.
+        names = [type(m.cls).__name__ if hasattr(m, "cls") else str(m)
+                 for m in app.user_middleware]
+        assert not any("Bearer" in n for n in names), (
+            f"loopback app should not have bearer middleware, got: {names}"
+        )
+
+    def test_non_loopback_without_token_raises(self, monkeypatch):
+        """0.0.0.0 with no token: build refuses (mirrors _resolve_sse_auth)."""
+        monkeypatch.delenv("MNEMOSYNE_MCP_TOKEN", raising=False)
+        from mnemosyne.mcp_server import _build_sse_app
+        with pytest.raises(RuntimeError, match="MNEMOSYNE_MCP_TOKEN"):
+            _build_sse_app(host="0.0.0.0")
+
+    def test_non_loopback_with_token_installs_middleware(self, monkeypatch):
+        """0.0.0.0 with token: app carries the bearer middleware."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "supersecret")
+        from mnemosyne.mcp_server import _build_sse_app
+        app = _build_sse_app(host="0.0.0.0")
+        # At least one middleware entry should be the bearer wrapper.
+        middleware_classes = [m.cls for m in app.user_middleware]
+        # The inner class is defined locally inside _build_sse_app so we
+        # match by class name rather than identity.
+        names = [c.__name__ for c in middleware_classes]
+        assert any("Bearer" in n for n in names), (
+            f"non-loopback app should install bearer middleware, got: {names}"
+        )
+
+    def test_bearer_middleware_rejects_missing_token(self, monkeypatch):
+        """End-to-end: TestClient hitting /sse without Authorization gets 401."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "supersecret")
+        from mnemosyne.mcp_server import _build_sse_app
+        from starlette.testclient import TestClient
+
+        app = _build_sse_app(host="0.0.0.0")
+        client = TestClient(app)
+        # POST to /messages without auth header
+        resp = client.post("/messages", json={"ping": "pong"})
+        assert resp.status_code == 401
+        body = resp.json()
+        assert "missing bearer token" in body.get("error", "").lower()
+
+    def test_bearer_middleware_rejects_wrong_token(self, monkeypatch):
+        """Wrong token: 401 (compare via hmac.compare_digest in production)."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "supersecret")
+        from mnemosyne.mcp_server import _build_sse_app
+        from starlette.testclient import TestClient
+
+        app = _build_sse_app(host="0.0.0.0")
+        client = TestClient(app)
+        resp = client.post(
+            "/messages",
+            json={"ping": "pong"},
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        assert resp.status_code == 401
+        body = resp.json()
+        assert "invalid bearer token" in body.get("error", "").lower()
+
+    def test_bearer_middleware_rejects_malformed_header(self, monkeypatch):
+        """Token without 'Bearer ' prefix is rejected as missing."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "supersecret")
+        from mnemosyne.mcp_server import _build_sse_app
+        from starlette.testclient import TestClient
+
+        app = _build_sse_app(host="0.0.0.0")
+        client = TestClient(app)
+        resp = client.post(
+            "/messages",
+            json={"ping": "pong"},
+            headers={"Authorization": "Basic c3VwZXJzZWNyZXQ="},  # not Bearer
+        )
+        assert resp.status_code == 401
+
+    def test_401_response_has_www_authenticate_header(self, monkeypatch):
+        """Per RFC 7235, 401 should advertise the auth scheme."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "supersecret")
+        from mnemosyne.mcp_server import _build_sse_app
+        from starlette.testclient import TestClient
+
+        app = _build_sse_app(host="0.0.0.0")
+        client = TestClient(app)
+        resp = client.post("/messages", json={})
+        assert resp.headers.get("www-authenticate") == "Bearer"


### PR DESCRIPTION
## Summary

Closes three findings from a local security audit. The fourth — indirect prompt injection via `prefetch()` rendering retrieved memory into LLM context — is architectural (needs schema tier for trust labels + coordinated agent-side change) and is filed as a separate follow-up.

### S1 — MCP SSE transport bound `0.0.0.0` with no auth (HIGH)

Pre-fix: `mnemosyne mcp --transport sse` exposed `/sse` and `/messages` on all network interfaces with no authentication. Anyone on the same LAN/WiFi could call `remember`/`recall`/`forget` on the user's memory store.

Fix:
- Default `host="127.0.0.1"` (loopback only) in `_run_sse`, `run_mcp_server`, and the CLI.
- New `--host` flag for explicit opt-in to non-loopback bind.
- Non-loopback bind requires `MNEMOSYNE_MCP_TOKEN`; server refuses to start without it.
- Bearer-token middleware installed when token is present, using `hmac.compare_digest` for constant-time comparison.
- 401 + `WWW-Authenticate: Bearer` on missing/invalid token.
- Helpers (`_is_loopback`, `_resolve_sse_auth`, `_build_sse_app`) split out so the policy + middleware install is unit-testable without spinning up uvicorn.

Stdio transport is unaffected.

### S3 — `.env` missing from `.gitignore` (MEDIUM)

Added `.env`, `.env.local`, `.env.*.local`. No `.env` is currently tracked; this closes a future-leak hazard.

### S4 — Third-party Actions tag-pinned (MEDIUM)

`release.yml` declares `permissions: id-token: write` and publishes to PyPI. Tag-pinned third-party actions mean a force-pushed tag could mint an OIDC token and publish a backdoored wheel under the project's name.

SHA-pinned:
- `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
- `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0`
- `softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2`
- `pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0`

Same first-party two pinned in `ci.yml`.

## Test plan

- [x] New `tests/test_s1_mcp_sse_auth.py` (30 tests): loopback aliases, env-var gating, raises on non-loopback without token, middleware installed only when needed, 401 on missing/wrong/malformed Bearer, `WWW-Authenticate` header on 401.
- [x] Updated existing `tests/test_mcp_server.py::test_mcp_server_main_accepts_explicit_argv` to expect the new `host` kwarg.
- [x] Targeted MCP slice green: 54/54 pass (`pytest tests/test_mcp_server.py tests/test_s1_mcp_sse_auth.py`).
- [x] Adjacent canary slice green: 95/95 pass on `test_mcp_server.py + test_s1_mcp_sse_auth.py + test_voice_attribution_and_beam_opt.py + test_gap_e_g_analysis.py`.
- [ ] CI will run the full matrix.

## Breaking change note

The default bind changed from `0.0.0.0` to `127.0.0.1`. Anyone currently running `mnemosyne mcp --transport sse` and relying on LAN access will need to either:
1. Pass `--host 0.0.0.0` AND set `MNEMOSYNE_MCP_TOKEN` (and have clients send `Authorization: Bearer <token>`), or
2. Stay on loopback (recommended).

This was an undocumented attack surface, not an intentional public API, so the breakage is the intended outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)