### PR TITLE
test: ensure recall relevance gates importance

### DIFF
--- a/tests/test_recall_precision_regressions.py
+++ b/tests/test_recall_precision_regressions.py
@@ -115,6 +115,28 @@ class TestRecallPrecisionRegressions(unittest.TestCase):
         results = self.beam.recall("customer invoices quantum", top_k=5)
         self.assertEqual([], results)
 
+    def test_high_importance_unrelated_memory_cannot_rescue_itself(self):
+        """Importance may boost relevant candidates, but must not create relevance."""
+        self.beam.remember(
+            "Orchid care dashboard access lives in the greenhouse portal and should be checked before watering schedules.",
+            source="imported_fixture",
+            importance=0.99,
+            scope="global",
+            veracity="imported",
+        )
+        self.beam.remember(
+            "Database adapter timeout is configured to 30 seconds for read replicas.",
+            source="imported_fixture",
+            importance=0.1,
+            scope="global",
+            veracity="imported",
+        )
+
+        results = self.beam.recall("database adapter timeout", top_k=5)
+        joined = "\n".join(r["content"] for r in results).lower()
+        self.assertIn("database adapter timeout", joined)
+        self.assertNotIn("orchid care dashboard", joined)
+
     def test_memoria_date_or_sequence_fact_does_not_force_top_slot(self):
         results = self.beam.recall("Where is the Orion runner jar and how should it bind?", top_k=5)
         self.assertTrue(results)


### PR DESCRIPTION
## Description

Adds regression coverage for recall ranking where a high-importance but unrelated memory should not be returned for an unrelated query.

The test codifies the intended recall invariant: relevance must be established before importance can affect ranking. A low-importance relevant memory should still surface, while a high-importance unrelated memory should not be rescued by importance alone.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / performance
- [x] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [ ] Existing tests still pass (`pytest tests/ -v`)
- [x] New tests added for any new functionality
- [x] Manual verification

Validation run locally:

```bash
python3 -m pytest tests/test_recall_precision_regressions.py -q -o 'addopts='
```

Result:

```text
11 passed
```

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py`  
  Not applicable: test-only regression coverage.
- [ ] `CHANGELOG.md` updated with a brief entry  
  Not applicable: no user-facing behavior change.
- [ ] README updated if user-facing behavior changed  
  Not applicable.
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency
