### PR TITLE
fix: add missing capture groups to multilingual named_months regex patterns

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -3380,7 +3380,7 @@ class BeamMemory:
             'named_months': r'((?:Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember|Jan|Feb|Mär|Apr|Mai|Jun|Jul|Aug|Sep|Okt|Nov|Dez)\s+\d{1,2}(?:\.)?\s*(?:\d{4})?)',
         },
         'ru': {
-            'negation': r'(?:Я(?: |\')?(?:никогда|не)|(?:никогда|не)\s+будет)\s+[^.,;!?\n]{6,120}',
+            'negation': r'((?:Я(?: |\')?(?:никогда|не)|(?:никогда|не)\s+будет)\s+[^.,;!?\n]{6,120})',
             'decision': r'(?:решил|решила|решили|выбрал|выбрала|выбрали|перешёл|перешла|перешли|переключился|переключилась|переключились|переехал|переехала|переехали|поменял|поменяла|поменяли)\s+([^.,;!?\n]{2,120})',
             'entity': r'(?:мой|моя|моё|мои|наш|наша|наше|наши|твой|твоя|твоё|твои|ваш|ваша|ваше|ваши)\s+([a-zA-Zа-яА-Я_]+(?:\s+(?:таблица|модель|схема|API|эндпоинт|функция|модуль|роут|обработчик|тул|плагин|скрипт|конфиг|настройка|воркфлоу|пайплайн|процесс|система|сервер|клиент|сервис|база|данных|запрос|файл|репозиторий|ветка|PR|ишью|таска|джоба|контейнер|образ|проект|релиз|версия))?)\s+(?:нуждается|требует|должен|должна|должны|может|могут|будет|будут|имеет|имеют|использует|используют|работает|работают|обрабатывает|поддерживает|запущен|запущена|настроен|настроена|готов|готова|готовы|запланирован|обновлён|обновлена|опубликован|опубликована|создан|создана)\s+([^.,;!?\n]{3,80})',
             'sequence': r'((?:во-первых|во-вторых|в-третьих|в-четвёртых|в-пятых|наконец|затем|потом|после этого|дальше|сначала)\s*,?\s*[^.,;!?\n]{6,120})',
@@ -3392,7 +3392,7 @@ class BeamMemory:
             'instruction': r'(?:всегда|никогда|должен|не должен|нужно|не нужно|обязательно|нельзя|не забывай|запомни|помни|следует|стоит)\\s+([^.,;!?\\n]{6,200})',
         },
         'it': {
-            'negation': r"(?:Non(?: |')?(?:ho|ho mai|mai|non)\s+[^.,;!?\n]{15,120})",
+            'negation': r"((?:Non(?: |')?(?:ho|ho mai|mai|non)\s+[^.,;!?\n]{15,120}))",
             'decision': r'(?:ho deciso|mi sono deciso|ho scelto|ho optato|ho cambiato|sono passato|sono passata|ho selezionato|scelto)\s+([^.,;!?\n]{10,120})',
             'entity': r"(?:il|la|i|le|il mio|la mia|i miei|le mie|il tuo|la tua|il nostro|la nostra)\s+([a-z_]+(?:\s+(?:tabella|modello|schema|API|endpoint|funzione|modulo|route|handler|tool|plugin|script|config|impostazione|workflow|pipeline|processo|sistema|server|client|servizio|database|query|file|repo|branch|PR|issue|task|job|progetto)))\s+(?:ha bisogno|richiede|dovrebbe|potrebbe|vorra|ha|hanno|usa|usano|funziona|gestisce|processa|supporta)\s+([^.,;!?\n]{10,80})",
             'sequence': r'((?:primo|prima|secondo|seconda|terzo|terza|quarto|quinta|infine|poi|dopo|dopodiche|successivamente|quindi)[^.,;!?\n]{15,120})',

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2261,7 +2261,10 @@ class BeamMemory:
             # Populates memoria_facts, memoria_timelines, memoria_kg for the
             # structured retrieval router. Runs silently on every remember()
             # so the MEMORIA tables stay current regardless of extract=True.
-            self.extract_and_store_facts(content, message_idx=0, source_memory_id=existing_id)
+            try:
+                self.extract_and_store_facts(content, message_idx=0, source_memory_id=existing_id)
+            except Exception:
+                pass  # regex extraction failures must not block memory storage
             # Phase 3-4: Extract graph and consolidate veracity for dedup update
             self._ingest_graph_and_veracity(existing_id, content, source, veracity)
             self._emit_event("MEMORY_UPDATED", existing_id, content=content,
@@ -2339,7 +2342,10 @@ class BeamMemory:
         # Phase 2: MEMORIA regex-based extraction (always-on, zero-LLM-cost).
         # Populates memoria_facts, memoria_timelines, memoria_kg for the
         # structured retrieval router. Runs on every remember() call.
-        self.extract_and_store_facts(content, message_idx=0, source_memory_id=memory_id)
+        try:
+            self.extract_and_store_facts(content, message_idx=0, source_memory_id=memory_id)
+        except Exception:
+            pass  # regex extraction failures must not block memory storage
 
         # Phase 3-4: Extract graph and consolidate veracity for new memory
         self._ingest_graph_and_veracity(memory_id, content, source, veracity)
@@ -2597,7 +2603,10 @@ class BeamMemory:
                 if extract:
                     _extract_and_store_facts(self, memory_id, row_content, item_source)
                 # Phase 2: MEMORIA regex-based extraction for every batch row.
-                self.extract_and_store_facts(row_content, message_idx=0, source_memory_id=memory_id)
+                try:
+                    self.extract_and_store_facts(row_content, message_idx=0, source_memory_id=memory_id)
+                except Exception:
+                    pass  # regex extraction failures must not block memory storage
                 # MEMORY_ADDED parity with remember() -- streaming
                 # observers + DeltaSync see batch rows the same way
                 # they see single-row writes.
@@ -3379,7 +3388,7 @@ class BeamMemory:
             'instruction_imperative': 'всегда|никогда|помни|запомни|используй|пользуйся|храни|избегай|убедись|проверь|запусти|тестируй|собери|задеплой|сделай пуш|сделай пулл|мёржи|закрой|открой|обнови|установи|настрой|включи|отключи|добавь|удали|создай|удали|запусти|останови|рестартни|перезагрузи|сбрось|попробуй|реализуй|напиши|прочитай|переключи|передвинь|скопируй|переименуй|отправь|ответь',
             'preference': r'(?:(?:Я(?: |\')?(?:люблю|ненавижу|предпочитаю|терпеть не могу|не люблю|не нравится|использую|пользуюсь|остаюсь на|перешёл на|переключился на|хочу|нуждаюсь|обычно|скорее|предпочитаю не|стараюсь избегать|привык|надоело|устал от|доволен|устраивает))|мне\s+(?:нравится|не нравится|проще|удобнее|лень|надоело)|терпеть не могу|надоело|привык|устраивает)\s+([^.,;!?\n]{3,200})',
             'event_keywords': ['встреча', 'созвон', 'запланировано', 'состоялось', 'произошло', 'планирую', 'будет', 'дедлайн', 'релиз', 'запуск', 'деплой', 'опубликовано', 'начал', 'начался', 'закончил', 'завершил', 'событие', 'конференция', 'воркшоп', 'встреча'],
-            'named_months': r'(?:(?:(?:января|февраля|марта|апреля|мая|июня|июля|августа|сентября|октября|ноября|декабря|янв|фев|мар|апр|май|июн|июл|авг|сен|окт|ноя|дек)\s+\d{1,2}(?:-го)?,?\s*(?:\d{4})?)|(?:\d{1,2}\s+(?:января|февраля|марта|апреля|мая|июня|июля|августа|сентября|октября|ноября|декабря)(?:\s+\d{4})?))',
+            'named_months': r'((?:(?:января|февраля|марта|апреля|мая|июня|июля|августа|сентября|октября|ноября|декабря|янв|фев|мар|апр|май|июн|июл|авг|сен|окт|ноя|дек)\s+\d{1,2}(?:-го)?,?\s*(?:\d{4})?)|(?:\d{1,2}\s+(?:января|февраля|марта|апреля|мая|июня|июля|августа|сентября|октября|ноября|декабря)(?:\s+\d{4})?))',
             'instruction': r'(?:всегда|никогда|должен|не должен|нужно|не нужно|обязательно|нельзя|не забывай|запомни|помни|следует|стоит)\\s+([^.,;!?\\n]{6,200})',
         },
         'it': {
@@ -3400,7 +3409,7 @@ class BeamMemory:
             'instruction': r'(?:sempre|mai|non deve|non devono|dovrebbe(?: non)?(?=\s+(?:tu|voi|noi|io|si)\s+(?:IMPVERBS))|ha bisogno di|deve|devono|preferisci(?: non)?|vuole(?: evitare|assicurarsi|usare|tenere))\s+([^.,;!?\n]{10,200})',
             'preference': r"(?:Io(?: |')?(?:mi piace|amo|preferisco|odio|non mi piace|uso|utilizzo|sono passato a|ho cambiato a|voglio|ho bisogno|tendo a|di solito|preferirei|non mi piace per niente|non voglio|non sono un fan di|mi va bene|mi trovo bene|sono abituato a|sono felice con|sono stanco di|cerco di evitare|trovo piu facile|trovo meglio|trovo utile))\s+([^.,;!?\n]{10,200})",
             'event_keywords': ['riunione', 'chiamata', 'incontro', 'programmato', 'successo', 'accaduto', 'pianifico', 'sara il', 'scadenza', 'rilascio', 'lancio', 'pubblicato', 'iniziato', 'cominciato', 'finito', 'completato', 'evento', 'conferenza', 'workshop', 'appuntamento'],
-            'named_months': r'(?:(?:(?:Gennaio|Febbraio|Marzo|Aprile|Maggio|Giugno|Luglio|Agosto|Settembre|Ottobre|Novembre|Dicembre|gen|feb|mar|apr|mag|giu|lug|ago|set|ott|nov|dic)\s+\d{1,2}(?:°)?,?\s*(?:\d{4})?))',
+            'named_months': r'((?:(?:Gennaio|Febbraio|Marzo|Aprile|Maggio|Giugno|Luglio|Agosto|Settembre|Ottobre|Novembre|Dicembre|gen|feb|mar|apr|mag|giu|lug|ago|set|ott|nov|dic)\s+\d{1,2}(?:°)?,?\s*(?:\d{4})?))',
         },
         'es': {
             'negation': r'(nunca|jamás|tampoco|ni\s+(?:siquiera|de coña|loc[ao]|de broma|hablar)|no\s+(?:me\s+(?:gusta|convence|interesa|molesta|duele)|lo\s+(?:hag[ao]s|haré|haría)|hace\s+falta|quiero|voy\s+a|sé|sabía|puedo|debo|es\s+(?:para\s+tanto|plan|momento)|tiene\s+sentido|estoy\s+(?:de\s+acuerdo|seguro)|hay\s+(?:derecho|manera|tipo|quien)|teng[ao]\s+(?:ni\s+idea|claro)|pienso|creo|son|era|está|estaba|será|está\s+mal|vamos\s+mal))\s+([^.,;!?¿¡\\n]{15,120})',
@@ -3455,7 +3464,7 @@ class BeamMemory:
                 'agendé', 'agende', 'ocurrió', 'ocurrio', 'sucedió', 'sucedio',
                 'pasó', 'paso',
             ],
-            'named_months': r'(\d{1,2})\s*de\s*(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|oct|nov|dic)\s*(?:de\s*(\d{4}))?',
+            'named_months': r'((?:\d{1,2})\s*de\s*(?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre|ene|feb|mar|abr|may|jun|jul|ago|sep|oct|nov|dic)\s*(?:de\s*(?:\d{4}))?)',
         },
     }
 


### PR DESCRIPTION
## Problem

`mnemosyne_remember` raises `IndexError: no such group` when the input contains Russian, Italian, or Spanish date strings **or** Russian/Italian negation sentences. This is triggered inside `extract_and_store_facts()` where the code unconditionally calls `m.group(1)` on pattern matches that have zero capture groups.

## Root cause

### named_months patterns (original fix)

| Language | Old pattern | Groups | Problem |
|----------|-----------|--------|---------|
| Russian (ru) | `r'(?:...)...` | **0** | `m.group(1)` → IndexError |
| Italian (it) | `r'(?:...)...` | **0** | `m.group(1)` → IndexError |
| Spanish (es) | `r'(\\d{1,2})...de...(enero|...)...(?:de(\\d{4}))?'` | **3** | `m.group(1)` returns only day number instead of full date |

English and German named_months patterns were correct (1 capture group).

### negation patterns (added in v2)

| Language | Old pattern | Groups | Problem |
|----------|-----------|--------|---------|
| Russian (ru) | `r'(?:...)...` | **0** | `m.group(1)` → IndexError |
| Italian (it) | `r'(?:...)...` | **0** | `m.group(1)` → IndexError |

English, German, and Spanish negation patterns already had >=1 capture group.

## Fix

### named_months

1. **Russian `named_months`**: wrapped `(?:...)` → `((?:...))` — now has 1 capture group
2. **Italian `named_months`**: same fix
3. **Spanish `named_months`**: consolidated all 3 groups into 1 outer group

### negation

4. **Russian `negation`**: wrapped `(?:...)` → `((?:...))` — now has 1 capture group
5. **Italian `negation`**: same fix

### Defense-in-depth

6. Wrapped all three `extract_and_store_facts()` calls (`remember()` dedup path, `remember()` new-row path, `remember_batch()`) in `try/except` so regex extraction failures never block memory storage

## Impact

Any Russian, Italian, or Spanish text containing date references or Russian/Italian negation phrases causes `remember()` to crash. The `try/except` guard prevents similar undiscovered pattern issues from affecting memory writes.

## Full verification

All 35 patterns (5 languages × 7 types: named_months, negation, decision, entity, sequence, instruction, preference) were programmatically verified:
- All have >=1 capture group
- entity patterns have exactly 2 (used with m.group(1) + m.group(2))
- Runtime tested with real text samples for all languages
- All compiled without regex syntax errors

## Statistics

- Files changed: 1 (`mnemosyne/core/beam.py`)
- Additions: +18, Deletions: -6