### PR TITLE
fix(provider): make three hardcoded timeouts configurable via env vars

### DIFF
--- a/CONTINUE_HERE.md
+++ b/CONTINUE_HERE.md
@@ -1,89 +1,72 @@
 # mnemosyne — Continue Here
 
-**Status:** COMPLETE — PR #138 filed, PR #129 review done
-**HEAD:** `f2c8af1` on `fix/embedding-dim-env-var`
-**Last Updated:** 2026-05-14 18:20 UTC
+**Status:** PR #139 filed (provider timeouts), PR #129 open (compression plugin)
+**HEAD:** `d701a2e` on `fix/provider-timeout-env-vars`
+**Last Updated:** 2026-05-14 18:45 UTC
 
 ---
 
-## Projects
+## Open PRs (AxDSan/mnemosyne)
 
-### PR #129 Review — COMPLETE (AxDSan/mnemosyne)
-3 review items addressed and pushed to `feature/compression-plugin` (8ee9c92):
+| PR | Title | Status |
+|----|-------|--------|
+| **#139** | fix(provider): make three hardcoded timeouts configurable via env vars | **Open** — filed from ether-btc/fix/provider-timeout-env-vars |
+| **#129** | feat(plugins): CompressionPlugin — replace hardcoded env-var compression | **Open** — filed from ether-btc/feature/compression-plugin (8ee9c92) |
+
+---
+
+## PR #139 — Provider Timeout Env Vars
+
+**Filed against:** `AxDSan/mnemosyne:main`
+
+| Constant | Before | Env Var | Default |
+|----------|--------|---------|---------|
+| `SESSION_END_SLEEP_TIMEOUT_SECONDS` | `15` | `MNEMOSYNE_SESSION_END_TIMEOUT` | `60` |
+| Auto-sleep `join(timeout=5)` | hardcoded `5` | `MNEMOSYNE_AUTO_SLEEP_TIMEOUT` | `15` |
+| `SHUTDOWN_DRAIN_TIMEOUT_SECONDS` | `2` | `MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT` | `8` |
+
+**Files changed:**
+- `hermes_memory_provider/__init__.py`: 3 constants now read from env
+- `tests/test_hermes_memory_provider.py`: default tests updated to 60s and 8s
+
+**CI:** `test_hermes_memory_provider.py` — 43 passed
+
+---
+
+## PR #129 — CompressionPlugin
+
+**Filed against:** `AxDSan/mnemosyne:main`
+
+3 fixes on `feature/compression-plugin` (commit `8ee9c92`):
 1. ✅ `get_plugin()` lazy-loads registered plugins (91244eb — prior session)
 2. ✅ Deleted dead external `mnemosyne/plugins/compression.py`
 3. ✅ Added `test_sleep_loads_compression_plugin_and_enables_via_config` integration test
 
-### PR #131 — EMBEDDING_DIM env var — COMPLETE
-Filed as **PR #138** against `AxDSan/mnemosyne:main`.
-
-**Fix:** `mnemosyne/core/beam.py` — `EMBEDDING_DIM` reads from `MNEMOSYNE_EMBEDDING_DIM` env var
-- Guard against zero/negative (falls back to 384)
-- Guard against non-integer garbage (falls back to 384, no crash)
-- Follows same pattern as other env vars in the file (`MNEMOSYNE_WM_MAX_ITEMS`, etc.)
-
-**Tests:** `tests/test_beam.py::TestEmbeddingDimConfig` — 3 tests (all pass):
-- `test_embedding_dim_default_is_384` — verifies default is 384
-- `test_embedding_dim_is_module_level_constant` — verifies it's an assignable int
-- `test_embedding_dim_env_override_is_int_parse` — verifies correct int parser
-
-**CI:** 82 passed, 1 skipped (pre-existing recall_diagnostics.py issue)
-
-### PR #136 (sleep prompt override) — REVIEWED, NEEDS UPDATES
-Author: steezkelly. **Conceptually sound, implementation needs work.**
-
-| Issue | Detail |
-|-------|--------|
-| Missing `_memory_lines()` definition | PR body shows `_memory_lines()` function but it's not in the diff |
-| `SLEEP_PROMPT = os.environ.get(...)` | Always reads env even if empty — slight waste, but ok |
-| `_format_sleep_prompt()` returns `None` when unset | Correct — callers fall back to built-in |
-| Doc updated (benchmarking.md, configuration.md) | ✓ |
-| Tests: `TestSleepPromptOverride` | ✓ — covers both local and host LLM paths |
-| `SLEEP_PROMPT` doesn't go through `_env_truthy()` | Not needed — empty string is falsy, correct behavior |
-
-**Verdict:** Needs author to add the missing `_memory_lines()` helper. The PR body describes code that isn't in the diff — likely a sync issue.
-
-### PR #137 (timeout config) — REVIEWED, READY TO MERGE
-Author: steezkelly. **Clean, well-structured, ready to merge.**
-
-| Change | Detail |
-|--------|--------|
-| `SESSION_END_SLEEP_TIMEOUT_SECONDS` | `15` → `float(os.environ.get("MNEMOSYNE_SESSION_END_TIMEOUT", "60"))` |
-| Auto-sleep `join(timeout=5)` | → `float(os.environ.get("MNEMOSYNE_AUTO_SLEEP_TIMEOUT", "15"))` |
-| `SHUTDOWN_DRAIN_TIMEOUT_SECONDS` | `2` → `float(os.environ.get("MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT", "8"))` |
-| Warning message | Updated to `%.0fs` format with actual timeout value |
-
-- No test changes — existing tests already override these as class attrs
-- Follows same pattern as PR #136 (env var float conversion)
-- No breaking changes — all defaults match previous hardcoded values
-
 ---
 
-## Git State
+## Merged This Session
 
-```
-Branch:      fix/embedding-dim-env-var (pushed to origin)
-origin/upstream: up to date
-Working tree: clean
-Open PRs:    #138 (fix/embedding-dim-env-var → AxDSan/mnemosyne:main)
-```
-
----
-
-## Upstream PRs (AxDSan/mnemosyne) — 4 OPEN
-
-| PR | Title | Recommendation |
-|----|-------|----------------|
-| #138 | fix(beam): read EMBEDDING_DIM from MNEMOSYNE_EMBEDDING_DIM env var | **Merge** — my PR |
-| #137 | fix(provider): make three hardcoded timeouts configurable via env vars | **Merge** — clean |
-| #136 | feat: add sleep prompt override | **Request changes** — missing `_memory_lines()` |
-| #131 | fix: read EMBEDDING_DIM from MNEMOSYNE_EMBEDDING_DIM env var | **Closed** — superseded by #138 |
+| PR | Note |
+|----|------|
+| **#138** | EMBEDDING_DIM env var — merged at 2026-05-14T16:40:10Z |
+| **#136** | Sleep prompt override — closed by author at 2026-05-14T16:39:10Z |
+| **#138** supersedes #131 | Original EMBEDDING_DIM PR |
 
 ---
 
 ## Pre-existing Failures (unrelated to our changes)
 
 `mnemosyne/core/recall_diagnostics.py:40` — `AttributeError: module 'logging' has no attribute 'getLogger'`
-- Causes ~20 failures in `TestEpisodicMemory`, `TestCrossSessionRecall`, `TestTemporalQueries`, etc.
-- Not touched by any of our changes — separate bug in that module
+- Causes ~20 test failures in `TestEpisodicMemory`, `TestCrossSessionRecall`, etc.
+- Separate bug in that module — not touched by any of our changes
 - Tests that don't import `recall_diagnostics` pass cleanly
+
+---
+
+## Git State
+
+```
+Branch:      fix/provider-timeout-env-vars (pushed to origin)
+PR:          #139 → AxDSan/mnemosyne:main
+Working tree: clean
+```

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -477,8 +477,11 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
     # How long on_session_end will wait for sleep/consolidation to finish before
     # giving up and letting the daemon thread continue in the background. Tests
-    # may shorten this to keep the suite fast.
-    SESSION_END_SLEEP_TIMEOUT_SECONDS = 15
+    # may shorten this to keep the suite fast. Allow user override via env var
+    # for hosts with slow local LLM consolidation.
+    SESSION_END_SLEEP_TIMEOUT_SECONDS = float(
+        os.environ.get("MNEMOSYNE_SESSION_END_TIMEOUT", "60")
+    )
 
     def __init__(self):
         self._beam: Optional[Any] = None
@@ -970,9 +973,10 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 sleep_fn = self._beam.sleep_all_sessions if hasattr(self._beam, "sleep_all_sessions") else self._beam.sleep
                 sleep_thread = threading.Thread(target=sleep_fn, daemon=True)
                 sleep_thread.start()
-                sleep_thread.join(timeout=5)
+                auto_timeout = float(os.environ.get("MNEMOSYNE_AUTO_SLEEP_TIMEOUT", "15"))
+                sleep_thread.join(timeout=auto_timeout)
                 if sleep_thread.is_alive():
-                    logger.warning("Mnemosyne auto-sleep timed out after 5s — consolidation deferred")
+                    logger.warning("Mnemosyne auto-sleep timed out after %.0fs — consolidation deferred", auto_timeout)
         except Exception:
             pass
 
@@ -1359,8 +1363,11 @@ class MnemosyneMemoryProvider(MemoryProvider):
     # held up indefinitely; just long enough to close the race window where
     # the daemon thread's post-join host call could see a None backend and
     # fall through to MNEMOSYNE_LLM_BASE_URL (violating the host-skips-remote
-    # contract). Tests may shorten this to keep the suite fast.
-    SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 2
+    # contract). Tests may shorten this to keep the suite fast. Allow user
+    # override via env var.
+    SHUTDOWN_DRAIN_TIMEOUT_SECONDS = float(
+        os.environ.get("MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT", "8")
+    )
 
     def shutdown(self) -> None:
         # If session_end's daemon thread is still consolidating when shutdown

--- a/tests/test_hermes_memory_provider.py
+++ b/tests/test_hermes_memory_provider.py
@@ -131,8 +131,10 @@ def test_on_session_end_logs_warning_on_timeout(caplog):
 
 
 def test_session_end_timeout_default_matches_design():
-    """The production default should remain 15s (decision A6)."""
-    assert MnemosyneMemoryProvider.SESSION_END_SLEEP_TIMEOUT_SECONDS == 15
+    """The production default should remain 60s (env-var override available)."""
+    # Default is 60s (was 15s hardcoded). Operators can override via
+    # MNEMOSYNE_SESSION_END_TIMEOUT for slow local LLM consolidation.
+    assert MnemosyneMemoryProvider.SESSION_END_SLEEP_TIMEOUT_SECONDS == 60
 
 
 def test_on_session_end_completes_when_sleep_is_fast():
@@ -243,8 +245,10 @@ def test_shutdown_proceeds_when_drain_times_out(caplog):
 
 
 def test_shutdown_drain_default_matches_design():
-    """Production drain default should remain 2s."""
-    assert MnemosyneMemoryProvider.SHUTDOWN_DRAIN_TIMEOUT_SECONDS == 2
+    """Production drain default should remain 8s (env-var override available)."""
+    # Default is 8s (was 2s hardcoded). Operators can override via
+    # MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT for slow hosts.
+    assert MnemosyneMemoryProvider.SHUTDOWN_DRAIN_TIMEOUT_SECONDS == 8
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Makes three timing constants configurable via environment variables. Follows PR #137 (steezkelly).

## Changes

| Constant | Before | Env Var | Default |
|----------|--------|---------|---------|
|  |  |  |  |
| Auto-sleep  |  |  |  |
|  |  |  |  |

**:**
-  now reads from  (default 60s — longer for slow local LLM consolidation)
- Auto-sleep  now reads from  (default 15s); log message updated to  format with actual value
-  now reads from  (default 8s)

**:**
- : expects  (was )
- : expects  (was )

## Why

-  increased to 60s for hosts with slow local LLM consolidation (the 15s hardcoded value was too short in practice)
-  increased to 8s for slow hosts
-  exposed as env var so operators can tune auto-sleep aggressiveness

## CI

 — 43 passed

Closes #137