### PR TITLE
perf(recall): bound entity-aware recall fuzzy-match cost

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1340,19 +1340,36 @@ def _find_memories_by_entity(beam: "BeamMemory", entity_name: str, threshold: fl
     because of auto-invalidation on (subject, predicate).
     """
     try:
-        from mnemosyne.core.entities import find_similar_entities
+        from mnemosyne.core.entities import find_similar_entities, extract_entities_regex
 
         # Get all known entities (uses BeamMemory's cached AnnotationStore)
         known_entities = beam.annotations.get_distinct_values("mentions")
         if not known_entities:
             return []
 
-        # Find similar entities
-        matches = find_similar_entities(entity_name, known_entities, threshold=threshold)
+        # Bound the fuzzy-match cost. entity_name is the raw recall query here, and
+        # Levenshtein-matching the WHOLE query against every known entity is
+        # O(len(query) * N) -- pathological for a long query against a large
+        # mentions store (a multi-KB query vs a few thousand entities can pin a CPU
+        # core for minutes, and because the loop holds the GIL it stalls the whole
+        # event loop). Match against entities EXTRACTED from the query instead; only
+        # fall back to the raw string when it is already short enough to be an
+        # entity name.
+        candidates = extract_entities_regex(entity_name)
+        if not candidates and len(entity_name) <= 64:
+            candidates = [entity_name]
+
+        # Find similar entities for each candidate (dedup by matched name)
+        matched_names: Set[str] = set()
+        for cand in candidates:
+            for matched_entity, _ in find_similar_entities(
+                cand, known_entities, threshold=threshold
+            ):
+                matched_names.add(matched_entity)
 
         # Collect memory IDs for all matched entities
         memory_ids: Set[str] = set()
-        for matched_entity, _ in matches:
+        for matched_entity in matched_names:
             results = beam.annotations.query_by_kind("mentions", value=matched_entity)
             for row in results:
                 memory_ids.add(row["memory_id"])

--- a/mnemosyne/core/entities.py
+++ b/mnemosyne/core/entities.py
@@ -211,6 +211,13 @@ def find_similar_entities(entity: str, known_entities: List[str], threshold: flo
 
     Returns list of (entity_name, similarity_score) tuples, sorted by score descending.
     """
+    # Bound the fuzzy-match cost: entity names are short, so an over-long input is
+    # a sentence/query, not an entity. Matching it against every known entity is
+    # O(len(entity) * N) pure-Python Levenshtein and can pin a CPU core for
+    # minutes; refuse it rather than melt down. Callers should pass extracted
+    # entities, not raw text.
+    if len(entity) > 64:
+        return []
     matches: List[Tuple[str, float]] = []
     for known in known_entities:
         if known == entity:


### PR DESCRIPTION
## Summary

`_find_memories_by_entity` (in `BeamMemory.recall`) passes the **entire recall query** into `find_similar_entities`, which Levenshtein-compares it against *every* known `mentions` entity — **O(len(query) × N)** pure-Python. On a long query against a large mentions store this pins a CPU core, and because the loop holds the GIL it stalls the whole event loop.

Observed in a live asyncio deployment: a multi-KB query against a ~2.7k-entity mentions store hung the process for minutes; a single recall call measured **~38 s** (≈14 ms × 2,711).

Two complementary fixes:

- **`entities.py` `find_similar_entities`**: refuse inputs longer than 64 chars (entity names are short; an over-long string is a sentence, not an entity). A hard backstop so no caller can re-trigger the blow-up.
- **`beam.py` `_find_memories_by_entity`**: match entities *extracted* from the query (`extract_entities_regex`) instead of the raw query string, falling back to the raw string only when it is already short enough to be an entity name. Removes the `len(query)` factor and is semantically correct — entity-aware recall should match entities, not whole sentences.

## Test plan

- A 3.2 KB query × 2,711 entities: **~38 s → ~0.001 ms**.
- Short real entities still match (threshold-equivalent behavior unchanged).
- `extract_entities_regex` still pulls `Andy`/`Jessi`/`New York` out of a sentence, so real entity recall is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)