### PR TITLE
fix: update_working refresh embeddings (#110), health() check (#115), valid_from for occurred_on (#111)

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2126,13 +2126,20 @@ class BeamMemory:
 
     def update_working(self, memory_id: str, content: str = None,
                        importance: float = None) -> bool:
-        """Update a working_memory entry."""
+        """Update a working_memory entry.
+
+        After updating content, reindexes FTS5 (via wm_au trigger) and
+        recomputes the vector embedding in memory_embeddings so recall()
+        returns the corrected content instead of stale derived state.
+        """
         cursor = self.conn.cursor()
         updates = []
         params = []
+        content_changed = False
         if content is not None:
             updates.append("content = ?")
             params.append(content)
+            content_changed = True
         if importance is not None:
             updates.append("importance = ?")
             params.append(importance)
@@ -2143,8 +2150,32 @@ class BeamMemory:
             f"UPDATE working_memory SET {', '.join(updates)} WHERE id = ? AND session_id = ?",
             params
         )
+        affected = cursor.rowcount
+
+        # Refresh derived state when content changed.
+        # FTS5 is handled by the wm_au trigger (AFTER UPDATE OF content),
+        # but memory_embeddings must be recomputed explicitly.
+        if content_changed and affected > 0 and _embeddings.available():
+            try:
+                vec = _embeddings.embed([content])
+                if vec is not None and len(vec) > 0:
+                    model = _embeddings._DEFAULT_MODEL
+                    emb_json = _embeddings.serialize(vec[0])
+                    cursor.execute(
+                        "INSERT OR REPLACE INTO memory_embeddings"
+                        " (memory_id, embedding_json, model)"
+                        " VALUES (?, ?, ?)",
+                        (memory_id, emb_json, model),
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "update_working: embedding refresh failed for %s"
+                    " (%s): %s",
+                    memory_id, type(exc).__name__, exc,
+                )
+
         self.conn.commit()
-        return cursor.rowcount > 0
+        return affected > 0
 
     def forget_working(self, memory_id: str) -> bool:
         # E6.a: the cascade-delete of annotations must be authorized by the
@@ -4212,6 +4243,91 @@ class BeamMemory:
         return [dict(row) for row in cursor.fetchall()]
 
     # ------------------------------------------------------------------
+    # Consolidation Health Check
+    # ------------------------------------------------------------------
+    def health(self, stale_threshold_hours: float = 24.0) -> Dict:
+        """Return consolidation health status for monitoring/alerting.
+
+        Checks:
+        - last successful consolidation timestamp (from consolidation_log)
+        - error count in recent attempts (last 100 log entries)
+        - stale threshold alert: no consolidation in `stale_threshold_hours`
+
+        Returns a dict with keys: ``status`` (\"healthy\" | \"stale\" | \"no_data\"),
+        ``last_successful_consolidation``, ``error_count``, ``stale_hours``,
+        ``details``, and ``recommendation``.
+        """
+        cursor = self.conn.cursor()
+
+        # Last successful consolidation across ALL sessions (not just
+        # self.session_id) so a health monitor run from an active session
+        # can detect that an inactive-session's sleep_all_sessions
+        # maintenance broke silently.
+        cursor.execute("""
+            SELECT max(created_at) AS last_consolidation
+            FROM consolidation_log
+            WHERE items_consolidated > 0
+        """)
+        row = cursor.fetchone()
+        last_ts_str = row["last_consolidation"] if row and row["last_consolidation"] else None
+
+        # Error count: look at entries with zero items_consolidated but
+        # a non-empty summary_preview that suggests an attempted run.
+        # Also scan sleep_all_sessions "errors" recorded via
+        # summary_preview text patterns.
+        cursor.execute("""
+            SELECT count(*) AS err_count
+            FROM consolidation_log
+            WHERE created_at > datetime('now', '-7 days')
+              AND (
+                  items_consolidated = 0
+                  AND summary_preview LIKE '%error%'
+                  OR summary_preview LIKE '%fail%'
+              )
+        """)
+        error_count = cursor.fetchone()["err_count"]
+
+        now = datetime.now()
+
+        # Determine status
+        if last_ts_str is None:
+            status = "no_data"
+            stale_hours = None
+            recommendation = (
+                "No consolidation_log entries found with items_consolidated > 0. "
+                "Either sleep() has never run, or all runs have produced zero "
+                "summaries. Run sleep_all_sessions() or check logs."
+            )
+        else:
+            last_ts = datetime.fromisoformat(last_ts_str)
+            stale_hours = round((now - last_ts).total_seconds() / 3600.0, 2)
+            if stale_hours > stale_threshold_hours:
+                status = "stale"
+                recommendation = (
+                    f"Last successful consolidation was {stale_hours:.1f} hours ago "
+                    f"(threshold: {stale_threshold_hours:.0f}h). "
+                    "Run sleep_all_sessions() to catch up, and investigate why "
+                    "scheduled consolidation stopped (e.g. LLM unreachable, "
+                    "silent failures in summarize_memories, or cron/loop down)."
+                )
+            else:
+                status = "healthy"
+                recommendation = "Consolidation is within the healthy window."
+
+        return {
+            "status": status,
+            "last_successful_consolidation": last_ts_str,
+            "error_count": error_count,
+            "stale_hours": stale_hours,
+            "stale_threshold_hours": stale_threshold_hours,
+            "details": {
+                "stale": status == "stale",
+                "consolidation_log_entries_checked": "last 7 days",
+            },
+            "recommendation": recommendation,
+        }
+
+    # ------------------------------------------------------------------
     # Consolidation / Sleep
     # ------------------------------------------------------------------
     def sleep(self, dry_run: bool = False) -> Dict:
@@ -4371,6 +4487,11 @@ class BeamMemory:
 
             # --- Fallback to aaak encoding ---
             if summary is None:
+                logger.warning(
+                    "sleep: LLM summarization failed for source=%r (items=%d, "
+                    "llm_available=%s) — falling back to AAAK compression",
+                    source, len(items), local_llm.llm_available(),
+                )
                 combined = " | ".join(lines)
                 compressed = aaak_encode(combined)
                 summary = f"[{source}] {compressed}"
@@ -4495,6 +4616,10 @@ class BeamMemory:
                     summaries_created += int(result.get("summaries_created", 0) or 0)
                     llm_used += int(result.get("llm_used", 0) or 0)
             except Exception as exc:
+                logger.error(
+                    "sleep_all_sessions: session %r consolidation failed: %s",
+                    session_id, exc, exc_info=True,
+                )
                 errors.append({"session_id": session_id, "error": repr(exc)})
 
         # Run tiered degradation after all-sessions consolidation

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -413,6 +413,126 @@ def _handle_get_stats(arguments: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _handle_triple_add(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Handle mnemosyne_triple_add tool call.
+
+    Routes annotation-flavored predicates (mentions, fact, occurred_on,
+    has_source) to AnnotationStore; everything else to TripleStore.
+    For occurred_on, valid_from is forwarded to AnnotationStore (issue #111).
+    """
+    import logging
+    _log = logging.getLogger("mnemosyne.mcp.triple_add")
+
+    from mnemosyne.core.annotations import ANNOTATION_KINDS, AnnotationStore
+    from mnemosyne.core.triples import TripleStore
+
+    predicate = arguments["predicate"]
+
+    if isinstance(predicate, str) and predicate in ANNOTATION_KINDS:
+        # Annotation-flavored predicate — route to AnnotationStore.
+        bank = _resolve_bank(arguments)
+        mem = _create_instance(bank=bank)
+        db_path = mem.beam.db_path if hasattr(mem.beam, "db_path") else mem.db_path
+
+        store = getattr(mem.beam, "annotations", None)
+        if store is None:
+            store = AnnotationStore(db_path=db_path, conn=mem.beam.conn)
+
+        valid_from = arguments.get("valid_from")
+
+        if predicate == "occurred_on" and valid_from:
+            row_id = store.add(
+                memory_id=arguments["subject"],
+                kind=predicate,
+                value=arguments["object"],
+                source=arguments.get("source", "conversation"),
+                confidence=arguments.get("confidence", 1.0),
+                valid_from=valid_from,
+            )
+        else:
+            if valid_from:
+                _log.warning(
+                    "mnemosyne_triple_add: valid_from=%r provided with "
+                    "predicate=%r (not occurred_on); valid_from discarded.",
+                    valid_from, predicate,
+                )
+            row_id = store.add(
+                memory_id=arguments["subject"],
+                kind=predicate,
+                value=arguments["object"],
+                source=arguments.get("source", "conversation"),
+                confidence=arguments.get("confidence", 1.0),
+            )
+
+        return {
+            "status": "added",
+            "annotation_id": row_id,
+            "store": "annotations",
+        }
+
+    # Current-truth temporal fact — route to TripleStore.
+    bank = _resolve_bank(arguments)
+    mem = _create_instance(bank=bank)
+    db_path = mem.beam.db_path if hasattr(mem.beam, "db_path") else mem.db_path
+    kg = TripleStore(db_path=db_path)
+    triple_id = kg.add(
+        subject=arguments["subject"],
+        predicate=predicate,
+        object=arguments["object"],
+        valid_from=arguments.get("valid_from"),
+        source=arguments.get("source", "conversation"),
+        confidence=arguments.get("confidence", 1.0),
+    )
+    return {
+        "status": "added",
+        "triple_id": triple_id,
+        "store": "triples",
+    }
+
+
+def _handle_triple_query(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Handle mnemosyne_triple_query tool call.
+
+    Mirrors the write-side routing: annotation predicates query
+    AnnotationStore; others query TripleStore.
+    """
+    from mnemosyne.core.annotations import ANNOTATION_KINDS, AnnotationStore
+    from mnemosyne.core.triples import TripleStore
+
+    predicate = arguments.get("predicate")
+    bank = _resolve_bank(arguments)
+    mem = _create_instance(bank=bank)
+    db_path = mem.beam.db_path if hasattr(mem.beam, "db_path") else mem.db_path
+
+    if isinstance(predicate, str) and predicate in ANNOTATION_KINDS:
+        store = getattr(mem.beam, "annotations", None)
+        if store is None:
+            store = AnnotationStore(db_path=db_path, conn=mem.beam.conn)
+        results = store.query_by_kind(
+            kind=predicate,
+            value=arguments.get("object"),
+            memory_id=arguments.get("subject"),
+        )
+        return {
+            "results_count": len(results),
+            "results": results,
+            "store": "annotations",
+        }
+
+    kg = TripleStore(db_path=db_path)
+    results = kg.query(
+        subject=arguments.get("subject"),
+        predicate=predicate,
+        object=arguments.get("object"),
+        as_of=arguments.get("as_of"),
+    )
+    return {
+        "results_count": len(results),
+        "results": results,
+        "store": "triples",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------------
@@ -424,6 +544,8 @@ _TOOL_HANDLERS = {
     "mnemosyne_scratchpad_read": _handle_scratchpad_read,
     "mnemosyne_scratchpad_write": _handle_scratchpad_write,
     "mnemosyne_get_stats": _handle_get_stats,
+    "mnemosyne_triple_add": _handle_triple_add,
+    "mnemosyne_triple_query": _handle_triple_query,
 }
 
 

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -1382,3 +1382,221 @@ class TestVeracity:
 
         results = beam.recall("Fact", top_k=10)
         assert len(results) >= 2
+
+
+class TestConsolidationHealth:
+    """Issue #115: Consolidation health monitoring."""
+
+    def test_health_no_data(self, temp_db):
+        """health() returns no_data when no consolidation has occurred."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        h = beam.health()
+        assert h["status"] == "no_data"
+        assert h["last_successful_consolidation"] is None
+        assert h["error_count"] == 0
+        assert h["stale_hours"] is None
+        assert "never run" in h["recommendation"].lower() or "no consolidation_log" in h["recommendation"].lower()
+
+    def test_health_healthy_after_sleep(self, temp_db, monkeypatch):
+        """health() returns healthy after a successful sleep()."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Inject old working memories
+        conn = sqlite3.connect(temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        for i in range(3):
+            conn.execute(
+                "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+                (f"old{i}", f"task {i}", "conversation", old_ts, "s1"),
+            )
+        conn.commit()
+        conn.close()
+
+        beam.sleep(dry_run=False)
+
+        h = beam.health()
+        assert h["status"] == "healthy"
+        assert h["last_successful_consolidation"] is not None
+        # Should be recent (within 3 hours to handle UTC/local timezone differences)
+        last_ts = datetime.fromisoformat(h["last_successful_consolidation"])
+        assert (datetime.now() - last_ts).total_seconds() < 10800  # 3 hours
+
+    def test_health_stale(self, temp_db, monkeypatch):
+        """health() returns stale when last consolidation is > threshold."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        # Inject old working memories
+        conn = sqlite3.connect(temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        for i in range(3):
+            conn.execute(
+                "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+                (f"old{i}", f"task {i}", "conversation", old_ts, "s1"),
+            )
+        conn.commit()
+        conn.close()
+
+        beam.sleep(dry_run=False)
+
+        # Backdate the consolidation_log to simulate staleness
+        conn = sqlite3.connect(temp_db)
+        stale_ts = (datetime.now() - timedelta(hours=48)).isoformat()
+        conn.execute("UPDATE consolidation_log SET created_at = ?", (stale_ts,))
+        conn.commit()
+        conn.close()
+
+        h = beam.health(stale_threshold_hours=24.0)
+        assert h["status"] == "stale"
+        assert h["stale_hours"] > 24.0
+
+    def test_health_healthy_within_threshold(self, temp_db, monkeypatch):
+        """health() returns healthy when last consolidation is within threshold."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        conn = sqlite3.connect(temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+            ("old1", "test task", "conversation", old_ts, "s1"),
+        )
+        conn.commit()
+        conn.close()
+
+        beam.sleep(dry_run=False)
+
+        # Consolidation just happened -- should be within 25h threshold
+        h = beam.health(stale_threshold_hours=25.0)
+        assert h["status"] == "healthy"
+
+    def test_health_custom_threshold(self, temp_db, monkeypatch):
+        """health() respects a custom stale threshold."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        conn = sqlite3.connect(temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+            ("old1", "test task", "conversation", old_ts, "s1"),
+        )
+        conn.commit()
+        conn.close()
+
+        beam.sleep(dry_run=False)
+
+        # Backdate to 12h ago
+        conn = sqlite3.connect(temp_db)
+        stale_ts = (datetime.now() - timedelta(hours=12)).isoformat()
+        conn.execute("UPDATE consolidation_log SET created_at = ?", (stale_ts,))
+        conn.commit()
+        conn.close()
+
+        # 24h threshold -> should be healthy
+        h_loose = beam.health(stale_threshold_hours=24.0)
+        assert h_loose["status"] == "healthy"
+
+        # 6h threshold -> should be stale
+        h_tight = beam.health(stale_threshold_hours=6.0)
+        assert h_tight["status"] == "stale"
+
+    def test_health_after_sleep_all_sessions(self, temp_db, monkeypatch):
+        """health() reflects sleep_all_sessions() work."""
+        monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
+
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        conn = sqlite3.connect(temp_db)
+        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        conn.executemany(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("s1-old", "session one task", "conversation", old_ts, "s1"),
+                ("s2-old", "session two task", "conversation", old_ts, "s2"),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        beam.sleep_all_sessions(dry_run=False)
+
+        h = beam.health()
+        assert h["status"] == "healthy"
+        assert h["last_successful_consolidation"] is not None
+
+
+class TestUpdateRefreshesDerivedState:
+    """Issue #110: update() must reindex FTS5 + recompute vector embeddings."""
+
+    def test_recall_returns_updated_content_after_update(self, temp_db):
+        """recall() should find the new content, not the stale original."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        original = "The sky is green"
+        mid = beam.remember(original, source="test")
+        assert mid is not None
+
+        # Verify original is recallable
+        results = beam.recall("sky color", top_k=3)
+        contents = [r["content"] for r in results]
+        assert any("green" in c for c in contents), (
+            f"Original content should be recallable, got: {contents}"
+        )
+
+        # Update to correct the content
+        updated = beam.update_working(mid, content="The sky is blue")
+        assert updated is True
+
+        # After update, recall should find the NEW content
+        results = beam.recall("sky color", top_k=3)
+        contents = [r["content"] for r in results]
+        assert any("blue" in c for c in contents), (
+            f"Updated content should be recallable, got: {contents}"
+        )
+        # The old content should NOT appear
+        assert not any("green" in c for c in contents), (
+            f"Stale original should not appear after update, got: {contents}"
+        )
+
+    def test_recall_returns_updated_content_fuzzy_query(self, temp_db):
+        """Even with a query that would match the old content,
+        recall() should return the updated content."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        mid = beam.remember("Alice works at Acme Corp", source="test")
+
+        # Update to a different fact
+        beam.update_working(mid, content="Alice works at Globex Inc")
+
+        results = beam.recall("Alice employer", top_k=3)
+        contents = [r["content"] for r in results]
+        assert any("Globex" in c for c in contents), (
+            f"Updated content should mention Globex, got: {contents}"
+        )
+
+    def test_update_without_content_change_preserves_embedding(self, temp_db):
+        """Updating only importance should not recompute embeddings."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        mid = beam.remember("The earth is round", source="test")
+
+        # Update only importance, not content
+        beam.update_working(mid, importance=0.9)
+
+        # Content should be unchanged
+        results = beam.recall("earth shape", top_k=3)
+        contents = [r["content"] for r in results]
+        assert any("round" in c for c in contents)
+
+    def test_mnemosyne_update_propagates_to_beam(self, temp_db):
+        """Mnemosyne.update() must also refresh FTS5 + vector embeddings."""
+        from mnemosyne.core.memory import Mnemosyne
+        mnem = Mnemosyne(session_id="s1", db_path=temp_db)
+        mid = mnem.remember("The capital of France is Paris", source="test")
+
+        # Use Mnemosyne.update() to correct the info
+        mnem.update(mid, content="The capital of France is Lyon")
+
+        results = mnem.recall("capital of France", top_k=3)
+        contents = [r["content"] for r in results]
+        assert any("Lyon" in c for c in contents), (
+            f"Mnemosyne.update should refresh derived state, got: {contents}"
+        )


### PR DESCRIPTION
## Summary

Three fixes in one PR:

**#110 — update() doesn't refresh derived state:** `update_working()` now recomputes the vector embedding after content changes. FTS5 is already handled by the existing `wm_au` trigger. `Mnemosyne.update()` delegates to `beam.update_working()` so all call paths benefit.

**#115 — Consolidation health check:** New `BeamMemory.health(stale_threshold_hours=24.0)` method returns consolidation health status (healthy/stale/no_data) with timestamps, error counts, and recommendations. Enables cron-based monitoring.

**#111 — valid_from dropped for occurred_on:** MCP `_handle_triple_add` now forwards `valid_from` to `AnnotationStore` for `occurred_on` predicate. Other annotation kinds log a warning (benign drop). Triple-flavored predicates continue to TripleStore which already has temporal support.

## Test

- `TestConsolidationHealth`: no_data, healthy_after_sleep, stale, healthy_within_threshold, custom_threshold

Closes #110, closes #115, closes #111