### PR TITLE
fix: preserve schema during vector type probing

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -394,30 +394,39 @@ def _detect_vec_type(conn: sqlite3.Connection) -> str:
     """
     Detect whether sqlite-vec supports int8/bit.
     Falls back to float32 if the requested type is unavailable.
+
+    Keep the probe rollback scoped to the temporary vec test table. This
+    function runs during schema initialization, before init_beam() commits its
+    CREATE TABLE statements; a connection-wide rollback here can otherwise
+    undo unrelated schema DDL such as scratchpad.
     """
     if not _SQLITE_VEC_AVAILABLE:
         return "float32"
     if VEC_TYPE == "float32":
         return "float32"
+
     cursor = conn.cursor()
+
+    def _probe(candidate: str) -> bool:
+        cursor.execute("SAVEPOINT vec_type_probe")
+        try:
+            cursor.execute(
+                f"CREATE VIRTUAL TABLE _vec_test USING vec0(embedding {candidate}[{EMBEDDING_DIM}])"
+            )
+            cursor.execute("DROP TABLE IF EXISTS _vec_test")
+            cursor.execute("RELEASE SAVEPOINT vec_type_probe")
+            return True
+        except Exception:
+            cursor.execute("ROLLBACK TO SAVEPOINT vec_type_probe")
+            cursor.execute("RELEASE SAVEPOINT vec_type_probe")
+            return False
+
     test_type = VEC_TYPE  # int8 or bit
-    try:
-        cursor.execute(f"CREATE VIRTUAL TABLE IF NOT EXISTS _vec_test USING vec0(embedding {test_type}[{EMBEDDING_DIM}])")
-        cursor.execute("DROP TABLE IF EXISTS _vec_test")
-        conn.commit()
+    if _probe(test_type):
         return test_type
-    except Exception:
-        conn.rollback()
-        # Try int8 as fallback from bit
-        if test_type == "bit":
-            try:
-                cursor.execute(f"CREATE VIRTUAL TABLE IF NOT EXISTS _vec_test USING vec0(embedding int8[{EMBEDDING_DIM}])")
-                cursor.execute("DROP TABLE IF EXISTS _vec_test")
-                conn.commit()
-                return "int8"
-            except Exception:
-                conn.rollback()
-        return "float32"
+    if test_type == "bit" and _probe("int8"):
+        return "int8"
+    return "float32"
 
 
 def init_beam(db_path: Path = None):
@@ -5565,9 +5574,14 @@ class BeamMemory:
         method = "llm" if llm_used_count == summaries_created else ("llm+aaak" if llm_used_count > 0 else "aaak")
         if not dry_run:
             cursor.execute("""
-                INSERT INTO consolidation_log (session_id, items_consolidated, summary_preview)
-                VALUES (?, ?, ?)
-            """, (self.session_id, len(consolidated_ids), f"{summaries_created} summaries ({method}) from {len(consolidated_ids)} items"))
+                INSERT INTO consolidation_log (session_id, items_consolidated, summary_preview, created_at)
+                VALUES (?, ?, ?, ?)
+            """, (
+                self.session_id,
+                len(consolidated_ids),
+                f"{summaries_created} summaries ({method}) from {len(consolidated_ids)} items",
+                datetime.now().isoformat(),
+            ))
             self.conn.commit()
 
         # Run tiered degradation after consolidation

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 from datetime import datetime, timedelta
 
+from mnemosyne.core import beam as beam_module
 from mnemosyne.core.beam import BeamMemory, init_beam, _find_memories_by_fact
 from mnemosyne.core.memory import Mnemosyne
 
@@ -87,6 +88,27 @@ class TestBeamSchema:
         assert "consolidation_log" in tables
         # FTS5 virtual table
         assert "fts_episodes" in tables
+        conn.close()
+
+    def test_vec_type_probe_does_not_rollback_schema_ddl(self, temp_db, monkeypatch):
+        """Vector capability probing must not undo unrelated schema DDL.
+
+        Some sqlite-vec builds reject a requested vector type. The probe used
+        to call connection.rollback(), which could erase earlier CREATE TABLE
+        statements in init_beam() before the schema transaction was committed.
+        """
+        conn = sqlite3.connect(temp_db)
+        conn.execute("CREATE TABLE filler_table (id TEXT PRIMARY KEY)")
+
+        monkeypatch.setattr(beam_module, "_SQLITE_VEC_AVAILABLE", True)
+        monkeypatch.setattr(beam_module, "VEC_TYPE", "int8")
+
+        assert beam_module._detect_vec_type(conn) == "float32"
+
+        tables = [r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()]
+        assert "filler_table" in tables
         conn.close()
 
 

--- a/tests/test_outer_package_version.py
+++ b/tests/test_outer_package_version.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import tempfile
 import textwrap
 from pathlib import Path
 
@@ -35,33 +36,41 @@ def test_outer_package_reexports_version_and_author():
     # Run a subprocess with sys.path manipulated so the outer mnemosyne stub
     # is the resolved `mnemosyne` module — exactly the layout Hermes' plugin
     # loader produces when symlinking the repo root into ~/.hermes/plugins.
-    script = textwrap.dedent(f"""
-        import sys
-        # Put the parent of the repo first so `mnemosyne` resolves to the
-        # outer __init__.py at the repo root, mirroring the plugin layout.
-        sys.path.insert(0, {str(REPO_ROOT.parent)!r})
-        # Drop the inner-package path (if present) so we don't accidentally
-        # resolve to the inner __init__.py instead.
-        sys.path = [p for p in sys.path if p != {str(REPO_ROOT)!r}]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin_parent = Path(tmpdir)
+        plugin_package = plugin_parent / "mnemosyne"
+        plugin_package.symlink_to(REPO_ROOT, target_is_directory=True)
 
-        import mnemosyne
-        # Sanity check: we loaded the OUTER stub, not the inner library.
-        assert mnemosyne.__file__.endswith({str(REPO_ROOT / "__init__.py")!r}), (
-            "test setup failed: did not load outer package, got " + mnemosyne.__file__
+        script = textwrap.dedent(f"""
+            import sys
+            # Put a parent directory containing a repo-root symlink named
+            # `mnemosyne` first on sys.path. This mirrors the Hermes plugin
+            # layout without depending on the checkout directory itself being
+            # named `mnemosyne`.
+            sys.path.insert(0, {str(plugin_parent)!r})
+            # Drop editable-install/source paths that would otherwise resolve
+            # directly to the inner library package.
+            blocked = {{{str(REPO_ROOT)!r}, {str(REPO_ROOT.parent)!r}}}
+            sys.path = [p for p in sys.path if p not in blocked]
+
+            import mnemosyne
+            # Sanity check: we loaded the OUTER stub, not the inner library.
+            assert __import__('pathlib').Path(mnemosyne.__file__).resolve() == __import__('pathlib').Path({str(REPO_ROOT / "__init__.py")!r}), (
+                "test setup failed: did not load outer package, got " + mnemosyne.__file__
+            )
+
+            # The actual contract:
+            from mnemosyne import __version__, __author__
+            print("VERSION=" + __version__)
+            print("AUTHOR=" + __author__)
+        """)
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            cwd=str(plugin_parent),
         )
-
-        # The actual contract:
-        from mnemosyne import __version__, __author__
-        print("VERSION=" + __version__)
-        print("AUTHOR=" + __author__)
-    """)
-
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        capture_output=True,
-        text=True,
-        cwd=str(REPO_ROOT.parent),  # avoid CWD on path leaking inner package
-    )
 
     assert result.returncode == 0, (
         f"subprocess failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"


### PR DESCRIPTION
## Summary

- Scope sqlite-vec vector-type probe rollbacks to a savepoint so schema initialization cannot lose earlier DDL.
- Write consolidation log timestamps explicitly with the same local timestamp convention used by health checks.
- Make the outer-package version regression test independent of the checkout directory name.

## Why

When sqlite-vec is installed but rejects a requested vector type, `_detect_vec_type()` used `conn.rollback()`. During `init_beam()`, that rollback can undo earlier uncommitted `CREATE TABLE` statements, including `scratchpad`, causing scratchpad and export/import tests to fail.

The consolidation health check also compared local `datetime.now()` against a `CURRENT_TIMESTAMP` value from SQLite, which is UTC. In non-UTC environments this can make a fresh consolidation look stale.

The outer-package regression test assumed the repository checkout directory itself was named `mnemosyne`, which is not always true in local sandboxes or CI checkouts.

## Test plan

- `python -m pytest tests/test_beam.py::TestBeamSchema::test_vec_type_probe_does_not_rollback_schema_ddl tests/test_beam.py::TestBeamSchema::test_init_creates_tables tests/test_beam.py::TestScratchpad::test_scratchpad_write_read_clear tests/test_beam.py::TestExportImport::test_beam_export_to_dict tests/test_provider_all_15_tools.py::TestScratchpad::test_write_and_read -q -o 'addopts=' --tb=short`
- `python -m pytest tests/test_beam.py::TestConsolidationHealth::test_health_healthy_after_sleep -q -o 'addopts=' --tb=short`
- `python -m pytest tests/test_outer_package_version.py::test_outer_package_reexports_version_and_author -q -o 'addopts=' --tb=short`
- `ulimit -n 8192 2>/dev/null || true; python -m pytest -q -o 'addopts='`

Final full suite result: `1294 passed, 17 skipped, 1 warning`.
