### PR TITLE
fix(C29): coerce str db_path to Path in _get_connection (beam.py)

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -321,7 +321,7 @@ def _get_connection(db_path: Path = None) -> sqlite3.Connection:
     `_deferred_commits`. Connection is otherwise identical to a
     plain sqlite3.Connection.
     """
-    path = db_path or _default_db_path()
+    path = Path(db_path) if db_path else _default_db_path()
     if not hasattr(_thread_local, 'conn') or _thread_local.conn is None or getattr(_thread_local, 'db_path', None) != str(path):
         path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(


### PR DESCRIPTION
## Summary

`beam.py`'s `_get_connection` called `path = db_path or _default_db_path()` without coercing `db_path` to `Path`, causing `AttributeError: 'str' object has no attribute 'parent'` when callers pass a plain string (e.g. from config.yaml).

`memory.py`'s `_get_connection` (line 55) already does `path = Path(db_path) if db_path else _default_db_path()`. This PR brings `beam.py` in line.

## Fix

One-line change: `path = Path(db_path) if db_path else _default_db_path()`

## Test

```python
_get_connection('/tmp/test.db')           # str → OK
_get_connection(Path('/tmp/test.db'))     # Path → OK
_get_connection()                         # None → OK
```

Closes #117