### PR TITLE
feat: expose Mnemosyne Hermes memory provider

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,9 @@
 """
-Mnemosyne Plugin for Hermes Agent
-Entry point at repo root for `hermes plugins install` compatibility.
+Mnemosyne Plugin for Hermes Agent.
+
+This repo installs as a normal Hermes plugin (tools + hooks) and also exposes a
+lightweight MemoryProvider shim so Hermes can treat Mnemosyne as the active
+external memory provider.
 """
 
 import sys
@@ -26,10 +29,29 @@ except ImportError:
     __version__ = "unknown"
     __author__ = "Abdias J"
 
-# Graceful fallback when Hermes framework is not present
-# (e.g. pip-only / standalone installs without hermes_plugin)
 try:
-    from hermes_plugin import register
-    __all__ = ["register", "__version__", "__author__"]
+    from hermes_plugin import register as _register_plugin
 except ImportError:
-    __all__ = ["__version__", "__author__"]
+    _register_plugin = None
+
+try:
+    from .provider import MnemosyneMemoryProvider
+except ImportError:
+    MnemosyneMemoryProvider = None
+
+
+def register(ctx):
+    """Register Mnemosyne tools/hooks and, when supported, a memory provider."""
+    if _register_plugin is None:
+        raise ImportError("hermes_plugin is required to register Mnemosyne")
+    result = _register_plugin(ctx)
+    if MnemosyneMemoryProvider is not None and hasattr(ctx, "register_memory_provider"):
+        ctx.register_memory_provider(MnemosyneMemoryProvider())
+    return result
+
+
+__all__ = ["__version__", "__author__"]
+if _register_plugin is not None:
+    __all__.append("register")
+if MnemosyneMemoryProvider is not None:
+    __all__.append("MnemosyneMemoryProvider")

--- a/provider.py
+++ b/provider.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+
+
+class MnemosyneMemoryProvider(MemoryProvider):
+    """Lightweight Hermes memory-provider shim for the Mnemosyne plugin.
+
+    The installed Mnemosyne plugin already supplies the real tool surface and
+    prompt hooks via hermes_plugin.register(). This shim exists so Hermes's
+    external memory-provider system can recognize Mnemosyne as the active
+    provider in config/doctor/status flows.
+    """
+
+    def __init__(self):
+        self._memory = None
+        self._session_id = ""
+
+    @property
+    def name(self) -> str:
+        return "mnemosyne"
+
+    def is_available(self) -> bool:
+        try:
+            from mnemosyne.core.memory import Mnemosyne  # noqa: F401
+            return True
+        except Exception:
+            return False
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        from mnemosyne.core.memory import Mnemosyne
+
+        self._session_id = session_id
+        self._memory = Mnemosyne(session_id=f"hermes_{session_id}")
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Mnemosyne Memory\n"
+            "Active local memory provider. Durable memory is stored in the local "
+            "Mnemosyne SQLite/BEAM store."
+        )
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        # The installed Mnemosyne plugin already registers its tools through the
+        # normal plugin system. Returning an empty list avoids duplicate schemas.
+        return []
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        if not self._memory or action not in {"add", "replace"} or not content:
+            return
+        try:
+            self._memory.remember(
+                content=content,
+                source=f"legacy_memory:{target}",
+                importance=0.6,
+                metadata={
+                    "bridge": "builtin-memory",
+                    "target": target,
+                    "action": action,
+                },
+            )
+        except Exception:
+            # Never let provider bridging break the main agent flow.
+            pass
+
+    def shutdown(self) -> None:
+        self._memory = None

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     description="The Universal Memory Layer for Any AI Agent — Zero-Dependency, Sub-Millisecond, Fully Private",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    license="MIT",
     url="https://github.com/AxDSan/mnemosyne",
     packages=find_packages(),
     classifiers=[
@@ -32,7 +33,6 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Adds a Hermes memory provider integration for Mnemosyne while preserving upstream Hermes plugin compatibility.\n\nTested with: python -m py_compile __init__.py provider.py