### PR TITLE
feat: identity memory source type — auto-capture when users express identity-significant feelings

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -51,7 +51,7 @@ REMEMBER_SCHEMA = {
     "name": "mnemosyne_remember",
     "description": (
         "Store a durable memory in Mnemosyne. Use for ANY fact, preference, "
-        "insight, or context that should persist across sessions. Higher importance "
+        "identity, insight, or context that should persist across sessions. Higher importance "
         "(0.0-1.0) surfaces the memory more often. Use scope='global' for user-level "
         "facts; scope='session' for conversation-specific context. Use valid_until "
         "(ISO date YYYY-MM-DD) for time-bound facts. Use extract_entities=True to "
@@ -66,7 +66,7 @@ REMEMBER_SCHEMA = {
         "properties": {
             "content": {"type": "string", "description": "The memory content to store."},
             "importance": {"type": "number", "description": "Importance 0.0-1.0. Default 0.5.", "default": 0.5},
-            "source": {"type": "string", "description": "Source tag: preference, fact, insight, task, etc.", "default": "user"},
+            "source": {"type": "string", "description": "Source tag: preference, fact, insight, identity, task, etc.", "default": "user"},
             "scope": {"type": "string", "description": "'session' (default) or 'global'.", "default": "session"},
             "valid_until": {"type": "string", "description": "Optional expiry date YYYY-MM-DD.", "default": ""},
             "extract_entities": {"type": "boolean", "description": "Extract named entities for fuzzy recall. Default False.", "default": False},
@@ -481,7 +481,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
         return (
             "# Mnemosyne Memory\n"
             "Active (native local memory). Use mnemosyne_remember to store ANY "
-            "durable fact, preference, or insight. Use mnemosyne_recall to search. "
+            "durable fact, preference, identity, or insight. Use mnemosyne_recall to search. "
             "The legacy memory tool is deprecated for durable storage — Mnemosyne is primary."
         )
 
@@ -535,6 +535,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     importance=0.3,
                     extract_entities=True,
                 )
+                # Check for identity-significant signals in user content
+                self._capture_identity_signals(user_content)
             if assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
                 self._beam.remember(
                     content=f"[ASSISTANT] {assistant_content[:800]}",
@@ -547,6 +549,37 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 self._maybe_auto_sleep()
         except Exception as e:
             logger.debug("Mnemosyne sync_turn failed: %s", e)
+
+    # Identity-significant expressions the user may voice about themselves or
+    # their relationship to their work. When a match is found, the memory is
+    # saved with source="identity" and higher importance so it survives
+    # consolidation and remains recallable across sessions.
+    _IDENTITY_SIGNALS: List[str] = [
+        "feeling like",
+        "imposter",
+        "impostor",
+        "barely know",
+        "don't know my own",
+        "don't even know how",
+        "want them to feel",
+        "i'm proud",
+        "i feel like a",
+        "i don't know how to",
+    ]
+
+    def _capture_identity_signals(self, user_content: str) -> None:
+        content_lower = user_content.lower()
+        for signal in self._IDENTITY_SIGNALS:
+            if signal in content_lower:
+                # Save identity memory with high importance for durable recall
+                self._beam.remember(
+                    content=f"[IDENTITY] {user_content[:400]}",
+                    source="identity",
+                    importance=0.85,
+                    scope="global",
+                    veracity="stated",
+                )
+                break  # One identity memory per turn
 
     def _maybe_auto_sleep(self) -> None:
         try:

--- a/hermes_plugin/tools.py
+++ b/hermes_plugin/tools.py
@@ -25,7 +25,7 @@ REMEMBER_SCHEMA = {
             },
             "source": {
                 "type": "string",
-                "description": "Source of the memory (preference, fact, conversation, etc.)"
+                "description": "Source of the memory (preference, fact, identity, conversation, etc.)"
             },
             "valid_until": {
                 "type": "string",

--- a/tests/test_identity_memory.py
+++ b/tests/test_identity_memory.py
@@ -1,0 +1,114 @@
+"""Tests for identity memory auto-capture in sync_turn()."""
+
+import pytest
+import sqlite3
+import os
+import tempfile
+from unittest.mock import patch, MagicMock
+
+
+class TestIdentitySignals:
+    """Verify _capture_identity_signals detects identity-significant expressions."""
+
+    @pytest.fixture
+    def provider(self):
+        """Create a MnemosyneMemoryProvider with a temp database."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "mnemosyne.db")
+            provider = MnemosyneMemoryProvider()
+            # Initialize with temp path
+            provider._agent_context = "test"
+            provider._session_id = "test-session"
+            provider._skip_contexts = set()
+            provider._turn_count = 0
+            provider._auto_sleep_enabled = False
+
+            from mnemosyne.core.beam import BeamMemory
+            beam = BeamMemory(db_path=db_path)
+            beam.initialize()
+            provider._beam = beam
+
+            yield provider
+
+            # Cleanup
+            try:
+                os.remove(db_path)
+                for ext in ("-wal", "-shm"):
+                    try:
+                        os.remove(db_path + ext)
+                    except OSError:
+                        pass
+            except OSError:
+                pass
+
+    def test_captures_imposter_syndrome(self, provider):
+        """Identity memory saved when user expresses imposter feelings."""
+        provider._beam.remember = MagicMock()
+        provider.sync_turn(
+            "I feel like an imposter, I barely know my own codebase",
+            "Response here",
+        )
+        # Should have called remember for identity signal
+        identity_calls = [
+            c for c in provider._beam.remember.call_args_list
+            if c.kwargs.get("source") == "identity"
+        ]
+        assert len(identity_calls) >= 1
+        call = identity_calls[0].kwargs
+        assert call["importance"] >= 0.8
+        assert call["scope"] == "global"
+        assert call["source"] == "identity"
+
+    def test_captures_pride(self, provider):
+        """Identity memory saved when user expresses pride."""
+        provider._beam.remember = MagicMock()
+        provider.sync_turn(
+            "I'm proud of what we shipped today",
+            "Great work!",
+        )
+        identity_calls = [
+            c for c in provider._beam.remember.call_args_list
+            if c.kwargs.get("source") == "identity"
+        ]
+        assert len(identity_calls) >= 1
+
+    def test_no_false_positive_on_neutral(self, provider):
+        """No identity memory for neutral conversation."""
+        provider._beam.remember = MagicMock()
+        provider.sync_turn(
+            "Can you run the build and deploy to production?",
+            "Sure, running build now.",
+        )
+        identity_calls = [
+            c for c in provider._beam.remember.call_args_list
+            if c.kwargs.get("source") == "identity"
+        ]
+        assert len(identity_calls) == 0
+
+    def test_only_one_identity_per_turn(self, provider):
+        """Only one identity memory saved per turn (break after first match)."""
+        provider._beam.remember = MagicMock()
+        provider.sync_turn(
+            "I feel like a fraud and I don't even know how to fix this",
+            "Let me help.",
+        )
+        identity_calls = [
+            c for c in provider._beam.remember.call_args_list
+            if c.kwargs.get("source") == "identity"
+        ]
+        assert len(identity_calls) == 1
+
+    def test_identity_stored_in_db(self, provider):
+        """Identity memory actually persists to the database."""
+        provider.sync_turn(
+            "I feel like I barely know my own architecture",
+            "Response",
+        )
+        # Query the database directly
+        rows = provider._beam.recall("imposter feeling architecture")
+        identity_rows = [r for r in rows if r.get("source") == "identity"]
+        assert len(identity_rows) >= 1
+        assert identity_rows[0]["importance"] >= 0.8
+        assert "[IDENTITY]" in identity_rows[0]["content"]


### PR DESCRIPTION
Closes #104

## What

Adds `identity` as a first-class memory source type in Mnemosyne. The auto-memory system now detects when a user expresses identity-significant feelings and saves them with high importance for durable recall.

## Why

The current auto-memory system only captures:
- Preferences ("user prefers short responses")
- Environment facts ("project uses pytest")
- Conventions ("tags use kebab-case")

It has no awareness of emotional or identity-relevant conversations. When a user talks about feeling unsure about their work, questioning their expertise, or expressing pride in a feature they shipped — those are the most important things to remember, and Mnemosyne currently misses them all.

## Changes

### Tool schemas
- `REMEMBER_SCHEMA` source description now includes `identity`
- System prompt blurb updated: "durable fact, preference, **identity**, or insight"
- Plugin tools source description updated

### Auto-capture in `sync_turn()`
New `_capture_identity_signals()` method runs after every user turn. Detects identity-significant expressions via keyword matching:
- "feeling like", "imposter/impostor", "barely know"
- "don't know my own", "don't even know how"
- "i'm proud", "want them to feel"

When a match is found, saves as:
- `source="identity"` — new source type
- `importance=0.85` — high priority for recall
- `scope="global"` — survives session boundaries
- `veracity="stated"` — direct user assertion

Only one identity memory per turn (break after first match).

### Tests
5 test cases in `tests/test_identity_memory.py`:
- Detects imposter syndrome expressions
- Detects pride expressions  
- No false positives on neutral conversation
- Only one identity memory per turn
- Identity memory persists to database and is recallable

## Impact

- **Breaking change**: No. New source type, existing memories unchanged.
- **Storage**: Minimal — identity memories in the tens per user.
- **Runtime**: Negligible — simple string contains checks, no LLM calls.