### PR TITLE
fix: MCP SDK 1.x compatibility for stdio and SSE transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemosyne) (MAJOR.MINOR).
 
+## [2.9.0] — 2026-05-17
+
+### Fixed
+
+- **MCP SDK 1.x compatibility** (`mcp_server.py`). The `stdio_server()`
+  transport no longer accepts a `Server` object as argument since v0.9.1;
+  the stream pair is obtained via `async with stdio_server()` and then
+  passed to `server.run()`. Tool definitions are now returned as `Tool`
+  Pydantic objects instead of raw dicts, matching the SDK 1.x `list_tools`
+  handler signature. Both stdio and SSE transports are patched.
+
 ## [2.8.0] — 2026-05-14
 
 ### Added

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "2.8.0"
+__version__ = "2.9.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/mcp_server.py
+++ b/mnemosyne/mcp_server.py
@@ -100,7 +100,9 @@ async def _run_stdio() -> None:
 
     @server.list_tools()
     async def list_tools():
-        return get_tool_definitions()
+        from mcp.types import Tool
+        raw = get_tool_definitions()
+        return [Tool(**t) for t in raw]
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list:
@@ -110,7 +112,7 @@ async def _run_stdio() -> None:
         except Exception as e:
             return [TextContent(type="text", text=json.dumps({"status": "error", "message": str(e)}, indent=2))]
 
-    async with stdio_server(server) as (read_stream, write_stream):
+    async with stdio_server() as (read_stream, write_stream):
         await server.run(read_stream, write_stream, server.create_initialization_options())
 
 
@@ -146,7 +148,9 @@ def _build_sse_app(host: str = "127.0.0.1"):
 
     @server.list_tools()
     async def list_tools():
-        return get_tool_definitions()
+        from mcp.types import Tool
+        raw = get_tool_definitions()
+        return [Tool(**t) for t in raw]
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -274,6 +274,26 @@ class TestMCPIntegration:
         names = [t["name"] for t in tools]
         assert "mnemosyne_remember" in names
 
+    def test_tool_definitions_convertible_to_tool_pydantic(self):
+        """Tool dict definitions must be compatible with mcp SDK 1.x Tool Pydantic model.
+
+        The SDK 1.x list_tools handler expects Tool() instances with typed fields.
+        If get_tool_definitions() returns dicts with unexpected keys or missing
+        required fields, Tool(**t) will raise a ValidationError.
+        """
+        try:
+            from mcp.types import Tool
+        except ImportError:
+            pytest.skip("mcp SDK not installed")
+
+        tools = get_tool_definitions()
+        for t in tools:
+            tool = Tool(**t)
+            assert isinstance(tool, Tool)
+            assert tool.name == t["name"]
+            assert tool.description == t.get("description")
+            assert tool.inputSchema == t["inputSchema"]
+
     def test_top_level_cli_forwards_mcp_arguments(self, tmp_path):
         """`mnemosyne mcp ...` must pass subcommand args to the MCP parser."""
         env = os.environ.copy()


### PR DESCRIPTION
## Summary

Fix two compatibility issues between Mnemosyne's MCP server and the `mcp` SDK >= 1.0.0 (current: 1.27.1).

## Changes

### 1. `stdio_server()` API mismatch (`mcp_server.py`)

The `mcp.server.stdio.studio_server()` transport has never accepted a `Server` object as an argument (since at least v0.9.1). The correct API obtains the stream pair via `async with stdio_server()` and passes them to `server.run()`.

**Before:** `async with stdio_server(server) as (read, write):`
**After:** `async with stdio_server() as (read, write): await server.run(read, write, server.create_initialization_options())`

### 2. Tool definitions must be `Tool` Pydantic objects (`mcp_server.py`)

The SDK 1.x `@server.list_tools()` handler expects a list of `Tool` Pydantic instances, not raw dicts. `get_tool_definitions()` returns `List[Dict]`, so the handler now converts each dict with `Tool(**t)` before returning.

Both stdio (`_run_stdio`) and SSE (`_build_sse_app`) transports are patched.

### Housekeeping

- Version bumped to 2.9.0
- Changelog entry added
- Test: validates all 6 tool dicts convert to `Tool(**t)` without error

## Testing

```
pytest tests/test_mcp_server.py -v
# 25 passed
```