### PR TITLE
fix: strip <think> tags from LLM consolidation output + upgrade default model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,7 +62,7 @@ The `sleep()` function moves stale working memories into episodic memory:
 
 1. Fetches working memories past TTL or below importance threshold
 2. Groups them by source
-3. Attempts LLM summarization (local TinyLlama, remote OpenAI-compatible, or AAAK fallback)
+3. Attempts LLM summarization (local MiniCPM5-1B, remote OpenAI-compatible, or AAAK fallback)
 4. Stores the summary in episodic memory with embeddings
 5. Removes the originals from working memory
 6. Logs the consolidation event

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,13 +114,13 @@ MNEMOSYNE_EMBEDDING_DIM=768
 | `MNEMOSYNE_LLM_N_CTX` | `2048` | Context window size for the local model |
 | `MNEMOSYNE_LLM_MAX_TOKENS` | `2048` | Maximum output tokens per summary |
 | `MNEMOSYNE_LLM_N_THREADS` | `4` | CPU threads for local inference |
-| `MNEMOSYNE_LLM_REPO` | `TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF` | HuggingFace repo for GGUF model |
-| `MNEMOSYNE_LLM_FILE` | `tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf` | GGUF filename |
+| `MNEMOSYNE_LLM_REPO` | `openbmb/MiniCPM5-1B-GGUF` | HuggingFace repo for GGUF model |
+| `MNEMOSYNE_LLM_FILE` | `MiniCPM5-1B-Q4_K_M.gguf` | GGUF filename |
 | `MNEMOSYNE_SLEEP_PROMPT` | *(built-in)* | Optional sleep/consolidation prompt override. Supports `{source}`, `{memories}`, and `{memory_count}` placeholders for language-specific summaries. |
 
 ### Remote LLM (OpenAI-compatible)
 
-Use a remote model instead of local TinyLlama:
+Use a remote model instead of the local MiniCPM5-1B GGUF:
 
 | Variable | Default | Description |
 |---|---|---|
@@ -141,7 +141,7 @@ Route consolidation and fact extraction through a host-provided LLM (e.g., Herme
 | `MNEMOSYNE_HOST_LLM_ENABLED` | `false` | Opt in to host-adapter routing |
 | `MNEMOSYNE_HOST_LLM_PROVIDER` | *(none)* | Optional provider override, e.g. `openai-codex` |
 | `MNEMOSYNE_HOST_LLM_MODEL` | *(none)* | Optional model override, e.g. `gpt-5.1-mini` |
-| `MNEMOSYNE_HOST_LLM_N_CTX` | `32000` | Prompt-budget when host is the chosen path (TinyLlama-calibrated `LLM_N_CTX=2048` is too small for Codex/GPT-class) |
+| `MNEMOSYNE_HOST_LLM_N_CTX` | `32000` | Prompt-budget when host is the chosen path (local-model-calibrated `LLM_N_CTX=2048` is too small for Codex/GPT-class) |
 
 When the host call fails, the adapter falls back to the local GGUF model rather than the remote URL. See [hermes-llm-integration.md](hermes-llm-integration.md) for the full behavior model and session-shutdown semantics.
 
@@ -152,7 +152,7 @@ When the host call fails, the adapter falls back to the local GGUF model rather 
    ↓ (on failure: skip remote, go to local)
 1. Remote LLM (if MNEMOSYNE_LLM_BASE_URL is set AND host is not enabled)
    ↓ (on failure)
-2. Local LLM (ctransformers + TinyLlama GGUF)
+2. Local LLM (llama-cpp-python / ctransformers + MiniCPM5-1B GGUF)
    ↓ (on failure or not installed)
 3. AAAK encoding (keyword-based, no LLM required)
 ```

--- a/docs/hermes-llm-integration.md
+++ b/docs/hermes-llm-integration.md
@@ -35,7 +35,7 @@ when Mnemosyne is loaded as a Hermes memory provider):
      then return None / [].
 1. Remote OpenAI-compatible API (only if MNEMOSYNE_LLM_BASE_URL is set
    AND MNEMOSYNE_HOST_LLM_ENABLED is unset/false).
-2. Local llama-cpp-python / ctransformers GGUF (TinyLlama by default).
+2. Local llama-cpp-python / ctransformers GGUF (MiniCPM5-1B by default).
 3. Return None (consolidation) or [] (extraction) — caller falls back to
    the existing non-LLM path.
 ```
@@ -63,7 +63,7 @@ MNEMOSYNE_HOST_LLM_MODEL=gpt-5.1-mini
 
 # Optional: prompt context budget when the host is the chosen path.
 # Default 32000. The existing MNEMOSYNE_LLM_N_CTX (default 2048) is
-# calibrated for TinyLlama and is far too small for typical Codex/GPT
+# calibrated for the local GGUF model and is far too small for typical Codex/GPT
 # context windows — using it as the host budget produces wastefully many
 # small chunks and lossy multi-chunk summaries.
 MNEMOSYNE_HOST_LLM_N_CTX=32000

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -3154,6 +3154,9 @@ class BeamMemory:
             row_veracity = clamp_veracity(
                 veracity, context="consolidate_to_episodic.veracity"
             )
+        # Strip closed <think>...</think> blocks that some LLMs emit
+        import re as _re
+        summary = _re.sub(r"<think>.*?</think>", "", summary, flags=_re.DOTALL).strip()
         cursor = self.conn.cursor()
         cursor.execute("""
             INSERT INTO episodic_memory

--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -6,7 +6,7 @@ Uses llama-cpp-python (ARM64 + x86_64 native) with ctransformers fallback.
 Falls back to aaak encoding if the model is unavailable or inference fails.
 
 Model cache: ~/.hermes/mnemosyne/models/
-Default model: TinyLlama-1.1B-Chat-v1.0-GGUF (Q4_K_M, ~600MB)
+Default model: openbmb/MiniCPM5-1B-GGUF (Q4_K_M, ~656MB)
 """
 
 import os
@@ -16,8 +16,8 @@ from pathlib import Path
 from typing import List, Optional
 
 # --- Config ------------------------------------------------------------------
-DEFAULT_MODEL_REPO = "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF"
-DEFAULT_MODEL_FILE = "tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
+DEFAULT_MODEL_REPO = "openbmb/MiniCPM5-1B-GGUF"
+DEFAULT_MODEL_FILE = "MiniCPM5-1B-Q4_K_M.gguf"
 MODEL_CACHE_DIR = Path.home() / ".hermes" / "mnemosyne" / "models"
 
 LLM_ENABLED = os.environ.get("MNEMOSYNE_LLM_ENABLED", "true").lower() in ("1", "true", "yes")
@@ -46,7 +46,7 @@ HOST_LLM_ENABLED = os.environ.get("MNEMOSYNE_HOST_LLM_ENABLED", "false").lower()
 HOST_LLM_PROVIDER = os.environ.get("MNEMOSYNE_HOST_LLM_PROVIDER", "").strip() or None
 HOST_LLM_MODEL = os.environ.get("MNEMOSYNE_HOST_LLM_MODEL", "").strip() or None
 HOST_LLM_TIMEOUT = 15.0  # Per-attempt safety cap; not user-facing.
-# Host context window: TinyLlama-calibrated LLM_N_CTX (2048) is too small for
+# Host context window: local-model-calibrated LLM_N_CTX (2048) is too small for
 # Codex/GPT-class aux models; use this larger budget when the host is the path.
 HOST_LLM_N_CTX = int(os.environ.get("MNEMOSYNE_HOST_LLM_N_CTX", "32000"))
 
@@ -253,10 +253,10 @@ def _build_prompt(memories: List[str], source: str = "") -> str:
 
 
 def _build_host_prompt(memories: List[str], source: str = "") -> str:
-    """Plain-text consolidation prompt for host LLMs (no TinyLlama tokens).
+    """Plain-text consolidation prompt for host LLMs (no local-model tokens).
 
     The host adapter wraps this string as the user-message content of a
-    Chat Completions call; embedding TinyLlama chat-template tokens here
+    Chat Completions call; embedding local-model chat-template tokens here
     would degrade output quality on every modern aux provider.
     """
     custom = _format_sleep_prompt(memories, source=source)
@@ -325,16 +325,19 @@ def _try_host_llm(
         model=HOST_LLM_MODEL,
     )
     # NB: do NOT run host output through _clean_output(): that helper exists
-    # to scrub TinyLlama prompt-template echoes and bulleted prompt repeats
+    # to scrub local-model prompt-template echoes and bulleted prompt repeats
     # from local-model output. Host LLMs (Codex/GPT-class) don't echo our
     # prompt format, AND extract_facts() relies on `- bullet` lines surviving
     # so _parse_facts() can consume them. Just trim whitespace.
     text = raw.strip() if isinstance(raw, str) and raw.strip() else None
+    if text:
+        text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
     return (True, text)
 
 
 def _clean_output(text: str) -> str:
     """Strip assistant tokens and extra whitespace from model output."""
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
     text = text.replace("<|assistant|>", "").replace("<|user|>", "")
     text = text.replace("</s>", "").strip()
     text = re.sub(r"^(Summarize the following memories.*?[.!?:]\s*)", "", text, flags=re.IGNORECASE | re.DOTALL)
@@ -353,11 +356,11 @@ def _prompt_token_budget() -> int:
     """Return usable token budget for memory content (reserves overhead + output).
 
     Picks the larger HOST_LLM_N_CTX when the host backend will handle the
-    call; otherwise the TinyLlama-calibrated LLM_N_CTX. This avoids the
+    call; otherwise the local-model-calibrated LLM_N_CTX. This avoids the
     multi-chunk-summary degradation on 128K-context aux providers.
 
     NOTE: output_reserve is capped at min(LLM_MAX_TOKENS, n_ctx // 4) so
-    that LLM_MAX_TOKENS == n_ctx (the default for TinyLlama 1.1B with 2048
+    that LLM_MAX_TOKENS == n_ctx (the default for MiniCPM5-1B with 2048
     context) doesn't leave a negative budget for memory content. See
     BEAM-benchmark root-cause analysis (May 2026). Summarized output fits
     in 128-256 tokens for consolidation; reserving more than 1/4 of the

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -318,3 +318,65 @@ class TestHostAwareChunking:
         set_host_llm_backend(None)
         local_budget = local_llm._prompt_token_budget()
         assert local_budget < host_budget
+
+
+class TestThinkTagStripping:
+    """Verify think tag removal from LLM output (closed tags only).
+
+    Unclosed think tags are not stripped because there is no way to
+    distinguish thinking content from the actual response when the
+    closing tag is missing.
+    """
+
+    def test_clean_output_strips_closed_think_tags(self):
+        raw = f"<think>let me reason</think> The answer is 42."
+        assert local_llm._clean_output(raw) == "The answer is 42."
+
+    def test_clean_output_strips_multiline_closed_think_tags(self):
+        raw = f"<think>step 1\nstep 2</think>\nFinal answer."
+        assert local_llm._clean_output(raw) == "Final answer."
+
+    def test_clean_output_strips_multiple_think_blocks(self):
+        raw = f"<think>first</think>middle<think>second</think>end"
+        assert local_llm._clean_output(raw) == "middleend"
+
+    def test_clean_output_preserves_text_without_think_tags(self):
+        raw = "Just a normal summary with no thinking."
+        assert local_llm._clean_output(raw) == "Just a normal summary with no thinking."
+
+    def test_clean_output_empty_after_stripping(self):
+        raw = f"<think>only thinking, no output</think>"
+        assert local_llm._clean_output(raw) == ""
+
+    def test_clean_output_does_not_strip_unclosed_think_tag(self):
+        """Unclosed think tags are left as-is since we cannot determine
+        where thinking ends and the response begins."""
+        raw = f"middle<think>reasoning that never closes"
+        assert local_llm._clean_output(raw) == raw
+
+    def test_try_host_llm_strips_think_tags(self, monkeypatch):
+        """Host LLM output with closed think tags should be cleaned."""
+        monkeypatch.setattr(local_llm, "LLM_ENABLED", True)
+        monkeypatch.setattr(local_llm, "HOST_LLM_ENABLED", True)
+        monkeypatch.setattr(local_llm, "HOST_LLM_TIMEOUT", 5.0)
+        monkeypatch.setattr(local_llm, "HOST_LLM_PROVIDER", None)
+        monkeypatch.setattr(local_llm, "HOST_LLM_MODEL", None)
+        set_host_llm_backend(CallableLLMBackend("test", lambda prompt, **kw: f"<think>reasoning</think>Summary of memories."))
+
+        attempted, text = local_llm._try_host_llm("test prompt", max_tokens=128, temperature=0.3)
+        assert attempted is True
+        assert text == "Summary of memories."
+
+    def test_try_host_llm_does_not_strip_unclosed_think_tag(self, monkeypatch):
+        """Unclosed think tags in host output are left as-is."""
+        monkeypatch.setattr(local_llm, "LLM_ENABLED", True)
+        monkeypatch.setattr(local_llm, "HOST_LLM_ENABLED", True)
+        monkeypatch.setattr(local_llm, "HOST_LLM_TIMEOUT", 5.0)
+        monkeypatch.setattr(local_llm, "HOST_LLM_PROVIDER", None)
+        monkeypatch.setattr(local_llm, "HOST_LLM_MODEL", None)
+        set_host_llm_backend(CallableLLMBackend("test", lambda prompt, **kw: f"<think>reasoning\nActual output"))
+
+        attempted, text = local_llm._try_host_llm("test prompt", max_tokens=128, temperature=0.3)
+        assert attempted is True
+        # Unclosed tag is not stripped - we can't tell where thinking ends
+        assert "<think>" in text


### PR DESCRIPTION
Two changes in this PR.

Strip closed think tags from LLM output. Models like Qwen and MiniCPM emit thinking/reasoning blocks. Added stripping in _try_host_llm(), _clean_output(), and BeamMemory.consolidate_to_episodic(). Only closed tags are stripped. Unclosed tags are left alone because there is no way to tell where thinking ends and the response begins.

Switch the default local model from TinyLlama-1.1B to MiniCPM5-1B ([Artificial Analysis Intelligence Index](https://artificialanalysis.ai/articles/minicpm5-1b-the-leading-1b-open-weights-model), top score for sub-4B open models at 17.9). Same Q4_K_M quantization, similar size (~656MB vs ~600MB), Apache 2.0 license, 128K context window.

Updated docs (configuration.md, hermes-llm-integration.md, architecture.md) and code comments to reference MiniCPM5-1B instead of TinyLlama.

8 tests for think tag stripping: closed tags stripped, unclosed tags preserved, multiple blocks, passthrough, empty result, host LLM integration.

This fix the #222 issue.