### PR TITLE
fix: handle string booleans from YAML config in _apply_provider_config

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -597,7 +597,10 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if auto_sleep is None:
             auto_sleep = self._read_config_key("auto_sleep")
         if auto_sleep is not None:
-            self._auto_sleep_enabled = bool(auto_sleep)
+            if isinstance(auto_sleep, str):
+                self._auto_sleep_enabled = auto_sleep.lower() in ("true", "1", "yes", "on")
+            else:
+                self._auto_sleep_enabled = bool(auto_sleep)
         # env var is already applied in __init__, so it is the base default
 
         # sleep_threshold: prefer kwargs, then config.yaml, then default 50
@@ -631,7 +634,10 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if profile_isolation is None:
             profile_isolation = self._read_config_key("profile_isolation")
         if profile_isolation is not None:
-            self._profile_isolation_enabled = bool(profile_isolation)
+            if isinstance(profile_isolation, str):
+                self._profile_isolation_enabled = profile_isolation.lower() in ("true", "1", "yes", "on")
+            else:
+                self._profile_isolation_enabled = bool(profile_isolation)
 
     def _should_filter(self, content: str) -> bool:
         """Check if content matches any ignore pattern. Returns True if it should be skipped."""


### PR DESCRIPTION
## Bug
When `auto_sleep` or `profile_isolation` are set in `config.yaml` via the Hermes setup wizard, they arrive as YAML strings (`'false'`, `'true'`) instead of proper booleans. The code at `_apply_provider_config` does a bare `bool(auto_sleep)`, and in Python `bool('false')` evaluates to `True` — so **auto_sleep can never be disabled via config**.

## Fix
Add `isinstance(str)` checks before the `bool()` cast for both `auto_sleep` and `profile_isolation`. String values are parsed case-insensitively against `('true', '1', 'yes', 'on')`.

## Affected file
`hermes_memory_provider/__init__.py` — `_apply_provider_config()`

## Notes
The same bug affects `profile_isolation` (same code pattern). `sleep_threshold` is not affected because `int('50')` works correctly on numeric strings.