### PR TITLE
fix(provider): stop truncating prefetched memories by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ Importers preserve source metadata where available. `HindsightImporter` uses a d
 | `MNEMOSYNE_RECENCY_HALFLIFE` | `168` | Recency decay halflife in hours (1 week) |
 | `MNEMOSYNE_EP_LIMIT` | `50000` | Episodic memory recall limit |
 | `MNEMOSYNE_SLEEP_BATCH` | `5000` | Max working memories to fetch for consolidation |
+| `MNEMOSYNE_PREFETCH_CONTENT_CHARS` | `0` | Per-memory character limit for Hermes provider prefetch injection; `0` disables truncation |
 
 ### Local LLM (ctransformers/GGUF)
 

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -77,6 +77,42 @@ def _get_triple_module():
     return add_triple, query_triples
 
 
+def _prefetch_content_char_limit() -> int:
+    """Return the per-memory prefetch content limit.
+
+    ``0`` means no truncation. This is the default because the old hardcoded
+    200-character cap often removed the actual fact from LLM-authored memories.
+    Operators that need tighter prompt budgets can set
+    ``MNEMOSYNE_PREFETCH_CONTENT_CHARS`` to a positive integer.
+    """
+    raw = os.environ.get("MNEMOSYNE_PREFETCH_CONTENT_CHARS", "0").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning(
+            "Invalid MNEMOSYNE_PREFETCH_CONTENT_CHARS=%r; disabling prefetch truncation",
+            raw,
+        )
+        return 0
+
+
+def _format_prefetch_content(content: str, limit: int) -> str:
+    """Format recalled memory content for prompt injection.
+
+    When a positive limit is configured, truncate on a word boundary instead of
+    splitting mid-token. Without a positive limit, return the complete content.
+    """
+    if limit <= 0 or len(content) <= limit:
+        return content
+
+    cut = content[:limit].rstrip()
+    # Prefer a word boundary when one exists reasonably close to the limit.
+    boundary = cut.rfind(" ")
+    if boundary >= max(1, limit // 2):
+        cut = cut[:boundary].rstrip()
+    return f"{cut}..."
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas
 # ---------------------------------------------------------------------------
@@ -787,10 +823,12 @@ class MnemosyneMemoryProvider(MemoryProvider):
             if not filtered:
                 return ""
             lines = ["## Mnemosyne Context"]
+            content_limit = _prefetch_content_char_limit()
             for r in filtered:
-                content = r.get("content", "")[:200]
-                if len(r.get("content", "")) > 200:
-                    content += "..."
+                content = _format_prefetch_content(
+                    r.get("content", ""),
+                    content_limit,
+                )
                 ts = r.get("timestamp", "")[:16] if r.get("timestamp") else ""
                 imp = r.get("importance", 0.0)
                 trust = r.get("trust_tier", "STATED")

--- a/mnemosyne_codebase_surface.json
+++ b/mnemosyne_codebase_surface.json
@@ -417,6 +417,7 @@
     "MNEMOSYNE_EMBEDDING_MODEL": {"description": "Embedding model (local fastembed or openai/* API)", "default": "BAAI/bge-small-en-v1.5"},
     "MNEMOSYNE_EXTRACTION_PROMPT": {"description": "Custom prompt for fact extraction", "default": "built-in"},
     "MNEMOSYNE_AUTHOR_ID": {"description": "Default author_id for identity tracking", "default": ""},
+    "MNEMOSYNE_PREFETCH_CONTENT_CHARS": {"description": "Per-memory character limit for provider prefetch injection; 0 disables truncation", "default": "0"},
     "MNEMOSYNE_AUTHOR_TYPE": {"description": "Default author_type: human|agent|system", "default": ""},
     "MNEMOSYNE_CHANNEL_ID": {"description": "Default channel_id", "default": ""},
     "MNEMOSYNE_MCP_BANK": {"description": "Default bank for MCP server", "default": "default"},

--- a/tests/test_prefetch_content_truncation.py
+++ b/tests/test_prefetch_content_truncation.py
@@ -1,0 +1,70 @@
+"""Regression tests for issue #132: prefetch memory content truncation.
+
+The provider used to hard-cap each recalled memory at 200 characters inside
+``<memory-context>``. That drops the most specific facts from long,
+LLM-authored memories. The default should preserve the full recalled content,
+while still allowing operators to opt into a prompt-budget cap.
+"""
+from __future__ import annotations
+
+
+class FakeBeam:
+    author_id = "test-author"
+
+    def __init__(self, content: str):
+        self.content = content
+
+    def recall(self, query, top_k, temporal_weight, temporal_halflife, author_id):
+        return [
+            {
+                "content": self.content,
+                "timestamp": "2026-05-14T12:00:00Z",
+                "importance": 0.9,
+                "score": 0.9,
+                "trust_tier": "STATED",
+            }
+        ]
+
+
+def test_prefetch_preserves_full_memory_content_by_default(monkeypatch):
+    """Facts after char 200 must survive in the injected memory context."""
+    monkeypatch.delenv("MNEMOSYNE_PREFETCH_CONTENT_CHARS", raising=False)
+
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    long_content = f"{'context ' * 35}critical-tail-fact-survives"
+    assert len(long_content) > 250
+
+    provider = MnemosyneMemoryProvider()
+    provider._beam = FakeBeam(long_content)
+
+    rendered = provider.prefetch("critical tail fact")
+
+    assert "critical-tail-fact-survives" in rendered
+    assert long_content in rendered
+    assert "..." not in rendered
+
+
+def test_prefetch_content_limit_is_opt_in_and_word_boundary(monkeypatch):
+    """Positive env var values cap content without splitting mid-word."""
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_CONTENT_CHARS", "12")
+
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    provider = MnemosyneMemoryProvider()
+    provider._beam = FakeBeam("alpha beta gamma delta")
+
+    rendered = provider.prefetch("alpha")
+
+    assert "alpha beta..." in rendered
+    assert "alpha beta g..." not in rendered
+    assert "gamma delta" not in rendered
+
+
+def test_prefetch_content_limit_zero_means_no_truncation(monkeypatch):
+    """Explicit zero is the documented escape hatch for complete content."""
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_CONTENT_CHARS", "0")
+
+    from hermes_memory_provider import _format_prefetch_content
+
+    assert _format_prefetch_content("alpha beta gamma", 0) == "alpha beta gamma"


### PR DESCRIPTION
## Summary
- confirm and remove the hardcoded 200-character cap from Hermes provider `prefetch()` memory injection
- add `MNEMOSYNE_PREFETCH_CONTENT_CHARS` as an opt-in per-memory cap (`0` / unset = no truncation)
- when a cap is configured, truncate on a word boundary instead of splitting mid-token
- document the env var and add regression coverage for issue #132

## Verification
- `/home/steve/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_prefetch_content_truncation.py tests/test_c13_memory_context_single_injection.py tests/test_c27_provider_init_error_visible.py -q`
- `/home/steve/.hermes/hermes-agent/venv/bin/python -m json.tool mnemosyne_codebase_surface.json >/tmp/mnemosyne_surface_valid.json`

Fixes #132
