### PR TITLE
feat(embeddings): custom API endpoints, Jina model dims, SSL cert config

### DIFF
--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import ssl
 import urllib.request
 from typing import List, Optional
 from functools import lru_cache
@@ -37,11 +38,14 @@ _API_CALL_COUNT = 0
 
 def _is_api_model(model_name: str) -> bool:
     """Check if the model should use the OpenAI-compatible API."""
-    return (
-        model_name.startswith("openai/")
-        or "text-embedding" in model_name
-        or model_name.startswith("text-embedding")
-    )
+    if model_name.startswith("openai/") or "text-embedding" in model_name or model_name.startswith("text-embedding"):
+        return True
+    # Custom endpoint: if OPENROUTER_BASE_URL is set to a non-OpenRouter URL,
+    # assume the user has their own API server and any model name should route there.
+    base_url = os.environ.get("OPENROUTER_BASE_URL", "")
+    if base_url and "openrouter.ai" not in base_url:
+        return True
+    return False
 
 
 def _get_embedding_dim(model_name: str) -> int:
@@ -72,6 +76,9 @@ def _get_embedding_dim(model_name: str) -> int:
         "openai/text-embedding-3-large": 3072,
         "text-embedding-3-small": 1536,
         "text-embedding-3-large": 3072,
+        # --- Jina ---
+        "jina-embeddings-v5-omni-nano": 768,
+        "jina-embeddings-v5-omni-small": 1024,
     }
     # Check env override first
     env_dim = os.environ.get("MNEMOSYNE_EMBEDDING_DIM")
@@ -100,9 +107,12 @@ def _get_model():
 
 
 def _embed_api(texts: List[str]) -> Optional[np.ndarray]:
-    """Embed texts via OpenAI-compatible API (OpenRouter)."""
+    """Embed texts via OpenAI-compatible API (OpenRouter or custom endpoint)."""
     global _API_CALL_COUNT
-    if not _OPENAI_API_KEY:
+    # Require API key for OpenRouter; custom endpoints may not need one.
+    base_url = os.environ.get("OPENROUTER_BASE_URL", _OPENAI_BASE_URL)
+    is_custom = "openrouter.ai" not in base_url
+    if not is_custom and not _OPENAI_API_KEY:
         return None
 
     url = f"{_OPENAI_BASE_URL.rstrip('/')}/embeddings"
@@ -112,16 +122,23 @@ def _embed_api(texts: List[str]) -> Optional[np.ndarray]:
     }).encode()
 
     headers = {
-        "Authorization": f"Bearer {_OPENAI_API_KEY}",
         "Content-Type": "application/json",
         "HTTP-Referer": "https://mnemosyne.site",
         "X-Title": "Mnemosyne Embedding",
     }
+    if _OPENAI_API_KEY:
+        headers["Authorization"] = f"Bearer {_OPENAI_API_KEY}"
 
     for attempt in range(3):
         try:
             req = urllib.request.Request(url, data=payload, headers=headers)
-            with urllib.request.urlopen(req, timeout=30) as resp:
+            ctx = ssl.create_default_context()
+            # Support custom CA bundles (NixOS, enterprise proxies, etc.)
+            # SSL_CERT_FILE takes priority, then REQUESTS_CA_BUNDLE.
+            cert_file = os.environ.get("SSL_CERT_FILE") or os.environ.get("REQUESTS_CA_BUNDLE")
+            if cert_file:
+                ctx.load_verify_locations(cert_file)
+            with urllib.request.urlopen(req, timeout=30, context=ctx) as resp:
                 data = json.loads(resp.read())
             embeddings = [item["embedding"] for item in data["data"]]
             _API_CALL_COUNT += 1
@@ -141,6 +158,10 @@ def available() -> bool:
     if os.environ.get("MNEMOSYNE_NO_EMBEDDINGS"):
         return False
     if _is_api_model(_DEFAULT_MODEL):
+        # Custom endpoints (non-OpenRouter) may not require an API key
+        base_url = os.environ.get("OPENROUTER_BASE_URL", "")
+        if base_url and "openrouter.ai" not in base_url:
+            return True
         return bool(_OPENAI_API_KEY)
     return _FASTEMBED_AVAILABLE
 

--- a/tests/test_embeddings_multilingual.py
+++ b/tests/test_embeddings_multilingual.py
@@ -1,6 +1,13 @@
-"""Tests for embedding multilingual model dimension detection."""
+"""Tests for embedding multilingual model dimension detection and API model routing."""
+import os
 
 from mnemosyne.core import embeddings
+
+
+def setup_module():
+    """Clean env vars that would shadow dimension lookups."""
+    os.environ.pop("MNEMOSYNE_EMBEDDING_DIM", None)
+    os.environ.pop("OPENROUTER_BASE_URL", None)
 
 
 def test_get_embedding_dim_english_models():
@@ -25,9 +32,14 @@ def test_get_embedding_dim_multilingual_models():
     assert embeddings._get_embedding_dim("BAAI/bge-m3") == 1024
 
 
+def test_get_embedding_dim_jina_models():
+    """Jina v5 omni models have correct dimensions."""
+    assert embeddings._get_embedding_dim("jina-embeddings-v5-omni-nano") == 768
+    assert embeddings._get_embedding_dim("jina-embeddings-v5-omni-small") == 1024
+
+
 def test_get_embedding_dim_env_override():
     """MNEMOSYNE_EMBEDDING_DIM env var overrides model-based detection."""
-    import os
     os.environ["MNEMOSYNE_EMBEDDING_DIM"] = "768"
     try:
         assert embeddings._get_embedding_dim("BAAI/bge-small-en-v1.5") == 768
@@ -47,3 +59,61 @@ def test_get_embedding_dim_openai_models():
     assert embeddings._get_embedding_dim("openai/text-embedding-3-small") == 1536
     assert embeddings._get_embedding_dim("openai/text-embedding-3-large") == 3072
     assert embeddings._get_embedding_dim("text-embedding-3-small") == 1536
+
+
+# ---------------------------------------------------------------------------
+# _is_api_model tests — custom endpoint detection (PR #161)
+# ---------------------------------------------------------------------------
+
+def _clean_env():
+    """Remove test env vars that influence _is_api_model()."""
+    for key in ("OPENROUTER_BASE_URL",):
+        os.environ.pop(key, None)
+
+
+def test_is_api_model_openai_patterns():
+    """Model names matching openai/text-embedding patterns return True."""
+    _clean_env()
+    assert embeddings._is_api_model("openai/text-embedding-3-small") is True
+    assert embeddings._is_api_model("text-embedding-3-large") is True
+    assert embeddings._is_api_model("openai/custom-model") is True
+
+
+def test_is_api_model_unknown_without_custom_endpoint():
+    """Unknown model names return False when no custom endpoint is set."""
+    _clean_env()
+    assert embeddings._is_api_model("BAAI/bge-small-en-v1.5") is False
+    assert embeddings._is_api_model("jina-embeddings-v5-omni-nano") is False
+    assert embeddings._is_api_model("some/random-model") is False
+
+
+def test_is_api_model_custom_endpoint_non_openrouter():
+    """Custom endpoint (non-OpenRouter URL) → any model name returns True."""
+    _clean_env()
+    os.environ["OPENROUTER_BASE_URL"] = "https://llama.floory.uk/v1"
+    try:
+        assert embeddings._is_api_model("jina-embeddings-v5-omni-nano") is True
+        assert embeddings._is_api_model("BAAI/bge-small-en-v1.5") is True
+        assert embeddings._is_api_model("some/random-model") is True
+    finally:
+        _clean_env()
+
+
+def test_is_api_model_openrouter_url_not_custom():
+    """OpenRouter URL itself should NOT trigger custom endpoint detection."""
+    _clean_env()
+    os.environ["OPENROUTER_BASE_URL"] = "https://openrouter.ai/api/v1"
+    try:
+        # Unknown model on OpenRouter still uses fastembed (False)
+        assert embeddings._is_api_model("jina-embeddings-v5-omni-nano") is False
+        # But openai/ patterns still match on their own
+        assert embeddings._is_api_model("openai/text-embedding-3-small") is True
+    finally:
+        _clean_env()
+
+
+def test_is_api_model_text_embedding_substring():
+    """Models containing 'text-embedding' anywhere in name return True."""
+    _clean_env()
+    assert embeddings._is_api_model("my-org/text-embedding-custom") is True
+    assert embeddings._is_api_model("prefix-text-embedding-suffix") is True


### PR DESCRIPTION
## Summary

Four small improvements to `embeddings.py` that make Mnemosyne work better with self-hosted/compatible embedding servers and NixOS environments.

### Changes

1. **Custom endpoint detection** (`_is_api_model()`): When `OPENROUTER_BASE_URL` is set to a non-OpenRouter URL, treat any model name as API mode. This lets users run local/self-hosted embedding servers (llama-server, vLLM, etc.) without having to rename their models to match OpenAI patterns like `text-embedding-*`.

2. **Jina model dimensions** (`_get_embedding_dim()`): Added `jina-embeddings-v5-omni-nano` (768d) and `jina-embeddings-v5-omni-small` (1024d) to the built-in dimension table. These are popular multimodal embedding models.

3. **SSL certificate configuration**: `_embed_api()` now checks `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` env vars for custom CA bundles. NixOS and enterprise environments need this because Python's `urllib` can't find system certificates by default.

4. **Auth-optional for custom endpoints**: `_embed_api()` and `available()` no longer require an API key when the endpoint is a custom (non-OpenRouter) URL. Local servers typically don't need authentication.

### Test Plan
- [ ] `_is_api_model` still returns true for existing OpenAI model patterns
- [ ] Dimension lookup returns 768 for jina-nano, 1024 for jina-small
- [ ] `SSL_CERT_FILE=/path/to/ca-bundle.crt` → `load_verify_locations()` called
- [ ] Custom endpoint + no API key → `_embed_api()` proceeds (no auth header)
- [ ] Custom endpoint with `jina-embeddings-v5-omni-nano` model name → routes to API

### Migration
No breaking changes. Default behavior unchanged for existing OpenRouter users.