### PR TITLE
Add shared surface memory core CRUD

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -197,6 +197,55 @@ RECALL_SCHEMA = {
     },
 }
 
+SHARED_REMEMBER_SCHEMA = {
+    "name": "mnemosyne_shared_remember",
+    "description": (
+        "Store compact cross-agent surface memory in a dedicated shared Mnemosyne DB. "
+        "Use only for stable user/system/workflow metadata or general preferences. "
+        "Normal mnemosyne_remember writes stay private."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "Surface memory content to store."},
+            "kind": {"type": "string", "description": "meta | preference | correction | identity", "default": "meta"},
+            "importance": {"type": "number", "description": "Importance 0.0-1.0. Default 0.8.", "default": 0.8},
+            "veracity": {"type": "string", "description": "stated | inferred | tool | imported | unknown", "default": "unknown"},
+            "metadata": {"type": "object", "description": "Optional metadata object.", "default": {}},
+        },
+        "required": ["content"],
+    },
+}
+
+SHARED_RECALL_SCHEMA = {
+    "name": "mnemosyne_shared_recall",
+    "description": "Search only the shared Mnemosyne surface DB.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "limit": {"type": "integer", "default": 5},
+        },
+        "required": ["query"],
+    },
+}
+
+SHARED_FORGET_SCHEMA = {
+    "name": "mnemosyne_shared_forget",
+    "description": "Delete one working shared-surface memory by exact ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {"memory_id": {"type": "string"}},
+        "required": ["memory_id"],
+    },
+}
+
+SHARED_STATS_SCHEMA = {
+    "name": "mnemosyne_shared_stats",
+    "description": "Return shared surface DB path and counts.",
+    "parameters": {"type": "object", "properties": {}},
+}
+
 SLEEP_SCHEMA = {
     "name": "mnemosyne_sleep",
     "description": (
@@ -471,7 +520,8 @@ GRAPH_LINK_SCHEMA = {
 }
 
 ALL_TOOL_SCHEMAS = [
-    REMEMBER_SCHEMA, RECALL_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
+    REMEMBER_SCHEMA, RECALL_SCHEMA, SHARED_REMEMBER_SCHEMA, SHARED_RECALL_SCHEMA,
+    SHARED_FORGET_SCHEMA, SHARED_STATS_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
     INVALIDATE_SCHEMA, GET_SCHEMA, TRIPLE_ADD_SCHEMA, TRIPLE_QUERY_SCHEMA,
     SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
     EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
@@ -515,6 +565,9 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
     def __init__(self):
         self._beam: Optional[Any] = None
+        self._surface_beam: Optional[Any] = None
+        self._shared_surface_bank = "surface"
+        self._shared_surface_path: Optional[Path] = None
         # C27: capture init exception so downstream methods can surface it
         # instead of silently no-op'ing. `_beam is None AND _init_error is None`
         # means a deliberate skip (subagent/cron/skill_loop context, or pre-init);
@@ -657,6 +710,12 @@ class MnemosyneMemoryProvider(MemoryProvider):
             else:
                 self._profile_isolation_enabled = bool(profile_isolation)
 
+        shared_surface_path = kwargs.get("shared_surface_path")
+        if shared_surface_path is None:
+            shared_surface_path = self._read_config_key("shared_surface_path")
+        if shared_surface_path:
+            self._shared_surface_path = Path(str(shared_surface_path)).expanduser()
+
     def _should_filter(self, content: str) -> bool:
         """Check if content matches any ignore pattern. Returns True if it should be skipped."""
         if not self._ignore_patterns:
@@ -690,6 +749,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},
             {"key": "ignore_patterns", "description": "Regex patterns to filter from memory storage (one per line in config, or comma-separated). Memories matching any pattern are skipped.", "default": []},
             {"key": "profile_isolation", "description": "Enable per-profile memory isolation via Mnemosyne banks. Each Hermes profile gets its own SQLite database under mnemosyne/data/banks/<profile>/. Default false for backward compatibility.", "default": False},
+            {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
@@ -784,6 +844,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # and handle_tool_call() to silently write into the wrong session.
         # _init_error reset complements this for the failure-recovery case.
         self._beam = None
+        self._surface_beam = None
         self._init_error = None
 
         self._agent_context = kwargs.get("agent_context", "primary")
@@ -830,6 +891,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 BeamMemory = _get_beam_class()
                 self._beam = BeamMemory(session_id=self._session_id)
                 logger.info("Mnemosyne initialized: session=%s", self._session_id)
+
         except Exception as e:
             # C27: capture the exception so system_prompt_block() can render a
             # visible "UNAVAILABLE" banner every turn and handle_tool_call()
@@ -877,6 +939,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 "# Mnemosyne Memory\n"
                 "Active (native local memory). Use mnemosyne_remember to store ANY "
                 "durable fact, preference, identity, or insight. Use mnemosyne_recall to search. "
+                "Use mnemosyne_shared_* tools for manual shared surface CRUD. "
                 "The legacy memory tool is deprecated for durable storage — Mnemosyne is primary."
             )
         # C27: when init failed (as opposed to a deliberate skip-context),
@@ -1040,6 +1103,14 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_remember(args)
             elif tool_name == "mnemosyne_recall":
                 return self._handle_recall(args)
+            elif tool_name == "mnemosyne_shared_remember":
+                return self._handle_shared_remember(args)
+            elif tool_name == "mnemosyne_shared_recall":
+                return self._handle_shared_recall(args)
+            elif tool_name == "mnemosyne_shared_forget":
+                return self._handle_shared_forget(args)
+            elif tool_name == "mnemosyne_shared_stats":
+                return self._handle_shared_stats(args)
             elif tool_name == "mnemosyne_sleep":
                 return self._handle_sleep(args)
             elif tool_name == "mnemosyne_stats":
@@ -1147,6 +1218,117 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
         results = self._beam.recall(query, **recall_kwargs)
         return json.dumps({"query": query, "count": len(results), "temporal_weight": temporal_weight, "results": results})
+
+    @staticmethod
+    def _surface_hash(content: str) -> str:
+        import hashlib
+        normalized = " ".join(str(content).lower().split())
+        return hashlib.sha256(f"surface:v1:{normalized}".encode("utf-8")).hexdigest()[:24]
+
+    @staticmethod
+    def _surface_label(content: str, kind: str) -> str:
+        prefixes = ("surface meta:", "surface preference:", "surface correction:", "surface identity:", "surface fact:")
+        if content.lower().startswith(prefixes):
+            return content
+        label = {
+            "meta": "Surface meta",
+            "preference": "Surface preference",
+            "correction": "Surface correction",
+            "identity": "Surface identity",
+        }.get(kind, "Surface meta")
+        return f"{label}: {content}"
+
+    def _ensure_surface_beam(self) -> None:
+        if self._surface_beam is not None:
+            return
+        BeamMemory = _get_beam_class()
+        shared_path = self._shared_surface_path or (_mnemosyne_root / "data" / "shared" / "mnemosyne.db")
+        shared_path.parent.mkdir(parents=True, exist_ok=True)
+        self._shared_surface_path = shared_path
+        self._surface_beam = BeamMemory(session_id="hermes_shared_surface", db_path=shared_path)
+        logger.info("Mnemosyne shared surface initialized: db=%s", shared_path)
+
+    def _require_surface_beam(self) -> Optional[str]:
+        try:
+            self._ensure_surface_beam()
+        except Exception as exc:
+            logger.warning("Mnemosyne shared surface init failed: %s", exc)
+        if self._surface_beam is None:
+            return "shared surface DB is not initialized"
+        return None
+
+    def _handle_shared_remember(self, args: Dict[str, Any]) -> str:
+        from mnemosyne.core.veracity_consolidation import clamp_veracity
+        err = self._require_surface_beam()
+        if err:
+            return json.dumps({"error": err})
+        content = (args.get("content") or "").strip()
+        if not content:
+            return json.dumps({"error": "content is required"})
+        if content.startswith("[USER]") or content.startswith("[ASSISTANT]"):
+            return json.dumps({"error": "raw conversation content is not allowed in shared memory"})
+        kind = (args.get("kind") or "meta").strip().lower()
+        if kind not in {"meta", "preference", "correction", "identity"}:
+            return json.dumps({"error": "kind must be one of: meta, preference, correction, identity"})
+        importance = max(0.0, min(float(args.get("importance", 0.8)), 1.0))
+        metadata = args.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            return json.dumps({"error": "metadata must be an object"})
+        veracity = clamp_veracity(args.get("veracity"), context="mnemosyne_shared_remember")
+        surface_content = self._surface_label(content, kind)
+        stable_id = "sf_" + self._surface_hash(surface_content)
+        meta = dict(metadata)
+        meta.update({"shared_memory": True, "surface_kind": kind, "write_path": "manual_tool", "source_profile_session": self._session_id})
+        existing_id = self._surface_beam._find_duplicate(surface_content)
+        memory_id = self._surface_beam.remember(
+            content=surface_content,
+            source="surface_manual",
+            importance=importance,
+            metadata=meta,
+            scope="global",
+            memory_id=stable_id,
+            veracity=veracity,
+        )
+        return json.dumps({
+            "status": "existing_shared" if existing_id else "stored_shared",
+            "memory_id": memory_id,
+            "content_preview": surface_content[:120],
+            "shared_db": str(self._shared_surface_path or ""),
+            "kind": kind,
+            "veracity": veracity,
+        })
+
+    def _handle_shared_recall(self, args: Dict[str, Any]) -> str:
+        err = self._require_surface_beam()
+        if err:
+            return json.dumps({"error": err})
+        query = args.get("query", "")
+        if not query:
+            return json.dumps({"error": "query is required"})
+        top_k = int(args.get("limit", 5))
+        results = []
+        for r in self._surface_beam.recall(query, top_k=top_k):
+            r = dict(r)
+            r["shared_surface"] = True
+            r["bank"] = self._shared_surface_bank
+            results.append(r)
+        return json.dumps({"query": query, "count": len(results), "shared_db": str(self._shared_surface_path or ""), "results": results})
+
+    def _handle_shared_forget(self, args: Dict[str, Any]) -> str:
+        err = self._require_surface_beam()
+        if err:
+            return json.dumps({"error": err})
+        memory_id = (args.get("memory_id") or "").strip()
+        if not memory_id:
+            return json.dumps({"error": "memory_id is required"})
+        ok = self._surface_beam.forget_working(memory_id)
+        return json.dumps({"status": "deleted" if ok else "not_found", "memory_id": memory_id, "shared_db": str(self._shared_surface_path or "")})
+
+    def _handle_shared_stats(self, args: Dict[str, Any]) -> str:
+        err = self._require_surface_beam()
+        if err:
+            return json.dumps({"error": err})
+        return json.dumps({"provider": "mnemosyne_shared", "shared_db": str(self._shared_surface_path or ""), "working": self._surface_beam.get_working_stats(), "episodic": self._surface_beam.get_episodic_stats()})
 
     def _handle_sleep(self, args: Dict[str, Any]) -> str:
         dry_run = bool(args.get("dry_run", False))

--- a/tests/test_hermes_memory_provider_shared_crud.py
+++ b/tests/test_hermes_memory_provider_shared_crud.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_memory_provider import MnemosyneMemoryProvider
+
+
+def _provider(tmp_path: Path, monkeypatch):
+    data_dir = tmp_path / "mnemosyne-data"
+    hermes_home = tmp_path / "profiles" / "Mob"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir / "private"))
+    monkeypatch.setenv("MNEMOSYNE_HOST_LLM_ENABLED", "0")
+    provider = MnemosyneMemoryProvider()
+    provider.initialize(
+        session_id="mob-session",
+        hermes_home=str(hermes_home),
+        agent_identity="Mob",
+        shared_surface_path=str(data_dir / "shared" / "mnemosyne.db"),
+    )
+    assert provider._beam is not None
+    return provider, data_dir
+
+
+def _call(provider: MnemosyneMemoryProvider, name: str, args: dict) -> dict:
+    return json.loads(provider.handle_tool_call(name, args))
+
+
+def test_shared_surface_db_uses_configured_path(tmp_path, monkeypatch):
+    provider, data_dir = _provider(tmp_path, monkeypatch)
+
+    stats = _call(provider, "mnemosyne_shared_stats", {})
+
+    assert stats["shared_db"] == str(data_dir / "shared" / "mnemosyne.db")
+    assert provider._shared_surface_path.exists()
+    assert provider._beam.db_path != provider._surface_beam.db_path
+
+
+def test_shared_remember_stores_global_surface_memory(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch)
+
+    result = _call(provider, "mnemosyne_shared_remember", {
+        "content": "Project root lives at /tmp/project",
+        "kind": "meta",
+        "importance": 0.8,
+        "veracity": "stated",
+    })
+
+    assert result["status"] == "stored_shared"
+    assert result["memory_id"].startswith("sf_")
+    row = provider._surface_beam.conn.execute(
+        "SELECT content, source, scope FROM working_memory WHERE id = ?",
+        (result["memory_id"],),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "Surface meta: Project root lives at /tmp/project"
+    assert row[1] == "surface_manual"
+    assert row[2] == "global"
+
+
+def test_shared_remember_is_idempotent_for_same_content(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch)
+    args = {"content": "Surface meta: Mob project lives at /tmp/mob", "kind": "meta"}
+
+    first = _call(provider, "mnemosyne_shared_remember", args)
+    second = _call(provider, "mnemosyne_shared_remember", args)
+
+    assert first["status"] == "stored_shared"
+    assert second["status"] == "existing_shared"
+    assert first["memory_id"] == second["memory_id"]
+    count = provider._surface_beam.conn.execute(
+        "SELECT COUNT(*) FROM working_memory WHERE id = ?",
+        (first["memory_id"],),
+    ).fetchone()[0]
+    assert count == 1
+
+
+def test_shared_recall_tags_rows_as_surface_bank(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch)
+    _call(provider, "mnemosyne_shared_remember", {
+        "content": "Surface meta: Mob wiki lives at /tmp/mob-wiki",
+        "kind": "meta",
+    })
+
+    result = _call(provider, "mnemosyne_shared_recall", {"query": "mob wiki", "limit": 5})
+
+    assert result["count"] >= 1
+    match = next(r for r in result["results"] if "Mob wiki" in r.get("content", ""))
+    assert match["shared_surface"] is True
+    assert match["bank"] == "surface"
+
+
+def test_shared_forget_deletes_then_reports_not_found(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch)
+    stored = _call(provider, "mnemosyne_shared_remember", {
+        "content": "Surface meta: temporary shared fact",
+        "kind": "meta",
+    })
+
+    deleted = _call(provider, "mnemosyne_shared_forget", {"memory_id": stored["memory_id"]})
+    missing = _call(provider, "mnemosyne_shared_forget", {"memory_id": stored["memory_id"]})
+    recalled = _call(provider, "mnemosyne_shared_recall", {"query": "temporary shared fact", "limit": 5})
+
+    assert deleted["status"] == "deleted"
+    assert missing["status"] == "not_found"
+    assert all("temporary shared fact" not in r.get("content", "") for r in recalled["results"])
+
+
+def test_shared_stats_returns_counts_and_path(tmp_path, monkeypatch):
+    provider, data_dir = _provider(tmp_path, monkeypatch)
+
+    stats = _call(provider, "mnemosyne_shared_stats", {})
+
+    assert stats["provider"] == "mnemosyne_shared"
+    assert stats["shared_db"] == str(data_dir / "shared" / "mnemosyne.db")
+    assert "working" in stats
+    assert "episodic" in stats
+
+
+def test_private_remember_does_not_write_shared_db(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch)
+
+    private = _call(provider, "mnemosyne_remember", {
+        "content": "Private Mob-only fact",
+        "source": "fact",
+        "importance": 0.8,
+    })
+    _call(provider, "mnemosyne_shared_stats", {})
+    shared_count = provider._surface_beam.conn.execute(
+        "SELECT COUNT(*) FROM working_memory WHERE content LIKE ?",
+        ("%Private Mob-only fact%",),
+    ).fetchone()[0]
+
+    assert private["status"] == "stored"
+    assert shared_count == 0
+

--- a/tests/test_hermes_memory_provider_shared_multi_agent.py
+++ b/tests/test_hermes_memory_provider_shared_multi_agent.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_memory_provider import MnemosyneMemoryProvider
+
+
+AGENTS = ["Mob", "Rook", "Vale", "Nia", "Kite"]
+
+
+def _call(provider: MnemosyneMemoryProvider, name: str, args: dict) -> dict:
+    return json.loads(provider.handle_tool_call(name, args))
+
+
+def _agent_provider(tmp_path: Path, monkeypatch, agent: str, shared_db: Path) -> MnemosyneMemoryProvider:
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "mnemosyne-data"))
+    monkeypatch.setenv("MNEMOSYNE_HOST_LLM_ENABLED", "0")
+    hermes_home = tmp_path / "profiles" / agent
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    provider = MnemosyneMemoryProvider()
+    provider.initialize(
+        session_id=f"{agent.lower()}-session",
+        hermes_home=str(hermes_home),
+        agent_identity=agent,
+        profile_isolation=True,
+        shared_surface_path=str(shared_db),
+    )
+    assert provider._beam is not None
+    assert provider._resolve_profile_bank() == agent.lower()
+    return provider
+
+
+def test_five_profile_agents_share_surface_but_keep_private_memories_isolated(tmp_path, monkeypatch):
+    shared_db = tmp_path / "mnemosyne-data" / "shared" / "mnemosyne.db"
+    providers = {
+        agent: _agent_provider(tmp_path, monkeypatch, agent, shared_db)
+        for agent in AGENTS
+    }
+
+    # Each agent writes one private memory and one shared surface memory.
+    for agent, provider in providers.items():
+        private = _call(provider, "mnemosyne_remember", {
+            "content": f"Private {agent} scratch note should stay in {agent} bank only",
+            "source": "fact",
+            "importance": 0.8,
+        })
+        shared = _call(provider, "mnemosyne_shared_remember", {
+            "content": f"Surface meta: {agent} project root lives at /tmp/{agent.lower()}-project",
+            "kind": "meta",
+            "importance": 0.8,
+            "veracity": "stated",
+        })
+        assert private["status"] == "stored"
+        assert shared["status"] == "stored_shared"
+
+    # Every agent can recall every shared surface memory from the shared DB.
+    for reader, provider in providers.items():
+        result = _call(provider, "mnemosyne_shared_recall", {"query": "project root", "limit": 10})
+        contents = [row.get("content", "") for row in result["results"]]
+        assert result["count"] >= len(AGENTS), reader
+        for agent in AGENTS:
+            assert any(f"{agent} project root lives" in content for content in contents), (reader, agent, contents)
+        assert all(row.get("shared_surface") is True for row in result["results"])
+        assert all(row.get("bank") == "surface" for row in result["results"])
+
+    # Shared DB must not contain private scratch notes.
+    any_provider = providers[AGENTS[0]]
+    _call(any_provider, "mnemosyne_shared_stats", {})
+    leaked = any_provider._surface_beam.conn.execute(
+        "SELECT COUNT(*) FROM working_memory WHERE content LIKE ?",
+        ("%scratch note should stay%",),
+    ).fetchone()[0]
+    assert leaked == 0
+
+    # Private profile DBs are separate paths.
+    private_paths = {agent: provider._beam.db_path for agent, provider in providers.items()}
+    assert len(set(private_paths.values())) == len(AGENTS)
+    assert all(path != shared_db for path in private_paths.values())
+
+
+def test_five_profile_agents_reject_raw_chat_shared_dump(tmp_path, monkeypatch):
+    shared_db = tmp_path / "mnemosyne-data" / "shared" / "mnemosyne.db"
+    providers = {
+        agent: _agent_provider(tmp_path, monkeypatch, agent, shared_db)
+        for agent in AGENTS
+    }
+
+    for agent, provider in providers.items():
+        result = _call(provider, "mnemosyne_shared_remember", {
+            "content": f"[USER] raw chat dump from {agent} must not be shared",
+            "kind": "meta",
+        })
+        assert result == {"error": "raw conversation content is not allowed in shared memory"}
+
+    stats_provider = providers[AGENTS[0]]
+    _call(stats_provider, "mnemosyne_shared_stats", {})
+    count = stats_provider._surface_beam.conn.execute(
+        "SELECT COUNT(*) FROM working_memory WHERE content LIKE ?",
+        ("%raw chat dump%",),
+    ).fetchone()[0]
+    assert count == 0

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -49,10 +49,10 @@ def _tool_names(provider) -> set[str]:
 class TestToolRegistration:
     """Verify the provider registers and dispatches all 15 tools."""
 
-    def test_all_15_tools_registered(self, tmp_path):
+    def test_all_tools_registered(self, tmp_path):
         provider = _provider(tmp_path)
         names = _tool_names(provider)
-        assert len(names) == 18, f"Expected 18 tools, got {len(names)}"
+        assert len(names) == 22, f"Expected 22 tools, got {len(names)}"
 
     def test_new_8_tools_present(self, tmp_path):
         provider = _provider(tmp_path)
@@ -66,6 +66,12 @@ class TestToolRegistration:
         names = _tool_names(provider)
         for tool in ("remember", "recall", "sleep", "stats",
                      "invalidate", "triple_add", "triple_query"):
+            assert f"mnemosyne_{tool}" in names
+
+    def test_shared_surface_tools_present(self, tmp_path):
+        provider = _provider(tmp_path)
+        names = _tool_names(provider)
+        for tool in ("shared_remember", "shared_recall", "shared_forget", "shared_stats"):
             assert f"mnemosyne_{tool}" in names
 
     def test_unknown_tool_returns_error(self, tmp_path):


### PR DESCRIPTION
## Summary

This is the first split from #160.

This PR only adds the shared surface memory core:

- dedicated shared DB path
- manual shared CRUD tools
- tests for shared/private isolation

Normal `mnemosyne_remember` writes still go to the private profile DB. Shared writes only happen through the explicit shared tools.

## Added tools

- `mnemosyne_shared_remember`
- `mnemosyne_shared_recall`
- `mnemosyne_shared_forget`
- `mnemosyne_shared_stats`

## Out of scope

Keeping this small like requested. These are left for follow-up PRs:

- auto-promotion
- allowlist classifier
- shared recall/prefetch merge
- convenience config alias

I'll wait for review on this one before moving the next split forward, so PR2/PR3 don't drift if this core needs changes.

## Tests

Focused shared-surface tests:

```text
9 passed
```

Full suite:

```text
1312 passed, 18 skipped, 1 warning
```

The warning is an existing `DeprecationWarning` in `tests/test_mcp_server.py`.

The multi-agent test uses five temporary profiles (`Mob`, `Rook`, `Vale`, `Nia`, `Kite`) to check that all profiles can read shared surface rows while private rows stay out of the shared DB.
