### PR TITLE
Fix temporal recall timezone normalization

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -25,7 +25,7 @@ import threading
 import math
 
 logger = logging.getLogger(__name__)
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Optional, Any, Set, Union
 from pathlib import Path
 
@@ -981,6 +981,22 @@ def _normalize_weights(vec_weight: Optional[float], fts_weight: Optional[float],
     return (vw / total, fw / total, iw / total)
 
 
+def _normalize_datetime_utc(dt: datetime) -> datetime:
+    """Return dt as a timezone-aware UTC datetime.
+
+    Naive datetimes are treated as UTC to preserve existing naive timestamp
+    behavior while avoiding naive/aware comparison crashes.
+    """
+    if dt.tzinfo is None or dt.utcoffset() is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _parse_iso_datetime_utc(value: str) -> datetime:
+    """Parse an ISO datetime string and normalize it to UTC."""
+    return _normalize_datetime_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
+
+
 def _recency_decay(timestamp_str: str, halflife_hours: float = RECENCY_HALFLIFE_HOURS) -> float:
     """Calculate recency decay factor. 1.0 = brand new, ~0.5 = one halflife old.
     
@@ -989,32 +1005,33 @@ def _recency_decay(timestamp_str: str, halflife_hours: float = RECENCY_HALFLIFE_
     if not timestamp_str:
         return 0.5  # Unknown age = neutral
     try:
-        ts = datetime.fromisoformat(timestamp_str)
-        age_hours = (datetime.now() - ts).total_seconds() / 3600.0
+        ts = _parse_iso_datetime_utc(timestamp_str)
+        age_hours = (datetime.now(timezone.utc) - ts).total_seconds() / 3600.0
         return math.exp(-age_hours / halflife_hours)
     except Exception:
         return 0.5
 
 
 def _parse_query_time(query_time: Optional[Union[str, datetime]]) -> datetime:
-    """Parse query_time parameter into a datetime object.
+    """Parse query_time parameter into a timezone-aware UTC datetime object.
 
-    - None -> datetime.now()
-    - str  -> parsed from ISO format
-    - datetime -> returned as-is
+    - None -> current UTC time
+    - str  -> parsed from ISO format and normalized to UTC
+    - datetime -> normalized to UTC
+    Naive values are treated as UTC for backward compatibility.
     """
     if query_time is None:
-        return datetime.now()
+        return datetime.now(timezone.utc)
     if isinstance(query_time, datetime):
-        return query_time
+        return _normalize_datetime_utc(query_time)
     if isinstance(query_time, str):
         # Try ISO format with various precisions
         try:
-            return datetime.fromisoformat(query_time)
+            return _parse_iso_datetime_utc(query_time)
         except ValueError:
             # Try appending time if only date provided
             try:
-                return datetime.fromisoformat(f"{query_time}T00:00:00")
+                return _parse_iso_datetime_utc(f"{query_time}T00:00:00")
             except ValueError:
                 raise ValueError(f"Invalid query_time format: {query_time!r}. Expected ISO datetime string.")
     raise TypeError(f"query_time must be str, datetime, or None; got {type(query_time).__name__}")
@@ -1033,7 +1050,7 @@ def _parse_ts_fast(ts: str) -> Optional[datetime]:
     if cached is not None:
         return cached
     try:
-        dt = datetime.fromisoformat(ts)
+        dt = _parse_iso_datetime_utc(ts)
     except (ValueError, TypeError):
         return None
     if len(_TS_CACHE) >= _TS_CACHE_MAX:
@@ -1056,6 +1073,7 @@ def _temporal_boost(memory_timestamp_str: str, query_time: datetime,
     ts = _parse_ts_fast(memory_timestamp_str)
     if ts is None:
         return 0.0
+    query_time = _normalize_datetime_utc(query_time)
 
     # Clamp future timestamps to query_time (no negative deltas)
     if ts > query_time:
@@ -3375,13 +3393,13 @@ class BeamMemory:
         Temporal scoring (Phase 3):
             temporal_weight: Float 0.0-1.0. Soft boost for memories near query_time.
                 0.0 = no temporal boost (default, backward compatible).
-            query_time: Target time for temporal scoring. None = now().
+            query_time: Target time for temporal scoring. None = current UTC time.
             temporal_halflife: Hours for temporal decay. None = env var or 24h default.
 
         Temporal scoring (Phase 3):
             temporal_weight: Float 0.0-1.0. Soft boost for memories near query_time.
                 0.0 = no temporal boost (default, backward compatible).
-            query_time: Target time for temporal scoring. None = now().
+            query_time: Target time for temporal scoring. None = current UTC time.
             temporal_halflife: Hours for temporal decay. None = env var or 24h default.
 
         Configurable hybrid scoring (Phase 4):

--- a/tests/test_temporal_recall.py
+++ b/tests/test_temporal_recall.py
@@ -17,7 +17,7 @@ import os
 import unittest
 import tempfile
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -73,31 +73,44 @@ class TestTemporalBoostFunction(unittest.TestCase):
         boost = _temporal_boost(future.isoformat(), now, halflife_hours=24.0)
         self.assertAlmostEqual(boost, 1.0, places=5)
 
+    def test_boost_offset_aware_timestamp_against_naive_query_time(self):
+        """Aware memory timestamps can be compared to naive query_time."""
+        query_time = datetime(2026, 4, 29, 12, 0, 0)
+        timestamp = "2026-04-29T09:00:00+00:00"
+        boost = _temporal_boost(timestamp, query_time, halflife_hours=3.0)
+        self.assertAlmostEqual(boost, 0.367879, places=3)
+
 
 class TestParseQueryTime(unittest.TestCase):
     """Unit tests for _parse_query_time helper."""
 
     def test_none_returns_now(self):
-        """None -> datetime.now() (approximately)."""
+        """None -> current UTC time (approximately)."""
         result = _parse_query_time(None)
         self.assertIsInstance(result, datetime)
-        self.assertLess((datetime.now() - result).total_seconds(), 1.0)
+        self.assertEqual(result.tzinfo, timezone.utc)
+        self.assertLess((datetime.now(timezone.utc) - result).total_seconds(), 1.0)
 
-    def test_datetime_passed_through(self):
-        """datetime object returned as-is."""
+    def test_datetime_normalized_to_utc(self):
+        """Naive datetime object is treated as UTC."""
         dt = datetime(2026, 4, 29, 12, 0, 0)
         result = _parse_query_time(dt)
-        self.assertEqual(result, dt)
+        self.assertEqual(result, datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_iso_string_parsed(self):
-        """ISO string parsed correctly."""
+        """Naive ISO string parsed as UTC."""
         result = _parse_query_time("2026-04-29T12:00:00")
-        self.assertEqual(result, datetime(2026, 4, 29, 12, 0, 0))
+        self.assertEqual(result, datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc))
+
+    def test_offset_aware_iso_string_normalized_to_utc(self):
+        """Offset-aware ISO string is normalized to UTC."""
+        result = _parse_query_time("2026-04-29T15:00:00+03:00")
+        self.assertEqual(result, datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_date_only_string(self):
         """Date-only string gets midnight time appended."""
         result = _parse_query_time("2026-04-29")
-        self.assertEqual(result, datetime(2026, 4, 29, 0, 0, 0))
+        self.assertEqual(result, datetime(2026, 4, 29, 0, 0, 0, tzinfo=timezone.utc))
 
     def test_invalid_string_raises(self):
         """Invalid string raises ValueError."""
@@ -201,6 +214,22 @@ class TestTemporalRecallEndToEnd(unittest.TestCase):
         results = self.beam.recall("event", top_k=5,
                                     temporal_weight=0.3,
                                     query_time=last_week)
+        self.assertGreaterEqual(len(results), 1)
+
+    def test_offset_aware_imported_timestamp_with_default_query_time(self):
+        """Imported aware timestamps do not crash temporal scoring."""
+        self.beam.remember("Imported Hindsight launch memory",
+                           source="hindsight", importance=0.5)
+
+        imported_time = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        cursor = self.beam.conn.cursor()
+        cursor.execute("""
+            UPDATE working_memory SET timestamp = ? WHERE content LIKE ?
+        """, (imported_time, "%Hindsight launch%"))
+        self.beam.conn.commit()
+
+        results = self.beam.recall("Hindsight launch", top_k=5,
+                                    temporal_weight=0.3)
         self.assertGreaterEqual(len(results), 1)
 
     def test_temporal_halflife_override(self):


### PR DESCRIPTION
## Summary

- Normalize temporal query times and parsed memory timestamps to UTC-aware datetimes before temporal scoring.
- Treat naive `datetime` values as UTC for backward compatibility.
- Add regression coverage for offset-aware imported timestamps with the default `query_time=None` path.

## Bug

Temporal recall can crash when a memory timestamp is offset-aware but the query time is naive.

This shows up with Hindsight imports because Hindsight memory rows commonly preserve ISO timestamps like:

```text
2026-05-20T08:29:42.958511+00:00
```

Mnemosyne parses those as offset-aware datetimes. But when recall is called without an explicit `query_time`, `_parse_query_time(None)` returned `datetime.now()`, which is offset-naive. With temporal scoring enabled, `_temporal_boost()` then compares the two:

```python
if ts > query_time:
```

Python raises:

```text
TypeError: can't compare offset-naive and offset-aware datetimes
```

## Impact

The most visible failure is in Hermes' `MnemosyneMemoryProvider.prefetch()` path. It calls recall with a temporal boost, catches exceptions, and returns an empty context block. So the agent can appear to have working memory tools while pre-turn memory injection silently stops working.

The same failure is reproducible through `mnemosyne_recall` with `temporal_weight > 0` on imported offset-aware data. Recall without temporal scoring can still work, which makes the bug easy to miss in basic store/recall tests.

## Repro Shape

A minimal failing shape before this PR:

```python
from mnemosyne.core.beam import _parse_query_time, _temporal_boost

query_time = _parse_query_time(None)  # previously naive datetime.now()
_temporal_boost("2026-05-20T08:29:42.958511+00:00", query_time, 48)
```

In the Hermes provider path this appeared as:

```python
mnemosyne_recall({"query": "pandabot", "limit": 2, "temporal_weight": 0.2})
```

returning the TypeError, while `prefetch()` returned `""` because the provider swallowed the exception.

## Fix

- `_parse_query_time(None)` now returns an aware UTC `datetime`.
- Explicit naive query times are normalized to UTC-aware datetimes.
- Parsed memory timestamps are normalized before comparison.
- The temporal boost behavior remains compatible for naive historical values by treating them as UTC.

## Tests

Added/updated regression coverage in `tests/test_temporal_recall.py` for:

- default query time with offset-aware timestamps;
- explicit naive query time with offset-aware timestamps;
- temporal recall over imported-style offset-aware memories;
- future timestamp clamping after normalization.

Validation run:

- `uv run pytest tests/test_temporal_recall.py`
- `uv run pytest tests/test_configurable_scoring.py tests/test_prefetch_content_truncation.py`
- `PYTHONPATH=. uv run pytest tests/test_beam.py`
