### PR TITLE
test: default-disable local LLM in tests; fix vec_episodes read

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ Shared test fixtures for Mnemosyne test suite.
 
 Provides fixtures that handle SQLite thread-local connection cleanup
 to prevent "database is locked" and UNIQUE constraint collisions
-between tests.
+between tests, and that default-disable the local LLM so tests don't
+make real CPU inference calls when a model is available on disk.
 """
 
 import pytest
@@ -73,3 +74,114 @@ def _reset_thread_local_connections():
     _close_cached_connections()
     yield
     _close_cached_connections()
+
+
+# ---------------------------------------------------------------------------
+# Local-LLM default-disable (test environment hygiene)
+# ---------------------------------------------------------------------------
+#
+# Background: in dev environments that have a GGUF model file on disk plus
+# `llama-cpp-python` or `ctransformers` installed (e.g. the Hermes Agent
+# venv at ~/.hermes/hermes-agent/venv with tinyllama at
+# ~/.hermes/mnemosyne/models/), `mnemosyne.core.local_llm._load_llm()`
+# auto-loads the model on first call. Any test that exercises a
+# summarization path (`beam.sleep()`, `consolidate_to_episodic`, SHMR, the
+# extraction fallback) then runs real CPU inference -- 5-30 seconds per
+# call, multiplied by the number of items consolidated. The full suite
+# goes from ~20 seconds (CI: no model on disk) to 15+ minutes locally.
+#
+# This fixture default-disables `_load_llm` and clears its cached state
+# at the start of every test, so tests behave like CI by default.
+#
+# Tests that need to exercise an LLM-enabled code path should explicitly
+# opt in by either:
+#   - Using the `local_llm_enabled` fixture below, or
+#   - Calling `monkeypatch.setattr(local_llm, "_load_llm", lambda: fake)`
+#     with their own fake callable.
+#
+# Both `unittest.mock.patch.object(local_llm, "_load_llm", ...)` (context
+# manager) and `monkeypatch.setattr(local_llm, "_load_llm", ...)` applied
+# after the autouse fixture override our default-disable -- pytest's
+# monkeypatch is function-scoped and later setattrs win.
+
+
+@pytest.fixture(autouse=True)
+def _disable_local_llm_inference(monkeypatch):
+    """
+    Default-disable the local LLM model loader for every test.
+
+    Concretely, replaces ``mnemosyne.core.local_llm._load_llm`` with a
+    function that returns None, and clears the module's cached
+    availability flags so previously-set state from another import path
+    doesn't leak in.
+
+    Effect on the public API:
+      - ``local_llm.llm_available()`` returns False (since path 3 --
+        ``_load_llm()`` -- now yields None and ``_llm_available`` stays
+        None, so ``bool(None) == False``).
+      - ``local_llm._call_local_llm(...)`` returns None (short-circuits
+        on ``llm is None``).
+      - Sleep / extraction / SHMR code paths that gate on
+        ``llm_available()`` take the deterministic non-LLM branch.
+
+    Tests that want a working LLM path should opt in via the
+    ``local_llm_enabled`` fixture below, or set their own
+    ``_load_llm`` mock.
+    """
+    try:
+        from mnemosyne.core import local_llm
+    except Exception:
+        # local_llm import failures shouldn't abort the test session.
+        yield
+        return
+
+    monkeypatch.setattr(local_llm, "_llm_available", None, raising=False)
+    monkeypatch.setattr(local_llm, "_llm_instance", None, raising=False)
+    monkeypatch.setattr(local_llm, "_llm_backend", None, raising=False)
+    monkeypatch.setattr(local_llm, "_load_llm", lambda: None, raising=True)
+    yield
+
+
+@pytest.fixture
+def local_llm_enabled(monkeypatch):
+    """
+    Opt-in fixture for tests that need a working LLM path.
+
+    Installs a deterministic fake LLM via ``_load_llm``: the returned
+    object is callable (mimicking the ctransformers callable interface)
+    AND has a ``create_chat_completion`` method (mimicking the
+    llama-cpp-python interface), so tests don't have to care which
+    backend a given code path expects.
+
+    Usage::
+
+        def test_summarization(local_llm_enabled, ...):
+            # llm_available() is True here, and any code that calls
+            # _call_local_llm gets a fake completion.
+
+    Override the fake response per-test by capturing the fixture and
+    setting ``local_llm_enabled.response``:
+
+        def test_x(local_llm_enabled):
+            local_llm_enabled.response = "custom output"
+            ...
+    """
+    from mnemosyne.core import local_llm
+
+    class _FakeLLM:
+        response = "fake summary"
+
+        # ctransformers-style: instance is callable
+        def __call__(self, prompt, *args, **kwargs):
+            return self.response
+
+        # llama-cpp-python-style: create_chat_completion
+        def create_chat_completion(self, messages, **kwargs):
+            return {"choices": [{"message": {"content": self.response}}]}
+
+    fake = _FakeLLM()
+    monkeypatch.setattr(local_llm, "_load_llm", lambda: fake, raising=True)
+    monkeypatch.setattr(local_llm, "_llm_instance", fake, raising=False)
+    monkeypatch.setattr(local_llm, "_llm_available", True, raising=False)
+    monkeypatch.setattr(local_llm, "_llm_backend", "llamacpp", raising=False)
+    return fake

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -272,29 +272,34 @@ class TestSleepCycle:
 
         # Post-sleep, exactly one episodic row should exist (one consolidated
         # summary for the session). Dense store should hold a row for it.
+        #
+        # Use ``beam.conn`` rather than a fresh ``sqlite3.connect`` for the
+        # check: when sqlite-vec is installed, the extension is loaded on
+        # beam.conn (where the writes happened) but NOT on a freshly-opened
+        # connection. Reading vec_episodes through a fresh connection would
+        # raise "no such table" and steer us into the wrong assertion
+        # branch. beam.conn is the authoritative reader for this state.
         from mnemosyne.core.beam import _vec_available
 
-        conn = sqlite3.connect(temp_db)
-        ep_ids = [r[0] for r in conn.execute("SELECT id FROM episodic_memory").fetchall()]
+        bc = beam.conn
+        ep_ids = [r[0] for r in bc.execute("SELECT id FROM episodic_memory").fetchall()]
         assert len(ep_ids) == 1, f"expected 1 consolidated episodic row, got {len(ep_ids)}"
 
-        if _vec_available(conn):
-            vec_count = conn.execute("SELECT COUNT(*) FROM vec_episodes").fetchone()[0]
-            conn.close()
+        if _vec_available(bc):
+            vec_count = bc.execute("SELECT COUNT(*) FROM vec_episodes").fetchone()[0]
             assert vec_count >= 1, (
                 "sleep consolidated an episodic row but vec_episodes is "
-                "empty — the embed→_vec_insert path did not run. Likely "
+                "empty -- the embed->_vec_insert path did not run. Likely "
                 "cause: _embeddings.embed() returned None silently, or "
                 "_vec_insert raised and was swallowed."
             )
         else:
-            mem_count = conn.execute(
+            mem_count = bc.execute(
                 "SELECT COUNT(*) FROM memory_embeddings WHERE memory_id = ?", (ep_ids[0],)
             ).fetchone()[0]
-            conn.close()
             assert mem_count >= 1, (
                 "sleep consolidated an episodic row but memory_embeddings "
-                "fallback is empty — the embed→INSERT path did not run."
+                "fallback is empty -- the embed->INSERT path did not run."
             )
 
     def test_sleep_consolidated_content_is_recallable(self, temp_db, monkeypatch):

--- a/tests/test_t1_local_llm_default_disabled.py
+++ b/tests/test_t1_local_llm_default_disabled.py
@@ -1,0 +1,215 @@
+"""
+Regression tests for the conftest's default-disable of local LLM
+inference (T1, follow-up to the 2026-05-12 security audit).
+
+Background: in dev environments that have a GGUF model file on disk
+plus ``llama-cpp-python`` or ``ctransformers`` installed (e.g. the
+Hermes Agent venv with tinyllama at
+``~/.hermes/mnemosyne/models/``), ``local_llm._load_llm()`` auto-loads
+the model. ``beam.sleep()`` tests that don't explicitly monkeypatch
+``llm_available`` then run real CPU inference -- 5-30s per call,
+turning a 20-second suite into a 15+ minute one.
+
+The autouse fixture ``_disable_local_llm_inference`` in
+``tests/conftest.py`` neutralises this by replacing ``_load_llm``
+with a stub that returns None. The opt-in fixture
+``local_llm_enabled`` lets specific tests put a fake LLM back in
+place.
+
+This file locks in:
+  1. The default-disable actually works.
+  2. The opt-in fixture restores a working LLM path.
+  3. Per-test ``monkeypatch.setattr(local_llm, "_load_llm", ...)``
+     still wins over the autouse default (existing tests in
+     ``test_extraction.py`` rely on this).
+
+Run with: pytest tests/test_t1_local_llm_default_disabled.py -v
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Default state (autouse fixture)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultDisabled:
+    """Without opting in, no test should see a working local LLM."""
+
+    def test_llm_available_returns_false_by_default(self):
+        """The most important contract -- gating callers see False."""
+        from mnemosyne.core import local_llm
+        assert local_llm.llm_available() is False
+
+    def test_load_llm_returns_none_by_default(self):
+        """``_load_llm`` is the stub."""
+        from mnemosyne.core import local_llm
+        assert local_llm._load_llm() is None
+
+    def test_call_local_llm_returns_none_by_default(self):
+        """The whole call path short-circuits cleanly."""
+        from mnemosyne.core import local_llm
+        result = local_llm._call_local_llm("anything")
+        assert result is None
+
+    def test_cached_flags_reset_per_test(self):
+        """Each test sees a fresh (None, None, None) cache state.
+
+        Without this, a previous test that set ``_llm_available = True``
+        would leak forward.
+        """
+        from mnemosyne.core import local_llm
+        assert local_llm._llm_available is None
+        assert local_llm._llm_instance is None
+        assert local_llm._llm_backend is None
+
+
+# ---------------------------------------------------------------------------
+# Opt-in via the local_llm_enabled fixture
+# ---------------------------------------------------------------------------
+
+
+class TestOptInFixture:
+    """``local_llm_enabled`` fixture restores a working LLM path."""
+
+    def test_fixture_makes_llm_available_true(self, local_llm_enabled):
+        from mnemosyne.core import local_llm
+        assert local_llm.llm_available() is True
+
+    def test_fixture_provides_ctransformers_style_callable(self, local_llm_enabled):
+        """ctransformers backend: the loaded object is callable."""
+        from mnemosyne.core import local_llm
+        llm = local_llm._load_llm()
+        assert llm is not None
+        # ctransformers-style: instance is directly callable
+        result = llm("test prompt")
+        assert result == "fake summary"
+
+    def test_fixture_provides_llamacpp_style_interface(self, local_llm_enabled):
+        """llama-cpp-python backend: create_chat_completion method exists."""
+        from mnemosyne.core import local_llm
+        llm = local_llm._load_llm()
+        result = llm.create_chat_completion(
+            messages=[{"role": "user", "content": "test"}]
+        )
+        assert result["choices"][0]["message"]["content"] == "fake summary"
+
+    def test_response_is_customizable(self, local_llm_enabled):
+        """Tests can override the fake response per-test."""
+        local_llm_enabled.response = "different output"
+        from mnemosyne.core import local_llm
+        llm = local_llm._load_llm()
+        assert llm("anything") == "different output"
+
+    def test_isolation_after_opt_in_test(self):
+        """A NEXT test (this one) without the fixture should see the
+        default-disabled state again -- the opt-in didn't leak."""
+        from mnemosyne.core import local_llm
+        assert local_llm.llm_available() is False
+        assert local_llm._load_llm() is None
+
+
+# ---------------------------------------------------------------------------
+# Compatibility with per-test patches (existing tests rely on this)
+# ---------------------------------------------------------------------------
+
+
+class TestPerTestPatchOverridesAutouse:
+    """Tests that monkeypatch ``_load_llm`` themselves must still win."""
+
+    def test_monkeypatch_load_llm_after_autouse_takes_effect(self, monkeypatch):
+        """``monkeypatch.setattr`` applied INSIDE the test body should
+        override the autouse fixture's setattr, because pytest applies
+        setattrs in call order and the test's setattr happens later.
+
+        This mirrors what ``tests/test_extraction.py`` and other
+        existing tests do."""
+        from mnemosyne.core import local_llm
+
+        def fake_load():
+            class _F:
+                def __call__(self, prompt, *a, **kw):
+                    return "per-test fake"
+            return _F()
+
+        monkeypatch.setattr(local_llm, "_load_llm", fake_load)
+        llm = local_llm._load_llm()
+        assert llm is not None
+        assert llm("anything") == "per-test fake"
+
+    def test_patch_object_context_manager_overrides_autouse(self):
+        """``unittest.mock.patch.object`` (context manager) entered
+        after the autouse fixture should also win."""
+        from unittest.mock import patch
+        from mnemosyne.core import local_llm
+
+        class _F:
+            def __call__(self, prompt, *a, **kw):
+                return "ctx-mgr fake"
+
+        with patch.object(local_llm, "_load_llm", return_value=_F()):
+            llm = local_llm._load_llm()
+            assert llm("anything") == "ctx-mgr fake"
+
+        # After the `with`, autouse default is restored
+        assert local_llm._load_llm() is None
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the real bug stays fixed
+# ---------------------------------------------------------------------------
+
+
+class TestSleepIsFast:
+    """End-to-end check: ``beam.sleep()`` no longer invokes real
+    inference when run from a venv that happens to have a GGUF model on
+    disk. We can't directly assert "no model loaded" portably, but we
+    CAN assert the deterministic non-LLM summary path is hit by
+    confirming the consolidation completes nearly instantly.
+
+    A regression that re-enables the LLM by default would make this
+    test slow (seconds-to-minutes) -- detectable by CI runtime.
+    """
+
+    def test_sleep_does_not_hit_llm(self, tmp_path, monkeypatch):
+        """If anything calls _call_local_llm during sleep, it should
+        return None (the autouse stub). Sleep should still succeed
+        using the deterministic AAAK fallback."""
+        import sqlite3
+        from datetime import datetime, timedelta
+        from mnemosyne.core.beam import BeamMemory
+        from mnemosyne.core import local_llm
+
+        # Track whether anything tried to load the LLM
+        call_count = {"loads": 0}
+        original_load = local_llm._load_llm
+
+        def counting_load():
+            call_count["loads"] += 1
+            return original_load()  # still returns None per autouse
+
+        monkeypatch.setattr(local_llm, "_load_llm", counting_load)
+
+        db = tmp_path / "t1_sleep.db"
+        beam = BeamMemory(session_id="s1", db_path=db)
+        conn = sqlite3.connect(db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        conn.executemany(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            [(f"old{i}", f"task {i}", "conversation", old_ts, "s1")
+             for i in range(3)],
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.sleep(dry_run=False)
+        assert result["status"] == "consolidated"
+        assert result["items_consolidated"] == 3
+
+        # Even if _load_llm was called, it returned None (the stub),
+        # so no actual inference happened. The assertion isn't on
+        # call_count -- we just want to know sleep succeeded without
+        # blocking on a real model.


### PR DESCRIPTION
## Summary

Test-environment fix. Independent of PR #98 (security).

In dev environments that have a GGUF model file on disk plus `llama-cpp-python` or `ctransformers` installed (e.g. the Hermes Agent venv at `~/.hermes/hermes-agent/venv` with tinyllama at `~/.hermes/mnemosyne/models/`), `local_llm._load_llm()` auto-loads the model on first call. Any test that exercises a summarization path (`beam.sleep()`, `consolidate_to_episodic`, SHMR, extraction fallback) then runs real CPU inference — **5–30 seconds per call**, multiplied by the number of items consolidated. The full suite goes from **~20s on CI** (no model on disk) to **15+ minutes** locally on a developer laptop.

## What this PR adds

1. **Autouse fixture `_disable_local_llm_inference`** in `tests/conftest.py`. Replaces `_load_llm` with a stub that returns None and clears cached flags. `llm_available()` then returns False via path 3 (the `_load_llm()` fall-through); `_call_local_llm` short-circuits on `llm is None`. Tests behave like CI by default.

2. **Opt-in fixture `local_llm_enabled`** for tests that want a working LLM path. Installs a deterministic fake LLM that implements both the ctransformers callable interface AND `create_chat_completion` (llama-cpp-python style), so tests don't have to care which backend a given code path expects.

3. **Pre-existing test bug fix** in `test_sleep_writes_dense_embedding_for_consolidated_row`. The test was reading `vec_episodes` via a fresh `sqlite3.connect()` connection that doesn't have the sqlite-vec extension loaded, so `_vec_available()` returned False on that connection and the test fell through to checking the `memory_embeddings` fallback — which was empty because beam wrote to `vec_episodes` via its own (extension-loaded) connection. Switched the read to `beam.conn`, the authoritative reader. The test was hidden by the slow LLM path before this PR; running the suite to completion now exposes it.

4. **12 regression tests** in `tests/test_t1_local_llm_default_disabled.py` covering: default-disable contract, opt-in fixture behaviour, per-test `monkeypatch.setattr` and `unittest.mock.patch.object` override semantics, isolation between tests, and an end-to-end "sleep doesn't load a real model" check.

## Compatibility

- pytest's `monkeypatch` fixture is function-scoped; later `setattr` calls win. Tests in `test_extraction.py` and elsewhere that explicitly `monkeypatch.setattr(local_llm, "_load_llm", fake)` inside their bodies continue to work — the per-test setattr overrides the autouse default.
- `unittest.mock.patch.object(local_llm, "_load_llm", ...)` context managers also override correctly (verified by `TestPerTestPatchOverridesAutouse`).
- Existing `_close_cached_connections` helper already resets the host LLM backend registry between tests, so this PR composes with that.
- All 15 tests in `test_local_llm.py` (which exercises LLM paths via explicit mocks) pass under the autouse fixture.

## Empirics

| Suite | Before | After |
|---|---|---|
| Hermes venv full suite | 15+ min (never finished cleanly under timeout) | **87s, 1139/1139 pass** |
| Clean .venv full suite | 19.6s, 1110/1110 pass | **19.6s, 1110/1110 pass** (unaffected) |
| `tests/test_beam.py::TestSleepCycle` (the worst offender) | 6/7 timed out at 30s each | **7/7 pass in 1.3s** |

## Test plan

- [x] Targeted new-test slice: `pytest tests/test_t1_local_llm_default_disabled.py` — 12/12 pass in 1.0s
- [x] Previously-slow files: `test_beam.py`, `test_beam_e3_additive_sleep.py`, `test_temporal_recall.py` — all pass in <3s each
- [x] LLM-aware tests: `test_local_llm.py` — 15/15 pass under the autouse fixture
- [x] Full suite in hermes venv: 1139/1139 pass in 87s
- [ ] CI will run the full matrix

## Why this isn't bundled with PR #98 (security)

PR #98 is "harden MCP SSE transport, gitignore, action pinning" — three small mechanical security fixes. This is a developer-experience fix for the test suite. Different scope, different blast radius, different reviewer mental model. Kept separate so the security PR stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)