### PR TITLE
fix(core): generate and save working memory vector on remember

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1915,6 +1915,24 @@ class BeamMemory:
         self.conn.commit()
         self._trim_working_memory()
 
+        # Generate vector embedding for working memory hybrid search
+        if _embeddings.available():
+            try:
+                vec = _embeddings.embed([content])
+                if vec is not None and len(vec) > 0:
+                    model = _embeddings._DEFAULT_MODEL
+                    emb_json = _embeddings.serialize(vec[0])
+                    cursor.execute(
+                        "INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+                        (memory_id, emb_json, model)
+                    )
+                    self.conn.commit()
+            except Exception as exc:
+                logger.warning(
+                    "remember: embedding storage failed (%s): %s",
+                    type(exc).__name__, exc,
+                )
+
         # Auto-generate temporal triple
         self._add_temporal_triple(memory_id, timestamp, source, content)
 


### PR DESCRIPTION
## Summary
This PR resolves a silent degradation in working memory vector retrieval (hybrid search). 

Currently, while `remember_batch` generates and saves embeddings into the `memory_embeddings` table, the single-item `remember()` method only commits the text to `working_memory` and completely skips the embedding generation stage. 

Because `mnemosyne_recall` (and linear recall paths) rely on joining `working_memory` with `memory_embeddings` during vector similarity calculations (using `_wm_vec_search`), any memory stored via conversational single-item writes (the standard conversational workflow) ended up with **0** vector representation and was missed entirely by semantic searches.

## Changes
- Added embedding generation in `BeamMemory.remember()` right after writing to `working_memory`.
- Successfully writes the generated F32 dense vector to the `memory_embeddings` table, making all newly stored single-item memories immediately discoverable via dense vector similarity matching.

## Verification
- Verified locally that conversational writes (using `mnemosyne_remember`) now generate vectors in `memory_embeddings` automatically.
- Verified that subsequent `mnemosyne_recall` queries successfully match using semantic vector scores with a `dense_score` of `0.7271` instead of `0.0000`.