### PR TITLE
fix: move sys.path setup before mnemosyne imports for Hermes MemoryProvider

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -22,12 +22,14 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from datetime import datetime
-from mnemosyne.core.episodic_graph import GraphEdge
 
 # Ensure mnemosyne core is importable from this directory
+# MUST be before any `from mnemosyne.*` imports
 _mnemosyne_root = Path(__file__).resolve().parent.parent
 if str(_mnemosyne_root) not in sys.path:
     sys.path.insert(0, str(_mnemosyne_root))
+
+from mnemosyne.core.episodic_graph import GraphEdge
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Problem
When deployed as a Hermes MemoryProvider plugin, `sys.path.insert()` that adds the
repo root to Python's import path runs **after** the first
`from mnemosyne.core.episodic_graph import GraphEdge` statement.
This causes a `ModuleNotFoundError` on startup when `mnemosyne` is not already
on `sys.path` (which is the case when Hermes loads it from the plugin directory).

Error log:
```
WARNING:agent.memory_provider:Memory provider 'mnemosyne' failed: No module named 'mnemosyne'
```

## Fix
Move `sys.path.insert(0, str(_mnemosyne_root))` to **before** the first
`from mnemosyne.*` import. 4-line diff — just reordering existing code.

## Testing
- Installed in a Hermes Agent Docker container with `memory.provider=mnemosyne`
- Before fix: MemoryProvider fails to initialize
- After fix: MemoryProvider initializes correctly, all tools register, memory works
