### PR TITLE
feat(prefetch): selectable prefetch profiles + pluggable extra sources

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -19,8 +19,9 @@ import logging
 import os
 import sys
 import threading
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 from datetime import datetime
 
 # Ensure mnemosyne core is importable from this directory
@@ -145,6 +146,118 @@ def _is_low_quality_prefetch(content: str) -> bool:
                                 or c.lower() in _PREFETCH_FRAGMENT_STOPWORDS):
         return True
     return False
+
+
+# ---------------------------------------------------------------------------
+# Prefetch profiles
+#
+# A profile is a named bundle of the prefetch knobs (recall breadth, weights,
+# temporal decay, relevance thresholds, the low-quality filter + dedup toggles,
+# and which registered sources to merge). The built-in `general` profile
+# reproduces the prior hardcoded behavior exactly, so existing deployments see no
+# change. Operators select a profile via MNEMOSYNE_PREFETCH_PROFILE; libraries can
+# register their own with register_profile().
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PrefetchProfile:
+    name: str
+    top_k: int = 8
+    importance_weight: Optional[float] = None   # None -> recall() default
+    vec_weight: Optional[float] = None
+    fts_weight: Optional[float] = None
+    temporal_weight: float = 0.2
+    temporal_halflife: float = 48
+    min_score: float = 0.15
+    min_importance: float = 0.5
+    content_char_limit: int = 0                  # 0 -> use env / untruncated
+    drop_low_quality: bool = True
+    dedup: bool = True
+    sources: Tuple[str, ...] = ("bank",)         # which registered sources to merge
+
+
+_BUILTIN_PROFILES: Dict[str, PrefetchProfile] = {
+    # Exact prior behavior — the default.
+    "general": PrefetchProfile(name="general"),
+    # Favor recent, high-importance memories; same filter/dedup defaults.
+    "social-chat": PrefetchProfile(
+        name="social-chat", top_k=6,
+        importance_weight=0.6, temporal_weight=0.35, temporal_halflife=24,
+    ),
+}
+
+
+def register_profile(profile: "PrefetchProfile") -> None:
+    """Register (or override) a named prefetch profile."""
+    _BUILTIN_PROFILES[profile.name] = profile
+
+
+def _resolve_profile(name: Optional[str]) -> PrefetchProfile:
+    """Return the named profile, falling back to `general` for unknown/empty."""
+    return _BUILTIN_PROFILES.get((name or "general"), _BUILTIN_PROFILES["general"])
+
+
+def _norm_prefetch_line(line: str) -> str:
+    """Normalize a content line for cross-source dedup: lowercase, collapse
+    whitespace, drop a leading bracketed metadata prefix (e.g. timestamps)."""
+    s = line.strip()
+    while s.startswith("[") or s.startswith("("):
+        close = s.find("]") if s.startswith("[") else s.find(")")
+        if close == -1:
+            break
+        s = s[close + 1:].strip()
+    return " ".join(s.lower().split())
+
+
+def _dedup_blocks(blocks: List[str]) -> List[str]:
+    """Collapse near-duplicate content lines across blocks, preserving each
+    block's headers and order. A single block is returned unchanged."""
+    seen: Set[str] = set()
+    out: List[str] = []
+    for block in blocks:
+        kept: List[str] = []
+        for line in block.split("\n"):
+            is_header = line.lstrip().startswith("#") or not line.strip()
+            if is_header:
+                kept.append(line)
+                continue
+            norm = _norm_prefetch_line(line)
+            if norm and norm in seen:
+                continue
+            if norm:
+                seen.add(norm)
+            kept.append(line)
+        out.append("\n".join(kept))
+    return out
+
+
+def _coerce_source_output(out: Any, profile: "PrefetchProfile", header: str) -> str:
+    """Turn a registered source's return value into an injectable block.
+
+    A source may return a pre-formatted string (used verbatim) or a list of hit
+    dicts ({"content", optional "timestamp"/"importance"}). Lists are formatted
+    under `header`, low-quality-filtered + capped per the profile."""
+    if not out:
+        return ""
+    if isinstance(out, str):
+        return out
+    try:
+        hits = list(out)
+    except TypeError:
+        return ""
+    lines = [header]
+    limit = _prefetch_content_char_limit() or profile.content_char_limit
+    for r in hits[: profile.top_k]:
+        content = r.get("content", "") if isinstance(r, dict) else str(r)
+        if profile.drop_low_quality and _is_low_quality_prefetch(content):
+            continue
+        content = _format_prefetch_content(content, limit)
+        if isinstance(r, dict) and r.get("timestamp"):
+            lines.append(f"  [{str(r['timestamp'])[:16]}] {content}")
+        else:
+            lines.append(f"  {content}")
+    return "\n".join(lines) if len(lines) > 1 else ""
 
 
 # ---------------------------------------------------------------------------
@@ -680,6 +793,13 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if _skip_env is not None:
             _parsed = {c.strip() for c in _skip_env.split(",") if c.strip()}
             self._skip_contexts = _parsed if _parsed else set()
+        # Prefetch profile selection (env; default "general" = prior behavior).
+        self._prefetch_profile = (
+            os.environ.get("MNEMOSYNE_PREFETCH_PROFILE", "general").strip() or "general"
+        )
+        # Generic extra-source registry: name -> fn(query, *, session_id) -> hits|str.
+        # A profile opts a source in via its `sources`. "bank" is built in.
+        self._prefetch_sources: Dict[str, Callable[..., Any]] = {}
         # Profile memory isolation: when enabled, each Hermes profile gets its own
         # Mnemosyne bank (separate SQLite DB). Default OFF for backward compatibility.
         self._profile_isolation_enabled = False
@@ -1132,20 +1252,64 @@ class MnemosyneMemoryProvider(MemoryProvider):
             )
         return ""
 
+    def register_prefetch_source(self, name: str, fn: Callable[..., Any]) -> None:
+        """Register an extra prefetch source. ``fn(query, *, session_id)`` returns
+        either a pre-formatted block (str) or a list of hit dicts. A profile opts
+        the source in by listing ``name`` in its ``sources``. ``"bank"`` is the
+        built-in memory-bank source and cannot be overridden here."""
+        if name and name != "bank":
+            self._prefetch_sources[name] = fn
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        """Recall relevant context via Mnemosyne hybrid search with temporal weighting.
-        
-        Only includes memories above a relevance threshold to prevent context pollution
-        from low-quality matches. Scoped to the user's author_id when available."""
+        """Recall relevant context for injection, driven by the active profile.
+
+        The profile selects which sources to merge (default: just the memory
+        ``bank``), the recall knobs, and the filter/dedup toggles. The default
+        ``general`` profile reproduces the prior single-source behavior exactly."""
         if not self._beam or self._agent_context in self._skip_contexts:
             return ""
+        profile = _resolve_profile(self._prefetch_profile)
+        blocks: List[str] = []
+        for src in profile.sources:
+            try:
+                if src == "bank":
+                    block = self._prefetch_bank(query, session_id, profile)
+                else:
+                    fn = self._prefetch_sources.get(src)
+                    block = _coerce_source_output(
+                        fn(query, session_id=session_id), profile,
+                        header=f"## Context ({src})",
+                    ) if fn else ""
+            except Exception as e:
+                logger.debug("Mnemosyne prefetch source %r failed: %s", src, e)
+                block = ""
+            if block:
+                blocks.append(block)
+        if profile.dedup:
+            blocks = _dedup_blocks(blocks)
+        return "\n\n".join(b for b in blocks if b)
+
+    def _prefetch_bank(self, query: str, session_id: str, profile: "PrefetchProfile") -> str:
+        """The built-in memory-bank source: hybrid recall with temporal weighting,
+        relevance + low-quality filtering, scoped to author_id when available.
+        Parameterized by *profile*; with ``general`` this is the legacy behavior."""
         try:
             import os
             author_id = self._beam.author_id or os.environ.get("MNEMOSYNE_AUTHOR_ID")
+            overfetch = max(profile.top_k * 2, _PREFETCH_OVERFETCH)  # over-fetch; junk filtered below
             recall_kwargs: Dict[str, Any] = dict(
-                query=query, top_k=_PREFETCH_OVERFETCH,  # over-fetch; junk filtered below
-                temporal_weight=0.2, temporal_halflife=48,
+                query=query, top_k=overfetch,
+                temporal_weight=profile.temporal_weight,
+                temporal_halflife=profile.temporal_halflife,
             )
+            # Pass tuning weights only when the profile sets them, so the default
+            # profile preserves recall()'s own defaults exactly.
+            if profile.importance_weight is not None:
+                recall_kwargs["importance_weight"] = profile.importance_weight
+            if profile.vec_weight is not None:
+                recall_kwargs["vec_weight"] = profile.vec_weight
+            if profile.fts_weight is not None:
+                recall_kwargs["fts_weight"] = profile.fts_weight
             # Only pass author_id when explicitly non-empty.  Passing an empty
             # falsy author_id is harmless (no (1=1) bypass), but passing a real
             # non-empty one triggers the (1=1) clause in beam.recall() that
@@ -1161,20 +1325,19 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return ""
             # Filter out low-relevance results to prevent context pollution
             # Only include memories with score above threshold or high importance
-            MIN_SCORE_THRESHOLD = 0.15
-            MIN_IMPORTANCE_THRESHOLD = 0.5
             filtered = [
                 r for r in results
-                if (r.get("score", 0) >= MIN_SCORE_THRESHOLD
-                    or r.get("importance", 0) >= MIN_IMPORTANCE_THRESHOLD)
-                and not _is_low_quality_prefetch(r.get("content", ""))
+                if (r.get("score", 0) >= profile.min_score
+                    or r.get("importance", 0) >= profile.min_importance)
+                and not (profile.drop_low_quality
+                         and _is_low_quality_prefetch(r.get("content", "")))
             ]
             # Cap back to the intended injection size after over-fetch+filter.
-            filtered = filtered[:_PREFETCH_TOP_K]
+            filtered = filtered[:profile.top_k]
             if not filtered:
                 return ""
             lines = ["## Mnemosyne Context"]
-            content_limit = _prefetch_content_char_limit()
+            content_limit = _prefetch_content_char_limit() or profile.content_char_limit
             for r in filtered:
                 content = _format_prefetch_content(
                     r.get("content", ""),

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -117,6 +117,36 @@ def _format_prefetch_content(content: str, limit: int) -> str:
     return f"{cut}..."
 
 
+# Low-quality fragment filter for prefetch.
+#
+# The regex fact extractor can emit bare single-token "facts" (a stray adverb, a
+# particle, or a truncated word). Such tokens FTS-match common query words and can
+# outrank real memories in the per-turn prefetch window. A real, injectable memory
+# is a phrase, not a lone token, so drop lone short/stopword tokens. Exact- and
+# length-based only, so genuine short multi-word facts are never affected.
+_PREFETCH_FRAGMENT_STOPWORDS = frozenset({
+    "still", "what", "most", "almost", "back", "now", "too", "right",
+    "being", "going", "here", "there", "then", "just", "also", "only",
+    "even", "very", "really", "again", "away", "off", "out", "up",
+    "down", "over", "that", "this", "it", "so",
+})
+_PREFETCH_MIN_FRAGMENT_CHARS = 8   # lone tokens shorter than this are dropped
+_PREFETCH_OVERFETCH = 16           # recall more, then filter junk and cap
+_PREFETCH_TOP_K = 8                # final injected count (unchanged behavior)
+
+
+def _is_low_quality_prefetch(content: str) -> bool:
+    """True if recalled content is a bare single-token fragment with no value as
+    injected context. Multi-word phrases always pass."""
+    c = (content or "").strip()
+    if not c:
+        return True
+    if len(c.split()) <= 1 and (len(c) <= _PREFETCH_MIN_FRAGMENT_CHARS
+                                or c.lower() in _PREFETCH_FRAGMENT_STOPWORDS):
+        return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Tool schemas
 # ---------------------------------------------------------------------------
@@ -1113,7 +1143,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             import os
             author_id = self._beam.author_id or os.environ.get("MNEMOSYNE_AUTHOR_ID")
             recall_kwargs: Dict[str, Any] = dict(
-                query=query, top_k=8,
+                query=query, top_k=_PREFETCH_OVERFETCH,  # over-fetch; junk filtered below
                 temporal_weight=0.2, temporal_halflife=48,
             )
             # Only pass author_id when explicitly non-empty.  Passing an empty
@@ -1135,9 +1165,12 @@ class MnemosyneMemoryProvider(MemoryProvider):
             MIN_IMPORTANCE_THRESHOLD = 0.5
             filtered = [
                 r for r in results
-                if r.get("score", 0) >= MIN_SCORE_THRESHOLD
-                or r.get("importance", 0) >= MIN_IMPORTANCE_THRESHOLD
+                if (r.get("score", 0) >= MIN_SCORE_THRESHOLD
+                    or r.get("importance", 0) >= MIN_IMPORTANCE_THRESHOLD)
+                and not _is_low_quality_prefetch(r.get("content", ""))
             ]
+            # Cap back to the intended injection size after over-fetch+filter.
+            filtered = filtered[:_PREFETCH_TOP_K]
             if not filtered:
                 return ""
             lines = ["## Mnemosyne Context"]

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -720,6 +720,11 @@ class TestProviderContextSafety:
         spec = importlib.util.spec_from_file_location("mnemo_provider_test", provider_path)
         mod = importlib.util.module_from_spec(spec)
         assert spec.loader is not None
+        # Register before exec so dataclasses defined under
+        # ``from __future__ import annotations`` can resolve their module
+        # namespace (dataclass field processing does sys.modules[cls.__module__]).
+        # monkeypatch auto-reverts the entry after the test.
+        monkeypatch.setitem(sys.modules, spec.name, mod)
         spec.loader.exec_module(mod)
 
         provider = mod.MnemosyneMemoryProvider()

--- a/tests/test_prefetch_low_quality.py
+++ b/tests/test_prefetch_low_quality.py
@@ -1,0 +1,59 @@
+"""Tests for the prefetch low-quality fragment filter.
+
+The regex fact extractor can emit bare single-token "facts" (a stray adverb, a
+particle, or a truncated word). Those tokens FTS-match common query words and can
+score above real memories, so they must not dominate the per-turn prefetch window.
+A real, injectable memory is a phrase; a lone short/stopword token is dropped.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_memory_provider import _is_low_quality_prefetch as is_junk
+
+
+@pytest.mark.parametrize("frag", ["", "  ", "what", "very", "is", "still", "almost", "over"])
+def test_lone_fragments_are_dropped(frag):
+    assert is_junk(frag) is True
+
+
+@pytest.mark.parametrize("real", [
+    "Paris is the capital of France",
+    "water boils at 100C",
+    "film school",                 # two-word value survives
+    "the meeting is on Tuesday",
+])
+def test_real_phrases_are_kept(real):
+    assert is_junk(real) is False
+
+
+class FakeBeam:
+    """Returns a fixed mix of junk fragments and real phrases regardless of query."""
+    author_id = "test-author"
+
+    def recall(self, query, top_k, temporal_weight, temporal_halflife, author_id):
+        return [
+            # bare fragments scoring high on keyword match — must be filtered out
+            {"content": "what", "timestamp": "2026-05-14T12:00:00Z",
+             "importance": 0.1, "score": 0.63, "trust_tier": "STATED"},
+            {"content": "still", "timestamp": "2026-05-14T12:00:00Z",
+             "importance": 0.1, "score": 0.62, "trust_tier": "STATED"},
+            # a real, sentence-length memory scoring lower — must survive
+            {"content": "Paris is the capital of France", "timestamp": "2026-05-14T12:00:00Z",
+             "importance": 0.6, "score": 0.40, "trust_tier": "STATED"},
+        ]
+
+
+def test_prefetch_drops_fragments_and_keeps_real_memory(monkeypatch):
+    monkeypatch.delenv("MNEMOSYNE_PREFETCH_CONTENT_CHARS", raising=False)
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    provider = MnemosyneMemoryProvider()
+    provider._beam = FakeBeam()
+
+    block = provider.prefetch("what matters most")
+
+    assert "Paris is the capital of France" in block
+    # The bare fragments must not appear as injected memory lines.
+    for line in block.splitlines():
+        assert line.strip() not in {"what", "still"}

--- a/tests/test_prefetch_profiles.py
+++ b/tests/test_prefetch_profiles.py
@@ -1,0 +1,117 @@
+"""Tests for selectable prefetch profiles + the generic source-extension hook.
+
+The default `general` profile must reproduce prior behavior exactly; other
+profiles only change the documented knobs. The source registry lets a caller
+merge extra retrieval inputs without the core knowing what they are.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_memory_provider import (
+    MnemosyneMemoryProvider,
+    PrefetchProfile,
+    _resolve_profile,
+    register_profile,
+)
+
+
+class FakeBeam:
+    """Records the kwargs recall() was called with; returns fixed results."""
+    author_id = "test-author"
+
+    def __init__(self, results):
+        self.results = results
+        self.last_kwargs = None
+
+    def recall(self, **kwargs):
+        self.last_kwargs = kwargs
+        return self.results
+
+
+def _provider(profile_name, results):
+    p = MnemosyneMemoryProvider()
+    p._beam = FakeBeam(results)
+    p._prefetch_profile = profile_name
+    return p
+
+
+# --- profile resolution ------------------------------------------------------
+
+def test_unknown_profile_falls_back_to_general():
+    assert _resolve_profile("does-not-exist").name == "general"
+    assert _resolve_profile(None).name == "general"
+
+
+def test_general_is_the_default_and_passes_no_tuning_weights():
+    p = _provider("general", [
+        {"content": "Paris is the capital of France", "timestamp": "2026-05-14T12:00:00Z",
+         "importance": 0.9, "score": 0.9, "trust_tier": "STATED"},
+    ])
+    block = p.prefetch("capital of France")
+    assert block.startswith("## Mnemosyne Context")
+    assert "Paris is the capital of France" in block
+    # general leaves recall()'s own weighting defaults untouched
+    assert "importance_weight" not in p._beam.last_kwargs
+    assert p._beam.last_kwargs["temporal_weight"] == 0.2
+
+
+def test_social_chat_passes_its_tuning_to_recall():
+    p = _provider("social-chat", [
+        {"content": "the team ships on Friday", "timestamp": "2026-05-14T12:00:00Z",
+         "importance": 0.9, "score": 0.4, "trust_tier": "STATED"},
+    ])
+    p.prefetch("when do we ship")
+    assert p._beam.last_kwargs["importance_weight"] == 0.6
+    assert p._beam.last_kwargs["temporal_weight"] == 0.35
+    assert p._beam.last_kwargs["temporal_halflife"] == 24
+
+
+# --- generic source hook -----------------------------------------------------
+
+def test_registered_source_is_merged():
+    p = _provider("general", [
+        {"content": "Paris is the capital of France", "timestamp": "2026-05-14T12:00:00Z",
+         "importance": 0.9, "score": 0.9, "trust_tier": "STATED"},
+    ])
+    register_profile(PrefetchProfile(name="t-merge", sources=("bank", "dummy")))
+    p._prefetch_profile = "t-merge"
+    p.register_prefetch_source(
+        "dummy", lambda q, *, session_id="": [{"content": "Lake Baikal is the deepest lake"}])
+    block = p.prefetch("geography")
+    assert "Paris is the capital of France" in block
+    assert "Lake Baikal is the deepest lake" in block
+    assert "## Context (dummy)" in block
+
+
+def test_bank_source_cannot_be_overridden():
+    p = _provider("general", [])
+    p.register_prefetch_source("bank", lambda q, *, session_id="": "nope")
+    assert "bank" not in p._prefetch_sources
+
+
+def test_dedup_collapses_duplicate_content_across_sources():
+    p = _provider("general", [
+        {"content": "Mount Everest is the tallest mountain", "timestamp": "2026-05-14T12:00:00Z",
+         "importance": 0.9, "score": 0.9, "trust_tier": "STATED"},
+    ])
+    register_profile(PrefetchProfile(name="t-dedup", sources=("bank", "dummy"), dedup=True))
+    p._prefetch_profile = "t-dedup"
+    p.register_prefetch_source(
+        "dummy", lambda q, *, session_id="": [{"content": "Mount Everest is the tallest mountain"}])
+    block = p.prefetch("mountains")
+    assert block.count("Mount Everest is the tallest mountain") == 1
+
+
+# --- env precedence (back-compat with the existing content-chars override) ----
+
+def test_env_content_chars_override_beats_profile(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_CONTENT_CHARS", "20")
+    long_content = "Mount Everest " * 10 + "tail"
+    p = _provider("general", [
+        {"content": long_content, "timestamp": "2026-05-14T12:00:00Z",
+         "importance": 0.9, "score": 0.9, "trust_tier": "STATED"},
+    ])
+    block = p.prefetch("everest")
+    assert "tail" not in block          # truncated by the env limit
+    assert block.rstrip().endswith("...")


### PR DESCRIPTION
## What

Make the per-turn prefetch configurable via named **profiles** and let callers
register additional retrieval **sources**, without changing default behavior.

## Why

`prefetch()` hardcodes its knobs (`top_k`, recall weights, temporal decay,
thresholds) and reads a single source (the memory bank). Different deployments want
different recall behavior — a general assistant, a social-chat/companion agent, a
coding assistant — and some want to blend in their own retrieval inputs. Today that
needs a fork. This adds:

1. **`PrefetchProfile`** — a named bundle of the existing knobs (plus the
   low-quality fragment filter and dedup as toggles). A built-in registry ships
   `general` (the default) and `social-chat`; callers can `register_profile()`
   their own. Selection via `MNEMOSYNE_PREFETCH_PROFILE`.
2. **A generic source-extension hook** — `register_prefetch_source(name, fn)` — so
   a profile can merge hits from additional sources it names in `sources`. The core
   knows nothing about what a source is; downstreams keep their specifics to
   themselves. `"bank"` is the built-in memory source and cannot be overridden.

## Back-compat

Default profile is `general`, which reproduces current behavior exactly (knobs
unchanged; default `sources=("bank",)`; the bank path is factored into
`_prefetch_bank()` but byte-for-byte equivalent). No config required; everything
opt-in. Existing per-knob env overrides still win over the profile.

## Tests

Adds `tests/test_prefetch_profiles.py` — profile resolution + fallback, the
`general` default passing no tuning weights, `social-chat` tuning reaching
`recall()`, the source hook + merge, dedup across sources, and env-override
precedence. Also registers the dynamically-loaded provider module in `sys.modules`
in an existing test (`test_beam.py`), required now that the module defines a
dataclass under `from __future__ import annotations`.

## Note

Stacked on #243 (low-quality prefetch filter); until that merges, this PR's diff
includes its commit. Please review/merge after #243.
