### PR TITLE
fix: derive EMBEDDING_DIM from embeddings module (was hardcoded 384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
+## [Unreleased]
+
+### Fixed
+
+- **Hardcoded embedding dimension in `binary_vectors.py`.** `EMBEDDING_DIM` was
+  hardcoded to 384 (bge-small-en-v1.5), causing `maximally_informative_binarization`
+  to silently truncate larger embeddings (e.g. 1024-dim multilingual-e5-large) to
+  the first 384 components, losing up to 62.5% of vector information. The dimension
+  is now derived from `mnemosyne.core.embeddings.EMBEDDING_DIM` at import time with
+  a 384 fallback when the embeddings module is unavailable. `BYTES_PER_VECTOR`,
+  `compression_ratio`, and `theoretical_size_mb` in `get_stats()` are likewise
+  computed from the resolved dimension instead of hardcoded constants.
+
 ## [3.1.2] — 2026-05-28
 
 ### Fixed

--- a/mnemosyne/core/binary_vectors.py
+++ b/mnemosyne/core/binary_vectors.py
@@ -12,7 +12,7 @@ Replaces: float32 embeddings + HNSW index + cosine similarity
 With: binary vectors + exhaustive scan + Hamming distance
 
 Benefits:
-- 32x memory reduction
+- 32x memory reduction (model-dependent)
 - Deterministic retrieval (same query = same results)
 - No ANN index needed (no HNSW, no IVF, no PQ)
 - SQLite-native storage
@@ -25,11 +25,19 @@ import sqlite3
 from typing import List, Dict, Tuple, Optional
 from pathlib import Path
 
-
 # --- Configuration ---
-EMBEDDING_DIM = 384  # bge-small-en-v1.5 dimension
+# Derive EMBEDDING_DIM from the embeddings module so it always matches
+# the configured model (e.g. 384 for bge-small-en-v1.5, 1024 for
+# multilingual-e5-large).  Previously hardcoded to 384, which silently
+# truncated larger embeddings during binarization, losing up to 62.5%
+# of information when a 1024-dim model was in use.
+try:
+    from mnemosyne.core.embeddings import EMBEDDING_DIM as _EMB_DIM
+    EMBEDDING_DIM = _EMB_DIM
+except ImportError:
+    EMBEDDING_DIM = 384  # fallback for standalone / test use
 BITS_PER_BYTE = 8
-BYTES_PER_VECTOR = EMBEDDING_DIM // BITS_PER_BYTE  # 48 bytes for 384 bits
+BYTES_PER_VECTOR = EMBEDDING_DIM // BITS_PER_BYTE
 
 
 # --- Module-level function aliases for beam.py compatibility ---
@@ -90,7 +98,7 @@ class BinaryVectorStore:
             embedding: float32 numpy array of shape (EMBEDDING_DIM,)
             
         Returns:
-            bytes: Binary representation (48 bytes for 384 dims)
+            bytes: Binary representation (BYTES_PER_VECTOR bytes)
         """
         # Ensure correct shape
         embedding = embedding.flatten()[:EMBEDDING_DIM]
@@ -99,7 +107,7 @@ class BinaryVectorStore:
         binary_bits = (embedding > 0).astype(np.uint8)
         
         # Pack bits into bytes
-        # Reshape to (48, 8) for 384 bits
+        # n_bytes groups of 8 bits each
         n_bytes = (len(binary_bits) + 7) // 8
         padded = np.pad(binary_bits, (0, n_bytes * 8 - len(binary_bits)), mode='constant')
         
@@ -248,8 +256,8 @@ class BinaryVectorStore:
             "avg_bytes_per_vector": row["avg_bytes"] if row else 0,
             "max_bytes": row["max_bytes"] if row else 0,
             "min_bytes": row["min_bytes"] if row else 0,
-            "compression_ratio": 48.0 / (EMBEDDING_DIM * 4),  # 48 bytes vs 1536 bytes float32
-            "theoretical_size_mb": (count * 48) / (1024 * 1024)
+            "compression_ratio": BYTES_PER_VECTOR / (EMBEDDING_DIM * 4),
+            "theoretical_size_mb": (count * BYTES_PER_VECTOR) / (1024 * 1024)
         }
     
     def close(self):

--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -47,6 +47,14 @@ from mnemosyne.core.veracity_consolidation import (
     compute_fact_id,
 )
 
+# Cached embedding dim for vector normalization — resolved once at import time.
+# Avoids a per-row import inside the bit-vec normalization hot path.
+try:
+    from mnemosyne.core.embeddings import EMBEDDING_DIM as _EMB_DIM
+except ImportError:
+    _EMB_DIM = 384
+_EMBEDDING_DIM_BITS = float(_EMB_DIM)
+
 
 def _env_disabled(name: str) -> bool:
     """A/B toggle helper: return True iff env var is set to a falsy
@@ -335,9 +343,8 @@ class PolyphonicRecallEngine:
                             #   raw f32: 1/(1+dist) (L2 → (0, 1])
                             raw_dist = float(dist)
                             if vec_type == "bit":
-                                # 384 dims for MiniLM-class embeddings
-                                # (matches binary_vectors.EMBEDDING_DIM)
-                                sim = 1.0 - (raw_dist / 384.0)
+                                # Resolved from configured model dim
+                                sim = 1.0 - (raw_dist / _EMBEDDING_DIM_BITS)
                             elif vec_type == "int8":
                                 sim = 1.0 - (raw_dist / 2.0)
                             else:

--- a/mnemosyne/core/shmr.py
+++ b/mnemosyne/core/shmr.py
@@ -33,7 +33,7 @@ SHMR_MODEL = os.environ.get("MNEMOSYNE_SHMR_MODEL", "")
 SHMR_MIN_CLUSTER_SIZE = int(os.environ.get("MNEMOSYNE_SHMR_MIN_CLUSTER_SIZE", "2"))
 SHMR_TEMPERATURE = float(os.environ.get("MNEMOSYNE_SHMR_TEMPERATURE", "0.2"))
 
-EMBEDDING_DIM = 384  # bge-small-en-v1.5
+EMBEDDING_DIM = _embeddings.EMBEDDING_DIM  # derived from configured model
 
 # --- SQL Schema ---
 FACTS_SCHEMA_SQL = """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ import numpy as np
 from pathlib import Path
 
 from mnemosyne.core.typed_memory import classify_memory, MemoryType, get_type_priority
-from mnemosyne.core.binary_vectors import BinaryVectorStore
+from mnemosyne.core.binary_vectors import BinaryVectorStore, EMBEDDING_DIM, BYTES_PER_VECTOR
 from mnemosyne.core.episodic_graph import EpisodicGraph
 from mnemosyne.core.veracity_consolidation import VeracityConsolidator
 from mnemosyne.core.polyphonic_recall import PolyphonicRecallEngine
@@ -53,7 +53,7 @@ class TestBinaryVectors(unittest.TestCase):
     def setUp(self):
         self.temp_file = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
         self.store = BinaryVectorStore(db_path=Path(self.temp_file.name))
-        self.embedding = np.random.randn(384).astype(np.float32)
+        self.embedding = np.random.randn(EMBEDDING_DIM).astype(np.float32)
     
     def tearDown(self):
         self.store.close()
@@ -61,7 +61,7 @@ class TestBinaryVectors(unittest.TestCase):
     
     def test_binarization(self):
         binary = self.store.maximally_informative_binarization(self.embedding)
-        self.assertEqual(len(binary), 48)  # 384 bits / 8 = 48 bytes
+        self.assertEqual(len(binary), BYTES_PER_VECTOR)  # EMBEDDING_DIM bits / 8
     
     def test_hamming_distance(self):
         binary_a = self.store.maximally_informative_binarization(self.embedding)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -235,7 +235,7 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(result.memory_type, MemoryType.DECISION)
         
         # 2. Store binary vector
-        embedding = np.random.randn(384).astype(np.float32)
+        embedding = np.random.randn(EMBEDDING_DIM).astype(np.float32)
         self.store.store_vector("mem_001", embedding)
         
         # 3. Extract gist and facts


### PR DESCRIPTION
## Problem

Three hardcoded references to `EMBEDDING_DIM = 384` (bge-small-en-v1.5) silently break vector operations when using larger models like `intfloat/multilingual-e5-large` (1024-dim):

| File | Line | What\'s hardcoded | Impact |
|---|---|---|---|
| `binary_vectors.py` | 30 | `EMBEDDING_DIM = 384` | `maximally_informative_binarization` truncates 1024→384, losing 62.5% info |
| `binary_vectors.py` | 251-252 | `48.0`, `count * 48` | Stats always assume 48 bytes per vector |
| `shmr.py` | 36 | `EMBEDDING_DIM = 384` | Self-harmonizing reasoning uses wrong dimension |
| `polyphonic_recall.py` | 340 | `sim = 1.0 - (raw_dist / 384.0)` | Bit-vector similarity score always normalised to 384 |

While `embeddings.py` and `beam.py` correctly resolve to the configured model\'s dimension (e.g. 1024 for e5-large), these three files had their own hardcoded constants.

## Fix

Derive `EMBEDDING_DIM` from `mnemosyne.core.embeddings` at import time with a 384 fallback for standalone/test use:

* **`binary_vectors.py`** — imports `EMBEDDING_DIM` from `embeddings`; `BYTES_PER_VECTOR`, `compression_ratio`, and `theoretical_size_mb` now use the resolved dimension instead of hardcoded constants
* **`shmr.py`** — uses `_embeddings.EMBEDDING_DIM` instead of `384`
* **`polyphonic_recall.py`** — module-level cached `_EMBEDDING_DIM_BITS` for bit-vector normalisation (avoids per-row imports in hot path)
* **`test_integration.py`** — tests use `EMBEDDING_DIM`/`BYTES_PER_VECTOR` instead of hardcoded 384/48

## Verification

### Unit tests pass with both models

Default (bge-small, 384-dim): 4 binary vector tests passed ✅ \
With multilingual-e5-large (1024-dim): 4 tests passed ✅ \
EmbeddingDimConfig (3 tests): all passed ✅

### End-to-end on production DB (multilingual-e5-large)

1. Consolidated **38 working memories** → episodic with full 1024-dim vectors
2. `embeddings.EMBEDDING_DIM` = **1024** ✅
3. `vec_episodes` DDL: `int8[1024]` matches model output ✅
4. All vectors stored at **1024 bytes** (= int8[1024]) ✅
5. sqlite-vec semantic search returns correct results ✅

### CI note
The CI failure (`ModuleNotFoundError: No module named 'hermes_plugin'` in test collection) is a **pre-existing issue**, not caused by this PR.

## Files changed

```
CHANGELOG.md                        | 13 +++++++++++++
mnemosyne/core/binary_vectors.py    | 24 ++++++++++++++++--------
mnemosyne/core/polyphonic_recall.py | 13 ++++++++++---
mnemosyne/core/shmr.py              |  2 +-
tests/test_integration.py           |  8 ++++----
5 files changed, 44 insertions(+), 16 deletions(-)
```
