### PR TITLE
fix(memory): load sqlite-vec extension in memory._get_connection

### DIFF
--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -59,6 +59,13 @@ def _get_connection(db_path = None) -> sqlite3.Connection:
         _thread_local.conn.row_factory = sqlite3.Row
         _thread_local.conn.execute("PRAGMA journal_mode=WAL")
         _thread_local.conn.execute("PRAGMA busy_timeout=5000")
+        # Load sqlite-vec extension for vector search (matches beam._get_connection)
+        try:
+            import sqlite_vec
+            _thread_local.conn.enable_load_extension(True)
+            sqlite_vec.load(_thread_local.conn)
+        except Exception:
+            pass
         _thread_local.db_path = str(path)
     return _thread_local.conn
 


### PR DESCRIPTION
memory._get_connection() creates connections without loading the sqlite-vec extension, while beam._get_connection() does load it.

This means Mnemosyne.remember() writes embeddings to the legacy memory_embeddings table (JSON fallback) but cannot insert into the vec_episodes virtual table, breaking vector search for the high-level API.

The fix adds the same sqlite-vec loading that beam._get_connection uses:
  try:
      import sqlite_vec
      conn.enable_load_extension(True)
      sqlite_vec.load(conn)
  except Exception:
      pass

Closes the gap between the two connection factories so vector search works regardless of which code path creates the connection.