### PR TITLE
fix(beam): pass connection by keyword to VeracityConsolidator in recall

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6101,7 +6101,7 @@ class BeamMemory:
         try:
             # Import lazily so the consolidator module is only loaded on-demand
             from mnemosyne.core.veracity_consolidation import VeracityConsolidator
-            consolidator = VeracityConsolidator(self.conn)
+            consolidator = VeracityConsolidator(conn=self.conn, db_path=self.db_path)
             seen_subjects: set = set()
             for word in query_lower.split()[:6]:
                 if len(word) < 3:


### PR DESCRIPTION
Fixes #229.

## Problem

In the `consolidated_facts` recall path ("Source 2"), the connection is passed positionally:

```python
consolidator = VeracityConsolidator(self.conn)   # beam.py:6104
```

`VeracityConsolidator.__init__(self, db_path=None, conn=None)` — so `self.conn` binds to `db_path`, `conn` stays `None`, and the constructor falls into the `conn is None` branch:

```python
self.conn = sqlite3.connect(str(self.db_path), ...)
```

`str(<_BeamConnection object>)` becomes a filename, so each recall:

1. creates an empty SQLite file named `<mnemosyne.core.beam._BeamConnection object at 0x...>` in the CWD, and
2. queries that empty throwaway DB instead of the real one, so `get_consolidated_facts()` always returns nothing — Source 2 is silently dead.

## Fix

One line, matching the already-correct call site at `beam.py:1993`:

```python
consolidator = VeracityConsolidator(conn=self.conn, db_path=self.db_path)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)