### PR TITLE
feat(provider): add sync_roles config for role-based autosave filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ## [Unreleased]
 
+### Added
+
+- **`sync_roles` config for role-based autosave filtering.** `sync_turn()` now
+  checks `memory.mnemosyne.sync_roles` before persisting conversation turns.
+  Default `["user", "assistant"]` preserves existing behavior. Set to `["user"]`
+  to save only user turns, or `[]` to disable conversation autosave while keeping
+  explicit `mnemosyne_remember` calls working. Unknown roles are warned and ignored.
+
 ### Fixed
 
 - **Hardcoded embedding dimension in `binary_vectors.py`.** `EMBEDDING_DIM` was

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -20,7 +20,7 @@ import os
 import sys
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 from datetime import datetime
 
 # Ensure mnemosyne core is importable from this directory
@@ -635,6 +635,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
         self._auto_sleep_threshold = 50
         self._auto_sleep_enabled = os.environ.get("MNEMOSYNE_AUTO_SLEEP_ENABLED", "").strip().lower() in ("1", "true", "yes", "on")
         self._ignore_patterns: List[str] = []  # Regex patterns to filter from memory
+        self._sync_roles: Set[str] = {"user", "assistant"}  # Roles to autosave in sync_turn
         self._skip_contexts = {"cron", "flush", "subagent", "background", "skill_loop"}  # Agent contexts to skip
         # Allow override via MNEMOSYNE_SKIP_CONTEXTS env var.
         # Set to empty string to skip nothing (enable all contexts).
@@ -809,6 +810,25 @@ class MnemosyneMemoryProvider(MemoryProvider):
             elif isinstance(_skip_raw, (list, tuple, set)):
                 self._skip_contexts = set(str(s).strip() for s in _skip_raw if str(s).strip())
 
+        # sync_roles: which conversation roles to autosave in sync_turn().
+        # Default ["user", "assistant"] preserves existing behavior.
+        # Set to ["user"] to save only user turns, [] to disable autosave.
+        _sync_raw = kwargs.get("sync_roles")
+        if _sync_raw is None:
+            _sync_raw = self._read_config_key("sync_roles")
+        if _sync_raw is not None:
+            _valid_roles = {"user", "assistant"}
+            if isinstance(_sync_raw, str):
+                _parsed_roles = {r.strip() for r in _sync_raw.split(",") if r.strip()}
+            elif isinstance(_sync_raw, (list, tuple, set)):
+                _parsed_roles = {str(r).strip() for r in _sync_raw if str(r).strip()}
+            else:
+                _parsed_roles = set()
+            _unknown = _parsed_roles - _valid_roles
+            if _unknown:
+                logger.warning("Mnemosyne: unknown sync_roles ignored: %s", sorted(_unknown))
+            self._sync_roles = _parsed_roles & _valid_roles
+
         shared_surface_read = kwargs.get("shared_surface_read")
         if shared_surface_read is None:
             shared_surface_read = self._read_config_key("shared_surface_read")
@@ -854,6 +874,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},
+            {"key": "sync_roles", "description": "Conversation roles to autosave in sync_turn(). List of role names: 'user', 'assistant'. Default ['user', 'assistant'] saves both. Set to ['user'] for user turns only, or [] to disable conversation autosave entirely. Does not affect explicit mnemosyne_remember calls.", "default": ["user", "assistant"]},
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
@@ -1131,16 +1152,15 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if not self._beam or self._agent_context in self._skip_contexts:
             return
         try:
-            if user_content and len(user_content) > 5 and not self._should_filter(user_content):
+            if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
                 self._beam.remember(
                     content=f"[USER] {user_content[:500]}",
                     source="conversation",
                     importance=0.3,
                     extract_entities=True,
                 )
-                # Check for identity-significant signals in user content
                 self._capture_identity_signals(user_content)
-            if assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
+            if "assistant" in self._sync_roles and assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
                 self._beam.remember(
                     content=f"[ASSISTANT] {assistant_content[:800]}",
                     source="conversation",

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -609,6 +609,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
     # it's not re-parsed on every _maybe_auto_sleep call.
     _AUTO_SLEEP_TIMEOUT_SECONDS = _parse_env_float("MNEMOSYNE_AUTO_SLEEP_TIMEOUT", 5)
 
+    _VALID_SYNC_ROLES: frozenset = frozenset({"user", "assistant"})
+
     def __init__(self):
         self._beam: Optional[Any] = None
         self._surface_beam: Optional[Any] = None
@@ -635,7 +637,11 @@ class MnemosyneMemoryProvider(MemoryProvider):
         self._auto_sleep_threshold = 50
         self._auto_sleep_enabled = os.environ.get("MNEMOSYNE_AUTO_SLEEP_ENABLED", "").strip().lower() in ("1", "true", "yes", "on")
         self._ignore_patterns: List[str] = []  # Regex patterns to filter from memory
-        self._sync_roles: Set[str] = {"user", "assistant"}  # Roles to autosave in sync_turn
+        self._sync_roles: Set[str] = self._VALID_SYNC_ROLES.copy()
+        _sync_env = os.environ.get("MNEMOSYNE_SYNC_ROLES")
+        if _sync_env is not None:
+            _parsed_roles = {r.strip().lower() for r in _sync_env.split(",") if r.strip()}
+            self._sync_roles = _parsed_roles & self._VALID_SYNC_ROLES
         self._skip_contexts = {"cron", "flush", "subagent", "background", "skill_loop"}  # Agent contexts to skip
         # Allow override via MNEMOSYNE_SKIP_CONTEXTS env var.
         # Set to empty string to skip nothing (enable all contexts).
@@ -817,17 +823,24 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if _sync_raw is None:
             _sync_raw = self._read_config_key("sync_roles")
         if _sync_raw is not None:
-            _valid_roles = {"user", "assistant"}
             if isinstance(_sync_raw, str):
-                _parsed_roles = {r.strip() for r in _sync_raw.split(",") if r.strip()}
+                _parsed_roles = {r.strip().lower() for r in _sync_raw.split(",") if r.strip()}
             elif isinstance(_sync_raw, (list, tuple, set)):
-                _parsed_roles = {str(r).strip() for r in _sync_raw if str(r).strip()}
+                _parsed_roles = {str(r).strip().lower() for r in _sync_raw if str(r).strip()}
             else:
-                _parsed_roles = set()
-            _unknown = _parsed_roles - _valid_roles
-            if _unknown:
-                logger.warning("Mnemosyne: unknown sync_roles ignored: %s", sorted(_unknown))
-            self._sync_roles = _parsed_roles & _valid_roles
+                logger.warning("Mnemosyne: invalid sync_roles type %s (%r); keeping %s",
+                               type(_sync_raw).__name__, _sync_raw, sorted(self._sync_roles))
+                _sync_raw = None
+            if _sync_raw is not None:
+                _unknown = _parsed_roles - self._VALID_SYNC_ROLES
+                if _unknown:
+                    logger.warning("Mnemosyne: unknown sync_roles ignored: %s", sorted(_unknown))
+                _valid = _parsed_roles & self._VALID_SYNC_ROLES
+                if _parsed_roles and not _valid:
+                    logger.warning("Mnemosyne: no valid sync_roles in %r; keeping %s",
+                                   _parsed_roles, sorted(self._sync_roles))
+                else:
+                    self._sync_roles = _valid
 
         shared_surface_read = kwargs.get("shared_surface_read")
         if shared_surface_read is None:
@@ -874,7 +887,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},
-            {"key": "sync_roles", "description": "Conversation roles to autosave in sync_turn(). List of role names: 'user', 'assistant'. Default ['user', 'assistant'] saves both. Set to ['user'] for user turns only, or [] to disable conversation autosave entirely. Does not affect explicit mnemosyne_remember calls.", "default": ["user", "assistant"]},
+            {"key": "sync_roles", "description": "Conversation roles to autosave in sync_turn(). List of role names: 'user', 'assistant'. Default ['user', 'assistant'] saves both. Set to ['user'] for user turns only, or [] to disable conversation autosave entirely. Does not affect explicit mnemosyne_remember calls. Identity signal capture is gated by user sync — excluding 'user' also disables identity extraction. Also configurable via MNEMOSYNE_SYNC_ROLES env var.", "default": ["user", "assistant"]},
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.1.2"
+__version__ = "3.2.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/tests/test_sync_roles.py
+++ b/tests/test_sync_roles.py
@@ -1,0 +1,165 @@
+"""Tests for sync_roles config in sync_turn()."""
+
+import pytest
+import os
+import tempfile
+from unittest.mock import MagicMock
+
+
+class TestSyncRoles:
+    """Verify sync_roles controls which conversation roles are autosaved."""
+
+    @pytest.fixture
+    def provider(self):
+        from hermes_memory_provider import MnemosyneMemoryProvider
+        from mnemosyne.core.beam import BeamMemory
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "mnemosyne.db")
+            provider = MnemosyneMemoryProvider()
+            provider._agent_context = "test"
+            provider._session_id = "test-session"
+            provider._skip_contexts = set()
+            provider._turn_count = 0
+            provider._auto_sleep_enabled = False
+            provider._beam = BeamMemory(db_path=db_path)
+
+            yield provider
+
+            try:
+                os.remove(db_path)
+                for ext in ("-wal", "-shm"):
+                    try:
+                        os.remove(db_path + ext)
+                    except OSError:
+                        pass
+            except OSError:
+                pass
+
+    def test_default_saves_both_roles(self, provider):
+        """Default sync_roles saves both user and assistant turns."""
+        provider._beam.remember = MagicMock()
+        provider.sync_turn("Tell me about memory systems", "Here is what I know about memory.")
+
+        sources = [c.kwargs.get("content", "") for c in provider._beam.remember.call_args_list]
+        user_calls = [s for s in sources if s.startswith("[USER]")]
+        assistant_calls = [s for s in sources if s.startswith("[ASSISTANT]")]
+        assert len(user_calls) == 1
+        assert len(assistant_calls) == 1
+
+    def test_user_only(self, provider):
+        """sync_roles=['user'] saves user turns, skips assistant."""
+        provider._sync_roles = {"user"}
+        provider._beam.remember = MagicMock()
+        provider.sync_turn("Tell me about memory systems", "Here is what I know about memory.")
+
+        sources = [c.kwargs.get("content", "") for c in provider._beam.remember.call_args_list]
+        user_calls = [s for s in sources if s.startswith("[USER]")]
+        assistant_calls = [s for s in sources if s.startswith("[ASSISTANT]")]
+        assert len(user_calls) == 1
+        assert len(assistant_calls) == 0
+
+    def test_assistant_only(self, provider):
+        """sync_roles=['assistant'] saves assistant turns, skips user."""
+        provider._sync_roles = {"assistant"}
+        provider._beam.remember = MagicMock()
+        provider.sync_turn("Tell me about memory systems", "Here is what I know about memory.")
+
+        sources = [c.kwargs.get("content", "") for c in provider._beam.remember.call_args_list]
+        user_calls = [s for s in sources if s.startswith("[USER]")]
+        assistant_calls = [s for s in sources if s.startswith("[ASSISTANT]")]
+        assert len(user_calls) == 0
+        assert len(assistant_calls) == 1
+
+    def test_empty_disables_autosave(self, provider):
+        """sync_roles=[] disables all conversation autosave."""
+        provider._sync_roles = set()
+        provider._beam.remember = MagicMock()
+        provider.sync_turn("Tell me about memory systems", "Here is what I know about memory.")
+
+        conversation_calls = [
+            c for c in provider._beam.remember.call_args_list
+            if c.kwargs.get("source") == "conversation"
+        ]
+        assert len(conversation_calls) == 0
+
+    def test_empty_disables_identity_capture(self, provider):
+        """sync_roles=[] also disables identity signal capture."""
+        provider._sync_roles = set()
+        provider._beam.remember = MagicMock()
+        provider.sync_turn("I feel like an imposter at work", "That is understandable.")
+
+        identity_calls = [
+            c for c in provider._beam.remember.call_args_list
+            if c.kwargs.get("source") == "identity"
+        ]
+        assert len(identity_calls) == 0
+
+    def test_ignore_patterns_still_apply(self, provider):
+        """sync_roles does not bypass ignore_patterns filtering."""
+        provider._sync_roles = {"user", "assistant"}
+        provider._ignore_patterns = [r"^Done\.?$"]
+        provider._beam.remember = MagicMock()
+        provider.sync_turn("Done.", "Noted.")
+
+        conversation_calls = [
+            c for c in provider._beam.remember.call_args_list
+            if c.kwargs.get("source") == "conversation"
+        ]
+        user_calls = [c for c in conversation_calls if "[USER]" in c.kwargs.get("content", "")]
+        assert len(user_calls) == 0
+
+    def test_skip_contexts_overrides_sync_roles(self, provider):
+        """skip_contexts still disables everything regardless of sync_roles."""
+        provider._sync_roles = {"user", "assistant"}
+        provider._agent_context = "cron"
+        provider._skip_contexts = {"cron"}
+        provider._beam.remember = MagicMock()
+        provider.sync_turn("Important user message here", "Important assistant response here")
+
+        assert provider._beam.remember.call_count == 0
+
+    def test_turn_counter_increments_regardless(self, provider):
+        """Turn counter increments even when sync_roles filters both roles."""
+        provider._sync_roles = set()
+        provider._beam.remember = MagicMock()
+        assert provider._turn_count == 0
+        provider.sync_turn("Hello there", "Hi, how can I help?")
+        assert provider._turn_count == 1
+
+
+class TestSyncRolesConfig:
+    """Verify sync_roles config parsing in _apply_provider_config."""
+
+    @pytest.fixture
+    def provider(self):
+        from hermes_memory_provider import MnemosyneMemoryProvider
+        provider = MnemosyneMemoryProvider()
+        provider._hermes_home = ""
+        return provider
+
+    def test_config_list(self, provider):
+        provider._apply_provider_config({"sync_roles": ["user"]})
+        assert provider._sync_roles == {"user"}
+
+    def test_config_empty_list(self, provider):
+        provider._apply_provider_config({"sync_roles": []})
+        assert provider._sync_roles == set()
+
+    def test_config_csv_string(self, provider):
+        provider._apply_provider_config({"sync_roles": "user,assistant"})
+        assert provider._sync_roles == {"user", "assistant"}
+
+    def test_config_empty_string(self, provider):
+        provider._apply_provider_config({"sync_roles": ""})
+        assert provider._sync_roles == set()
+
+    def test_unknown_roles_ignored(self, provider):
+        provider._apply_provider_config({"sync_roles": ["user", "system", "tool"]})
+        assert provider._sync_roles == {"user"}
+
+    def test_not_set_preserves_default(self, provider):
+        default = provider._sync_roles.copy()
+        provider._apply_provider_config({})
+        assert provider._sync_roles == default
+        assert provider._sync_roles == {"user", "assistant"}

--- a/tests/test_sync_roles.py
+++ b/tests/test_sync_roles.py
@@ -3,7 +3,7 @@
 import pytest
 import os
 import tempfile
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 class TestSyncRoles:
@@ -95,6 +95,30 @@ class TestSyncRoles:
         ]
         assert len(identity_calls) == 0
 
+    def test_assistant_only_disables_identity_capture(self, provider):
+        """sync_roles=['assistant'] disables identity capture (derived from user content)."""
+        provider._sync_roles = {"assistant"}
+        provider._beam.remember = MagicMock()
+        provider.sync_turn("I feel like an imposter at work", "That is understandable.")
+
+        identity_calls = [
+            c for c in provider._beam.remember.call_args_list
+            if c.kwargs.get("source") == "identity"
+        ]
+        assert len(identity_calls) == 0
+
+    def test_user_only_preserves_identity_capture(self, provider):
+        """sync_roles=['user'] still captures identity signals."""
+        provider._sync_roles = {"user"}
+        provider._beam.remember = MagicMock()
+        provider.sync_turn("I feel like an imposter at work", "That is understandable.")
+
+        identity_calls = [
+            c for c in provider._beam.remember.call_args_list
+            if c.kwargs.get("source") == "identity"
+        ]
+        assert len(identity_calls) >= 1
+
     def test_ignore_patterns_still_apply(self, provider):
         """sync_roles does not bypass ignore_patterns filtering."""
         provider._sync_roles = {"user", "assistant"}
@@ -163,3 +187,40 @@ class TestSyncRolesConfig:
         provider._apply_provider_config({})
         assert provider._sync_roles == default
         assert provider._sync_roles == {"user", "assistant"}
+
+    def test_case_insensitive(self, provider):
+        provider._apply_provider_config({"sync_roles": ["User", "ASSISTANT"]})
+        assert provider._sync_roles == {"user", "assistant"}
+
+    @pytest.mark.parametrize("value", [True, False, 42, 3.14, {"user": True}])
+    def test_invalid_type_preserves_default(self, provider, value):
+        provider._apply_provider_config({"sync_roles": value})
+        assert provider._sync_roles == {"user", "assistant"}
+
+    def test_unknown_only_preserves_default(self, provider):
+        """Non-empty input with zero valid roles preserves default (typo safety)."""
+        provider._apply_provider_config({"sync_roles": ["users", "system"]})
+        assert provider._sync_roles == {"user", "assistant"}
+
+
+class TestSyncRolesEnvVar:
+    """Verify MNEMOSYNE_SYNC_ROLES env var support."""
+
+    def test_env_var_user_only(self):
+        from hermes_memory_provider import MnemosyneMemoryProvider
+        with patch.dict(os.environ, {"MNEMOSYNE_SYNC_ROLES": "user"}):
+            provider = MnemosyneMemoryProvider()
+            assert provider._sync_roles == {"user"}
+
+    def test_env_var_empty_disables(self):
+        from hermes_memory_provider import MnemosyneMemoryProvider
+        with patch.dict(os.environ, {"MNEMOSYNE_SYNC_ROLES": ""}):
+            provider = MnemosyneMemoryProvider()
+            assert provider._sync_roles == set()
+
+    def test_env_var_not_set_uses_default(self):
+        from hermes_memory_provider import MnemosyneMemoryProvider
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MNEMOSYNE_SYNC_ROLES", None)
+            provider = MnemosyneMemoryProvider()
+            assert provider._sync_roles == {"user", "assistant"}


### PR DESCRIPTION
## Problem

`sync_turn()` persists both user and assistant turns to working_memory unconditionally. The only existing filters are `ignore_patterns` (regex on content) and `skip_contexts` (disables all memory for a session type). Neither can express "save user turns but not assistant turns."

In interactive sessions (Telegram, WebUI), this creates two problems:

- **User turns** are often raw chat fragments ("yes", "ok do that", short questions) that pollute recall
- **Assistant turns** are operational exhaust (status reports, wrapups, tool boilerplate) with low recall value

The valuable signal — preferences, corrections, facts, identity — is already captured by `_capture_identity_signals()`, explicit `mnemosyne_remember` calls, and the extraction pipeline. Raw conversation transcript is noise for most deployments.

Related: [r/hermesagent thread](https://old.reddit.com/r/hermesagent/comments/1trpzh3/fyi_hermes_home_assistant_integration_issue/) where HA tool output was promoted through autosave/consolidation into 57 stale episodic memories. Same class of problem: unfiltered promotion of volatile state into durable recall.

Closes #209

## Solution

Add `memory.mnemosyne.sync_roles` — a role allowlist for `sync_turn()` autosave.

```yaml
memory:
  mnemosyne:
    sync_roles: ["user", "assistant"]  # default, backward compatible
    sync_roles: ["user"]               # user turns only
    sync_roles: []                     # disable conversation autosave
```

Also configurable via `MNEMOSYNE_SYNC_ROLES` env var (comma-separated), matching the `skip_contexts` pattern.

### Behaviour

- Default `["user", "assistant"]` preserves existing behaviour exactly
- Explicit `mnemosyne_remember` calls are not affected
- Identity signal capture is gated by `"user"` — excluding user also disables identity extraction
- `skip_contexts` remains the broader kill switch (checked first)
- `ignore_patterns` still applies within enabled roles

### Config robustness

- Case-insensitive (`["User", "ASSISTANT"]` works)
- Invalid types (bool, int, dict) warn and preserve default
- Non-empty input with zero valid roles preserves default (typo safety: `["users"]` warns instead of silently disabling)
- Unknown role names are warned and ignored
- `_VALID_SYNC_ROLES` is a class-level frozenset for easy future extension

## Tests

26 new tests covering:

- All role combinations (both, user-only, assistant-only, empty)
- Identity capture coupling (preserved with user, disabled without)
- Interaction with `skip_contexts` and `ignore_patterns`
- Turn counter still increments when autosave is filtered
- Config parsing: list, CSV string, empty list, empty string, missing key
- Case insensitivity, invalid types, typo safety
- `MNEMOSYNE_SYNC_ROLES` env var

Full suite: 1408 passed, 0 failed.