### PR TITLE
fix(prefetch): drop bare single-token extraction fragments from recall prefetch

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -117,6 +117,36 @@ def _format_prefetch_content(content: str, limit: int) -> str:
     return f"{cut}..."
 
 
+# Low-quality fragment filter for prefetch.
+#
+# The regex fact extractor can emit bare single-token "facts" (a stray adverb, a
+# particle, or a truncated word). Such tokens FTS-match common query words and can
+# outrank real memories in the per-turn prefetch window. A real, injectable memory
+# is a phrase, not a lone token, so drop lone short/stopword tokens. Exact- and
+# length-based only, so genuine short multi-word facts are never affected.
+_PREFETCH_FRAGMENT_STOPWORDS = frozenset({
+    "still", "what", "most", "almost", "back", "now", "too", "right",
+    "being", "going", "here", "there", "then", "just", "also", "only",
+    "even", "very", "really", "again", "away", "off", "out", "up",
+    "down", "over", "that", "this", "it", "so",
+})
+_PREFETCH_MIN_FRAGMENT_CHARS = 8   # lone tokens shorter than this are dropped
+_PREFETCH_OVERFETCH = 16           # recall more, then filter junk and cap
+_PREFETCH_TOP_K = 8                # final injected count (unchanged behavior)
+
+
+def _is_low_quality_prefetch(content: str) -> bool:
+    """True if recalled content is a bare single-token fragment with no value as
+    injected context. Multi-word phrases always pass."""
+    c = (content or "").strip()
+    if not c:
+        return True
+    if len(c.split()) <= 1 and (len(c) <= _PREFETCH_MIN_FRAGMENT_CHARS
+                                or c.lower() in _PREFETCH_FRAGMENT_STOPWORDS):
+        return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas
 # ---------------------------------------------------------------------------
@@ -1113,7 +1143,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             import os
             author_id = self._beam.author_id or os.environ.get("MNEMOSYNE_AUTHOR_ID")
             recall_kwargs: Dict[str, Any] = dict(
-                query=query, top_k=8,
+                query=query, top_k=_PREFETCH_OVERFETCH,  # over-fetch; junk filtered below
                 temporal_weight=0.2, temporal_halflife=48,
             )
             # Only pass author_id when explicitly non-empty.  Passing an empty
@@ -1135,9 +1165,12 @@ class MnemosyneMemoryProvider(MemoryProvider):
             MIN_IMPORTANCE_THRESHOLD = 0.5
             filtered = [
                 r for r in results
-                if r.get("score", 0) >= MIN_SCORE_THRESHOLD
-                or r.get("importance", 0) >= MIN_IMPORTANCE_THRESHOLD
+                if (r.get("score", 0) >= MIN_SCORE_THRESHOLD
+                    or r.get("importance", 0) >= MIN_IMPORTANCE_THRESHOLD)
+                and not _is_low_quality_prefetch(r.get("content", ""))
             ]
+            # Cap back to the intended injection size after over-fetch+filter.
+            filtered = filtered[:_PREFETCH_TOP_K]
             if not filtered:
                 return ""
             lines = ["## Mnemosyne Context"]

--- a/tests/test_prefetch_low_quality.py
+++ b/tests/test_prefetch_low_quality.py
@@ -1,0 +1,59 @@
+"""Tests for the prefetch low-quality fragment filter.
+
+The regex fact extractor can emit bare single-token "facts" (a stray adverb, a
+particle, or a truncated word). Those tokens FTS-match common query words and can
+score above real memories, so they must not dominate the per-turn prefetch window.
+A real, injectable memory is a phrase; a lone short/stopword token is dropped.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_memory_provider import _is_low_quality_prefetch as is_junk
+
+
+@pytest.mark.parametrize("frag", ["", "  ", "what", "very", "is", "still", "almost", "over"])
+def test_lone_fragments_are_dropped(frag):
+    assert is_junk(frag) is True
+
+
+@pytest.mark.parametrize("real", [
+    "Paris is the capital of France",
+    "water boils at 100C",
+    "film school",                 # two-word value survives
+    "the meeting is on Tuesday",
+])
+def test_real_phrases_are_kept(real):
+    assert is_junk(real) is False
+
+
+class FakeBeam:
+    """Returns a fixed mix of junk fragments and real phrases regardless of query."""
+    author_id = "test-author"
+
+    def recall(self, query, top_k, temporal_weight, temporal_halflife, author_id):
+        return [
+            # bare fragments scoring high on keyword match — must be filtered out
+            {"content": "what", "timestamp": "2026-05-14T12:00:00Z",
+             "importance": 0.1, "score": 0.63, "trust_tier": "STATED"},
+            {"content": "still", "timestamp": "2026-05-14T12:00:00Z",
+             "importance": 0.1, "score": 0.62, "trust_tier": "STATED"},
+            # a real, sentence-length memory scoring lower — must survive
+            {"content": "Paris is the capital of France", "timestamp": "2026-05-14T12:00:00Z",
+             "importance": 0.6, "score": 0.40, "trust_tier": "STATED"},
+        ]
+
+
+def test_prefetch_drops_fragments_and_keeps_real_memory(monkeypatch):
+    monkeypatch.delenv("MNEMOSYNE_PREFETCH_CONTENT_CHARS", raising=False)
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    provider = MnemosyneMemoryProvider()
+    provider._beam = FakeBeam()
+
+    block = provider.prefetch("what matters most")
+
+    assert "Paris is the capital of France" in block
+    # The bare fragments must not appear as injected memory lines.
+    for line in block.splitlines():
+        assert line.strip() not in {"what", "still"}


### PR DESCRIPTION
## Problem

`prefetch()` recalls top-k memories and keeps those above a score/importance gate.
The regex fact extractor, however, can emit bare single-token "facts" — a stray
adverb, a particle, or a truncated word. Because those tokens FTS-match common
query words, they can score **above** real memories and dominate the per-turn
prefetch window. On one production bank ~55% of consolidated facts were such
fragments, and a normal query surfaced several of them (scoring ~0.63) ahead of
genuine, sentence-length memories (~0.40). The existing `score >= 0.15` gate cannot
catch junk that legitimately scores high.

## Fix

Add a small read-time guard, `_is_low_quality_prefetch(content)`: a real,
injectable memory is a phrase; a lone token carries no context. Drop a recalled
entry whose content is a single token that is either very short (≤ 8 chars) or an
exact-match stopword/particle. Over-fetch then cap (`top_k 16 → filter → 8`) so the
filter can never starve the window.

## Scope / safety

- Only removes provable junk (lone short/stopword tokens). Multi-word phrases and
  meaningful short values are never affected.
- No config, no API change, no new dependencies.
- Behavior for clean data is unchanged aside from the over-fetch+cap (same final count).

## Tests

`tests/test_prefetch_low_quality.py` — unit tests for the guard plus a `prefetch()`
ranking test (a high-scoring fragment is dropped while a lower-scoring real phrase
survives). Existing `tests/test_prefetch_content_truncation.py` still passes.
