### PR TITLE
fix: read EMBEDDING_DIM from MNEMOSYNE_EMBEDDING_DIM env var

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -222,7 +222,7 @@ def _default_db_path() -> Path:
     return _default_data_dir() / "mnemosyne.db"
 
 # Config
-EMBEDDING_DIM = 384  # bge-small-en-v1.5
+EMBEDDING_DIM = int(os.environ.get("MNEMOSYNE_EMBEDDING_DIM", "384"))  # bge-small-en-v1.5
 WORKING_MEMORY_MAX_ITEMS = int(os.environ.get("MNEMOSYNE_WM_MAX_ITEMS", "10000"))
 WORKING_MEMORY_TTL_HOURS = int(os.environ.get("MNEMOSYNE_WM_TTL_HOURS", "24"))
 EPISODIC_RECALL_LIMIT = int(os.environ.get("MNEMOSYNE_EP_LIMIT", "50000"))


### PR DESCRIPTION
## Problem

`EMBEDDING_DIM` in `beam.py` is hardcoded to `384` (bge-small-en-v1.5), while every other config value in the same block properly reads from an `os.environ` variable with a fallback default. This means users who set `MNEMOSYNE_EMBEDDING_DIM=768` in their env file are silently ignored — the hardcoded 384 always wins.

## Impact

Silent dimension mismatch failure: when the user's embedding model returns vectors of a different dimensionality (e.g. 768-dim from jina-embeddings-v5-nano), the `vec_episodes` table was created with 384-dim slots because the env var was ignored at table creation time. This causes:

- `mnemosyne_sleep` consolidation fails on all sessions with `OperationalError: Dimension mismatch ... Expected 768 dimensions but received 384`
- `mnemosyne_recall` fails with similar dimension mismatch
- No error surfaced to the user — it's a silent failure until they debug the vector table

## Fix

One-line change: read `EMBEDDING_DIM` from `os.environ` with a default of `"384"` for backward compatibility, matching the exact pattern used by every other config value in the same block (lines 226-239).

## Verification

- Existing users with no `MNEMOSYNE_EMBEDDING_DIM` set: no change (defaults to 384 as before)
- Users with `MNEMOSYNE_EMBEDDING_DIM=768`: env var now respected, vectors match table dimensions