### PR TITLE
fix: improve local multilingual recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
+## [3.4.0] — 2026-06-01
+
+### Added
+
+- **Known dimensions for local SentenceTransformers multilingual models.**
+  `paraphrase-multilingual-MiniLM-L12-v2`, `all-MiniLM-L6-v2`, and
+  `paraphrase-multilingual-mpnet-base-v2` are now listed for low-resource
+  local multilingual embedding setups.
+
+### Fixed
+
+- **Unicode recall tokenization for Latin-script languages.** Recall lexical
+  gates now keep diacritics inside tokens, so words like `Stoßlüften`,
+  `Bürgeramt`, and `Primärquellen` are no longer split into ASCII fragments.
+
 ## [3.3.0] — 2026-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *Zero-dependency AI memory that works everywhere. SQLite-backed. Sub-millisecond.*
 
 [![Python](https://img.shields.io/badge/Python-3.9+-blue.svg)](https://python.org)
-[![PyPI](https://img.shields.io/pypi/v/mnemosyne-memory.svg?v=3.3.0)](https://pypi.org/project/mnemosyne-memory/)
+[![PyPI](https://img.shields.io/pypi/v/mnemosyne-memory.svg?v=3.4.0)](https://pypi.org/project/mnemosyne-memory/)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![CI](https://github.com/AxDSan/mnemosyne/actions/workflows/ci.yml/badge.svg)](https://github.com/AxDSan/mnemosyne/actions/workflows/ci.yml)
 [![BEAM](https://img.shields.io/badge/BEAM-ICLR%202026-purple.svg)](https://beam-benchmark.github.io/)
@@ -287,7 +287,7 @@ results = beam.recall("editor preferences", top_k=5)
 
 | `MNEMOSYNE_EMBEDDING_API_URL` | `${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}` | Preferred name for custom embedding API endpoint (OpenAI-compatible). Falls back to `OPENROUTER_BASE_URL`. |
 | `MNEMOSYNE_EMBEDDING_API_KEY` | `${OPENROUTER_API_KEY:-${OPENAI_API_KEY:-}}` | Preferred name for embedding API key. Falls back to `OPENROUTER_API_KEY`, then `OPENAI_API_KEY`. |
-| `MNEMOSYNE_EMBEDDING_MODEL` | `BAAI/bge-small-en-v1.5` | Embedding model. Swap for multilingual: `BAAI/bge-m3`, `intfloat/multilingual-e5-base`, etc. |
+| `MNEMOSYNE_EMBEDDING_MODEL` | `BAAI/bge-small-en-v1.5` | Embedding model. Low-resource multilingual: `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`; larger options: `intfloat/multilingual-e5-base`, `BAAI/bge-m3`. |
 
 Full reference: [docs/configuration.md](docs/configuration.md)
 
@@ -296,10 +296,13 @@ Full reference: [docs/configuration.md](docs/configuration.md)
 Default embeddings are English-optimized (`bge-small-en-v1.5`). For **non-English or multilingual** recall, swap the model:
 
 ```bash
-# Multilingual (100+ languages)
-export MNEMOSYNE_EMBEDDING_MODEL=BAAI/bge-m3
+# Low-resource local multilingual embeddings
+export MNEMOSYNE_EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
 
-# Or Chinese, German, etc.
+# Larger multilingual embeddings
+export MNEMOSYNE_EMBEDDING_MODEL=intfloat/multilingual-e5-base
+
+# Or Chinese-specific embeddings
 export MNEMOSYNE_EMBEDDING_MODEL=BAAI/bge-small-zh-v1.5
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,8 +73,8 @@ Switch the embedding model via env var:
 # Chinese embeddings
 MNEMOSYNE_EMBEDDING_MODEL=BAAI/bge-small-zh-v1.5
 
-# Multilingual embeddings (100+ languages)
-MNEMOSYNE_EMBEDDING_MODEL=BAAI/bge-m3
+# Low-resource local multilingual embeddings
+MNEMOSYNE_EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
 
 # Or any fastembed-supported model
 MNEMOSYNE_EMBEDDING_MODEL=intfloat/multilingual-e5-base
@@ -93,6 +93,10 @@ The embedding dimension is **auto-detected** from the model name. Supported mode
 | `intfloat/multilingual-e5-small` | 384 | Multilingual |
 | `intfloat/multilingual-e5-base` | 768 | Multilingual |
 | `intfloat/multilingual-e5-large` | 1,024 | Multilingual |
+| `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` | 384 | Multilingual |
+| `sentence-transformers/all-MiniLM-L6-v2` | 384 | Multilingual |
+| `sentence-transformers/paraphrase-multilingual-mpnet-base-v2` | 768 | Multilingual |
+| `BAAI/bge-m3` | 1,024 | Multilingual |
 | `openai/text-embedding-3-small` | 1,536 | API |
 | `openai/text-embedding-3-large` | 3,072 | API |
 

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1350,7 +1350,16 @@ _FACT_MATCH_STOPWORDS: Set[str] = {
     "with", "you", "your",
 }
 
-_RECALL_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_.:/+-]*")
+# Unicode-aware recall tokenization.
+#
+# The previous ASCII-only pattern split words with diacritics, e.g.
+# "Stoßlüften" became "sto" + "ften" and "Bürgeramt" became
+# "b" + "rgeramt".  That weakened lexical gates and fallback scoring for
+# German and other Latin-script languages while dense multilingual embeddings
+# still saw the original text.  Keep path/version separators inside tokens
+# only when followed by another Unicode alphanumeric char so trailing
+# punctuation such as "Bürgeramt:" is not absorbed.
+_RECALL_TOKEN_RE = re.compile(r"(?u)[^\W_][\w]*(?:[_.:/+-]+[^\W_][\w]*)*")
 
 _RECALL_SYNONYMS: Dict[str, tuple[str, ...]] = {
     # Small, conservative query expansion for common user-facing wording.

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -89,6 +89,10 @@ def _get_embedding_dim(model_name: str) -> int:
         "intfloat/multilingual-e5-small": 384,
         "intfloat/multilingual-e5-base": 768,
         "intfloat/multilingual-e5-large": 1024,
+        # --- SentenceTransformers multilingual / local fastembed ---
+        "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2": 384,
+        "sentence-transformers/all-MiniLM-L6-v2": 384,
+        "sentence-transformers/paraphrase-multilingual-mpnet-base-v2": 768,
         # --- Multilingual BGE ---
         "BAAI/bge-m3": 1024,            # M3: multilingual (100+ langs), 1024-dim
         "BAAI/bge-multilingual-gemma2": 3584,

--- a/tests/test_multilingual_local_recall.py
+++ b/tests/test_multilingual_local_recall.py
@@ -1,0 +1,25 @@
+from mnemosyne.core import embeddings
+from mnemosyne.core.beam import _recall_tokens
+
+
+def test_recall_tokens_preserve_unicode_words():
+    tokens = _recall_tokens(
+        "Stoßlüften im Bürgeramt: Primärquellen für den Mensa-Plan prüfen"
+    )
+
+    assert "stoßlüften" in tokens
+    assert "bürgeramt" in tokens
+    assert "primärquellen" in tokens
+    assert "mensa-plan" in tokens
+    assert "sto" not in tokens
+    assert "ften" not in tokens
+    assert "rgeramt" not in tokens
+
+
+def test_sentence_transformers_multilingual_dimensions_are_known():
+    assert embeddings._get_embedding_dim(
+        "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+    ) == 384
+    assert embeddings._get_embedding_dim(
+        "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
+    ) == 768


### PR DESCRIPTION
## Summary

- Makes recall tokenization Unicode-aware for Latin-script languages
- Preserves words with diacritics such as `Stoßlüften`, `Bürgeramt`, and `Primärquellen`
- Adds regression coverage for multilingual local recall
- Documents local multilingual embedding model options

Fixes #215

## Test Plan

- `pytest tests/test_multilingual_local_recall.py`
- Full test suite checked locally; one unrelated pre-existing baseline failure was observed on `main`
