### PR TITLE
fix(beam): ensure _vec_insert commits after sqlite-vec virtual table write

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1667,6 +1667,14 @@ def _vec_insert(conn: sqlite3.Connection, rowid: int, embedding: List[float]):
             "INSERT INTO vec_episodes(rowid, embedding) VALUES (?, ?)",
             (rowid, emb_json)
         )
+    # Ensure the insert is committed even when the caller's connection
+    # has _defer_commit=True (_BeamConnection). Without this, inserts
+    # sit in the deferred transaction and disappear if the caller
+    # later rolls back or the connection is reused in a different context.
+    if isinstance(conn, _BeamConnection):
+        conn._real_commit()
+    else:
+        conn.commit()
 
 
 def _vec_search(conn: sqlite3.Connection, embedding: List[float], k: int = 20) -> List[Dict]:


### PR DESCRIPTION
## Bug

_vec_insert writes to sqlite-vec virtual tables (vec_episodes/vec_facts) but never calls commit(). When the caller's _BeamConnection has _defer_commit=True, its commit() is a no-op, leaving the insert in a deferred transaction. The connection is later reused or rolled back, silently losing the vector data with no error or warning.

## Root Cause

_sqlite3.Connection_ auto-commits after the first statement in a fresh connection, BUT _BeamConnection sets _defer_commit=True (via BEGIN DEFERRED) to batch multiple writes in a single transaction. When commit() is called on such a connection, it is intentionally a no-op — the caller is expected to manage the transaction lifecycle. _vec_insert never calls commit(), so the INSERT stays in the deferred transaction and disappears on rollback or connection reuse.

## Fix

After the INSERT, call conn._real_commit() for _BeamConnection (bypasses the defer_commit guard) or conn.commit() for normal connections. This ensures the vector data is persisted regardless of the caller's transaction state.

## Testing

Verified locally by:
1. Clearing vec_episodes
2. Calling _refresh_episodic_embedding (which calls _vec_insert internally)
3. Confirming vec_episodes now correctly contains the inserted rows (previously they were silently lost)