### PR TITLE
Update installation script link

### DIFF
--- a/docs/integrations/hermes-mcp.md
+++ b/docs/integrations/hermes-mcp.md
@@ -21,7 +21,7 @@ Tools register as native Hermes commands.
 If you installed Mnemosyne via `deploy_hermes_provider.sh`, it's already active:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/AxDSan/mnemosyne/main/deploy_hermes_provider.sh | bash
+curl -sSL https://raw.githubusercontent.com/AxDSan/mnemosyne/main/scripts/install.sh | bash
 ```
 
 This symlinks the provider into `~/.hermes/plugins/mnemosyne`.


### PR DESCRIPTION
## Description

As the title says, it's using the outdated url for "One-Liner Deploy" and it's updated for new script url also with an suggestion on `Hermes Integration` section.

## Related Issue

Closes #(issue)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [X] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [ ] Existing tests still pass (`pytest tests/ -v`)
- [ ] New tests added for any new functionality
- [ ] Manual verification (describe what you tested)

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py`
- [ ] `CHANGELOG.md` updated with a brief entry
- [ ] README updated if user-facing behavior changed
- [ ] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency