### PR TITLE
fix(vec_search): sqlite-vec int8 k constraint syntax for SQLite 3.40.x

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1421,7 +1421,7 @@ def _vec_search(conn: sqlite3.Connection, embedding: List[float], k: int = 20) -
         ).fetchall()
     elif vec_type == "int8":
         rows = conn.execute(
-            f"SELECT rowid, distance FROM vec_episodes WHERE embedding MATCH vec_quantize_int8(?, 'unit') ORDER BY distance LIMIT {k}",
+            f'SELECT rowid, distance FROM vec_episodes WHERE embedding MATCH vec_quantize_int8(?, "unit") AND k={k} ORDER BY distance',
             (emb_json,)
         ).fetchall()
     else:


### PR DESCRIPTION
## Problem

On SQLite 3.40.x (Raspberry Pi 5, Raspbian/bookworm), the `LIMIT` clause is rejected for quantized vector queries:

```
sqlite3.OperationalError: A LIMIT or 'k = ?' constraint is required on vec0 knn queries.
```

The current upstream code uses:

```python
f"SELECT rowid, distance FROM vec_episodes WHERE embedding MATCH vec_quantize_int8(?, 'unit') ORDER BY distance LIMIT {k}"
```

This works on SQLite 3.41+ but fails on SQLite 3.40.x due to how `xBestIndex` resolves the LIMIT parameter during query planning.

## Fix

Change the kNN constraint syntax from `LIMIT {k}` to `AND k={k}`:

```python
f'SELECT rowid, distance FROM vec_episodes WHERE embedding MATCH vec_quantize_int8(?, "unit") AND k={k} ORDER BY distance'
```

The `k=N` constraint must be a SQL literal in the WHERE clause, not a LIMIT parameter. This is valid across all sqlite-vec versions and all SQLite versions.

## Verification

- Tested on RPi5 (SQLite 3.40.1)
- Regression test: `bm.recall('high automation appetite cron monitoring', top_k=2)` returns 2 working-memory results
- Original issue: hermes-agent issue tracking, mnemosyne #148 context, 2026-05-22

## Compatibility note

`LIMIT {k}` works on SQLite 3.41+. If there's a version-detection path that uses LIMIT on newer SQLite and AND k= on 3.40.x, that would be ideal. This PR at minimum fixes the 3.40.x case without breaking 3.41+.
