### PR TITLE
feat: unified recall merges shared surface results

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -568,6 +568,12 @@ class MnemosyneMemoryProvider(MemoryProvider):
         self._surface_beam: Optional[Any] = None
         self._shared_surface_bank = "surface"
         self._shared_surface_path: Optional[Path] = None
+        # When true, mnemosyne_recall merges shared-surface results into the
+        # private bank's recall response. Each result is tagged with `bank`
+        # ("private" or "surface") so callers can distinguish provenance.
+        # Default false preserves existing behavior for deployments that have
+        # not opted in.
+        self._shared_surface_read = False
         # C27: capture init exception so downstream methods can surface it
         # instead of silently no-op'ing. `_beam is None AND _init_error is None`
         # means a deliberate skip (subagent/cron/skill_loop context, or pre-init);
@@ -716,6 +722,15 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if shared_surface_path:
             self._shared_surface_path = Path(str(shared_surface_path)).expanduser()
 
+        shared_surface_read = kwargs.get("shared_surface_read")
+        if shared_surface_read is None:
+            shared_surface_read = self._read_config_key("shared_surface_read")
+        if shared_surface_read is not None:
+            if isinstance(shared_surface_read, str):
+                self._shared_surface_read = shared_surface_read.lower() in ("true", "1", "yes", "on")
+            else:
+                self._shared_surface_read = bool(shared_surface_read)
+
     def _should_filter(self, content: str) -> bool:
         """Check if content matches any ignore pattern. Returns True if it should be skipped."""
         if not self._ignore_patterns:
@@ -750,6 +765,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "ignore_patterns", "description": "Regex patterns to filter from memory storage (one per line in config, or comma-separated). Memories matching any pattern are skipped.", "default": []},
             {"key": "profile_isolation", "description": "Enable per-profile memory isolation via Mnemosyne banks. Each Hermes profile gets its own SQLite database under mnemosyne/data/banks/<profile>/. Default false for backward compatibility.", "default": False},
             {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
+            {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
@@ -1233,7 +1249,39 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 recall_kwargs[weight_key] = args[weight_key]
 
         results = self._beam.recall(query, **recall_kwargs)
-        return json.dumps({"query": query, "count": len(results), "temporal_weight": temporal_weight, "results": results})
+        # Tag private results with their bank so callers can distinguish from
+        # shared-surface entries when surface read is enabled.
+        for r in results:
+            r.setdefault("bank", "private")
+
+        # Optionally merge shared-surface results. Each surface result keeps
+        # its own score (computed by the surface beam) and is tagged
+        # bank="surface" / shared_surface=True. We merge the two ranked lists
+        # by score (when present) and truncate to top_k overall.
+        if self._shared_surface_read:
+            try:
+                self._ensure_surface_beam()
+            except Exception as exc:
+                logger.warning("Mnemosyne shared surface read failed: %s", exc)
+            if self._surface_beam is not None:
+                try:
+                    surface_results = self._surface_beam.recall(query, top_k=top_k)
+                    for r in surface_results:
+                        r["shared_surface"] = True
+                        r["bank"] = self._shared_surface_bank
+                    combined = list(results) + list(surface_results)
+                    combined.sort(key=lambda x: x.get("score") or 0.0, reverse=True)
+                    results = combined[:top_k]
+                except Exception as exc:
+                    logger.warning("Mnemosyne shared surface recall failed: %s", exc)
+
+        return json.dumps({
+            "query": query,
+            "count": len(results),
+            "temporal_weight": temporal_weight,
+            "shared_surface_read": self._shared_surface_read,
+            "results": results,
+        })
 
     @staticmethod
     def _surface_hash(content: str) -> str:

--- a/tests/test_hermes_memory_provider_unified_recall.py
+++ b/tests/test_hermes_memory_provider_unified_recall.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_memory_provider import MnemosyneMemoryProvider
+
+
+def _provider(tmp_path: Path, monkeypatch, *, shared_surface_read: bool = False):
+    data_dir = tmp_path / "mnemosyne-data"
+    hermes_home = tmp_path / "profiles" / "Mob"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir / "private"))
+    monkeypatch.setenv("MNEMOSYNE_HOST_LLM_ENABLED", "0")
+    provider = MnemosyneMemoryProvider()
+    provider.initialize(
+        session_id="mob-session",
+        hermes_home=str(hermes_home),
+        agent_identity="Mob",
+        shared_surface_path=str(data_dir / "shared" / "mnemosyne.db"),
+        shared_surface_read=shared_surface_read,
+    )
+    assert provider._beam is not None
+    return provider, data_dir
+
+
+def _call(provider: MnemosyneMemoryProvider, name: str, args: dict) -> dict:
+    return json.loads(provider.handle_tool_call(name, args))
+
+
+def _seed_private(provider: MnemosyneMemoryProvider, content: str, importance: float = 0.6) -> str:
+    res = _call(provider, "mnemosyne_remember", {
+        "content": content,
+        "importance": importance,
+        "source": "fact",
+        "scope": "global",
+    })
+    assert res["status"] == "stored", res
+    return res["memory_id"]
+
+
+def _seed_surface(provider: MnemosyneMemoryProvider, content: str, kind: str = "preference") -> str:
+    res = _call(provider, "mnemosyne_shared_remember", {
+        "content": content,
+        "kind": kind,
+        "importance": 0.8,
+    })
+    assert res["status"] == "stored_shared", res
+    return res["memory_id"]
+
+
+# --- Default behavior: shared_surface_read=False ---------------------------
+
+def test_recall_default_returns_private_only(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch)
+
+    _seed_private(provider, "User keeps notes in /home/user/notes.md")
+    _seed_surface(provider, "User prefers Tailscale over OpenVPN")
+
+    res = _call(provider, "mnemosyne_recall", {"query": "Tailscale", "limit": 10})
+
+    assert res["shared_surface_read"] is False
+    contents = [r["content"] for r in res["results"]]
+    assert all("Tailscale" not in c for c in contents)
+
+
+def test_recall_default_tags_results_as_private(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch)
+    _seed_private(provider, "Project root lives at /tmp/project")
+
+    res = _call(provider, "mnemosyne_recall", {"query": "project root", "limit": 5})
+
+    assert len(res["results"]) >= 1
+    for r in res["results"]:
+        assert r.get("bank") == "private"
+        assert not r.get("shared_surface")
+
+
+# --- Opt-in behavior: shared_surface_read=True -----------------------------
+
+def test_recall_with_surface_read_includes_shared_results(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch, shared_surface_read=True)
+    _seed_private(provider, "User stores notes in /tmp/notes.md")
+    _seed_surface(provider, "User prefers Tailscale over OpenVPN for VPN")
+
+    res = _call(provider, "mnemosyne_recall", {"query": "Tailscale VPN", "limit": 10})
+
+    assert res["shared_surface_read"] is True
+    banks = {r.get("bank") for r in res["results"]}
+    assert "surface" in banks
+
+
+def test_recall_tags_surface_results_with_bank_surface(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch, shared_surface_read=True)
+    _seed_surface(provider, "User uses cargo nextest for Rust testing")
+
+    res = _call(provider, "mnemosyne_recall", {"query": "cargo nextest", "limit": 5})
+
+    surface_rows = [r for r in res["results"] if r.get("bank") == "surface"]
+    assert surface_rows, res
+    for r in surface_rows:
+        assert r["shared_surface"] is True
+
+
+def test_recall_merges_results_from_both_banks(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch, shared_surface_read=True)
+    _seed_private(provider, "User project Acme uses Postgres on port 5432")
+    _seed_surface(provider, "User prefers Postgres for production databases")
+
+    res = _call(provider, "mnemosyne_recall", {"query": "Postgres", "limit": 10})
+
+    banks = {r.get("bank") for r in res["results"]}
+    assert "private" in banks
+    assert "surface" in banks
+
+
+def test_recall_truncates_to_top_k_after_merge(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch, shared_surface_read=True)
+    for i in range(5):
+        _seed_private(provider, f"User runs script number {i} for migration tasks")
+    for i in range(5):
+        _seed_surface(provider, f"User prefers tool variant {i} for migration tasks")
+
+    res = _call(provider, "mnemosyne_recall", {"query": "migration tasks", "limit": 4})
+
+    assert res["count"] <= 4
+    assert len(res["results"]) <= 4
+
+
+def test_recall_surface_init_failure_falls_back_to_private(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch, shared_surface_read=True)
+    _seed_private(provider, "User has a homelab Proxmox setup")
+    # Force surface beam to fail by clearing it and breaking the path
+    provider._surface_beam = None
+    provider._shared_surface_path = Path("/nonexistent/dir/that/cannot/be/created/file.db")
+
+    # Bypass mkdir guard by also patching _ensure_surface_beam to raise
+    def _raise(*_a, **_k):
+        raise RuntimeError("surface init forced failure")
+    monkeypatch.setattr(provider, "_ensure_surface_beam", _raise, raising=True)
+
+    res = _call(provider, "mnemosyne_recall", {"query": "Proxmox homelab", "limit": 5})
+
+    assert res["shared_surface_read"] is True
+    # Private results should still come through
+    assert len(res["results"]) >= 1
+    for r in res["results"]:
+        assert r.get("bank") == "private"
+
+
+# --- Config wiring ----------------------------------------------------------
+
+def test_shared_surface_read_in_config_schema(tmp_path, monkeypatch):
+    provider, _ = _provider(tmp_path, monkeypatch)
+    schema = provider.get_config_schema()
+    keys = [entry["key"] for entry in schema]
+    assert "shared_surface_read" in keys
+    entry = next(e for e in schema if e["key"] == "shared_surface_read")
+    assert entry["default"] is False
+
+
+def test_shared_surface_read_reads_from_config_yaml(tmp_path, monkeypatch):
+    data_dir = tmp_path / "mnemosyne-data"
+    hermes_home = tmp_path / "profiles" / "Mob"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text(
+        "memory:\n  mnemosyne:\n    shared_surface_read: true\n"
+    )
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir / "private"))
+    monkeypatch.setenv("MNEMOSYNE_HOST_LLM_ENABLED", "0")
+
+    provider = MnemosyneMemoryProvider()
+    provider.initialize(
+        session_id="mob-session",
+        hermes_home=str(hermes_home),
+        agent_identity="Mob",
+        shared_surface_path=str(data_dir / "shared" / "mnemosyne.db"),
+    )
+
+    assert provider._shared_surface_read is True
+
+
+def test_shared_surface_read_kwarg_overrides_config(tmp_path, monkeypatch):
+    data_dir = tmp_path / "mnemosyne-data"
+    hermes_home = tmp_path / "profiles" / "Mob"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text(
+        "memory:\n  mnemosyne:\n    shared_surface_read: true\n"
+    )
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir / "private"))
+    monkeypatch.setenv("MNEMOSYNE_HOST_LLM_ENABLED", "0")
+
+    provider = MnemosyneMemoryProvider()
+    provider.initialize(
+        session_id="mob-session",
+        hermes_home=str(hermes_home),
+        agent_identity="Mob",
+        shared_surface_path=str(data_dir / "shared" / "mnemosyne.db"),
+        shared_surface_read=False,
+    )
+
+    assert provider._shared_surface_read is False

--- a/tools/bench_unified_recall.py
+++ b/tools/bench_unified_recall.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Benchmark unified recall (PR: shared_surface_read flag).
+
+Compares latency of `mnemosyne_recall` with shared_surface_read=False (current
+behavior) vs True (new merged-bank behavior). Uses an isolated tmp DB so it
+runs deterministically regardless of host environment.
+
+Usage:
+    python tools/bench_unified_recall.py [--memories N] [--queries Q]
+
+Reports p50/p95 latency for both configs and the delta. The merged-bank path
+adds a single shared-surface beam.recall() call plus a Python sort over the
+combined list, so the expected overhead is small and bounded.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+
+def _bootstrap(env_dir: Path):
+    """Init a provider with private + shared surface set up."""
+    os.environ["MNEMOSYNE_DATA_DIR"] = str(env_dir / "private")
+    os.environ["MNEMOSYNE_HOST_LLM_ENABLED"] = "0"
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    hermes_home = env_dir / "profile"
+    hermes_home.mkdir(parents=True)
+
+    provider = MnemosyneMemoryProvider()
+    provider.initialize(
+        session_id="bench-session",
+        hermes_home=str(hermes_home),
+        agent_identity="Bench",
+        shared_surface_path=str(env_dir / "shared" / "mnemosyne.db"),
+    )
+    return provider
+
+
+def _seed(provider, n_private: int, n_surface: int) -> None:
+    """Populate both banks with N rows of synthetic content."""
+    topics = [
+        "Tailscale VPN setup", "Postgres tuning notes", "Docker Compose workflow",
+        "GitHub PR workflow", "Rust async runtime", "Python type hints",
+        "FTS5 query syntax", "SQLite vacuum", "Linux file permissions",
+        "OpenAI API rate limits", "ML training pipeline", "Multilingual NLP",
+        "Notion API quirks", "Zsh prompt config", "Tmux key bindings",
+    ]
+    for i in range(n_private):
+        topic = topics[i % len(topics)]
+        provider.handle_tool_call("mnemosyne_remember", {
+            "content": f"Private memory #{i}: detail about {topic}",
+            "importance": 0.5,
+            "source": "fact",
+        })
+    for i in range(n_surface):
+        topic = topics[i % len(topics)]
+        provider.handle_tool_call("mnemosyne_shared_remember", {
+            "content": f"Shared note #{i}: user prefers {topic}",
+            "kind": "preference",
+            "importance": 0.6,
+        })
+
+
+def _measure(provider, query: str, *, surface_read: bool, iters: int) -> list[float]:
+    provider._shared_surface_read = surface_read
+    durations: list[float] = []
+    # Warmup
+    for _ in range(5):
+        provider.handle_tool_call("mnemosyne_recall", {"query": query, "limit": 5})
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        provider.handle_tool_call("mnemosyne_recall", {"query": query, "limit": 5})
+        durations.append((time.perf_counter() - t0) * 1000.0)
+    return durations
+
+
+def _summary(label: str, samples: list[float]) -> dict:
+    samples_sorted = sorted(samples)
+    p50 = samples_sorted[len(samples_sorted) // 2]
+    p95 = samples_sorted[max(0, int(len(samples_sorted) * 0.95) - 1)]
+    return {
+        "config": label,
+        "n": len(samples),
+        "mean_ms": round(statistics.mean(samples), 3),
+        "p50_ms": round(p50, 3),
+        "p95_ms": round(p95, 3),
+        "min_ms": round(min(samples), 3),
+        "max_ms": round(max(samples), 3),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--private", type=int, default=200)
+    ap.add_argument("--surface", type=int, default=50)
+    ap.add_argument("--queries", type=int, default=100)
+    args = ap.parse_args()
+
+    queries = [
+        "VPN preference Tailscale",
+        "database tuning Postgres",
+        "Rust async runtime",
+        "FTS5 query syntax",
+        "Docker Compose workflow",
+    ]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        env_dir = Path(tmp)
+        provider = _bootstrap(env_dir)
+        print(f"Seeding {args.private} private + {args.surface} shared rows...")
+        _seed(provider, args.private, args.surface)
+
+        results: list[dict] = []
+        for label, surface_read in (("baseline_private_only", False),
+                                     ("merged_with_surface", True)):
+            print(f"Benchmarking {label}...")
+            samples: list[float] = []
+            iters_per_query = max(1, args.queries // len(queries))
+            for q in queries:
+                samples.extend(_measure(
+                    provider, q,
+                    surface_read=surface_read,
+                    iters=iters_per_query,
+                ))
+            results.append(_summary(label, samples))
+
+        baseline_p50 = results[0]["p50_ms"]
+        merged_p50 = results[1]["p50_ms"]
+        delta_ms = merged_p50 - baseline_p50
+        delta_pct = (delta_ms / baseline_p50 * 100.0) if baseline_p50 else 0.0
+
+        report = {
+            "private_rows": args.private,
+            "surface_rows": args.surface,
+            "queries": args.queries,
+            "results": results,
+            "delta_p50_ms": round(delta_ms, 3),
+            "delta_p50_pct": round(delta_pct, 2),
+        }
+        print()
+        print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Reopens #177 (closed by the v3.1.0 history rewrite) on a fresh base, with a benchmark added per CONTRIBUTING rule #2.

Adds `shared_surface_read` config flag. When enabled, `mnemosyne_recall` returns results from both the private bank and the shared surface in one call. Each result is tagged with `bank` ("private" or "surface") so callers can tell where it came from. Default stays off  existing setups keep current behavior.
example case:

Why this matters: with profile isolation on, every agent has its own private bank, but they share one surface DB for cross-agent facts. Today an agent has to choose between `mnemosyne_recall` and `mnemosyne_shared_recall` upfront. With this flag on, recall just searches both and merges by score  agents get the full picture without picking the right tool.

Behavior:
- `shared_surface_read=false` (default): recall stays private-only, results tagged `bank=private`
- `shared_surface_read=true`: also searches the surface beam, merges both lists by score, truncates to `top_k` overall, surface rows tagged `bank=surface` and `shared_surface=true`
- Surface init or recall failure logs a warning and falls back to private-only  never breaks recall

Resolution order is `kwargs > config.yaml > default false`, same pattern as the other shared-surface options. `mnemosyne_shared_recall` is unchanged.

## Benchmark

`tools/bench_unified_recall.py` measures `mnemosyne_recall` p50/p95 with the flag off vs on.

Local run on this branch (200 private rows, 50 shared rows, 100 queries):

```
baseline (private_only):  p50=3.94ms  p95=19.2ms
merged   (with surface):  p50=3.81ms  p95=19.0ms
delta:                    -0.13ms p50  (-3.25%)
```

The merged path adds one extra `surface_beam.recall()` call plus a Python sort over the combined list. Cost is within measurement noise here. Anyone reviewing can reproduce with `python tools/bench_unified_recall.py`.

## Tests

`tests/test_hermes_memory_provider_unified_recall.py` — 10 tests:

- default behavior keeps recall private-only
- private results get `bank=private` tag
- surface read on includes shared rows
- surface rows tagged `bank=surface` + `shared_surface=true`
- merged results contain both banks
- top_k truncation applies after merge
- surface init failure falls back to private-only
- config schema entry exists with default false
- config.yaml `shared_surface_read: true` is read at init
- kwarg overrides config.yaml

```
tests/test_hermes_memory_provider_unified_recall.py ..........  [10 passed]
+ broader regression suite (shared_crud, shared_multi_agent,
  temporal_recall, all_15_tools): 71 passed total, 0 regressions
```

## Changes

- `hermes_memory_provider/__init__.py` — 50 insertions, 1 deletion (flag + merge logic + schema entry)
- `tests/test_hermes_memory_provider_unified_recall.py` — 202 lines new
- `tools/bench_unified_recall.py` — 152 lines new

Total: 403 insertions across 3 files. No schema migration. Backward compatible. Single feature, single commit.

Refs the prior closed PR #177; rebased onto v3.1.0.
