### PR TITLE
fix: manually normalize embeddings before int8 quantization

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1670,9 +1670,23 @@ def _effective_vec_type(conn: sqlite3.Connection) -> str:
 
 
 def _vec_insert(conn: sqlite3.Connection, rowid: int, embedding: List[float]):
-    """Insert embedding into sqlite-vec table with quantization via SQL functions."""
+    """Insert embedding into sqlite-vec table with quantization via SQL functions.
+
+    Manually normalizes the embedding to unit length before quantization.
+    ``vec_quantize_int8(x, 'unit')`` in sqlite-vec 0.1.9 fails to normalize
+    1024-dim vectors (works for 3-dim, silently passes through unnormalized
+    vectors at high dimensions).  Pre-normalizing works around the bug until
+    upstream sqlite-vec ships a fix.
+    """
     vec_type = _effective_vec_type(conn)
-    emb_json = json.dumps(embedding)
+    # Normalize to unit length before quantization
+    # (sqlite-vec 0.1.9 'unit' param fails at 1024-dim)
+    import numpy as _np
+    emb_arr = _np.array(embedding, dtype=_np.float32)
+    norm = _np.linalg.norm(emb_arr)
+    if norm > 0:
+        emb_arr = emb_arr / norm
+    emb_json = json.dumps(emb_arr.tolist())
     if vec_type == "bit":
         conn.execute(
             "INSERT INTO vec_episodes(rowid, embedding) VALUES (?, vec_quantize_binary(?))",
@@ -1699,9 +1713,21 @@ def _vec_insert(conn: sqlite3.Connection, rowid: int, embedding: List[float]):
 
 
 def _vec_search(conn: sqlite3.Connection, embedding: List[float], k: int = 20) -> List[Dict]:
-    """Search sqlite-vec and return rowids with distances."""
+    """Search sqlite-vec and return rowids with distances.
+
+    Normalizes the query embedding to unit length before quantization so
+    distances are commensurate with the stored int8 vectors (which are also
+    unit-normalized at insert time — see _vec_insert).
+    """
     vec_type = _effective_vec_type(conn)
-    emb_json = json.dumps(embedding)
+    # Normalize to unit length before quantization
+    # (sqlite-vec 0.1.9 'unit' param fails at 1024-dim)
+    import numpy as _np
+    emb_arr = _np.array(embedding, dtype=_np.float32)
+    norm = _np.linalg.norm(emb_arr)
+    if norm > 0:
+        emb_arr = emb_arr / norm
+    emb_json = json.dumps(emb_arr.tolist())
     # NOTE: sqlite-vec requires the KNN limit to be known at query planning time.
     # Parameter binding (LIMIT ?) fails on some versions because xBestIndex
     # can't resolve the parameter value. We inline k safely since it's


### PR DESCRIPTION
## Problem

`vec_quantize_int8(x, 'unit')` in sqlite-vec 0.1.9 fails to normalize 1024-dim vectors. It works correctly at 3-dim but silently passes through unnormalized vectors at high dimensions.

**Result:** stored int8 vectors have dequantized norm ~22.7 instead of ~1.0. L2 distance on raw int8 bytes produces 1400–2750 between vectors (expected 0–~256 for unit vectors). The recall similarity `max(0, 1-d/max_d)` collapses to 0.0 for ALL results, making dense vector search silently useless.

**Symptom:** `mnemosyne_recall` returns results but ALL have `dense_score: 0.0` and `voice_scores.vec: 0.0`.

Discovered during model migration from `bge-small-en-v1.5` (384-dim) to `intfloat/multilingual-e5-large` (1024-dim).

## Fix

Pre-normalize the embedding to unit length before calling `vec_quantize_int8` in both `_vec_insert` and `_vec_search`. Workaround until sqlite-vec ships a fix.

## Verification

- Self-match distance = 0.000000
- Cross-match distances ~60-80 (reasonable for 1024-dim int8 unit vectors)
- Dense scores in recall are non-zero (0.03-0.15 range)