### PR TITLE
fix(stats): count binary/JSON episodic vectors when sqlite-vec ANN absent

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6242,6 +6242,14 @@ class BeamMemory:
                     vec_type = "json"
             except Exception:
                 logger.info("memory_embeddings count failed", exc_info=True)
+        # No usable vectors of any kind -> no backend is serving recall.
+        # Normalize vec_type to "none" so an empty-but-present ANN table
+        # (vec_episodes exists with 0 rows -> _effective_vec_type would say
+        # "int8"/"float32") doesn't report a backend that has nothing to
+        # serve. Keeps the (vectors=0 <-> vec_type="none") contract stable
+        # across environments with and without the sqlite-vec extension.
+        if vec_count == 0:
+            vec_type = "none"
         return {"total": total, "last": last[0] if last else None, "vectors": vec_count, "vec_type": vec_type}
 
     def get_memoria_stats(self) -> Dict:

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6195,6 +6195,22 @@ class BeamMemory:
         total = cursor.fetchone()[0]
         cursor.execute(f"SELECT timestamp FROM episodic_memory{where_str} ORDER BY timestamp DESC LIMIT 1", params)
         last = cursor.fetchone()
+        # Report the vector coverage that recall *actually* uses, in
+        # priority order. Previously this only counted the sqlite-vec ANN
+        # table (vec_episodes). When the SQLite build can't load the
+        # sqlite-vec extension, that table never exists and the count is
+        # always 0 -- even though semantic recall is fully functional via
+        # the binary-vector voice (episodic_memory.binary_vector) or the
+        # float32 JSON embeddings (memory_embeddings). Reporting 0 there is
+        # misleading and trips a false "episodic vectors=0, run sleep" hint
+        # in diagnose. Fall back to whichever representation is populated.
+        def _filtered(extra_pred: str) -> str:
+            # Append a predicate to the (optional) author/channel filter,
+            # reusing `where_str`/`params` so both filtered and unfiltered
+            # callers stay correct.
+            joiner = " AND" if where_clauses else " WHERE"
+            return f"{where_str}{joiner} {extra_pred}"
+
         vec_count = 0
         vec_type = "none"
         if _vec_available(self.conn):
@@ -6202,7 +6218,30 @@ class BeamMemory:
                 vec_count = cursor.execute("SELECT COUNT(*) FROM vec_episodes").fetchone()[0]
                 vec_type = _effective_vec_type(self.conn)
             except Exception:
-                logger.info("Regex extraction failed, skipping", exc_info=True)
+                logger.info("vec_episodes count failed; falling back to non-ANN vectors", exc_info=True)
+        if vec_count == 0:
+            # Binary-vector voice: packed Hamming vector stored inline.
+            try:
+                vec_count = cursor.execute(
+                    f"SELECT COUNT(*) FROM episodic_memory{_filtered('binary_vector IS NOT NULL')}",
+                    params,
+                ).fetchone()[0]
+                if vec_count:
+                    vec_type = "binary"
+            except Exception:
+                logger.info("binary_vector count failed", exc_info=True)
+        if vec_count == 0:
+            # Float32 JSON embeddings (brute-force cosine fallback).
+            try:
+                vec_count = cursor.execute(
+                    f"SELECT COUNT(*) FROM episodic_memory"
+                    f"{_filtered('id IN (SELECT memory_id FROM memory_embeddings)')}",
+                    params,
+                ).fetchone()[0]
+                if vec_count:
+                    vec_type = "json"
+            except Exception:
+                logger.info("memory_embeddings count failed", exc_info=True)
         return {"total": total, "last": last[0] if last else None, "vectors": vec_count, "vec_type": vec_type}
 
     def get_memoria_stats(self) -> Dict:

--- a/mnemosyne/diagnose.py
+++ b/mnemosyne/diagnose.py
@@ -178,6 +178,7 @@ def run_diagnostics() -> Dict:
     embed_ok = any(e["check"] == "embeddings_available" and e["status"] == "YES" for e in entries)
     vec_ok = any(e["check"] == "sqlite_vec_available" and e["status"] == "YES" for e in entries)
     ep_vec = next((e for e in entries if e["check"] == "episodic_vectors"), None)
+    ep_vec_type = next((e for e in entries if e["check"] == "episodic_vec_type"), None)
 
     if not embed_ok:
         summary["key_findings"].append("fastembed not available - install with: pip install mnemosyne-memory[embeddings]")
@@ -188,7 +189,15 @@ def run_diagnostics() -> Dict:
     if embed_ok and vec_ok and ep_vec and ep_vec["status"] == "0":
         summary["key_findings"].append("Both fastembed and sqlite-vec are available but episodic vectors=0 - memories may not have been consolidated yet. Run: hermes mnemosyne sleep")
     if embed_ok and vec_ok and ep_vec and int(ep_vec["status"]) > 0:
-        summary["key_findings"].append("Semantic search is active with " + ep_vec["status"] + " vectors in episodic memory")
+        vtype = ep_vec_type["status"] if ep_vec_type else "unknown"
+        msg = f"Semantic search is active with {ep_vec['status']} vectors in episodic memory (backend: {vtype})"
+        if vtype in ("binary", "json"):
+            # vec_episodes (the sqlite-vec ANN table) is absent -- usually
+            # because this Python's sqlite3 can't load the sqlite-vec
+            # extension. Recall still works via the binary/JSON fallback;
+            # the ANN index only matters at much larger scale.
+            msg += " - the sqlite-vec ANN index is not in use (extension not loadable); the fallback is fine at small/medium scale"
+        summary["key_findings"].append(msg)
 
     return summary
 

--- a/tests/test_episodic_stats_vector_fallback.py
+++ b/tests/test_episodic_stats_vector_fallback.py
@@ -1,0 +1,137 @@
+"""Regression tests for get_episodic_stats vector-count fallback.
+
+Pre-fix: BeamMemory.get_episodic_stats only counted the sqlite-vec ANN
+table (``vec_episodes``). When the running Python's ``sqlite3`` module is
+built without loadable-extension support, sqlite-vec can never load and
+``vec_episodes`` never exists, so the reported ``vectors`` count is always
+0 -- even though semantic recall is fully functional via the binary-vector
+voice (``episodic_memory.binary_vector``) or the float32 JSON embeddings
+(``memory_embeddings``). The bogus 0 also tripped a false
+"episodic vectors=0, run sleep" hint in diagnose.
+
+Post-fix: when vec_episodes is unavailable/empty, the stat falls back to
+counting whichever representation is actually populated, and reports a
+truthful ``vec_type`` ("binary" or "json") instead of "none".
+
+These tests deliberately seed the fallback tables directly rather than
+relying on fastembed/sqlite-vec being installed, so they pin the fallback
+logic deterministically in any environment (mirroring the CI/macOS
+no-extension case).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db(tmp_path: Path) -> Path:
+    return tmp_path / "mnemosyne_epstats.db"
+
+
+def _add_episodic(beam: BeamMemory, mem_id: str) -> None:
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES (?, ?, 'test', datetime('now'), 0.5)",
+        (mem_id, f"content for {mem_id}"),
+    )
+    beam.conn.commit()
+
+
+def test_no_vectors_reports_none(temp_db):
+    """Episodic rows with no vector representation report 0 / 'none'."""
+    beam = BeamMemory(session_id="epstats", db_path=temp_db)
+    _add_episodic(beam, "em-a")
+
+    stats = beam.get_episodic_stats()
+    assert stats["total"] == 1
+    assert stats["vectors"] == 0
+    assert stats["vec_type"] == "none"
+
+
+def test_binary_vector_counted_when_ann_absent(temp_db):
+    """When vec_episodes is absent, populated binary_vector columns are
+    counted and reported as the 'binary' backend."""
+    beam = BeamMemory(session_id="epstats", db_path=temp_db)
+    _add_episodic(beam, "em-a")
+    _add_episodic(beam, "em-b")
+    # Only em-a carries a binary vector.
+    beam.conn.execute(
+        "UPDATE episodic_memory SET binary_vector = ? WHERE id = 'em-a'",
+        (b"\x00\x01\x02\x03",),
+    )
+    beam.conn.commit()
+
+    stats = beam.get_episodic_stats()
+    assert stats["total"] == 2
+    assert stats["vectors"] == 1
+    assert stats["vec_type"] == "binary"
+
+
+def test_json_embeddings_counted_when_no_binary(temp_db):
+    """With no binary vectors, JSON embeddings in memory_embeddings are
+    counted and reported as the 'json' backend."""
+    beam = BeamMemory(session_id="epstats", db_path=temp_db)
+    _add_episodic(beam, "em-a")
+    vec = np.ones(8, dtype=np.float32)
+    beam.conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) "
+        "VALUES (?, ?, ?)",
+        ("em-a", json.dumps(vec.tolist()), "test-model"),
+    )
+    beam.conn.commit()
+
+    stats = beam.get_episodic_stats()
+    assert stats["total"] == 1
+    assert stats["vectors"] == 1
+    assert stats["vec_type"] == "json"
+
+
+def test_binary_preferred_over_json(temp_db):
+    """Binary vectors take precedence over JSON embeddings in the fallback
+    chain (binary is the cheaper recall voice)."""
+    beam = BeamMemory(session_id="epstats", db_path=temp_db)
+    _add_episodic(beam, "em-a")
+    beam.conn.execute(
+        "UPDATE episodic_memory SET binary_vector = ? WHERE id = 'em-a'",
+        (b"\x00\x01",),
+    )
+    beam.conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) "
+        "VALUES (?, ?, ?)",
+        ("em-a", json.dumps([1.0, 2.0]), "test-model"),
+    )
+    beam.conn.commit()
+
+    stats = beam.get_episodic_stats()
+    assert stats["vec_type"] == "binary"
+
+
+def test_fallback_respects_author_filter(temp_db):
+    """The fallback count honors the same author/channel filter as the
+    total count, so a filtered view doesn't over-report vectors."""
+    beam = BeamMemory(session_id="epstats", db_path=temp_db)
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance, author_id) "
+        "VALUES ('em-a', 'a', 'test', datetime('now'), 0.5, 'alice')"
+    )
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance, author_id) "
+        "VALUES ('em-b', 'b', 'test', datetime('now'), 0.5, 'bob')"
+    )
+    for mid in ("em-a", "em-b"):
+        beam.conn.execute(
+            "UPDATE episodic_memory SET binary_vector = ? WHERE id = ?",
+            (b"\x00\x01", mid),
+        )
+    beam.conn.commit()
+
+    stats = beam.get_episodic_stats(author_id="alice")
+    assert stats["total"] == 1
+    assert stats["vectors"] == 1
+    assert stats["vec_type"] == "binary"


### PR DESCRIPTION
## Problem

\`mnemosyne stats\` / \`diagnose\` report **\`episodic vectors: 0\`** and \`vec_type: none\` on systems where the running Python's \`sqlite3\` module was built **without loadable-extension support** (common on macOS system Python and some distro builds). In that case the \`sqlite_vec\` *pip package* imports fine — so \`diagnose\` cheerfully reports "sqlite-vec available: YES" — but \`conn.enable_load_extension\` is missing, the extension can never load, and the \`vec_episodes\` ANN table is never created.

\`get_episodic_stats\` counts vectors *only* via \`SELECT COUNT(*) FROM vec_episodes\`, so it always returns 0 there. This is misleading: semantic recall is fully functional through the other two vector paths that **are** populated — the binary-vector voice (\`episodic_memory.binary_vector\`) and the float32 JSON embeddings (\`memory_embeddings\`). Worse, the bogus 0 trips this false hint in \`diagnose\`:

> Both fastembed and sqlite-vec are available but episodic vectors=0 - memories may not have been consolidated yet. Run: hermes mnemosyne sleep

…which no amount of consolidation can ever clear, sending users chasing a non-issue.

Observed on a real DB (114 episodic rows, all with binary + JSON vectors): stats reported \`vectors: 0, vec_type: none\` despite recall working.

## Fix

\`get_episodic_stats\` now reports the vector representation recall **actually** uses, in priority order:

1. \`vec_episodes\` (sqlite-vec ANN) → \`vec_type\` from \`_effective_vec_type\` (unchanged when available)
2. else \`episodic_memory.binary_vector\` populated → \`vec_type="binary"\`
3. else \`memory_embeddings\` JSON rows → \`vec_type="json"\`
4. else 0 / \`"none"\`

The author/channel filter is applied consistently across all paths. \`diagnose\` now reports semantic search as active and notes when the ANN index isn't in use (extension not loadable) — the fallback is fine at small/medium scale.

Same live DB after the fix: \`{'total': 114, 'vectors': 114, 'vec_type': 'binary'}\`.

## Tests

New \`tests/test_episodic_stats_vector_fallback.py\` (5 cases): none-reports-none, binary counted when ANN absent, JSON counted when no binary, binary preferred over JSON, and fallback respects the author filter. The tables are seeded directly so the fallback logic is pinned deterministically without requiring fastembed/sqlite-vec to be installed (mirrors the no-extension CI/macOS case). Existing \`test_cli_stats\`, \`test_degrade_vector\`, and \`test_e5a_vector_voice_dense_rewire\` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)