### PR TITLE
fix: two bugs in PR #106's identity-memory test fixture blocking CI

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1340,6 +1340,17 @@ class BeamMemory:
         self.author_id = author_id
         self.author_type = author_type
         self.channel_id = channel_id or session_id  # default channel = session
+        # Coerce path-like inputs (e.g. tempfile-produced strings) to a
+        # Path so downstream consumers like _get_connection that do
+        # `path.parent.mkdir(...)` don't blow up with
+        # ``AttributeError: 'str' object has no attribute 'parent'``.
+        # The previous contract was implicit (Path-only); making it
+        # explicit here is backward-compatible -- a real Path stays a
+        # Path -- and unbreaks every caller that passes a string,
+        # including the test_identity_memory.py fixtures added by
+        # PR #106 which now run on every PR's CI matrix.
+        if db_path is not None and not isinstance(db_path, Path):
+            db_path = Path(db_path)
         self.db_path = db_path or _default_db_path()
         self.use_cloud = use_cloud  # Enable LLM fact extraction during remember()
         self._extraction_client = None  # Lazy-loaded ExtractionClient

--- a/tests/test_beam_db_path_string_coercion.py
+++ b/tests/test_beam_db_path_string_coercion.py
@@ -1,0 +1,71 @@
+"""
+Regression test: ``BeamMemory(db_path=<str>)`` must work.
+
+PR #106 added ``tests/test_identity_memory.py`` whose fixtures pass a
+string ``db_path`` directly:
+
+    beam = BeamMemory(db_path=db_path)  # db_path is a tempfile string
+
+Pre-fix, ``BeamMemory.__init__`` stored the string as-is, then
+``_get_connection`` did ``path.parent.mkdir(...)`` which raised
+``AttributeError: 'str' object has no attribute 'parent'`` -- breaking
+every PR's CI matrix on the test_identity_memory.py setup phase.
+
+Fix: ``BeamMemory.__init__`` coerces any non-Path input via
+``Path(db_path)`` before storage. Real ``Path`` inputs stay ``Path``;
+strings get coerced; ``None`` still gets ``_default_db_path()``.
+
+Run with: pytest tests/test_beam_db_path_string_coercion.py -v
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+
+
+class TestBeamMemoryDbPathCoercion:
+    """``db_path`` accepts str / Path / None uniformly."""
+
+    def test_accepts_string_db_path(self, tmp_path):
+        """The PR #106 fixture pattern: pass a string path. Pre-fix this
+        crashed in _get_connection with AttributeError on .parent."""
+        db_path_str = str(tmp_path / "mnemosyne.db")
+        # Must not raise
+        beam = BeamMemory(session_id="s1", db_path=db_path_str)
+        # And internal state is now a Path (so downstream consumers
+        # that expect .parent etc. work)
+        assert isinstance(beam.db_path, Path)
+        assert beam.db_path == Path(db_path_str)
+        beam.conn.close()
+
+    def test_accepts_path_db_path(self, tmp_path):
+        """Pre-fix behavior preserved for Path callers."""
+        db_path = tmp_path / "mnemosyne.db"
+        beam = BeamMemory(session_id="s1", db_path=db_path)
+        assert isinstance(beam.db_path, Path)
+        assert beam.db_path == db_path
+        beam.conn.close()
+
+    def test_accepts_none_db_path(self, tmp_path, monkeypatch):
+        """None falls back to _default_db_path() (a Path)."""
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+        beam = BeamMemory(session_id="s1", db_path=None)
+        assert isinstance(beam.db_path, Path)
+        beam.conn.close()
+
+    def test_get_connection_accepts_string_after_coercion(self, tmp_path):
+        """End-to-end smoke: the failing operation pre-fix was
+        ``self.db_path.parent.mkdir(...)`` inside ``_get_connection``.
+        After the coercion the call site doesn't change but ``self.db_path``
+        is now always a Path, so ``.parent`` works."""
+        db_path_str = str(tmp_path / "subdir" / "mnemosyne.db")
+        # Note: subdir doesn't exist yet -- mkdir(parents=True) creates it.
+        # Pre-fix this raised AttributeError on the path-as-string.
+        beam = BeamMemory(session_id="s1", db_path=db_path_str)
+        assert (tmp_path / "subdir").is_dir()
+        beam.conn.close()

--- a/tests/test_identity_memory.py
+++ b/tests/test_identity_memory.py
@@ -26,8 +26,12 @@ class TestIdentitySignals:
             provider._auto_sleep_enabled = False
 
             from mnemosyne.core.beam import BeamMemory
+            # BeamMemory has no separate initialize() method -- __init__
+            # already opens the connection and runs init_beam() (schema
+            # setup, sleep_log, etc.). The previous beam.initialize()
+            # call raised AttributeError, breaking this fixture on every
+            # PR's CI run. Drop it; __init__ is sufficient.
             beam = BeamMemory(db_path=db_path)
-            beam.initialize()
             provider._beam = beam
 
             yield provider


### PR DESCRIPTION
## Summary

PR #106 added ``tests/test_identity_memory.py`` whose fixture errors on **every PR's CI matrix** with two separate setup failures, currently blocking all five of my open PRs (#98, #101, #102, #105, #107). Same fixture errors would block every future PR until fixed.

The fixture is correct in intent — the test BODIES exercise real behavior. Only the setup has two bugs that combined to make the suite show `5 errors` and mark the CI run failed.

## Two bugs in the same fixture

### Bug 1: `BeamMemory(db_path=<str>)` crashes at first connection

```python
beam = BeamMemory(db_path=db_path)  # db_path is a tempfile string
```

`BeamMemory.__init__` stored the string as-is, then `_get_connection` at `beam.py:326` did `path.parent.mkdir(parents=True, exist_ok=True)` → ``AttributeError: 'str' object has no attribute 'parent'``.

**Fix**: `BeamMemory.__init__` now coerces any non-Path `db_path` via `Path(db_path)` before storage. Backward-compatible — real `Path` inputs stay `Path`, strings get coerced, `None` still falls back to `_default_db_path()`. The implicit Path-only contract is now explicit and tolerant.

### Bug 2: `beam.initialize()` is not a thing

```python
beam = BeamMemory(db_path=db_path)
beam.initialize()  # <-- AttributeError
```

`BeamMemory` has no `initialize()` method. `MnemosyneMemoryProvider` does, and the test author may have left this over from a refactor. `BeamMemory.__init__` already opens the connection and runs `init_beam()` for schema setup.

**Fix**: drop the spurious `beam.initialize()` call from the fixture.

## Test plan

- [x] New `tests/test_beam_db_path_string_coercion.py`: 4 regression tests pinning the db_path acceptance contract across `str` / `Path` / `None` inputs, plus an end-to-end smoke that exercises the `.parent.mkdir(parents=True)` path that the original AttributeError hit.
- [x] PR #106's 5 identity tests now pass (verified locally with the fix).
- [x] 143/143 in the broader slice across hermes_memory_provider, hermes_plugin_session, plugins, integration, data_dir_scripts.
- [ ] CI matrix will confirm.

## Why this PR exists

This fix could/should land on main directly without going through a PR, but since the CI bug is blocking five separate open PRs that I've been shipping, this is the fastest path to unblock all of them at once. Maintainer can land this first, then rebase the other five PRs onto the cleaned main.

If you'd prefer to fold these two changes into a different PR, happy to close this one — just say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)