### PR TITLE
feat(embeddings): explicit opt-in for non-OpenAI OpenRouter embedding models

### DIFF
--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -54,6 +54,16 @@ def _is_api_model(model_name: str) -> bool:
     base_url = os.environ.get("OPENROUTER_BASE_URL", "")
     if base_url and "openrouter.ai" not in base_url:
         return True
+    # Explicit opt-in for non-OpenAI embedding models hosted on OpenRouter
+    # (qwen/qwen3-embedding-*, baai/bge-*, jina-embeddings-*, nvidia/*-embed-*, etc.).
+    # Distinct from the substring/prefix checks above because the default fastembed
+    # model id (BAAI/bge-small-en-v1.5) shares the same vendor-prefix shape as those
+    # OpenRouter models — pure name-pattern matching would silently break fastembed
+    # users that also have OPENROUTER_API_KEY set for chat. Requiring an explicit
+    # env flag keeps local-first behavior the default while giving a clean opt-in
+    # for OpenRouter-hosted embedding models.
+    if os.environ.get("MNEMOSYNE_EMBEDDINGS_VIA_API", "").strip().lower() in ("1", "true", "yes", "on"):
+        return True
     return False
 
 


### PR DESCRIPTION
## Problem

`_is_api_model()` routes through the OpenAI-compatible API for models matching `openai/*` or `text-embedding`, and for any model when `OPENROUTER_BASE_URL` points off-OpenRouter. OpenRouter hosts 25+ embedding models from other vendors (`qwen/qwen3-embedding-*`, `baai/bge-*`, `jina-embeddings-*`, `nvidia/llama-nemotron-embed-*`, `mistralai/mistral-embed-*`) that match none of those conditions. Setting `MNEMOSYNE_EMBEDDING_MODEL=qwen/qwen3-embedding-8b` with a valid `OPENROUTER_API_KEY` silently falls back to local fastembed — no log, no warning.

## Why not a name-pattern fix

A pure pattern-match (e.g. "any `vendor/model` with `OPENROUTER_API_KEY` set routes via API") would regress the default install: `BAAI/bge-small-en-v1.5` is the documented fastembed default and shares the same vendor-prefix shape as the OpenRouter models. Users running local fastembed who happen to have `OPENROUTER_API_KEY` set for chat completions (a common Hermes setup) would have their local embeddings silently rerouted through the API.

## Fix — explicit env-var opt-in

Mirrors the existing `OPENROUTER_BASE_URL` pattern: setting the env var states user intent.

```python
if os.environ.get("MNEMOSYNE_EMBEDDINGS_VIA_API", "").strip().lower() in ("1", "true", "yes", "on"):
    return True
```

Properties:
- Zero ambiguity, zero heuristic — either the user opts in or not.
- Zero regression on existing installs — fastembed-default users keep their current behavior even when an OpenRouter key is present.
- Discoverable in docs alongside `MNEMOSYNE_EMBEDDING_MODEL`.

## Verified

End-to-end against OpenRouter `/v1/embeddings` with `qwen/qwen3-embedding-8b`:
- 4096-dim float32 vectors returned, dim matches catalog
- $0.01/Mtok cost matches published pricing
- Response shape is OpenAI-standard; existing `_embed_api` parses cleanly

`Mnemosyne().remember()` + `.recall()` over a 4-fact corpus returns the correct top match on 3/3 paraphrased queries (queries share no keywords with stored facts).

Complements #161 (custom-endpoint detection via `OPENROUTER_BASE_URL`) for the vendor-prefixed-on-OpenRouter case.

## Followup (separate PR)

`_embed_api` swallows `HTTPError` silently — that's what made this gap invisible. Will file as a separate small PR after this one lands.
