### PR TITLE
fix: report active provider DB path in diagnose

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1480,6 +1480,38 @@ class MnemosyneMemoryProvider(MemoryProvider):
     def _handle_diagnose(self, args: Dict[str, Any]) -> str:
         from mnemosyne.diagnose import run_diagnostics
         result = run_diagnostics()
+
+        # run_diagnostics() reports Mnemosyne's legacy/default DB path. When
+        # Hermes profile isolation is enabled, the active provider may use a
+        # profile bank instead (mnemosyne/data/banks/<profile>/mnemosyne.db).
+        # Surface the active provider DB too so operators do not mistake the
+        # diagnostic default path for the live memory bank.
+        active_db = None
+        try:
+            if self._beam is not None:
+                active_db = getattr(self._beam, "db_path", None)
+        except Exception:
+            active_db = None
+
+        if active_db:
+            result["active_provider_db_path"] = str(active_db)
+            result["profile_isolation_enabled"] = bool(self._profile_isolation_enabled)
+            result.setdefault("key_findings", []).append(
+                f"Active Hermes Mnemosyne provider DB: {active_db}"
+            )
+            try:
+                import sqlite3
+                con = sqlite3.connect(str(active_db))
+                cur = con.cursor()
+                result["active_provider_counts"] = {
+                    "working_memory": cur.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0],
+                    "episodic_memory": cur.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0],
+                    "facts": cur.execute("SELECT COUNT(*) FROM facts").fetchone()[0],
+                }
+                con.close()
+            except Exception as exc:
+                result["active_provider_counts_error"] = str(exc)
+
         return json.dumps(result, indent=2, default=str)
 
     def _handle_graph_query(self, args: Dict[str, Any]) -> str:

--- a/tests/test_hermes_memory_provider_diagnose_active_db.py
+++ b/tests/test_hermes_memory_provider_diagnose_active_db.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mnemosyne.core.beam import BeamMemory
+from hermes_memory_provider import MnemosyneMemoryProvider
+
+
+def _provider_with_beam(tmp_path: Path) -> tuple[MnemosyneMemoryProvider, Path]:
+    db_path = tmp_path / "banks" / "sisyphus" / "mnemosyne.db"
+    beam = BeamMemory(session_id="diagnose-test", db_path=db_path)
+    provider = MnemosyneMemoryProvider()
+    provider._beam = beam
+    provider._session_id = "diagnose-test"
+    provider._agent_context = "primary"
+    provider._profile_isolation_enabled = True
+    return provider, db_path
+
+
+def test_diagnose_reports_active_provider_db_path_and_counts(tmp_path, monkeypatch):
+    provider, db_path = _provider_with_beam(tmp_path)
+    provider._beam.remember("active bank row", source="fact", importance=0.7)
+
+    legacy_path = tmp_path / "legacy" / "mnemosyne.db"
+    monkeypatch.setattr(
+        "mnemosyne.diagnose.run_diagnostics",
+        lambda: {
+            "checks_total": 1,
+            "checks_passed": 1,
+            "key_findings": [],
+            "entries": [
+                {
+                    "category": "db",
+                    "check": "db_path",
+                    "status": str(legacy_path),
+                    "detail": "",
+                }
+            ],
+        },
+    )
+
+    result = json.loads(provider._handle_diagnose({}))
+
+    assert result["active_provider_db_path"] == str(db_path)
+    assert result["profile_isolation_enabled"] is True
+    assert result["active_provider_counts"]["working_memory"] == 1
+    assert result["active_provider_counts"]["episodic_memory"] == 0
+    assert result["active_provider_counts"]["facts"] == 0
+    assert any(
+        str(db_path) in finding
+        for finding in result["key_findings"]
+    )
+    assert result["entries"][0]["status"] == str(legacy_path)
+
+
+def test_diagnose_without_active_beam_keeps_base_diagnostics(monkeypatch):
+    provider = MnemosyneMemoryProvider()
+    monkeypatch.setattr(
+        "mnemosyne.diagnose.run_diagnostics",
+        lambda: {"checks_total": 1, "key_findings": ["base finding"]},
+    )
+
+    result = json.loads(provider._handle_diagnose({}))
+
+    assert result == {"checks_total": 1, "key_findings": ["base finding"]}
+
+
+def test_diagnose_reports_count_error_without_failing(tmp_path, monkeypatch):
+    provider, db_path = _provider_with_beam(tmp_path)
+    provider._beam.conn.execute("DROP TABLE facts")
+    provider._beam.conn.commit()
+    monkeypatch.setattr(
+        "mnemosyne.diagnose.run_diagnostics",
+        lambda: {"checks_total": 1, "key_findings": []},
+    )
+
+    result = json.loads(provider._handle_diagnose({}))
+
+    assert result["active_provider_db_path"] == str(db_path)
+    assert "active_provider_counts_error" in result
+    assert "no such table: facts" in result["active_provider_counts_error"]


### PR DESCRIPTION
## Summary

When profile isolation is enabled, `mnemosyne_diagnose` only reports the legacy/default DB path from `run_diagnostics()`. The active provider uses a profile bank at a different path (e.g. `data/banks/sisyphus/mnemosyne.db`), which causes operator confusion.

This PR adds:
- `active_provider_db_path` — the actual DB the provider is reading/writing
- `profile_isolation_enabled` — whether profile isolation is active
- `active_provider_counts` — working_memory, episodic_memory, facts counts from the active DB
- `active_provider_counts_error` — graceful error if count query fails

Legacy diagnostic output is unchanged.

## Tests

New file: `tests/test_hermes_memory_provider_diagnose_active_db.py`

Covers:
- Active DB path and counts appear when beam is initialized
- No active beam keeps base diagnostics unchanged
- Count query failure reports error without crashing

```
40 passed in 6.34s
```

## Changes

- `hermes_memory_provider/__init__.py` — 32 insertions in `_handle_diagnose`
- `tests/test_hermes_memory_provider_diagnose_active_db.py` — 82 lines new