### PR TITLE
feat: add sleep prompt override

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -146,6 +146,7 @@ If you don't enable this for benchmarks ≥100K, expect FTS-driven recall to mis
 |---|---|---|
 | `MNEMOSYNE_WM_TTL_HOURS` | `24` | Working memory rows older than this get pulled into `sleep()`. The benchmark harness backdates timestamps to ensure rows are eligible. |
 | `MNEMOSYNE_SLEEP_BATCH` | `5000` | Max rows pulled per `sleep()` invocation. Larger batches reduce sleep overhead; smaller batches reduce peak memory during summarization. |
+| `MNEMOSYNE_SLEEP_PROMPT` | *(built-in)* | Optional consolidation prompt override. Pin this across multilingual benchmark arms because it changes episodic summary language/content. |
 | `MNEMOSYNE_LLM_ENABLED` | `true` | When `false`, `sleep()` skips local LLM summarization and falls back to AAAK encoding. Useful for benchmark runs that want deterministic summaries without per-row LLM latency. |
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,7 @@ All values use 384-dimensional vectors (bge-small-en-v1.5 embedding model).
 | `MNEMOSYNE_LLM_N_THREADS` | `4` | CPU threads for local inference |
 | `MNEMOSYNE_LLM_REPO` | `TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF` | HuggingFace repo for GGUF model |
 | `MNEMOSYNE_LLM_FILE` | `tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf` | GGUF filename |
+| `MNEMOSYNE_SLEEP_PROMPT` | *(built-in)* | Optional sleep/consolidation prompt override. Supports `{source}`, `{memories}`, and `{memory_count}` placeholders for language-specific summaries. |
 
 ### Remote LLM (OpenAI-compatible)
 

--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -50,6 +50,10 @@ HOST_LLM_TIMEOUT = 15.0  # Per-attempt safety cap; not user-facing.
 # Codex/GPT-class aux models; use this larger budget when the host is the path.
 HOST_LLM_N_CTX = int(os.environ.get("MNEMOSYNE_HOST_LLM_N_CTX", "32000"))
 
+# Optional consolidation prompt override. Supports {source}, {memories}, and
+# {memory_count}; unset keeps the historical built-in prompt.
+SLEEP_PROMPT = os.environ.get("MNEMOSYNE_SLEEP_PROMPT", "").strip()
+
 # --- Lazy singleton ----------------------------------------------------------
 _llm_instance = None
 _llm_backend = None  # "llamacpp", "ctransformers", or None
@@ -203,6 +207,29 @@ def _call_local_llm(prompt: str) -> Optional[str]:
         return None
 
 
+def _memory_lines(memories: List[str]) -> str:
+    """Format memories for insertion into consolidation prompts."""
+    return "\n".join(f"- {m}" for m in memories if m)
+
+
+def _format_sleep_prompt(memories: List[str], source: str = "") -> Optional[str]:
+    """Render MNEMOSYNE_SLEEP_PROMPT when configured.
+
+    Supported placeholders:
+    - {source}: source label passed by sleep() / summarize_memories()
+    - {memories}: newline-separated bullet list of source memories
+    - {memory_count}: number of non-empty memories in this chunk
+    """
+    if not SLEEP_PROMPT:
+        return None
+    non_empty = [m for m in memories if m]
+    return SLEEP_PROMPT.format(
+        source=source,
+        memories=_memory_lines(memories),
+        memory_count=len(non_empty),
+    )
+
+
 def _build_prompt(memories: List[str], source: str = "") -> str:
     """Build a consolidation prompt from a list of memory strings.
 
@@ -210,6 +237,10 @@ def _build_prompt(memories: List[str], source: str = "") -> str:
     suitable for both local GGUF models and any LLM. For host LLM
     calls, use :func:`_build_host_prompt` instead.
     """
+    custom = _format_sleep_prompt(memories, source=source)
+    if custom is not None:
+        return custom
+
     header = (
         "Summarize the following memories into 1-3 concise sentences. "
         "Preserve facts, names, preferences, and decisions. Discard fluff."
@@ -217,8 +248,7 @@ def _build_prompt(memories: List[str], source: str = "") -> str:
     if source:
         header += f" Source: {source}."
 
-    lines = "\n".join(f"- {m}" for m in memories if m)
-    prompt = f"{header}\n\n{lines}\n\nSummary:"
+    prompt = f"{header}\n\n{_memory_lines(memories)}\n\nSummary:"
     return prompt
 
 
@@ -229,6 +259,10 @@ def _build_host_prompt(memories: List[str], source: str = "") -> str:
     Chat Completions call; embedding TinyLlama chat-template tokens here
     would degrade output quality on every modern aux provider.
     """
+    custom = _format_sleep_prompt(memories, source=source)
+    if custom is not None:
+        return custom
+
     header = (
         "Summarize the following memories into 1-3 concise sentences. "
         "Preserve facts, names, preferences, and decisions. Discard fluff."
@@ -236,8 +270,7 @@ def _build_host_prompt(memories: List[str], source: str = "") -> str:
     if source:
         header += f" Source: {source}."
 
-    lines = "\n".join(f"- {m}" for m in memories if m)
-    return f"{header}\n\n{lines}"
+    return f"{header}\n\n{_memory_lines(memories)}"
 
 
 def _host_backend_will_handle_call() -> bool:

--- a/mnemosyne_codebase_surface.json
+++ b/mnemosyne_codebase_surface.json
@@ -416,6 +416,7 @@
     "MNEMOSYNE_HOST_LLM_N_CTX": {"description": "Host LLM context window", "default": "32000"},
     "MNEMOSYNE_EMBEDDING_MODEL": {"description": "Embedding model (local fastembed or openai/* API)", "default": "BAAI/bge-small-en-v1.5"},
     "MNEMOSYNE_EXTRACTION_PROMPT": {"description": "Custom prompt for fact extraction", "default": "built-in"},
+    "MNEMOSYNE_SLEEP_PROMPT": {"description": "Custom prompt for sleep/consolidation summaries; supports {source}, {memories}, {memory_count}", "default": "built-in"},
     "MNEMOSYNE_AUTHOR_ID": {"description": "Default author_id for identity tracking", "default": ""},
     "MNEMOSYNE_AUTHOR_TYPE": {"description": "Default author_type: human|agent|system", "default": ""},
     "MNEMOSYNE_CHANNEL_ID": {"description": "Default channel_id", "default": ""},

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -121,6 +121,43 @@ class TestRemoteLLM:
                 mock_load.assert_called_once()
 
 
+class TestSleepPromptOverride:
+    def test_build_prompt_uses_sleep_prompt_override(self, monkeypatch):
+        """MNEMOSYNE_SLEEP_PROMPT can steer local consolidation language."""
+        monkeypatch.setattr(
+            local_llm,
+            "SLEEP_PROMPT",
+            "Fasse diese Erinnerungen auf Deutsch zusammen.\nQuelle: {source}\n{memories}\nAntwort:",
+            raising=False,
+        )
+
+        prompt = local_llm._build_prompt(
+            ["Ich mag Kaffee", "Berlin bleibt wichtig"],
+            source="conversation",
+        )
+
+        assert "Fasse diese Erinnerungen auf Deutsch zusammen." in prompt
+        assert "Quelle: conversation" in prompt
+        assert "- Ich mag Kaffee" in prompt
+        assert "- Berlin bleibt wichtig" in prompt
+        assert "Summarize the following memories" not in prompt
+
+    def test_build_host_prompt_uses_same_sleep_prompt_override(self, monkeypatch):
+        """Host LLM consolidation gets the same language-controlled prompt."""
+        monkeypatch.setattr(
+            local_llm,
+            "SLEEP_PROMPT",
+            "Write in German. Source={source}. Memories:\n{memories}",
+            raising=False,
+        )
+
+        prompt = local_llm._build_host_prompt(["User prefers tea"], source="profile")
+
+        assert prompt == "Write in German. Source=profile. Memories:\n- User prefers tea"
+        assert "<|user|>" not in prompt
+        assert "</s>" not in prompt
+
+
 class TestHostLLMBackend:
     """Tests for the host LLM adapter integration in summarize_memories()."""
 


### PR DESCRIPTION
## Summary

Fixes #134 by adding `MNEMOSYNE_SLEEP_PROMPT`, an optional sleep/consolidation prompt override for multilingual deployments.

Behavior:
- unset env var keeps the existing built-in consolidation prompt
- set env var overrides both local GGUF and host-LLM consolidation prompts
- supported placeholders:
  - `{source}` — source label passed by `sleep()` / `summarize_memories()`
  - `{memories}` — newline-separated bullet list of source memories
  - `{memory_count}` — number of non-empty memories in the chunk

Docs/metadata:
- documents the new env var in `docs/configuration.md`
- adds benchmark note to pin the prompt across multilingual A/B runs
- updates `mnemosyne_codebase_surface.json`

## Test Plan

RED first:
```bash
/home/steve/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_local_llm.py::TestSleepPromptOverride -q
# 2 failed before implementation; both failures showed the built-in English prompt was still used
```

GREEN / regression:
```bash
/home/steve/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_local_llm.py::TestSleepPromptOverride -q
# 2 passed

/home/steve/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_local_llm.py -q
# 17 passed

/home/steve/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_beam.py::TestSleepCycle::test_sleep_consolidates_old_memories tests/test_beam.py::TestTokenAwareConsolidation::test_sleep_chunks_large_batches -q
# 2 passed

MNEMOSYNE_SLEEP_PROMPT='Bitte auf Deutsch. Quelle={source}.\n{memories}' /home/steve/.hermes/hermes-agent/venv/bin/python - <<'PY'
from mnemosyne.core import local_llm
prompt = local_llm._build_host_prompt(['Nutzer mag Kaffee'], source='chat')
print(prompt)
assert 'Bitte auf Deutsch' in prompt
assert 'Quelle=chat' in prompt
assert '- Nutzer mag Kaffee' in prompt
PY
# passed

/home/steve/.hermes/hermes-agent/venv/bin/python -m py_compile mnemosyne/core/local_llm.py
# passed

/home/steve/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_local_llm.py tests/test_beam.py -q
# 81 passed, 1 skipped
```
