### PR TITLE
feat(core): add LLM model fallback chain for remote summarization

### DIFF
--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -37,6 +37,14 @@ LLM_BASE_URL = os.environ.get("MNEMOSYNE_LLM_BASE_URL", "").rstrip("/")
 LLM_API_KEY = os.environ.get("MNEMOSYNE_LLM_API_KEY", "")
 LLM_REMOTE_MODEL = os.environ.get("MNEMOSYNE_LLM_MODEL", "")
 
+# Retryable errors only: 404/400 (model-not-found), 5xx, connection. Not 401/403/429.
+LLM_FALLBACK_MODELS = [
+    m.strip() for m in os.environ.get("MNEMOSYNE_LLM_FALLBACK_MODELS", "").split(",")
+    if m.strip()
+]
+LLM_FALLBACK_BASE_URL = os.environ.get("MNEMOSYNE_LLM_FALLBACK_BASE_URL", "").rstrip("/") or LLM_BASE_URL
+LLM_FALLBACK_API_KEY = os.environ.get("MNEMOSYNE_LLM_FALLBACK_API_KEY", "") or LLM_API_KEY
+
 # Host LLM adapter (Hermes or another agent). Disabled by default to preserve
 # existing standalone behavior. When MNEMOSYNE_HOST_LLM_ENABLED=true and a
 # backend is registered via mnemosyne.core.llm_backends.set_host_llm_backend(),
@@ -428,15 +436,47 @@ def llm_available() -> bool:
     return bool(_llm_available)
 
 
-def _call_remote_llm(prompt: str, temperature: float = 0.3) -> Optional[str]:
-    """Call an OpenAI-compatible remote endpoint for summarization.
+def _is_retryable_status(status_code: int) -> bool:
+    """Return True if an HTTP status is worth retrying against a fallback model.
 
-    ``temperature`` defaults to 0.3 (paraphrase-safe for consolidation);
-    callers that need deterministic output (e.g., fact extraction) can
-    pass ``temperature=0.0``.
+    404/400: the requested model is missing or unrecognized on this endpoint —
+    another model name on the same host may exist. 5xx: transient server-side
+    failure. 401/403/429 are NOT retryable: a bad key or rate limit won't be
+    fixed by swapping model names.
     """
-    if not LLM_BASE_URL:
-        return None
+    if status_code in (401, 403, 429):
+        return False
+    if status_code in (404, 400) or 500 <= status_code < 600:
+        return True
+    return False
+
+
+def _call_remote_llm_with_model(
+    prompt: str,
+    model: str,
+    temperature: float = 0.3,
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    timeout: float = 60.0,
+) -> "tuple[Optional[str], Optional[int], Optional[Exception]]":
+    """Call an OpenAI-compatible endpoint with a specific model name.
+
+    Returns ``(text, status, exc)``:
+
+    - ``(text, None, None)`` on success (text may be None for an empty body).
+    - ``(None, status, exc)`` on HTTP/network failure. ``status`` is the HTTP
+      status code when available, else None. ``exc`` is the underlying exception
+      (HTTPStatusError, ConnectError, TimeoutException, etc.) or None.
+    - ``(None, None, exc)`` for non-HTTP failures (JSON decode, malformed body).
+
+    Callers (see ``_call_remote_llm``) use ``status`` to decide whether to
+    retry against ``LLM_FALLBACK_MODELS``.
+    """
+    base_url = (base_url or LLM_BASE_URL).rstrip("/")
+    if not base_url:
+        return (None, None, RuntimeError("MNEMOSYNE_LLM_BASE_URL is empty"))
+    api_key = api_key if api_key is not None else LLM_API_KEY
 
     import json
 
@@ -446,15 +486,13 @@ def _call_remote_llm(prompt: str, temperature: float = 0.3) -> Optional[str]:
     except ImportError:
         has_httpx = False
 
-    url = f"{LLM_BASE_URL}/chat/completions"
+    url = f"{base_url}/chat/completions"
     headers = {"Content-Type": "application/json"}
-    if LLM_API_KEY:
-        headers["Authorization"] = f"Bearer {LLM_API_KEY}"
-
-    model = LLM_REMOTE_MODEL or "local"
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
 
     payload = {
-        "model": model,
+        "model": model or "local",
         "messages": [{"role": "user", "content": prompt}],
         "max_tokens": LLM_MAX_TOKENS,
         "temperature": temperature,
@@ -463,27 +501,76 @@ def _call_remote_llm(prompt: str, temperature: float = 0.3) -> Optional[str]:
 
     try:
         if has_httpx:
-            with httpx.Client(timeout=60.0) as client:
+            with httpx.Client(timeout=timeout) as client:
                 response = client.post(url, json=payload, headers=headers)
-                response.raise_for_status()
-                data = response.json()
+                status = response.status_code
+                if status >= 400:
+                    try:
+                        response.raise_for_status()
+                    except Exception as exc:
+                        return (None, status, exc)
+                try:
+                    data = response.json()
+                except Exception as exc:
+                    return (None, status, exc)
         else:
             import urllib.request
+            import urllib.error
             req = urllib.request.Request(
                 url,
                 data=json.dumps(payload).encode(),
                 headers=headers,
                 method="POST"
             )
-            with urllib.request.urlopen(req, timeout=60.0) as resp:
-                data = json.loads(resp.read().decode())
+            try:
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    status = getattr(resp, "status", 200)
+                    data = json.loads(resp.read().decode())
+            except urllib.error.HTTPError as exc:
+                return (None, exc.code, exc)
+            except Exception as exc:
+                return (None, None, exc)
 
-        choices = data.get("choices", [])
+        choices = data.get("choices", []) if isinstance(data, dict) else []
         if choices and choices[0].get("message", {}).get("content"):
-            return choices[0]["message"]["content"]
+            return (choices[0]["message"]["content"], status, None)
+        return (None, status, None)
+    except Exception as exc:
+        return (None, None, exc)
+
+
+def _call_remote_llm(prompt: str, temperature: float = 0.3) -> Optional[str]:
+    """Call an OpenAI-compatible remote endpoint for summarization.
+
+    ``temperature`` defaults to 0.3 (paraphrase-safe for consolidation);
+    callers that need deterministic output (e.g., fact extraction) can
+    pass ``temperature=0.0``.
+
+    Tries the primary ``LLM_REMOTE_MODEL`` first; on a retryable error
+    (see ``_is_retryable_status``), iterates ``LLM_FALLBACK_MODELS`` in
+    order. Returns the first successful response, or ``None`` if every
+    model fails (caller falls through to local GGUF / None).
+    """
+    if not LLM_BASE_URL:
         return None
-    except Exception:
-        return None
+
+    primary = LLM_REMOTE_MODEL or "local"
+    candidates: List[tuple[str, str, str]] = [(primary, LLM_BASE_URL, LLM_API_KEY)]
+    for fb in LLM_FALLBACK_MODELS:
+        if fb and fb != primary:
+            candidates.append((fb, LLM_FALLBACK_BASE_URL or LLM_BASE_URL, LLM_FALLBACK_API_KEY or LLM_API_KEY))
+
+    for model, base_url, api_key in candidates:
+        text, status, exc = _call_remote_llm_with_model(
+            prompt, model, temperature, base_url=base_url, api_key=api_key
+        )
+        if text:
+            return text
+        if status is None:
+            continue
+        if not _is_retryable_status(status):
+            return None
+    return None
 
 
 def summarize_memories(memories: List[str], source: str = "") -> Optional[str]:

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -37,8 +37,11 @@ class TestRemoteLLM:
 
         # Mock httpx by patching the import inside _call_remote_llm
         mock_client = MagicMock()
-        mock_client.post.return_value.raise_for_status = lambda: None
-        mock_client.post.return_value.json.return_value = mock_response
+        mock_response_obj = MagicMock()
+        mock_response_obj.status_code = 200
+        mock_response_obj.raise_for_status = lambda: None
+        mock_response_obj.json.return_value = mock_response
+        mock_client.post.return_value = mock_response_obj
         mock_client.__enter__ = lambda s: s
         mock_client.__exit__ = lambda *args: None
 
@@ -318,3 +321,194 @@ class TestHostAwareChunking:
         set_host_llm_backend(None)
         local_budget = local_llm._prompt_token_budget()
         assert local_budget < host_budget
+
+
+class TestRemoteLLMFallback:
+    """Tests for the LLM_FALLBACK_MODELS chain in _call_remote_llm()."""
+
+    def _ok(self, text="ok"):
+        return (text, 200, None)
+
+    def _err(self, status):
+        return (None, status, RuntimeError(f"http {status}"))
+
+    def _connerr(self):
+        return (None, None, ConnectionError("boom"))
+
+    def test_is_retryable_status(self):
+        assert local_llm._is_retryable_status(404) is True
+        assert local_llm._is_retryable_status(400) is True
+        assert local_llm._is_retryable_status(500) is True
+        assert local_llm._is_retryable_status(502) is True
+        assert local_llm._is_retryable_status(503) is True
+        assert local_llm._is_retryable_status(401) is False
+        assert local_llm._is_retryable_status(403) is False
+        assert local_llm._is_retryable_status(429) is False
+        assert local_llm._is_retryable_status(200) is False
+
+    def test_primary_success_skips_fallback(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://x/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["fb1", "fb2"])
+
+        with patch.object(
+            local_llm, "_call_remote_llm_with_model", return_value=self._ok("primary-out")
+        ) as m:
+            assert local_llm._call_remote_llm("p") == "primary-out"
+            assert m.call_count == 1
+            assert m.call_args.args[1] == "primary"
+
+    def test_404_triggers_fallback(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://x/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["fb1"])
+
+        with patch.object(
+            local_llm,
+            "_call_remote_llm_with_model",
+            side_effect=[self._err(404), self._ok("fb-out")],
+        ) as m:
+            assert local_llm._call_remote_llm("p") == "fb-out"
+            assert m.call_count == 2
+            assert m.call_args_list[0].args[1] == "primary"
+            assert m.call_args_list[1].args[1] == "fb1"
+
+    def test_5xx_triggers_fallback(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://x/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["fb1"])
+
+        with patch.object(
+            local_llm,
+            "_call_remote_llm_with_model",
+            side_effect=[self._err(502), self._ok("fb-out")],
+        ):
+            assert local_llm._call_remote_llm("p") == "fb-out"
+
+    def test_401_does_not_trigger_fallback(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://x/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["fb1", "fb2"])
+
+        with patch.object(
+            local_llm, "_call_remote_llm_with_model", return_value=self._err(401)
+        ) as m:
+            assert local_llm._call_remote_llm("p") is None
+            assert m.call_count == 1
+
+    def test_429_does_not_trigger_fallback(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://x/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["fb1"])
+
+        with patch.object(
+            local_llm, "_call_remote_llm_with_model", return_value=self._err(429)
+        ) as m:
+            assert local_llm._call_remote_llm("p") is None
+            assert m.call_count == 1
+
+    def test_connection_error_triggers_fallback(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://x/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["fb1"])
+
+        with patch.object(
+            local_llm,
+            "_call_remote_llm_with_model",
+            side_effect=[self._connerr(), self._ok("fb-out")],
+        ):
+            assert local_llm._call_remote_llm("p") == "fb-out"
+
+    def test_iterates_all_fallbacks_until_success(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://x/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["fb1", "fb2", "fb3"])
+
+        with patch.object(
+            local_llm,
+            "_call_remote_llm_with_model",
+            side_effect=[
+                self._err(404),
+                self._err(503),
+                self._ok("fb2-out"),
+            ],
+        ) as m:
+            assert local_llm._call_remote_llm("p") == "fb2-out"
+            assert m.call_count == 3
+
+    def test_returns_none_when_all_fail(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://x/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["fb1", "fb2"])
+
+        with patch.object(
+            local_llm,
+            "_call_remote_llm_with_model",
+            side_effect=[
+                self._err(404),
+                self._err(500),
+                self._connerr(),
+            ],
+        ):
+            assert local_llm._call_remote_llm("p") is None
+
+    def test_empty_fallback_list_only_tries_primary(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://x/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", [])
+
+        with patch.object(
+            local_llm, "_call_remote_llm_with_model", return_value=self._ok("p")
+        ) as m:
+            assert local_llm._call_remote_llm("p") == "p"
+            assert m.call_count == 1
+
+    def test_primary_deduped_from_fallback_list(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://x/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["primary", "fb1"])
+
+        with patch.object(
+            local_llm, "_call_remote_llm_with_model", return_value=self._err(404)
+        ) as m:
+            assert local_llm._call_remote_llm("p") is None
+            assert m.call_count == 2
+            models = [call.args[1] for call in m.call_args_list]
+            assert models == ["primary", "fb1"]
+
+    def test_fallback_uses_overridden_base_url(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://primary/v1")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["fb1"])
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_BASE_URL", "http://fb-host/v1")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_API_KEY", "fb-key")
+
+        with patch.object(
+            local_llm,
+            "_call_remote_llm_with_model",
+            side_effect=[self._err(404), self._ok("fb-out")],
+        ) as m:
+            assert local_llm._call_remote_llm("p") == "fb-out"
+            primary_call = m.call_args_list[0]
+            assert primary_call.kwargs["base_url"] == "http://primary/v1"
+            fb_call = m.call_args_list[1]
+            assert fb_call.kwargs["base_url"] == "http://fb-host/v1"
+            assert fb_call.kwargs["api_key"] == "fb-key"
+
+    def test_fallback_inherits_primary_url_when_no_override(self, monkeypatch):
+        monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://primary/v1")
+        monkeypatch.setattr(local_llm, "LLM_API_KEY", "primary-key")
+        monkeypatch.setattr(local_llm, "LLM_REMOTE_MODEL", "primary")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_MODELS", ["fb1"])
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_BASE_URL", "")
+        monkeypatch.setattr(local_llm, "LLM_FALLBACK_API_KEY", "")
+
+        with patch.object(
+            local_llm,
+            "_call_remote_llm_with_model",
+            side_effect=[self._err(404), self._ok("fb-out")],
+        ) as m:
+            assert local_llm._call_remote_llm("p") == "fb-out"
+            fb_call = m.call_args_list[1]
+            assert fb_call.kwargs["base_url"] == "http://primary/v1"
+            assert fb_call.kwargs["api_key"] == "primary-key"


### PR DESCRIPTION
## Summary

`_call_remote_llm()` currently picks **one** model from `MNEMOSYNE_LLM_MODEL` against **one** URL from `MNEMOSYNE_LLM_BASE_URL`. If that combination 404s (e.g. omlx evicts the pinned model after its idle window), the call fails, the remote tier returns `None`, and the existing fallback chain drops straight to local GGUF / `None`. Memory consolidation silently degrades to AAAK encoding.

This adds a model-level fallback chain **within** the remote tier.

## New env vars (all optional, empty disables the chain)

| Var | Purpose | Default |
|---|---|---|
| `MNEMOSYNE_LLM_FALLBACK_MODELS` | Comma-separated model names tried in order | (disabled) |
| `MNEMOSYNE_LLM_FALLBACK_BASE_URL` | Endpoint for fallbacks | inherits `MNEMOSYNE_LLM_BASE_URL` |
| `MNEMOSYNE_LLM_FALLBACK_API_KEY` | Auth for fallbacks | inherits `MNEMOSYNE_LLM_API_KEY` |

## Retry policy

- **Retry**: 404, 400, 5xx, connection errors, timeouts. The other model might exist on the same host.
- **Don't retry**: 401, 403, 429. Bad credentials and rate limits won't be fixed by swapping model names — propagate so the user knows.
- **Don't retry** on a successful 200 with empty body — the endpoint is healthy, the prompt may just be wrong.

## Example

```bash
export MNEMOSYNE_LLM_BASE_URL=http://localhost:8080/v1
export MNEMOSYNE_LLM_MODEL=Qwen3.6-35B-A3B-PARO
export MNEMOSYNE_LLM_FALLBACK_MODELS=Qwen3.6-27B-MXFP4-MTP,Qwen2.5-32B-Instruct
```

## Implementation

- New private helper `_call_remote_llm_with_model(prompt, model, temperature, *, base_url, api_key, timeout)` returns a 3-tuple `(text, status, exc)` so callers can decide whether to retry.
- New `_is_retryable_status(status_code)` centralizes the status-code policy.
- Public `_call_remote_llm()` becomes a thin orchestrator: build candidate list (primary + deduped fallbacks), iterate, return first success.
- No public API breakage. The 5-tier fallback chain (host, remote, llama-cpp, ctransformers, None) is unchanged. The remote tier is now multi-model.

## Tests

12 new cases in `TestRemoteLLMFallback`:

- Status-code policy table-driven test (9 cases)
- Primary success skips fallback
- 404 / 5xx / connection error trigger fallback
- 401 / 429 do NOT trigger fallback
- Multiple fallbacks iterate in order
- Returns `None` when every model fails
- Empty fallback list → only primary tried
- Primary deduplicated from `LLM_FALLBACK_MODELS` (no self-retry)
- Fallback base URL/key override takes effect
- Fallback inherits primary base URL/key when not overridden

Test count: 30 / 30 pass in `tests/test_local_llm.py`. Full suite: 1390 pass, 44 pre-existing failures (all in `test_c4_recall_diagnostics`, `test_recall_precision_regressions`, `test_temporal_recall`, etc. — recall/beam scoring, none touching this change; verified by stashing the diff and re-running).

## Files changed

- `mnemosyne/core/local_llm.py` (+108 / -25)
- `tests/test_local_llm.py` (+186 / -0)

## Notes for review

- One pre-existing test (`TestRemoteLLM::test_call_remote_llm_with_mock_response`) had a brittle mock that didn't set `status_code` on the fake response. I added `status_code=200` to the mock — minimal, makes the test reflect real httpx behavior.
- Pre-existing LSP errors at lines 99/207/213/504 (`hf_hub_download` overload, `ctransformers` API drift, unbound `httpx`) are unrelated to this change and exist on `main`.