### PR TITLE
feat(provider): port all 15 Mnemosyne tools to memory provider path

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1068,7 +1068,9 @@ class MnemosyneMemoryProvider(MemoryProvider):
         output_path = args.get("output_path", "").strip()
         if not output_path:
             return json.dumps({"error": "output_path is required"})
-        result = self._beam.export_to_file(output_path)
+        from mnemosyne.core.memory import Mnemosyne
+        mem = Mnemosyne(session_id=self._session_id, db_path=self._beam.db_path)
+        result = mem.export_to_file(output_path)
         return json.dumps(result)
 
     def _handle_update(self, args: Dict[str, Any]) -> str:
@@ -1099,6 +1101,9 @@ class MnemosyneMemoryProvider(MemoryProvider):
         dry_run = bool(args.get("dry_run", False))
         force = bool(args.get("force", False))
 
+        from mnemosyne.core.memory import Mnemosyne
+        mem = Mnemosyne(session_id=self._session_id, db_path=self._beam.db_path)
+
         if provider:
             api_key = args.get("api_key", "").strip()
             user_id = args.get("user_id", "").strip() or None
@@ -1118,7 +1123,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
             from mnemosyne.core.importers import import_from_provider
             result = import_from_provider(
-                provider, self._beam,
+                provider, mem,
                 api_key=api_key,
                 user_id=user_id,
                 agent_id=agent_id,
@@ -1133,13 +1138,13 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 "error": "Either input_path (for file import) or provider "
                          "(for cross-provider import) is required",
             })
-        stats = self._beam.import_from_file(input_path, force=force)
+        stats = mem.import_from_file(input_path, force=force)
         return json.dumps({"status": "imported", "stats": stats})
 
     def _handle_diagnose(self, args: Dict[str, Any]) -> str:
         from mnemosyne.diagnose import run_diagnostics
         result = run_diagnostics()
-        return json.dumps(result, indent=2)
+        return json.dumps(result, indent=2, default=str)
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
         self._turn_count = turn_number

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -237,9 +237,130 @@ TRIPLE_QUERY_SCHEMA = {
     },
 }
 
+SCRATCHPAD_WRITE_SCHEMA = {
+    "name": "mnemosyne_scratchpad_write",
+    "description": "Write a temporary note to the Mnemosyne scratchpad.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "Content to write"},
+        },
+        "required": ["content"],
+    },
+}
+
+SCRATCHPAD_READ_SCHEMA = {
+    "name": "mnemosyne_scratchpad_read",
+    "description": "Read the Mnemosyne scratchpad entries.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
+SCRATCHPAD_CLEAR_SCHEMA = {
+    "name": "mnemosyne_scratchpad_clear",
+    "description": "Clear all entries from the Mnemosyne scratchpad.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
+EXPORT_SCHEMA = {
+    "name": "mnemosyne_export",
+    "description": "Export all Mnemosyne memories to a JSON file for backup or migration.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "output_path": {
+                "type": "string",
+                "description": "File path to write the export JSON (e.g., /tmp/mnemosyne_backup.json)",
+            },
+        },
+        "required": ["output_path"],
+    },
+}
+
+UPDATE_SCHEMA = {
+    "name": "mnemosyne_update",
+    "description": "Update the content or importance of an existing memory by ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "ID of the memory to update"},
+            "content": {"type": "string", "description": "New content for the memory (optional)"},
+            "importance": {"type": "number", "description": "New importance from 0.0 to 1.0 (optional)"},
+        },
+        "required": ["memory_id"],
+    },
+}
+
+FORGET_SCHEMA = {
+    "name": "mnemosyne_forget",
+    "description": "Permanently delete a memory by ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "ID of the memory to delete"},
+        },
+        "required": ["memory_id"],
+    },
+}
+
+IMPORT_SCHEMA = {
+    "name": "mnemosyne_import",
+    "description": "Import Mnemosyne memories from a JSON file or another memory provider (Hindsight, Mem0). Idempotent by default.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "input_path": {
+                "type": "string",
+                "description": "File path to read the export JSON from (for file imports)",
+            },
+            "provider": {
+                "type": "string",
+                "description": "Provider to import from: 'hindsight', 'mem0'. Requires api_key.",
+            },
+            "api_key": {
+                "type": "string",
+                "description": "API key for the source provider (can also be set via env var)",
+            },
+            "user_id": {
+                "type": "string",
+                "description": "Filter imported memories by user ID (provider-specific)",
+            },
+            "agent_id": {
+                "type": "string",
+                "description": "Filter imported memories by agent ID (provider-specific)",
+            },
+            "base_url": {
+                "type": "string",
+                "description": "Base URL for self-hosted provider instances",
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "If true, validate and transform but don't write any memories",
+                "default": False,
+            },
+            "channel_id": {
+                "type": "string",
+                "description": "Channel to assign imported memories to",
+            },
+            "force": {
+                "type": "boolean",
+                "description": "If true, overwrite existing records instead of skipping",
+                "default": False,
+            },
+        },
+    },
+}
+
+DIAGNOSE_SCHEMA = {
+    "name": "mnemosyne_diagnose",
+    "description": "Run PII-safe diagnostics on Mnemosyne installation. Checks dependencies, database state, and vector search readiness. Never includes memory content or API keys.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
 ALL_TOOL_SCHEMAS = [
     REMEMBER_SCHEMA, RECALL_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
     INVALIDATE_SCHEMA, TRIPLE_ADD_SCHEMA, TRIPLE_QUERY_SCHEMA,
+    SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
+    EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
 ]
 
 
@@ -791,6 +912,22 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_triple_add(args)
             elif tool_name == "mnemosyne_triple_query":
                 return self._handle_triple_query(args)
+            elif tool_name == "mnemosyne_scratchpad_write":
+                return self._handle_scratchpad_write(args)
+            elif tool_name == "mnemosyne_scratchpad_read":
+                return self._handle_scratchpad_read(args)
+            elif tool_name == "mnemosyne_scratchpad_clear":
+                return self._handle_scratchpad_clear(args)
+            elif tool_name == "mnemosyne_export":
+                return self._handle_export(args)
+            elif tool_name == "mnemosyne_update":
+                return self._handle_update(args)
+            elif tool_name == "mnemosyne_forget":
+                return self._handle_forget(args)
+            elif tool_name == "mnemosyne_import":
+                return self._handle_import(args)
+            elif tool_name == "mnemosyne_diagnose":
+                return self._handle_diagnose(args)
             else:
                 return json.dumps({"error": f"Unknown Mnemosyne tool: {tool_name}"})
         except Exception as e:
@@ -911,6 +1048,98 @@ class MnemosyneMemoryProvider(MemoryProvider):
         results = query_triples(subject=subject, predicate=predicate, object=obj,
                                 db_path=self._beam.db_path)
         return json.dumps({"count": len(results), "results": results})
+
+    def _handle_scratchpad_write(self, args: Dict[str, Any]) -> str:
+        content = args.get("content", "").strip()
+        if not content:
+            return json.dumps({"error": "Content is required"})
+        pad_id = self._beam.scratchpad_write(content)
+        return json.dumps({"status": "written", "id": pad_id})
+
+    def _handle_scratchpad_read(self, args: Dict[str, Any]) -> str:
+        entries = self._beam.scratchpad_read()
+        return json.dumps({"entries_count": len(entries), "entries": entries})
+
+    def _handle_scratchpad_clear(self, args: Dict[str, Any]) -> str:
+        self._beam.scratchpad_clear()
+        return json.dumps({"status": "cleared"})
+
+    def _handle_export(self, args: Dict[str, Any]) -> str:
+        output_path = args.get("output_path", "").strip()
+        if not output_path:
+            return json.dumps({"error": "output_path is required"})
+        result = self._beam.export_to_file(output_path)
+        return json.dumps(result)
+
+    def _handle_update(self, args: Dict[str, Any]) -> str:
+        memory_id = args.get("memory_id", "").strip()
+        if not memory_id:
+            return json.dumps({"error": "memory_id is required"})
+        content = args.get("content")
+        importance = args.get("importance")
+        ok = self._beam.update_working(memory_id, content=content, importance=importance)
+        return json.dumps({
+            "status": "updated" if ok else "not_found",
+            "memory_id": memory_id,
+        })
+
+    def _handle_forget(self, args: Dict[str, Any]) -> str:
+        memory_id = args.get("memory_id", "").strip()
+        if not memory_id:
+            return json.dumps({"error": "memory_id is required"})
+        ok = self._beam.forget_working(memory_id)
+        return json.dumps({
+            "status": "deleted" if ok else "not_found",
+            "memory_id": memory_id,
+        })
+
+    def _handle_import(self, args: Dict[str, Any]) -> str:
+        provider = (args.get("provider") or "").strip().lower()
+        input_path = args.get("input_path", "").strip()
+        dry_run = bool(args.get("dry_run", False))
+        force = bool(args.get("force", False))
+
+        if provider:
+            api_key = args.get("api_key", "").strip()
+            user_id = args.get("user_id", "").strip() or None
+            agent_id = args.get("agent_id", "").strip() or None
+            base_url = args.get("base_url", "").strip() or None
+            channel_id = args.get("channel_id")
+
+            if not api_key:
+                import os
+                env_key = f"{provider.upper()}_API_KEY"
+                api_key = os.environ.get(env_key, "")
+            if not api_key:
+                return json.dumps({
+                    "error": f"api_key required for {provider} import. "
+                             f"Set {provider.upper()}_API_KEY env var or pass api_key parameter.",
+                })
+
+            from mnemosyne.core.importers import import_from_provider
+            result = import_from_provider(
+                provider, self._beam,
+                api_key=api_key,
+                user_id=user_id,
+                agent_id=agent_id,
+                base_url=base_url,
+                dry_run=dry_run,
+                channel_id=channel_id,
+            )
+            return json.dumps(result.to_dict())
+
+        if not input_path:
+            return json.dumps({
+                "error": "Either input_path (for file import) or provider "
+                         "(for cross-provider import) is required",
+            })
+        stats = self._beam.import_from_file(input_path, force=force)
+        return json.dumps({"status": "imported", "stats": stats})
+
+    def _handle_diagnose(self, args: Dict[str, Any]) -> str:
+        from mnemosyne.diagnose import run_diagnostics
+        result = run_diagnostics()
+        return json.dumps(result, indent=2)
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
         self._turn_count = turn_number

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -1,0 +1,283 @@
+"""
+Tests for MnemosyneMemoryProvider — all 15 tools wired in provider mode.
+
+Verifies schema registration, dispatch routing, and handler execution
+for each of the 8 tools ported from hermes_plugin (scratchpad, export,
+update, forget, import, diagnose) plus the 7 already-existing tools.
+"""
+
+import json
+import pytest
+from pathlib import Path
+
+from mnemosyne.core.beam import BeamMemory
+from hermes_memory_provider import MnemosyneMemoryProvider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_beam(tmp_path):
+    """Create a BeamMemory backed by a temporary database."""
+    db_path = Path(tmp_path) / "test.db"
+    return BeamMemory(session_id="test_provider", db_path=db_path)
+
+
+def _build_provider(beam) -> MnemosyneMemoryProvider:
+    """Return a ready-to-test MnemosyneMemoryProvider with beam injected."""
+    provider = MnemosyneMemoryProvider()
+    provider._beam = beam
+    provider._session_id = "test_provider"
+    provider._agent_context = "primary"
+    return provider
+
+
+def _provider(tmp_path) -> MnemosyneMemoryProvider:
+    """One-liner to get a fully-wired provider backed by a tmp DB."""
+    return _build_provider(_make_beam(tmp_path))
+
+
+def _tool_names(provider) -> set[str]:
+    return {s["name"] for s in provider.get_tool_schemas()}
+
+
+# ---------------------------------------------------------------------------
+# Tool schema & dispatch registration
+# ---------------------------------------------------------------------------
+
+class TestToolRegistration:
+    """Verify the provider registers and dispatches all 15 tools."""
+
+    def test_all_15_tools_registered(self, tmp_path):
+        provider = _provider(tmp_path)
+        names = _tool_names(provider)
+        assert len(names) == 15, f"Expected 15 tools, got {len(names)}"
+
+    def test_new_8_tools_present(self, tmp_path):
+        provider = _provider(tmp_path)
+        names = _tool_names(provider)
+        for tool in ("scratchpad_write", "scratchpad_read", "scratchpad_clear",
+                     "export", "update", "forget", "import", "diagnose"):
+            assert f"mnemosyne_{tool}" in names
+
+    def test_existing_7_tools_present(self, tmp_path):
+        provider = _provider(tmp_path)
+        names = _tool_names(provider)
+        for tool in ("remember", "recall", "sleep", "stats",
+                     "invalidate", "triple_add", "triple_query"):
+            assert f"mnemosyne_{tool}" in names
+
+    def test_unknown_tool_returns_error(self, tmp_path):
+        provider = _provider(tmp_path)
+        result = json.loads(provider.handle_tool_call("mnemosyne_nonexistent", {}))
+        assert "error" in result
+        assert "Unknown" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Scratchpad tools
+# ---------------------------------------------------------------------------
+
+class TestScratchpad:
+    def test_write_and_read(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider._handle_scratchpad_write({"content": "hello"}))
+        assert r["status"] == "written"
+        r2 = json.loads(provider._handle_scratchpad_read({}))
+        assert r2["entries_count"] >= 1
+
+    def test_write_empty(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider._handle_scratchpad_write({"content": ""}))
+        assert "error" in r
+
+    def test_clear(self, tmp_path):
+        provider = _provider(tmp_path)
+        provider._handle_scratchpad_write({"content": "temp"})
+        r = json.loads(provider._handle_scratchpad_clear({}))
+        assert r["status"] == "cleared"
+        r2 = json.loads(provider._handle_scratchpad_read({}))
+        assert r2["entries_count"] == 0
+
+    def test_dispatch_scratchpad_write(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider.handle_tool_call("mnemosyne_scratchpad_write",
+                                                  {"content": "dispatch"}))
+        assert r["status"] == "written"
+
+    def test_dispatch_scratchpad_read(self, tmp_path):
+        provider = _provider(tmp_path)
+        provider._handle_scratchpad_write({"content": "ping"})
+        r = json.loads(provider.handle_tool_call("mnemosyne_scratchpad_read", {}))
+        assert r["entries_count"] >= 1
+
+    def test_dispatch_scratchpad_clear(self, tmp_path):
+        provider = _provider(tmp_path)
+        provider._handle_scratchpad_write({"content": "del"})
+        r = json.loads(provider.handle_tool_call("mnemosyne_scratchpad_clear", {}))
+        assert r["status"] == "cleared"
+
+
+# ---------------------------------------------------------------------------
+# Update tool
+# ---------------------------------------------------------------------------
+
+class TestUpdate:
+    def test_update_content(self, tmp_path):
+        beam = _make_beam(tmp_path)
+        provider = _build_provider(beam)
+        mid = beam.remember("original", importance=0.5)
+        r = json.loads(provider._handle_update({"memory_id": mid,
+                                                 "content": "updated"}))
+        assert r["status"] == "updated"
+        found = beam.recall("updated", top_k=5)
+        assert any("updated" in x.get("content", "") for x in found)
+
+    def test_update_not_found(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider._handle_update({"memory_id": "noid",
+                                                 "content": "x"}))
+        assert r["status"] == "not_found"
+
+    def test_update_missing_id(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider._handle_update({}))
+        assert "error" in r
+
+    def test_dispatch_update(self, tmp_path):
+        beam = _make_beam(tmp_path)
+        provider = _build_provider(beam)
+        mid = beam.remember("old", importance=0.5)
+        r = json.loads(provider.handle_tool_call("mnemosyne_update",
+                                                  {"memory_id": mid,
+                                                   "content": "new"}))
+        assert r["status"] == "updated"
+
+
+# ---------------------------------------------------------------------------
+# Forget tool
+# ---------------------------------------------------------------------------
+
+class TestForget:
+    def test_forget_existing(self, tmp_path):
+        beam = _make_beam(tmp_path)
+        provider = _build_provider(beam)
+        mid = beam.remember("to delete", importance=0.5)
+        r = json.loads(provider._handle_forget({"memory_id": mid}))
+        assert r["status"] == "deleted"
+        found = beam.recall("delete", top_k=5)
+        assert not any(x.get("id") == mid for x in found)
+
+    def test_forget_not_found(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider._handle_forget({"memory_id": "noid"}))
+        assert r["status"] == "not_found"
+
+    def test_forget_missing_id(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider._handle_forget({}))
+        assert "error" in r
+
+    def test_dispatch_forget(self, tmp_path):
+        beam = _make_beam(tmp_path)
+        provider = _build_provider(beam)
+        mid = beam.remember("del", importance=0.5)
+        r = json.loads(provider.handle_tool_call("mnemosyne_forget",
+                                                  {"memory_id": mid}))
+        assert r["status"] == "deleted"
+
+
+# ---------------------------------------------------------------------------
+# Export tool
+# ---------------------------------------------------------------------------
+
+class TestExport:
+    def test_export_to_file(self, tmp_path):
+        beam = _make_beam(tmp_path)
+        provider = _build_provider(beam)
+        beam.remember("test export", importance=0.8)
+        beam.scratchpad_write("note")
+        out = tmp_path / "export.json"
+        r = json.loads(provider._handle_export({"output_path": str(out)}))
+        assert r["status"] == "exported"
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert "working_memory" in data
+
+    def test_export_missing_path(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider._handle_export({}))
+        assert "error" in r
+
+    def test_dispatch_export(self, tmp_path):
+        beam = _make_beam(tmp_path)
+        provider = _build_provider(beam)
+        beam.remember("dispatch export", importance=0.5)
+        out = tmp_path / "dispatch.json"
+        r = json.loads(provider.handle_tool_call("mnemosyne_export",
+                                                  {"output_path": str(out)}))
+        assert r["status"] == "exported"
+        assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Import tool (file path)
+# ---------------------------------------------------------------------------
+
+class TestImport:
+    def test_import_from_file(self, tmp_path):
+        # Export first
+        beam1 = _make_beam(tmp_path / "src")
+        p1 = _build_provider(beam1)
+        beam1.remember("source memory", importance=0.5)
+        export_path = tmp_path / "data.json"
+        p1._handle_export({"output_path": str(export_path)})
+
+        # Import into a fresh DB
+        beam2 = _make_beam(tmp_path / "dst")
+        p2 = _build_provider(beam2)
+        r = json.loads(p2._handle_import({"input_path": str(export_path)}))
+        assert r["status"] == "imported"
+        assert r["stats"]["beam"]["working_memory"]["inserted"] >= 1
+
+    def test_import_missing_args(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider._handle_import({}))
+        assert "error" in r
+
+
+# ---------------------------------------------------------------------------
+# Diagnose tool
+# ---------------------------------------------------------------------------
+
+class TestDiagnose:
+    def test_diagnose_returns_valid_json(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider._handle_diagnose({}))
+        assert isinstance(r, dict)
+        assert len(r) > 0
+
+    def test_dispatch_diagnose(self, tmp_path):
+        provider = _provider(tmp_path)
+        r = json.loads(provider.handle_tool_call("mnemosyne_diagnose", {}))
+        assert isinstance(r, dict)
+
+
+# ---------------------------------------------------------------------------
+# Provider not-initialized guard
+# ---------------------------------------------------------------------------
+
+class TestUnavailableGuard:
+    def test_tool_call_returns_reason_when_not_initialized(self):
+        provider = MnemosyneMemoryProvider()
+        provider._beam = None
+        provider._hermes_home = ""
+        r = json.loads(provider.handle_tool_call("mnemosyne_remember",
+                                                  {"content": "test"}))
+        assert r["status"] == "memory_unavailable"
+
+    def test_system_prompt_empty_when_not_initialized(self):
+        provider = MnemosyneMemoryProvider()
+        provider._beam = None
+        assert provider.system_prompt_block() == ""


### PR DESCRIPTION
## Description

Fixes #121 — the memory provider only exposed 7 of 15 documented tools. This PR ports the remaining 8 tool implementations from  into  so they're available in provider mode.

## Changes

**8 new tool schemas added** to :
-  — write temp notes to scratchpad
-  — read scratchpad entries
-  — clear scratchpad
-  — export memories to JSON file
-  — update memory content/importance by ID
-  — delete memory by ID
-  — import from JSON file or cross-provider (Hindsight, Mem0)
-  — run PII-safe diagnostics

Each tool includes its schema definition (added to ), a dispatch branch in , and a handler method delegating to the existing  instance.

## Testing

- Syntax verified with 
- All 15 tools confirmed in  list
- All 15 dispatch branches present in 
- All 15 handler methods implemented
- plugin.yaml already listed all 15 tools (no change needed there)

Note: plugin.yaml already declared all 15 tools — this PR makes provider mode match that declaration.

closes #121