### PR TITLE
fix: use llama.cpp token args in fact extraction

### DIFF
--- a/mnemosyne/core/extraction.py
+++ b/mnemosyne/core/extraction.py
@@ -73,6 +73,33 @@ def _parse_facts(raw_output: str) -> List[str]:
     return cleaned[:5]  # Cap at 5 facts
 
 
+def _call_local_extraction_llm(llm, prompt: str) -> str:
+    """Run deterministic local extraction for the loaded local LLM backend.
+
+    llama-cpp-python exposes ``max_tokens`` via its completion/chat APIs,
+    while ctransformers exposes ``max_new_tokens`` on the direct callable.
+    Using ctransformers kwargs against a llama.cpp ``Llama`` instance raises
+    ``unexpected keyword argument 'max_new_tokens'`` and disables fact
+    extraction on installs where llama-cpp-python is preferred.
+    """
+    if getattr(local_llm, "_llm_backend", None) == "llamacpp":
+        response = llm.create_chat_completion(
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=local_llm.LLM_MAX_TOKENS,
+            stop=["</s>", "<|user|>"],
+            temperature=0.0,
+        )
+        choices = response.get("choices", []) if isinstance(response, dict) else []
+        if choices:
+            return choices[0].get("message", {}).get("content", "") or ""
+        return ""
+    return llm(
+        prompt,
+        max_new_tokens=local_llm.LLM_MAX_TOKENS,
+        stop=["</s>", "<|user|>"],
+    )
+
+
 def extract_facts(text: str) -> List[str]:
     """
     Extract structured facts from raw text using LLM.
@@ -168,11 +195,7 @@ def extract_facts(text: str) -> List[str]:
             return []
         if llm is not None:
             try:
-                raw_output = llm(
-                    prompt,
-                    max_new_tokens=local_llm.LLM_MAX_TOKENS,
-                    stop=["</s>", "<|user|>"],
-                )
+                raw_output = _call_local_extraction_llm(llm, prompt)
                 facts = _parse_facts(local_llm._clean_output(raw_output))
                 if facts:
                     diag.record_success("local", fact_count=len(facts))
@@ -231,11 +254,7 @@ def extract_facts(text: str) -> List[str]:
         return []
     if llm is not None:
         try:
-            raw_output = llm(
-                prompt,
-                max_new_tokens=local_llm.LLM_MAX_TOKENS,
-                stop=["</s>", "<|user|>"],
-            )
+            raw_output = _call_local_extraction_llm(llm, prompt)
             facts = _parse_facts(local_llm._clean_output(raw_output))
             if facts:
                 diag.record_success("local", fact_count=len(facts))

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -16,6 +16,7 @@ from mnemosyne.core.extraction import (
     extract_facts,
     extract_facts_safe,
     _build_extraction_prompt,
+    _call_local_extraction_llm,
     _parse_facts,
     EXTRACTION_PROMPT,
 )
@@ -76,6 +77,52 @@ def test_parse_facts_empty():
     facts = _parse_facts("   \n   ")
     assert facts == []
     print("PASS: test_parse_facts_empty")
+
+
+def test_call_local_extraction_llm_uses_llamacpp_chat_api(monkeypatch):
+    """llama-cpp-python uses max_tokens, not ctransformers' max_new_tokens."""
+    monkeypatch.setattr(local_llm, "_llm_backend", "llamacpp")
+    monkeypatch.setattr(local_llm, "LLM_MAX_TOKENS", 123)
+
+    class FakeLlamaCpp:
+        def __init__(self):
+            self.kwargs = None
+
+        def create_chat_completion(self, **kwargs):
+            self.kwargs = kwargs
+            return {"choices": [{"message": {"content": "The user likes coffee."}}]}
+
+        def __call__(self, *args, **kwargs):  # pragma: no cover - should not run
+            raise AssertionError("llama.cpp extraction should use chat completion API")
+
+    llm = FakeLlamaCpp()
+    output = _call_local_extraction_llm(llm, "prompt")
+
+    assert output == "The user likes coffee."
+    assert llm.kwargs["max_tokens"] == 123
+    assert llm.kwargs["temperature"] == 0.0
+    assert "max_new_tokens" not in llm.kwargs
+
+
+def test_call_local_extraction_llm_preserves_ctransformers_kwargs(monkeypatch):
+    """ctransformers still receives max_new_tokens on the direct callable."""
+    monkeypatch.setattr(local_llm, "_llm_backend", "ctransformers")
+    monkeypatch.setattr(local_llm, "LLM_MAX_TOKENS", 456)
+
+    class FakeCTransformers:
+        def __init__(self):
+            self.kwargs = None
+
+        def __call__(self, prompt, **kwargs):
+            self.kwargs = kwargs
+            return "The user likes tea."
+
+    llm = FakeCTransformers()
+    output = _call_local_extraction_llm(llm, "prompt")
+
+    assert output == "The user likes tea."
+    assert llm.kwargs["max_new_tokens"] == 456
+    assert "max_tokens" not in llm.kwargs
 
 
 def test_extract_facts_safe_no_llm():


### PR DESCRIPTION
## Summary
- route local fact extraction through a backend-aware helper
- use llama-cpp-python chat completions with max_tokens/temperature=0.0
- preserve existing ctransformers max_new_tokens behavior

## Test plan
- python3 -m pytest tests/test_extraction.py -q
- python3 -m pytest tests/test_c13b_extraction_diagnostics.py tests/test_extraction_integration.py -q

## Context
On ARM64/macOS installs, local extraction loads llama-cpp-python first. The previous direct call passed ctransformers-only max_new_tokens to a llama_cpp.Llama instance, causing: Llama.__call__() got an unexpected keyword argument 'max_new_tokens'.