### PR TITLE
feat: collaborative memory validation with attestation chain

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -295,6 +295,52 @@ INVALIDATE_SCHEMA = {
     },
 }
 
+VALIDATE_SCHEMA = {
+    "name": "mnemosyne_validate",
+    "description": (
+        "Attest, update, or invalidate a memory the caller did not necessarily author. "
+        "Supports collaborative ownership: any agent can validate any memory in either "
+        "the private bank or the shared surface. The original author is preserved; "
+        "validator + validated_at are updated to record the most recent attester. "
+        "A 3-entry ring buffer keeps lightweight history. "
+        "Actions: 'attest' (confirm correctness), 'update' (replace content), "
+        "'invalidate' (mark superseded), 'delete' (remove)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "ID of memory to validate."},
+            "action": {
+                "type": "string",
+                "enum": ["attest", "update", "invalidate", "delete"],
+                "description": "What kind of validation to record.",
+            },
+            "validator": {
+                "type": "string",
+                "description": "Agent identifier performing the validation. Defaults to the caller's agent_identity if not set.",
+                "default": "",
+            },
+            "new_content": {
+                "type": "string",
+                "description": "New content (only used with action='update').",
+                "default": "",
+            },
+            "note": {
+                "type": "string",
+                "description": "Optional reason or evidence for this validation.",
+                "default": "",
+            },
+            "bank": {
+                "type": "string",
+                "enum": ["private", "surface"],
+                "description": "Which bank holds the memory. Default 'private'.",
+                "default": "private",
+            },
+        },
+        "required": ["memory_id", "action"],
+    },
+}
+
 GET_SCHEMA = {
     "name": "mnemosyne_get",
     "description": (
@@ -522,7 +568,7 @@ GRAPH_LINK_SCHEMA = {
 ALL_TOOL_SCHEMAS = [
     REMEMBER_SCHEMA, RECALL_SCHEMA, SHARED_REMEMBER_SCHEMA, SHARED_RECALL_SCHEMA,
     SHARED_FORGET_SCHEMA, SHARED_STATS_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
-    INVALIDATE_SCHEMA, GET_SCHEMA, TRIPLE_ADD_SCHEMA, TRIPLE_QUERY_SCHEMA,
+    INVALIDATE_SCHEMA, VALIDATE_SCHEMA, GET_SCHEMA, TRIPLE_ADD_SCHEMA, TRIPLE_QUERY_SCHEMA,
     SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
     EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
     GRAPH_QUERY_SCHEMA, GRAPH_LINK_SCHEMA,
@@ -1133,6 +1179,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_stats(args)
             elif tool_name == "mnemosyne_invalidate":
                 return self._handle_invalidate(args)
+            elif tool_name == "mnemosyne_validate":
+                return self._handle_validate(args)
             elif tool_name == "mnemosyne_get":
                 return self._handle_get(args)
             elif tool_name == "mnemosyne_triple_add":
@@ -1370,6 +1418,124 @@ class MnemosyneMemoryProvider(MemoryProvider):
             return json.dumps({"error": "memory_id is required"})
         self._beam.invalidate(memory_id, replacement_id=replacement_id if replacement_id else None)
         return json.dumps({"status": "invalidated", "memory_id": memory_id})
+
+    def _handle_validate(self, args: Dict[str, Any]) -> str:
+        """Collaborative attestation: any agent can attest, update, invalidate,
+        or delete any memory in either bank. Original author_id is preserved.
+        validator/validated_at/validation_count on the live row capture the
+        most recent attester. memory_validations table holds last 3 entries
+        (trim trigger maintains the ring buffer).
+        """
+        memory_id = args.get("memory_id", "")
+        action = args.get("action", "")
+        bank = args.get("bank", "private")
+        validator = args.get("validator") or self._agent_identity or "unknown"
+        new_content = args.get("new_content", "")
+        note = args.get("note", "")
+
+        if not memory_id:
+            return json.dumps({"error": "memory_id is required"})
+        if action not in ("attest", "update", "invalidate", "delete"):
+            return json.dumps({"error": f"unknown action: {action}"})
+        if bank not in ("private", "surface"):
+            return json.dumps({"error": f"unknown bank: {bank}"})
+        if action == "update" and not new_content:
+            return json.dumps({"error": "new_content is required for action='update'"})
+
+        # Pick the right beam (private vs surface)
+        if bank == "surface":
+            err = self._require_surface_beam()
+            if err:
+                return json.dumps({"error": err})
+            target_beam = self._surface_beam
+        else:
+            if not self._beam:
+                return json.dumps({"error": "private beam not initialized"})
+            target_beam = self._beam
+
+        conn = target_beam.conn
+
+        # Verify the memory exists in this bank
+        existing = conn.execute(
+            "SELECT id, author_id, content FROM working_memory WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+        if not existing:
+            return json.dumps({
+                "error": "memory_not_found",
+                "memory_id": memory_id,
+                "bank": bank,
+            })
+
+        author_id = existing[1]
+        prev_content = existing[2]
+
+        # Apply the action atomically
+        try:
+            if action == "delete":
+                conn.execute("DELETE FROM working_memory WHERE id = ?", (memory_id,))
+            elif action == "update":
+                conn.execute(
+                    "UPDATE working_memory SET content = ?, validator = ?, "
+                    "validated_at = CURRENT_TIMESTAMP, "
+                    "validation_count = COALESCE(validation_count, 0) + 1 "
+                    "WHERE id = ?",
+                    (new_content, validator, memory_id),
+                )
+            elif action == "invalidate":
+                conn.execute(
+                    "UPDATE working_memory SET valid_until = CURRENT_TIMESTAMP, "
+                    "validator = ?, validated_at = CURRENT_TIMESTAMP, "
+                    "validation_count = COALESCE(validation_count, 0) + 1 "
+                    "WHERE id = ?",
+                    (validator, memory_id),
+                )
+            else:  # attest
+                conn.execute(
+                    "UPDATE working_memory SET validator = ?, "
+                    "validated_at = CURRENT_TIMESTAMP, "
+                    "validation_count = COALESCE(validation_count, 0) + 1 "
+                    "WHERE id = ?",
+                    (validator, memory_id),
+                )
+
+            # Append to ring buffer (trigger trims to last 3 per memory_id)
+            conn.execute(
+                "INSERT INTO memory_validations "
+                "(memory_id, validator, action, new_content, note) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (memory_id, validator, action,
+                 new_content if action == "update" else None,
+                 note or None),
+            )
+            conn.commit()
+        except Exception as exc:
+            return json.dumps({
+                "error": "validation_failed",
+                "reason": str(exc),
+                "memory_id": memory_id,
+            })
+
+        # Audit log if available
+        try:
+            if hasattr(self, "_audit_event"):
+                self._audit_event(
+                    action=f"validate_{action}",
+                    memory_id=memory_id,
+                    bank=bank,
+                    source_tool="mnemosyne_validate",
+                )
+        except Exception:
+            logger.debug("Mnemosyne audit event failed for validate", exc_info=True)
+
+        return json.dumps({
+            "status": f"validation_{action}",
+            "memory_id": memory_id,
+            "bank": bank,
+            "validator": validator,
+            "author_id": author_id,
+            "previous_content": prev_content[:200] if prev_content else None,
+        })
 
     def _handle_get(self, args: Dict[str, Any]) -> str:
         memory_id = args.get("memory_id", "")

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -796,6 +796,49 @@ def init_beam(db_path: Path = None):
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_em_author ON episodic_memory(author_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_em_channel ON episodic_memory(channel_id)")
 
+    # --- Migration: collaborative attestation (v2.7) ---
+    # author_id captures the original writer; validator/validated_at capture
+    # the most recent agent that attested or updated the memory. Together they
+    # let multiple agents collaborate on shared facts without losing origin.
+    _add_column_if_missing(conn, "working_memory", "validator", "TEXT DEFAULT NULL")
+    _add_column_if_missing(conn, "working_memory", "validated_at", "TIMESTAMP DEFAULT NULL")
+    _add_column_if_missing(conn, "working_memory", "validation_count", "INTEGER DEFAULT 0")
+    _add_column_if_missing(conn, "episodic_memory", "validator", "TEXT DEFAULT NULL")
+    _add_column_if_missing(conn, "episodic_memory", "validated_at", "TIMESTAMP DEFAULT NULL")
+    _add_column_if_missing(conn, "episodic_memory", "validation_count", "INTEGER DEFAULT 0")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_wm_validator ON working_memory(validator)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_wm_validated_at ON working_memory(validated_at)")
+
+    # Ring-buffer log capped at 3 entries per memory (lightweight history).
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS memory_validations (
+            validation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            memory_id TEXT NOT NULL,
+            validator TEXT NOT NULL,
+            validated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            action TEXT NOT NULL,
+            new_content TEXT,
+            note TEXT
+        )
+    """)
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_validations_memory ON memory_validations(memory_id)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_validations_validator ON memory_validations(validator)")
+    # Trim each memory's validation history to the most recent 3 entries.
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS trim_validations_to_3
+        AFTER INSERT ON memory_validations
+        BEGIN
+            DELETE FROM memory_validations
+            WHERE memory_id = NEW.memory_id
+              AND validation_id NOT IN (
+                  SELECT validation_id FROM memory_validations
+                  WHERE memory_id = NEW.memory_id
+                  ORDER BY validation_id DESC
+                  LIMIT 3
+              );
+        END
+    """)
+
     # --- FACTS (LLM-extracted structured knowledge) ---
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS facts (

--- a/tests/test_hermes_memory_provider_validation.py
+++ b/tests/test_hermes_memory_provider_validation.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_memory_provider import MnemosyneMemoryProvider
+
+
+def _provider(tmp_path: Path, monkeypatch, agent_identity="Sisyphus"):
+    data_dir = tmp_path / "mnemosyne-data"
+    hermes_home = tmp_path / "profiles" / agent_identity.lower()
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir / "private"))
+    monkeypatch.setenv("MNEMOSYNE_HOST_LLM_ENABLED", "0")
+    provider = MnemosyneMemoryProvider()
+    provider.initialize(
+        session_id=f"{agent_identity.lower()}-session",
+        hermes_home=str(hermes_home),
+        agent_identity=agent_identity,
+        shared_surface_path=str(data_dir / "shared" / "mnemosyne.db"),
+    )
+    assert provider._beam is not None
+    return provider
+
+
+def _call(provider, name, args):
+    return json.loads(provider.handle_tool_call(name, args))
+
+
+def _seed_private(provider, content, author="Sisyphus"):
+    res = _call(provider, "mnemosyne_remember", {
+        "content": content,
+        "importance": 0.7,
+        "source": "fact",
+    })
+    assert res["status"] == "stored"
+    mid = res["memory_id"]
+    # Tag the seed row as authored by `author` so we can verify preservation
+    provider._beam.conn.execute(
+        "UPDATE working_memory SET author_id = ? WHERE id = ?",
+        (author, mid),
+    )
+    provider._beam.conn.commit()
+    return mid
+
+
+def _seed_surface(provider, content, kind="preference"):
+    res = _call(provider, "mnemosyne_shared_remember", {
+        "content": content,
+        "kind": kind,
+        "importance": 0.7,
+    })
+    assert res["status"] == "stored_shared"
+    return res["memory_id"]
+
+
+def _row(provider, mid, bank="private"):
+    beam = provider._beam if bank == "private" else provider._surface_beam
+    return beam.conn.execute(
+        "SELECT id, content, author_id, validator, validated_at, "
+        "validation_count, valid_until "
+        "FROM working_memory WHERE id = ?",
+        (mid,),
+    ).fetchone()
+
+
+def _validation_log(provider, mid, bank="private"):
+    beam = provider._beam if bank == "private" else provider._surface_beam
+    return beam.conn.execute(
+        "SELECT validator, action, new_content, note "
+        "FROM memory_validations WHERE memory_id = ? ORDER BY validation_id",
+        (mid,),
+    ).fetchall()
+
+
+# --- Schema migration sanity ----------------------------------------------
+
+def test_validator_columns_exist_after_init(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    cols = [r[1] for r in provider._beam.conn.execute(
+        "PRAGMA table_info(working_memory)"
+    ).fetchall()]
+    assert "validator" in cols
+    assert "validated_at" in cols
+    assert "validation_count" in cols
+
+
+def test_memory_validations_table_exists(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    row = provider._beam.conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_validations'"
+    ).fetchone()
+    assert row is not None
+
+
+def test_trim_trigger_exists(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    row = provider._beam.conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='trim_validations_to_3'"
+    ).fetchone()
+    assert row is not None
+
+
+# --- Action: attest --------------------------------------------------------
+
+def test_validate_attest_preserves_author_and_records_validator(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_private(provider, "SSH key at /home/hilman/.ssh/pc", author="Sisyphus")
+
+    res = _call(provider, "mnemosyne_validate", {
+        "memory_id": mid,
+        "action": "attest",
+        "validator": "Albedo",
+        "note": "confirmed during deploy",
+    })
+
+    assert res["status"] == "validation_attest"
+    assert res["validator"] == "Albedo"
+    assert res["author_id"] == "Sisyphus"
+
+    row = _row(provider, mid)
+    # author preserved, validator updated, count incremented
+    assert row[2] == "Sisyphus"          # author_id
+    assert row[3] == "Albedo"            # validator
+    assert row[4] is not None            # validated_at
+    assert row[5] == 1                   # validation_count
+
+
+def test_validate_attest_falls_back_to_agent_identity(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch, agent_identity="Hopz")
+    mid = _seed_private(provider, "Project at /tmp/proj", author="Sisyphus")
+
+    res = _call(provider, "mnemosyne_validate", {
+        "memory_id": mid,
+        "action": "attest",
+    })
+
+    assert res["validator"] == "Hopz"
+
+
+# --- Action: update --------------------------------------------------------
+
+def test_validate_update_replaces_content_and_keeps_author(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_private(provider, "SSH key at /home/hilman/.ssh/pc", author="Sisyphus")
+
+    res = _call(provider, "mnemosyne_validate", {
+        "memory_id": mid,
+        "action": "update",
+        "validator": "Albedo",
+        "new_content": "SSH key at /home/hilman/.ssh/laptop",
+    })
+
+    assert res["status"] == "validation_update"
+    row = _row(provider, mid)
+    assert row[1] == "SSH key at /home/hilman/.ssh/laptop"  # content updated
+    assert row[2] == "Sisyphus"                               # author preserved
+    assert row[3] == "Albedo"                                 # validator updated
+
+
+def test_validate_update_requires_new_content(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_private(provider, "test fact")
+
+    res = _call(provider, "mnemosyne_validate", {
+        "memory_id": mid,
+        "action": "update",
+        "validator": "Albedo",
+    })
+    assert "new_content is required" in res["error"]
+
+
+# --- Action: invalidate ----------------------------------------------------
+
+def test_validate_invalidate_sets_valid_until(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_private(provider, "outdated fact about VPN", author="Sisyphus")
+
+    res = _call(provider, "mnemosyne_validate", {
+        "memory_id": mid,
+        "action": "invalidate",
+        "validator": "Hopz",
+        "note": "user changed VPN",
+    })
+
+    assert res["status"] == "validation_invalidate"
+    row = _row(provider, mid)
+    assert row[6] is not None  # valid_until set
+    assert row[3] == "Hopz"    # validator recorded
+    assert row[2] == "Sisyphus"  # author preserved
+
+
+# --- Action: delete --------------------------------------------------------
+
+def test_validate_delete_removes_row(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_private(provider, "stale fact", author="Sisyphus")
+
+    res = _call(provider, "mnemosyne_validate", {
+        "memory_id": mid,
+        "action": "delete",
+        "validator": "Albedo",
+    })
+
+    assert res["status"] == "validation_delete"
+    assert _row(provider, mid) is None
+
+
+# --- Cross-bank: surface validation ---------------------------------------
+
+def test_validate_works_on_shared_surface(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_surface(provider, "User prefers Tailscale over OpenVPN")
+
+    res = _call(provider, "mnemosyne_validate", {
+        "memory_id": mid,
+        "action": "attest",
+        "validator": "Albedo",
+        "bank": "surface",
+    })
+
+    assert res["status"] == "validation_attest"
+    assert res["bank"] == "surface"
+    row = _row(provider, mid, bank="surface")
+    assert row[3] == "Albedo"
+
+
+# --- Ring buffer behavior --------------------------------------------------
+
+def test_ring_buffer_keeps_only_last_three_validations(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_private(provider, "SSH key location", author="Sisyphus")
+
+    for i, who in enumerate(["v1", "v2", "v3", "v4", "v5"]):
+        _call(provider, "mnemosyne_validate", {
+            "memory_id": mid,
+            "action": "attest",
+            "validator": who,
+        })
+
+    log = _validation_log(provider, mid)
+    validators = [row[0] for row in log]
+    assert len(log) == 3
+    assert validators == ["v3", "v4", "v5"]
+
+
+def test_validation_count_grows_unbounded(tmp_path, monkeypatch):
+    """validation_count on the live row keeps growing even though the log is trimmed."""
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_private(provider, "tracked fact")
+
+    for who in ["a", "b", "c", "d", "e", "f"]:
+        _call(provider, "mnemosyne_validate", {
+            "memory_id": mid,
+            "action": "attest",
+            "validator": who,
+        })
+
+    row = _row(provider, mid)
+    assert row[5] == 6  # validation_count
+
+
+# --- Error handling --------------------------------------------------------
+
+def test_validate_unknown_memory_returns_error(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    res = _call(provider, "mnemosyne_validate", {
+        "memory_id": "nonexistent",
+        "action": "attest",
+    })
+    assert res["error"] == "memory_not_found"
+
+
+def test_validate_unknown_action_rejected(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_private(provider, "fact")
+    res = _call(provider, "mnemosyne_validate", {
+        "memory_id": mid,
+        "action": "frobnicate",
+    })
+    assert "unknown action" in res["error"]
+
+
+def test_validate_unknown_bank_rejected(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_private(provider, "fact")
+    res = _call(provider, "mnemosyne_validate", {
+        "memory_id": mid,
+        "action": "attest",
+        "bank": "weird",
+    })
+    assert "unknown bank" in res["error"]
+
+
+def test_validate_missing_memory_id_rejected(tmp_path, monkeypatch):
+    provider = _provider(tmp_path, monkeypatch)
+    res = _call(provider, "mnemosyne_validate", {"action": "attest"})
+    assert "memory_id is required" in res["error"]
+
+
+# --- Cross-agent collaborative scenario (Master's SSH example) ------------
+
+def test_collaborative_attestation_chain(tmp_path, monkeypatch):
+    """Master's example: sisyphus authors, albedo updates, sisyphus updates,
+    hopz attests. Author preserved throughout, ring buffer captures last 3."""
+    provider = _provider(tmp_path, monkeypatch)
+    mid = _seed_private(provider, "SSH key at /home/hilman/.ssh/pc", author="Sisyphus")
+
+    _call(provider, "mnemosyne_validate", {
+        "memory_id": mid, "action": "update", "validator": "Albedo",
+        "new_content": "SSH key at /home/hilman/.ssh/laptop",
+    })
+    _call(provider, "mnemosyne_validate", {
+        "memory_id": mid, "action": "update", "validator": "Sisyphus",
+        "new_content": "SSH key at /home/hilman/.ssh/main",
+    })
+    _call(provider, "mnemosyne_validate", {
+        "memory_id": mid, "action": "attest", "validator": "Hopz",
+    })
+
+    row = _row(provider, mid)
+    assert row[2] == "Sisyphus"            # author preserved
+    assert row[3] == "Hopz"                # latest validator
+    assert row[5] == 3                     # validation_count
+    assert "main" in row[1]                # latest content
+
+    log = _validation_log(provider, mid)
+    assert [r[0] for r in log] == ["Albedo", "Sisyphus", "Hopz"]
+    assert [r[1] for r in log] == ["update", "update", "attest"]

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -52,7 +52,7 @@ class TestToolRegistration:
     def test_all_tools_registered(self, tmp_path):
         provider = _provider(tmp_path)
         names = _tool_names(provider)
-        assert len(names) == 22, f"Expected 22 tools, got {len(names)}"
+        assert len(names) == 23, f"Expected 23 tools, got {len(names)}"
 
     def test_new_8_tools_present(self, tmp_path):
         provider = _provider(tmp_path)
@@ -67,6 +67,11 @@ class TestToolRegistration:
         for tool in ("remember", "recall", "sleep", "stats",
                      "invalidate", "triple_add", "triple_query"):
             assert f"mnemosyne_{tool}" in names
+
+    def test_validate_tool_present(self, tmp_path):
+        provider = _provider(tmp_path)
+        names = _tool_names(provider)
+        assert "mnemosyne_validate" in names
 
     def test_shared_surface_tools_present(self, tmp_path):
         provider = _provider(tmp_path)

--- a/tools/bench_validation.py
+++ b/tools/bench_validation.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Benchmark mnemosyne_validate latency.
+
+Each `validate` call updates the live row, inserts to memory_validations,
+and the trim trigger may delete an older row. This script measures the
+per-call cost so reviewers can confirm the ring-buffer trigger doesn't
+impose surprise overhead at scale.
+
+Usage:
+    python tools/bench_validation.py [--ops N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+
+def _bootstrap(env_dir: Path):
+    os.environ["MNEMOSYNE_DATA_DIR"] = str(env_dir / "private")
+    os.environ["MNEMOSYNE_HOST_LLM_ENABLED"] = "0"
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    hermes_home = env_dir / "profile"
+    hermes_home.mkdir(parents=True)
+
+    provider = MnemosyneMemoryProvider()
+    provider.initialize(
+        session_id="bench-session",
+        hermes_home=str(hermes_home),
+        agent_identity="Bench",
+        shared_surface_path=str(env_dir / "shared" / "mnemosyne.db"),
+    )
+    return provider
+
+
+def _seed_targets(provider, n: int) -> list[str]:
+    """Pre-create N memories that will be repeatedly validated."""
+    ids: list[str] = []
+    for i in range(n):
+        result = json.loads(provider.handle_tool_call("mnemosyne_remember", {
+            "content": f"target memory {i} for validation benchmark",
+            "importance": 0.5,
+            "source": "fact",
+        }))
+        ids.append(result["memory_id"])
+    return ids
+
+
+def _measure(provider, target_ids: list[str], action: str, iters: int) -> list[float]:
+    durations: list[float] = []
+    n_targets = len(target_ids)
+
+    def _args(i: int) -> dict:
+        out = {
+            "memory_id": target_ids[i % n_targets],
+            "action": action,
+            "validator": f"agent_{i % 4}",
+        }
+        # `update` requires new_content; everything else doesn't take it.
+        if action == "update":
+            out["new_content"] = f"updated content rev-{i} for benchmark"
+        return out
+
+    # Warmup
+    for i in range(min(20, iters)):
+        provider.handle_tool_call("mnemosyne_validate", _args(i))
+    # Measure
+    for i in range(iters):
+        args = _args(i)
+        t0 = time.perf_counter()
+        provider.handle_tool_call("mnemosyne_validate", args)
+        durations.append((time.perf_counter() - t0) * 1000.0)
+    return durations
+
+
+def _summary(label: str, samples: list[float]) -> dict:
+    samples_sorted = sorted(samples)
+    p50 = samples_sorted[len(samples_sorted) // 2]
+    p95 = samples_sorted[max(0, int(len(samples_sorted) * 0.95) - 1)]
+    return {
+        "config": label,
+        "n": len(samples),
+        "mean_ms": round(statistics.mean(samples), 3),
+        "p50_ms": round(p50, 3),
+        "p95_ms": round(p95, 3),
+        "min_ms": round(min(samples), 3),
+        "max_ms": round(max(samples), 3),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ops", type=int, default=200)
+    ap.add_argument("--targets", type=int, default=50)
+    args = ap.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        provider = _bootstrap(Path(tmp))
+        target_ids = _seed_targets(provider, args.targets)
+
+        # Compare: remember (baseline) vs each validate action.
+        # remember is the reference cost; validate should be in the same ballpark.
+        remember_samples: list[float] = []
+        for i in range(args.ops):
+            t0 = time.perf_counter()
+            provider.handle_tool_call("mnemosyne_remember", {
+                "content": f"remember-bench {i}",
+                "importance": 0.5,
+                "source": "fact",
+            })
+            remember_samples.append((time.perf_counter() - t0) * 1000.0)
+
+        results = [_summary("remember_baseline", remember_samples)]
+        for action in ("attest", "update", "invalidate"):
+            samples = _measure(provider, target_ids, action, args.ops)
+            results.append(_summary(f"validate_{action}", samples))
+
+    print(json.dumps({
+        "ops_per_config": args.ops,
+        "targets": args.targets,
+        "results": results,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Reopens #178 (closed by the v3.1.0 history rewrite) on a fresh base, with a benchmark added per CONTRIBUTING rule #2.

Adds `mnemosyne_validate` so any agent can attest, update, invalidate, or delete a memory in either the private bank or the shared surface without overwriting `author_id`. The most recent attester is captured in new `validator` + `validated_at` columns on the live row, and a 3-entry ring buffer in `memory_validations` keeps lightweight history.

Why this matters now that v3.1.0 ships shared surface CRUD: with profile isolation on, agents have private banks and share one surface DB. There's no way for one agent to update or confirm another agent's memory without losing origin. With this PR, agent A authors a fact, agent B updates it later when new info comes in, agent C confirms it again and `author_id` stays as A throughout. If A goes offline, the fact isn't orphaned: B and C can still validate it.

If PR #182 (audit log) also lands, the audit log picks up these events as `validate_attest`, `validate_update`, `validate_invalidate`, `validate_delete` for end-to-end traceability. Both PRs are independent at the file level.

Schema migrations (idempotent via existing `_add_column_if_missing` pattern, applied to both private and surface DBs since they share schema):

- `working_memory` and `episodic_memory` get `validator TEXT`, `validated_at TIMESTAMP`, `validation_count INTEGER DEFAULT 0`
- New `memory_validations` table: `validation_id`, `memory_id`, `validator`, `validated_at`, `action`, `new_content`, `note`
- New `trim_validations_to_3` trigger keeps the most recent 3 entries per `memory_id`. `validation_count` on the live row keeps the running total.
- New indexes on `validator` and `validated_at`

Tool surface:

```
mnemosyne_validate(memory_id, action, validator?, new_content?, note?, bank?)
  action: 'attest' | 'update' | 'invalidate' | 'delete'
  bank:   'private' (default) | 'surface'
  validator: defaults to caller's agent_identity when omitted
  new_content: required only when action='update'
```

Behavior:
- `attest`: bumps validator + validated_at + validation_count, content unchanged
- `update`: replaces content, bumps validator metadata
- `invalidate`: sets `valid_until=now()`, bumps validator metadata
- `delete`: removes the row entirely
- Ring buffer trigger keeps `memory_validations` at most 3 rows per memory
- Author preservation enforced at the SQL level (no UPDATE touches `author_id`)

## Benchmark

`tools/bench_validation.py` measures `validate` latency for each action vs `remember` as reference cost.

Local run (200 ops per config, 50 target memories):

```
remember_baseline:    p50=20.06ms   p95=22.30ms   (reference, full pipeline)
validate_attest:      p50=0.21ms    p95=0.29ms
validate_update:      p50=0.46ms    p95=0.75ms
validate_invalidate:  p50=0.16ms    p95=0.21ms
```

Validate ops are sub-millisecond p95. Ring-buffer trigger overhead is invisible at this scale. Reproducible with `python tools/bench_validation.py`.

## Tests

`tests/test_hermes_memory_provider_validation.py` 17 tests covering:

- Schema migration: validator columns, table, trigger all present after init
- `attest`: preserves author, records validator, increments count
- `attest`: validator falls back to caller's `agent_identity` when omitted
- `update`: replaces content, preserves author, bumps validator
- `update`: requires `new_content`
- `invalidate`: sets `valid_until`, preserves author
- `delete`: removes row
- Cross-bank: same flow works on `bank=surface`
- Ring buffer: 5 inserts → only last 3 survive
- `validation_count` keeps growing past 3 (live-row counter is unbounded)
- Errors: unknown memory, unknown action, unknown bank, missing memory_id
- Collaborative chain: A → B update → A update → C attest, author=A throughout

```
17 new tests + 36 broader tests = 53 passed
```

Also bumps `test_provider_all_15_tools.py` tool count from 22 to 23 and adds `test_validate_tool_present`.

## Changes

- `mnemosyne/core/beam.py` 43 insertions (schema migrations)
- `hermes_memory_provider/__init__.py` 168 insertions (VALIDATE_SCHEMA + dispatcher + handler)
- `tests/test_hermes_memory_provider_validation.py` 329 lines new
- `tests/test_provider_all_15_tools.py` 7 insertions, 2 deletions
- `tools/bench_validation.py` added in this rebased version

Total feature: 545 insertions across 4 files. Schema is backward-compatible (new columns nullable, new table created if missing).

Refs the prior closed PR #178; rebased onto v3.1.0.
