### PR TITLE
feat(embeddings): add MNEMOSYNE_EMBEDDING_API_URL/KEY as preferred env var names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemosyne) (MAJOR.MINOR).
 
+## [3.2.0] — 2026-05-28
+
+### Added
+
+- **Preferred embedding env vars.** `MNEMOSYNE_EMBEDDING_API_URL` and `MNEMOSYNE_EMBEDDING_API_KEY` are now the preferred names for custom embedding endpoints. The old `OPENROUTER_BASE_URL` and `OPENROUTER_API_KEY` names still work as fallbacks for backward compatibility. Restores the v2.8.x naming convention. ([#193](https://github.com/AxDSan/mnemosyne/issues/193))
+
 ## [3.1.0] — 2026-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Simple Versioning](https://github.com/AxDSan/mnemosyne) (MAJOR.MINOR).
 
-## [3.2.0] — 2026-05-28
+## [3.1.1] — 2026-05-28
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ results = beam.recall("editor preferences", top_k=5)
 | `MNEMOSYNE_WM_MAX_ITEMS` | `10000` | Working memory limit |
 | `MNEMOSYNE_RECENCY_HALFLIFE` | `168` | Decay halflife in hours |
 
+| `MNEMOSYNE_EMBEDDING_API_URL` | `${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}` | Preferred name for custom embedding API endpoint (OpenAI-compatible). Falls back to `OPENROUTER_BASE_URL`. |
+| `MNEMOSYNE_EMBEDDING_API_KEY` | `${OPENROUTER_API_KEY:-${OPENAI_API_KEY:-}}` | Preferred name for embedding API key. Falls back to `OPENROUTER_API_KEY`, then `OPENAI_API_KEY`. |
+
 Full reference: [docs/configuration.md](docs/configuration.md)
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,13 @@
 
 Mnemosyne is designed to work with zero configuration. All settings have sensible defaults and are overridden via environment variables.
 
+## Custom Embedding Endpoint
+
+|| Variable | Default | Description |
+||---|---|---|
+|| `MNEMOSYNE_EMBEDDING_API_URL` | `${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}` | Preferred name for custom embedding API endpoint. Falls back to `OPENROUTER_BASE_URL`. |
+|| `MNEMOSYNE_EMBEDDING_API_KEY` | `${OPENROUTER_API_KEY:-${OPENAI_API_KEY:-}}` | Preferred name for embedding API key. Falls back to `OPENROUTER_API_KEY`, then `OPENAI_API_KEY`. |
+
 ## Data Directory
 
 ```bash

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.2.0"
+__version__ = "3.1.1"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -36,8 +36,8 @@ _FASTEMBED_AVAILABLE = np is not None and TextEmbedding is not None
 _FASTEMBED_CACHE_DIR = os.path.join(os.path.expanduser("~/.hermes"), "cache", "fastembed")
 
 # --- OpenAI-compatible API ---
-_OPENAI_API_KEY = os.environ.get("OPENROUTER_API_KEY", os.environ.get("OPENAI_API_KEY", ""))
-_OPENAI_BASE_URL = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+_OPENAI_API_KEY = os.environ.get("MNEMOSYNE_EMBEDDING_API_KEY", os.environ.get("OPENROUTER_API_KEY", os.environ.get("OPENAI_API_KEY", "")))
+_OPENAI_BASE_URL = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL", os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"))
 
 # --- Model selection ---
 _DEFAULT_MODEL = os.environ.get("MNEMOSYNE_EMBEDDING_MODEL", "BAAI/bge-small-en-v1.5")
@@ -49,9 +49,9 @@ def _is_api_model(model_name: str) -> bool:
     """Check if the model should use the OpenAI-compatible API."""
     if model_name.startswith("openai/") or "text-embedding" in model_name or model_name.startswith("text-embedding"):
         return True
-    # Custom endpoint: if OPENROUTER_BASE_URL is set to a non-OpenRouter URL,
+    # Custom endpoint: if OPENROUTER_BASE_URL or MNEMOSYNE_EMBEDDING_API_URL is set to a non-OpenRouter URL,
     # assume the user has their own API server and any model name should route there.
-    base_url = os.environ.get("OPENROUTER_BASE_URL", "")
+    base_url = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL", os.environ.get("OPENROUTER_BASE_URL", ""))
     if base_url and "openrouter.ai" not in base_url:
         return True
     # Explicit opt-in for non-OpenAI embedding models hosted on OpenRouter
@@ -129,7 +129,7 @@ def _embed_api(texts: List[str]) -> Optional[np.ndarray]:
     """Embed texts via OpenAI-compatible API (OpenRouter or custom endpoint)."""
     global _API_CALL_COUNT
     # Require API key for OpenRouter; custom endpoints may not need one.
-    base_url = os.environ.get("OPENROUTER_BASE_URL", _OPENAI_BASE_URL)
+    base_url = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL", os.environ.get("OPENROUTER_BASE_URL", _OPENAI_BASE_URL))
     is_custom = "openrouter.ai" not in base_url
     if not is_custom and not _OPENAI_API_KEY:
         return None
@@ -178,7 +178,7 @@ def available() -> bool:
         return False
     if _is_api_model(_DEFAULT_MODEL):
         # Custom endpoints (non-OpenRouter) may not require an API key
-        base_url = os.environ.get("OPENROUTER_BASE_URL", "")
+        base_url = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL", os.environ.get("OPENROUTER_BASE_URL", ""))
         if base_url and "openrouter.ai" not in base_url:
             return True
         return bool(_OPENAI_API_KEY)


### PR DESCRIPTION
## Description

PR #161 added custom API endpoint support but used `OPENROUTER_BASE_URL` and `OPENROUTER_API_KEY` as the env var names. These names are misleading — they imply OpenRouter-specific usage, but the endpoint is just a generic OpenAI-compatible API. This also conflicts if someone uses OpenRouter for their LLM but a different endpoint (e.g., local llama-swap) for embeddings.

This PR adds `MNEMOSYNE_EMBEDDING_API_URL` and `MNEMOSYNE_EMBEDDING_API_KEY` as the preferred names, restoring backward compatibility with v2.8.x naming convention. The old `OPENROUTER_*` names continue to work as fallbacks.

**No breaking changes** — existing configs continue to work. The new names are checked first, falling back to the old names if not set.

Also fixes the CHANGELOG v3.1.0 entry that referenced `MNEMOSYNE_EMBEDDING_BASE_URL` but never implemented it.

## Changes
| File | Change |
|------|--------|
| `mnemosyne/core/embeddings.py` | Added MNEMOSYNE_EMBEDDING_API_URL/KEY as preferred env var names with OPENROUTER_* fallback in all 4 read sites |
| `mnemosyne/__init__.py` | Bump 3.1.0 → 3.2.0 |
| `CHANGELOG.md` | Added v3.2.0 entry referencing #193 |
| `README.md` | Added embedding env vars to Environment Variables table |
| `docs/configuration.md` | Added Custom Embedding Endpoint section |

## Related
- Issue: #193
- PR #161 (original custom endpoint support)
- PR #187 (MNEMOSYNE_EMBEDDINGS_VIA_API opt-in)