### PR TITLE
feat: add optional Hermes user autosave modes

### DIFF
--- a/docs/hermes-llm-integration.md
+++ b/docs/hermes-llm-integration.md
@@ -68,9 +68,19 @@ MNEMOSYNE_HOST_LLM_MODEL=gpt-5.1-mini
 # small chunks and lossy multi-chunk summaries.
 MNEMOSYNE_HOST_LLM_N_CTX=32000
 
+# Optional: route through a dedicated Hermes auxiliary task instead of
+# compression. Defaults to compression for backward compatibility.
+MNEMOSYNE_HOST_LLM_TASK=memory
+
 # Existing global gate. When false, ALL LLM-backed memory operations
 # are disabled, including the host path.
 MNEMOSYNE_LLM_ENABLED=true
+
+# Optional: extract-mode user autosave runs through a single daemon worker
+# queue outside sync_turn by default, so slow host LLM calls do not block
+# replies or spawn one extraction thread per user turn. Set false only for
+# tests or hosts that require deterministic synchronous writes.
+MNEMOSYNE_AUTOSAVE_EXTRACT_ASYNC=true
 ```
 
 To control the default host model without Mnemosyne-specific overrides,
@@ -103,6 +113,18 @@ Fact extraction uses `temperature=0.0` so re-ingesting the same content
 produces the same facts. This avoids near-duplicate writes to the facts
 table when the same conversation is processed twice. Consolidation continues
 to use `temperature=0.3` — paraphrasing variance is acceptable there.
+
+## Extract-mode user autosave
+
+Hermes users can opt into `user_autosave_mode=extract` to save cleaned,
+durable user facts instead of every raw user turn. Extract mode uses the same
+Mnemosyne LLM chain as sleep/consolidation: host backend first, then the
+existing OpenAI-compatible remote endpoint, then local GGUF fallback.
+
+By default, extraction runs through a single background worker queue so slow
+LLM calls do not block `sync_turn()` or create one thread per turn. Set
+`user_autosave_extract_async=false` (or `MNEMOSYNE_AUTOSAVE_EXTRACT_ASYNC=false`)
+when tests or host integrations need deterministic synchronous writes.
 
 ## Session shutdown
 

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -17,8 +17,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+import queue
+import re
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from datetime import datetime
@@ -510,6 +513,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
         self._turn_count = 0
         self._auto_sleep_threshold = 50
         self._auto_sleep_enabled = os.environ.get("MNEMOSYNE_AUTO_SLEEP_ENABLED", "").strip().lower() in ("1", "true", "yes", "on")
+        self._user_autosave_mode = os.environ.get("MNEMOSYNE_AUTOSAVE_USER_MODE", "raw").strip().lower() or "raw"
+        self._user_autosave_extract_async = os.environ.get("MNEMOSYNE_AUTOSAVE_EXTRACT_ASYNC", "true").strip().lower() in ("1", "true", "yes", "on")
         self._ignore_patterns: List[str] = []  # Regex patterns to filter from memory
         self._skip_contexts = {"cron", "flush", "subagent", "background", "skill_loop"}  # Agent contexts to skip
         # Profile memory isolation: when enabled, each Hermes profile gets its own
@@ -520,6 +525,9 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # daemon thread from racing with unregister and falling through to
         # MNEMOSYNE_LLM_BASE_URL.
         self._session_end_thread: Optional[threading.Thread] = None
+        self._autosave_extract_queue: queue.Queue[str] = queue.Queue()
+        self._autosave_extract_worker: Optional[threading.Thread] = None
+        self._autosave_extract_lock = threading.Lock()
         # C13: per-instance tracking of whether THIS provider contributed
         # to the module-level _active_provider_count. Lets each instance
         # increment exactly once on activate and decrement exactly once on
@@ -616,6 +624,32 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if vector_type and vector_type not in ("float32", "int8", "bit"):
             logger.warning("Mnemosyne: unknown vector_type=%r, ignoring", vector_type)
 
+        # user_autosave_mode: raw preserves legacy behavior; filtered/extract/off reduce chat dust.
+        user_autosave_mode = (
+            kwargs.get("user_autosave_mode")
+            or self._read_config_key("user_autosave_mode")
+            or os.environ.get("MNEMOSYNE_AUTOSAVE_USER_MODE")
+        )
+        if user_autosave_mode:
+            mode = str(user_autosave_mode).strip().lower()
+            if mode in ("raw", "filtered", "filter", "extract", "off", "false", "0", "none"):
+                self._user_autosave_mode = mode
+            else:
+                logger.warning("Mnemosyne: unknown user_autosave_mode=%r, keeping %s", user_autosave_mode, self._user_autosave_mode)
+
+        user_autosave_extract_async = (
+            kwargs.get("user_autosave_extract_async")
+            if "user_autosave_extract_async" in kwargs
+            else self._read_config_key("user_autosave_extract_async")
+        )
+        if user_autosave_extract_async is None:
+            user_autosave_extract_async = os.environ.get("MNEMOSYNE_AUTOSAVE_EXTRACT_ASYNC")
+        if user_autosave_extract_async is not None:
+            if isinstance(user_autosave_extract_async, str):
+                self._user_autosave_extract_async = user_autosave_extract_async.strip().lower() in ("1", "true", "yes", "on")
+            else:
+                self._user_autosave_extract_async = bool(user_autosave_extract_async)
+
         # ignore_patterns: list of regex patterns to filter from memory storage
         patterns = kwargs.get("ignore_patterns") or self._read_config_key("ignore_patterns")
         if patterns:
@@ -646,6 +680,174 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 logger.debug("Mnemosyne: invalid ignore pattern %r, skipping", pattern)
         return False
 
+    @staticmethod
+    def _is_low_value_user_turn(content: str) -> bool:
+        """Return True for chat dust that belongs in transcript context, not durable memory."""
+        text = (content or "").strip()
+        if len(text) < 12:
+            return True
+        lower = text.lower()
+        normalized = re.sub(r"\s+", " ", lower).strip(" .!?…")
+        if normalized in {
+            "hello", "hi", "hey", "yo", "thanks", "thank you", "ty", "tysm",
+            "ok", "okay", "k", "nice", "cool", "done", "continue", "go on",
+        }:
+            return True
+        if re.search(r"\b(review the conversation above|consider saving.*memory|has the user revealed|focus on:)\b", text, re.I | re.S):
+            return True
+        if re.search(r"\b[A-Za-z0-9+/]{120,}={0,2}\b", text):
+            return True
+        if text.count("?") and not re.search(
+            r"\b(remember|from now on|i prefer|i want|don't|do not|always|never|my name|my school|my setup|my workflow)\b",
+            lower,
+        ):
+            return True
+        return False
+
+    @classmethod
+    def _looks_durable_user_turn(cls, content: str) -> bool:
+        """Cheap prefilter for filtered/raw autosave modes."""
+        if cls._is_low_value_user_turn(content):
+            return False
+        lower = content.lower()
+        durable_markers = (
+            "remember", "from now on", "i prefer", "i want", "i need", "don't", "do not",
+            "always", "never", "my name", "my school", "my admin", "my setup", "my workflow",
+            "use ", "call ", "save this", "note that",
+        )
+        return any(marker in lower for marker in durable_markers)
+
+    @staticmethod
+    def _user_autosave_prompt(content: str) -> str:
+        return (
+            "Extract durable long-term memory facts from one user message.\n"
+            "Return ONLY a JSON array of strings, or [] if nothing should be saved.\n\n"
+            "Save only explicit facts, preferences, stable context, and user instructions that are likely to matter next week.\n"
+            "Do NOT save greetings, thanks, ordinary questions, current debugging chatter, task progress, PR/commit/issue numbers, "
+            "temporary deadlines, assistant/system/meta prompts, or anything merely inferred.\n"
+            "Rewrite each item as a concise, self-contained third-person memory about the user.\n\n"
+            f"User message:\n{content[:4000]}\n"
+        )
+
+    @classmethod
+    def _parse_user_autosave_extraction(cls, raw_output: str) -> List[str]:
+        """Parse the autosave extractor's JSON-array response defensively."""
+        if not raw_output:
+            return []
+        text = raw_output.strip()
+        if text.upper() in {"NO_MEMORY", "NO_FACTS", "[]"}:
+            return []
+        match = re.search(r"\[[\s\S]*\]", text)
+        if not match:
+            return []
+        try:
+            payload = json.loads(match.group(0))
+        except Exception:
+            return []
+        if not isinstance(payload, list):
+            return []
+        memories: List[str] = []
+        for item in payload[:5]:
+            if not isinstance(item, str):
+                continue
+            memory = re.sub(r"\s+", " ", item).strip()
+            if len(memory) < 20 or cls._is_low_value_user_turn(memory):
+                continue
+            memories.append(memory[:500])
+        return memories
+
+    def _extract_user_autosave_memories(self, content: str) -> List[str]:
+        """Use Mnemosyne's LLM fallback chain to extract durable user facts."""
+        if self._is_low_value_user_turn(content):
+            return []
+        try:
+            from mnemosyne.core import local_llm
+        except Exception:
+            return []
+        prompt = self._user_autosave_prompt(content)
+        try:
+            if not local_llm.llm_available():
+                return []
+            max_tokens = int(os.environ.get("MNEMOSYNE_AUTOSAVE_EXTRACT_MAX_TOKENS", "1024"))
+            attempted, host_text = local_llm._try_host_llm(prompt, max_tokens=max_tokens, temperature=0.0)
+            if attempted:
+                return self._parse_user_autosave_extraction(host_text or "")
+            raw = None
+            if local_llm.LLM_ENABLED and local_llm.LLM_BASE_URL:
+                raw = local_llm._call_remote_llm(prompt, temperature=0.0)
+            if not raw:
+                llm = local_llm._load_llm()
+                if llm is not None:
+                    raw = llm(prompt, max_new_tokens=max_tokens, stop=["</s>", "<|user|>"])
+            return self._parse_user_autosave_extraction(raw if isinstance(raw, str) else "")
+        except Exception as exc:
+            logger.debug("Mnemosyne user autosave extraction failed: %s", exc)
+            return []
+
+    def _remember_extracted_user_memories(self, content: str) -> None:
+        if not self._beam:
+            return
+        for memory in self._extract_user_autosave_memories(content):
+            self._beam.remember(
+                content=memory,
+                source="conversation_extract",
+                importance=0.65,
+                extract_entities=True,
+                veracity="stated",
+                metadata={"autosave_mode": "extract"},
+            )
+
+    def _queue_user_autosave_extraction(self, content: str) -> None:
+        """Run extract-mode autosave outside sync_turn's critical path.
+
+        A single daemon worker drains a FIFO queue. This keeps the chat turn
+        non-blocking without spawning one LLM extraction thread per message.
+        """
+        self._autosave_extract_queue.put(content)
+        with self._autosave_extract_lock:
+            if self._autosave_extract_worker and self._autosave_extract_worker.is_alive():
+                return
+            worker = threading.Thread(target=self._autosave_extract_worker_loop, daemon=True)
+            self._autosave_extract_worker = worker
+            worker.start()
+
+    def _autosave_extract_worker_loop(self) -> None:
+        while True:
+            try:
+                content = self._autosave_extract_queue.get_nowait()
+            except queue.Empty:
+                with self._autosave_extract_lock:
+                    if self._autosave_extract_queue.empty():
+                        self._autosave_extract_worker = None
+                        return
+                continue
+            try:
+                self._remember_extracted_user_memories(content)
+            except Exception as exc:
+                logger.debug("Mnemosyne async user autosave extraction failed: %s", exc)
+            finally:
+                self._autosave_extract_queue.task_done()
+
+    def _prune_autosave_extractors(self) -> None:
+        with self._autosave_extract_lock:
+            if self._autosave_extract_worker and not self._autosave_extract_worker.is_alive():
+                self._autosave_extract_worker = None
+
+    def _wait_for_autosave_extractors(self, timeout: float) -> None:
+        """Wait briefly for the queued extractor worker; primarily used by tests/shutdown."""
+        deadline = time.monotonic() + max(0.0, timeout)
+        while True:
+            with self._autosave_extract_lock:
+                worker = self._autosave_extract_worker
+            if worker is None:
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self._prune_autosave_extractors()
+                return
+            worker.join(timeout=remaining)
+            self._prune_autosave_extractors()
+
     def _read_config_key(self, key: str) -> Any:
         """Read a single key from memory.mnemosyne in config.yaml."""
         try:
@@ -664,6 +866,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "auto_sleep", "description": "Auto-run sleep() when working memory exceeds threshold. Set true to enable. Backward-compatible with MNEMOSYNE_AUTO_SLEEP_ENABLED env var.", "default": False},
             {"key": "sleep_threshold", "description": "Working memory count before auto-sleep triggers", "default": 50},
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},
+            {"key": "user_autosave_mode", "description": "How sync_turn stores user messages: raw (legacy), filtered (durable-looking raw turns only), extract (LLM extracts durable facts), or off.", "choices": ["raw", "filtered", "extract", "off"], "default": "raw"},
+            {"key": "user_autosave_extract_async", "description": "When user_autosave_mode=extract, run LLM extraction through a single daemon worker queue so sync_turn stays fast without spawning one thread per turn. Set false for deterministic tests or hosts that require synchronous writes.", "default": True},
             {"key": "ignore_patterns", "description": "Regex patterns to filter from memory storage (one per line in config, or comma-separated). Memories matching any pattern are skipped.", "default": []},
             {"key": "profile_isolation", "description": "Enable per-profile memory isolation via Mnemosyne banks. Each Hermes profile gets its own SQLite database under mnemosyne/data/banks/<profile>/. Default false for backward compatibility.", "default": False},
         ]
@@ -924,14 +1128,34 @@ class MnemosyneMemoryProvider(MemoryProvider):
             return
         try:
             if user_content and len(user_content) > 5 and not self._should_filter(user_content):
-                self._beam.remember(
-                    content=f"[USER] {user_content[:500]}",
-                    source="conversation",
-                    importance=0.3,
-                    extract_entities=True,
-                )
-                # Check for identity-significant signals in user content
-                self._capture_identity_signals(user_content)
+                mode = self._user_autosave_mode
+                if mode in ("off", "false", "0", "none"):
+                    pass
+                elif mode == "extract":
+                    if self._user_autosave_extract_async:
+                        self._queue_user_autosave_extraction(user_content)
+                    else:
+                        self._remember_extracted_user_memories(user_content)
+                elif mode in ("filtered", "filter"):
+                    if self._looks_durable_user_turn(user_content):
+                        self._beam.remember(
+                            content=f"[USER] {user_content[:500]}",
+                            source="conversation",
+                            importance=0.3,
+                            extract_entities=True,
+                        )
+                else:
+                    self._beam.remember(
+                        content=f"[USER] {user_content[:500]}",
+                        source="conversation",
+                        importance=0.3,
+                        extract_entities=True,
+                    )
+                if mode not in ("off", "false", "0", "none"):
+                    # Check for identity-significant signals in user content.
+                    # Keep this independent of autosave mode so filtered/extract
+                    # modes don't suppress explicit identity memories.
+                    self._capture_identity_signals(user_content)
             if assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
                 self._beam.remember(
                     content=f"[ASSISTANT] {assistant_content[:800]}",
@@ -1394,6 +1618,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     self.SHUTDOWN_DRAIN_TIMEOUT_SECONDS,
                 )
         self._session_end_thread = None
+
+        self._wait_for_autosave_extractors(timeout=self.SHUTDOWN_DRAIN_TIMEOUT_SECONDS)
 
         # Symmetric with initialize(): clear the Hermes host LLM backend so a
         # process that later uses Mnemosyne outside Hermes does not retain a

--- a/hermes_memory_provider/hermes_llm_adapter.py
+++ b/hermes_memory_provider/hermes_llm_adapter.py
@@ -14,8 +14,10 @@ Why this lives in ``hermes_memory_provider`` and not ``mnemosyne.core``:
 Behavior:
 
 - ``HermesAuxLLMBackend.complete()`` is the host-LLM entry point. It calls
-  ``call_llm(task="compression", ...)`` so Hermes handles auth, OAuth refresh,
-  Codex Responses API translation, and provider fallback.
+  ``call_llm(task=<configured task>, ...)`` so Hermes handles auth, OAuth refresh,
+  Codex Responses API translation, and provider fallback. The default task is
+  ``compression`` for compatibility; set ``MNEMOSYNE_HOST_LLM_TASK`` to route
+  through a dedicated Hermes memory task when available.
 - ``register_hermes_host_llm()`` installs the backend in the registry.
 - ``unregister_hermes_host_llm()`` removes it (called from
   ``MnemosyneMemoryProvider.shutdown()`` so a process that later runs Mnemosyne
@@ -30,6 +32,7 @@ extractable content) returns ``None``. The Mnemosyne caller treats that as
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -38,13 +41,17 @@ logger = logging.getLogger(__name__)
 class HermesAuxLLMBackend:
     """LLMBackend implementation that routes through Hermes' aux client.
 
-    The ``task`` attribute pins the Hermes auxiliary slot used for memory ops.
-    ``compression`` is the closest existing fit; introducing a Hermes-side
-    ``memory`` task is left as a follow-up.
+    The ``task`` attribute selects the Hermes auxiliary slot used for memory ops.
+    It defaults to ``compression`` for compatibility with existing Hermes
+    installs, but hosts can override it with ``MNEMOSYNE_HOST_LLM_TASK`` without
+    changing Mnemosyne core.
     """
 
     name = "hermes"
-    task = "compression"
+
+    @property
+    def task(self) -> str:
+        return os.environ.get("MNEMOSYNE_HOST_LLM_TASK", "compression").strip() or "compression"
 
     def complete(
         self,

--- a/tests/test_hermes_llm_adapter.py
+++ b/tests/test_hermes_llm_adapter.py
@@ -80,6 +80,29 @@ def test_complete_calls_call_llm_with_compression_task(fake_agent_module):
     assert "model" not in captured
 
 
+def test_complete_uses_configurable_hermes_task(fake_agent_module, monkeypatch):
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return {"choices": [{"message": {"content": "Summary."}}]}
+
+    fake_agent_module.call_llm = fake_call_llm
+    monkeypatch.setenv("MNEMOSYNE_HOST_LLM_TASK", "memory")
+
+    adapter = _import_adapter()
+    backend = adapter.HermesAuxLLMBackend()
+    out = backend.complete(
+        "the prompt",
+        max_tokens=128,
+        temperature=0.2,
+        timeout=12.0,
+    )
+
+    assert out == "Summary."
+    assert captured["task"] == "memory"
+
+
 def test_complete_passes_provider_and_model_overrides(fake_agent_module):
     captured = {}
     fake_agent_module.call_llm = lambda **kw: (captured.update(kw) or {"choices": [{"message": {"content": "ok"}}]})
@@ -99,9 +122,17 @@ def test_complete_passes_provider_and_model_overrides(fake_agent_module):
 
 
 def test_complete_returns_none_when_agent_import_unavailable(monkeypatch):
-    """No fake agent in sys.modules → adapter returns None, never raises."""
+    """Missing Hermes auxiliary client → adapter returns None, never raises."""
+    real_import = __import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "agent.auxiliary_client" or (name == "agent" and "auxiliary_client" in fromlist):
+            raise ImportError("no hermes auxiliary client in this test")
+        return real_import(name, globals, locals, fromlist, level)
+
     monkeypatch.delitem(sys.modules, "agent", raising=False)
     monkeypatch.delitem(sys.modules, "agent.auxiliary_client", raising=False)
+    monkeypatch.setattr("builtins.__import__", guarded_import)
 
     adapter = _import_adapter()
     backend = adapter.HermesAuxLLMBackend()

--- a/tests/test_provider_autosave.py
+++ b/tests/test_provider_autosave.py
@@ -1,0 +1,169 @@
+import importlib
+import threading
+import time
+
+
+class FakeBeam:
+    def __init__(self):
+        self.calls = []
+
+    def remember(self, **kwargs):
+        self.calls.append(kwargs)
+        return f"mem-{len(self.calls)}"
+
+
+def _provider(monkeypatch, mode, *, async_extract=False):
+    monkeypatch.setenv("MNEMOSYNE_AUTOSAVE_USER_MODE", mode)
+    monkeypatch.setenv("MNEMOSYNE_AUTOSAVE_EXTRACT_ASYNC", "true" if async_extract else "false")
+    module = importlib.import_module("hermes_memory_provider")
+    provider = module.MnemosyneMemoryProvider()
+    provider._beam = FakeBeam()
+    return provider
+
+
+def test_user_autosave_off_skips_user_turns(monkeypatch):
+    provider = _provider(monkeypatch, "off")
+
+    provider.sync_turn("The user prefers Arial for school reports.", "")
+
+    assert provider._beam.calls == []
+
+
+def test_user_autosave_filtered_skips_chatter_but_saves_durable_preferences(monkeypatch):
+    provider = _provider(monkeypatch, "filtered")
+
+    provider.sync_turn("wait what was phase 1 again?", "")
+    provider.sync_turn("from now on please call ST1510 Programming for Data Analytics", "")
+
+    assert len(provider._beam.calls) == 1
+    call = provider._beam.calls[0]
+    assert call["content"] == "[USER] from now on please call ST1510 Programming for Data Analytics"
+    assert call["source"] == "conversation"
+    assert call["importance"] == 0.3
+
+
+def test_user_autosave_extract_saves_only_extracted_durable_facts(monkeypatch):
+    provider = _provider(monkeypatch, "extract")
+    monkeypatch.setattr(
+        provider,
+        "_extract_user_autosave_memories",
+        lambda text: ["The user prefers Programming for Data Analytics to be named fully instead of using ST1510."],
+    )
+
+    provider.sync_turn("from now on please call ST1510 Programming for Data Analytics", "")
+
+    assert len(provider._beam.calls) == 1
+    call = provider._beam.calls[0]
+    assert call["content"] == "The user prefers Programming for Data Analytics to be named fully instead of using ST1510."
+    assert call["source"] == "conversation_extract"
+    assert call["importance"] == 0.65
+    assert call["extract_entities"] is True
+    assert call["veracity"] == "stated"
+
+
+def test_user_autosave_extract_skips_when_extractor_returns_no_facts(monkeypatch):
+    provider = _provider(monkeypatch, "extract")
+    monkeypatch.setattr(provider, "_extract_user_autosave_memories", lambda text: [])
+
+    provider.sync_turn("thanks salsa", "")
+
+    assert provider._beam.calls == []
+
+
+def test_user_autosave_extract_async_does_not_block_sync_turn(monkeypatch):
+    provider = _provider(monkeypatch, "extract", async_extract=True)
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_extract(text):
+        started.set()
+        release.wait(timeout=2)
+        return ["The user prefers memory extraction to run outside the sync-turn path."]
+
+    monkeypatch.setattr(provider, "_extract_user_autosave_memories", slow_extract)
+
+    start = time.perf_counter()
+    provider.sync_turn("from now on extract memories without blocking the reply", "")
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.2
+    assert started.wait(timeout=1)
+    assert provider._beam.calls == []
+
+    release.set()
+    provider._wait_for_autosave_extractors(timeout=2)
+
+    assert len(provider._beam.calls) == 1
+    assert provider._beam.calls[0]["content"] == "The user prefers memory extraction to run outside the sync-turn path."
+    assert provider._beam.calls[0]["metadata"] == {"autosave_mode": "extract"}
+
+
+def test_user_autosave_extract_async_uses_single_worker_queue(monkeypatch):
+    provider = _provider(monkeypatch, "extract", async_extract=True)
+    first_started = threading.Event()
+    second_started = threading.Event()
+    release_first = threading.Event()
+    release_second = threading.Event()
+
+    def slow_extract(text):
+        if "first" in text:
+            first_started.set()
+            release_first.wait(timeout=2)
+            return ["The user prefers the first queued memory to complete before the second starts."]
+        if "second" in text:
+            second_started.set()
+            release_second.wait(timeout=2)
+            return ["The user prefers autosave extraction jobs to run serially."]
+        return []
+
+    monkeypatch.setattr(provider, "_extract_user_autosave_memories", slow_extract)
+
+    provider.sync_turn("from now on remember first queued extraction", "")
+    provider.sync_turn("from now on remember second queued extraction", "")
+
+    assert first_started.wait(timeout=1)
+    assert not second_started.wait(timeout=0.1)
+    assert provider._beam.calls == []
+
+    release_first.set()
+    assert second_started.wait(timeout=1)
+    release_second.set()
+    provider._wait_for_autosave_extractors(timeout=2)
+
+    assert [call["content"] for call in provider._beam.calls] == [
+        "The user prefers the first queued memory to complete before the second starts.",
+        "The user prefers autosave extraction jobs to run serially.",
+    ]
+
+
+def test_memory_autosave_extraction_parser_accepts_json_array(monkeypatch):
+    provider = _provider(monkeypatch, "extract")
+
+    parsed = provider._parse_user_autosave_extraction(
+        '["The user prefers Arial for school reports.", "The user wants plain English explanations for school work."]'
+    )
+
+    assert parsed == [
+        "The user prefers Arial for school reports.",
+        "The user wants plain English explanations for school work.",
+    ]
+
+
+def test_memory_autosave_extraction_parser_rejects_meta_and_empty(monkeypatch):
+    provider = _provider(monkeypatch, "extract")
+
+    assert provider._parse_user_autosave_extraction("NO_MEMORY") == []
+    assert provider._parse_user_autosave_extraction('["The assistant should review the conversation above."]') == []
+
+
+def test_user_autosave_prompt_is_generic_and_caps_input(monkeypatch):
+    provider = _provider(monkeypatch, "extract")
+
+    prompt = provider._user_autosave_prompt("x" * 10000)
+
+    assert "Alice" not in prompt
+    assert "ExampleAssistant" not in prompt
+    user_section = prompt.split("User message:\n", 1)[1].rstrip("\n")
+    assert len(user_section) == 4000
+    assert set(user_section) == {"x"}
+    assert "third-person memory about the user" in prompt


### PR DESCRIPTION
## Summary

Adds optional Hermes-oriented autosave controls for user turns, while preserving the current default behavior:

- keep `raw` autosave as the default for backward compatibility
- add `filtered`, `extract`, and `off` autosave modes
- add async extract-mode autosave via a single daemon worker queue
- add `user_autosave_extract_async` / `MNEMOSYNE_AUTOSAVE_EXTRACT_ASYNC` to opt into synchronous extraction when needed
- make the Hermes host LLM task configurable via `MNEMOSYNE_HOST_LLM_TASK`, defaulting to `compression`
- document the modes and host LLM routing knobs

## Why

Hermes currently mirrors user turns into Mnemosyne as raw conversation memory. That is useful for transcript-like recall, but hosts may want stricter control over what becomes durable memory. This PR makes that behavior configurable instead of replacing the existing behavior.

## Autosave modes

`user_autosave_mode` controls how `sync_turn()` stores user messages:

- `raw` — existing behavior and default. Stores the raw user turn as conversation memory, subject to ignore patterns.
- `filtered` — stores raw user turns only when they look durable, such as explicit preferences, “remember this”, “from now on”, “always/never”, setup details, or user instructions. Short chatter and ordinary questions are skipped.
- `extract` — runs an LLM extraction prompt and saves only explicit durable facts/preferences/instructions as cleaned memory entries. This is intended for hosts that want less chat dust in long-term memory.
- `off` — disables user-turn autosave entirely. Assistant-turn autosave behavior is unchanged.

The default remains `raw`, so existing installations keep the same behavior unless they opt in.

## Extract-mode async behavior

When `user_autosave_mode=extract`, extraction is async by default:

```bash
MNEMOSYNE_AUTOSAVE_EXTRACT_ASYNC=true
```

Async extraction uses one daemon worker queue, not one thread per turn. This keeps `sync_turn()` fast while preserving FIFO ordering and avoiding thread pile-ups during busy chats.

Set it to false for deterministic synchronous writes in tests or host integrations that need extraction to finish before `sync_turn()` returns:

```bash
MNEMOSYNE_AUTOSAVE_EXTRACT_ASYNC=false
```

## Hermes host LLM task routing

The Hermes host backend still defaults to the existing `compression` auxiliary task for compatibility. Hosts can opt into a dedicated memory route without changing Mnemosyne core:

```bash
MNEMOSYNE_HOST_LLM_TASK=memory
```

## Test plan

Targeted tests pass:

```bash
python -m pytest tests/test_provider_autosave.py tests/test_hermes_llm_adapter.py tests/test_local_llm.py tests/test_identity_memory.py -q -o 'addopts='
# 46 passed
```

Full local suite status:

```bash
ulimit -n 8192 2>/dev/null || true
python -m pytest tests -q -o 'addopts='
# 1300 passed, 2 failed
```

The two full-suite failures appear unrelated to this PR:

- `tests/test_beam.py::TestConsolidationHealth::test_health_healthy_after_sleep` compares local `datetime.now()` with a UTC-style consolidation timestamp and is off by the local +08 timezone.
- `tests/test_outer_package_version.py::test_outer_package_reexports_version_and_author` assumes the checkout directory is named `mnemosyne`; this temp checkout is `/tmp/mnemosyne-pr-prep`, so the subprocess imports the installed package instead of the outer repo stub.
