### PR TITLE
feat(core): owner-scoped canonical (single-source-of-truth) facts (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
+## [3.5.0] — 2026-06-09
+
+### Added
+
+- **Owner-scoped canonical (single-source-of-truth) facts** (issue #256). A new
+  `CanonicalStore` (`mnemosyne/core/canonical.py`) gives long-running personas an
+  identity layer where each `(owner_id, category, name)` slot holds exactly one
+  current value. Restating a stable self-fact is a no-op (no duplicate
+  accumulation); a new value supersedes the old one, which is preserved as
+  history — the TripleStore `valid_until` pattern, extended with an owner
+  dimension. Implemented as **one SQLite table plus a partial unique index**
+  (`… WHERE valid_until IS NULL`); no new dependency, no FTS table.
+  - Two new tools, `mnemosyne_remember_canonical` and `mnemosyne_recall_canonical`
+    (the latter covers exact-slot read, category/whole-bank listing, version
+    history, and owner-scoped substring search). Exposed on both the Hermes
+    provider and the MCP surface — total tool count 23 → 25.
+  - `BeamMemory` now exposes `self.canonical`, sharing its thread-local
+    connection (no extra file descriptor), mirroring `self.annotations`.
+  - Owner isolation is enforced by construction: the provider derives `owner_id`
+    from the active profile identity and never reads it from tool args, so one
+    profile cannot read or write another's canonical bank. The shared surface is
+    untouched and keeps its cross-profile role.
+  - Fully additive and opt-in: the `canonical_facts` table is created lazily on
+    first init; existing tables, tools, and recall output are unchanged.
+
 ## [3.4.0] — 2026-06-01
 
 ### Added

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -538,6 +538,46 @@ triples = store.get_triples_for_subject("memory_id_abc")
 
 ---
 
+## CanonicalStore (Single Source of Truth)
+
+**Module:** `mnemosyne.core.canonical`
+
+Owner-scoped canonical facts. Each `(owner_id, category, name)` slot holds
+exactly **one** current value — the right home for a persona's stable identity
+cards (name, voice, durable preferences) that must not contradict themselves
+over time. Restating a value is a no-op; a new value supersedes the old one,
+which is preserved as history (the TripleStore `valid_until` pattern, with an
+owner dimension). Backed by one SQLite table plus a partial unique index — no
+new dependency.
+
+```python
+from mnemosyne.core.canonical import CanonicalStore
+
+store = CanonicalStore(db_path)
+
+# Upsert the canonical value for a slot (returns the current row + status).
+store.remember("jessi", "identity", "name", "My name is Jessi.")   # status="created"
+store.remember("jessi", "identity", "name", "My name is Jessi.")   # status="unchanged" (no-op)
+store.remember("jessi", "identity", "name", "I go by Jess now.")    # status="updated"
+
+store.recall("jessi", "identity", "name")["body"]      # "I go by Jess now."
+store.list("jessi")                                    # all current slots for the owner
+store.list("jessi", category="identity")               # one category
+store.history("jessi", "identity", "name")             # every version, newest first
+store.search("jessi", "Jess")                          # owner-scoped substring search
+store.forget("jessi", "identity", "name")              # retire a slot (kept as history)
+```
+
+When used through `BeamMemory` the store is available as `beam.canonical`,
+sharing the beam's connection. Two profiles each get an isolated namespace via
+`owner_id`; the shared surface remains the place for *cross-profile* sharing.
+
+Exposed as the `mnemosyne_remember_canonical` and `mnemosyne_recall_canonical`
+tools (see below). The provider derives `owner_id` from the active profile, so a
+profile cannot reach another profile's canonical bank.
+
+---
+
 ## MCP Server
 
 **Module:** `mnemosyne.mcp_server`

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -531,6 +531,51 @@ TRIPLE_QUERY_SCHEMA = {
     },
 }
 
+REMEMBER_CANONICAL_SCHEMA = {
+    "name": "mnemosyne_remember_canonical",
+    "description": (
+        "Store a CANONICAL (single-source-of-truth) self-fact for the current "
+        "profile. Each (category, name) slot holds exactly one current value: "
+        "restating the same body is a no-op, and a new body supersedes the old "
+        "one (kept as history). Use for stable identity cards — name, voice, "
+        "stable preferences, relationships — that must not contradict themselves "
+        "over time. Scoped privately to this profile. For relational facts use "
+        "mnemosyne_triple_add; for episodic recall use mnemosyne_remember."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "category": {"type": "string", "description": "Slot group, e.g. 'identity', 'voice', 'preference'"},
+            "name": {"type": "string", "description": "Slot key within the category, e.g. 'name', 'pronouns'"},
+            "body": {"type": "string", "description": "The authoritative free-text value for this slot"},
+            "source": {"type": "string", "description": "Optional provenance label", "default": ""},
+            "confidence": {"type": "number", "description": "Optional 0..1 confidence", "default": 1.0},
+        },
+        "required": ["category", "name", "body"],
+    },
+}
+
+RECALL_CANONICAL_SCHEMA = {
+    "name": "mnemosyne_recall_canonical",
+    "description": (
+        "Read CANONICAL self-facts for the current profile. With category+name: "
+        "return the single authoritative value for that slot. With category "
+        "only: list that category's slots. With query: substring-search the "
+        "profile's canonical values. With nothing: list all canonical slots. "
+        "Set include_history=true to also return superseded versions of a slot."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "category": {"type": "string", "default": ""},
+            "name": {"type": "string", "default": ""},
+            "query": {"type": "string", "description": "Substring search across the profile's canonical values", "default": ""},
+            "include_history": {"type": "boolean", "description": "Include superseded versions (requires category+name)", "default": False},
+            "limit": {"type": "integer", "description": "Max results for query/list modes", "default": 10},
+        },
+    },
+}
+
 SCRATCHPAD_WRITE_SCHEMA = {
     "name": "mnemosyne_scratchpad_write",
     "description": "Write a temporary note to the Mnemosyne scratchpad.",
@@ -712,6 +757,7 @@ ALL_TOOL_SCHEMAS = [
     REMEMBER_SCHEMA, RECALL_SCHEMA, SHARED_REMEMBER_SCHEMA, SHARED_RECALL_SCHEMA,
     SHARED_FORGET_SCHEMA, SHARED_STATS_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
     INVALIDATE_SCHEMA, VALIDATE_SCHEMA, GET_SCHEMA, TRIPLE_ADD_SCHEMA, TRIPLE_QUERY_SCHEMA,
+    REMEMBER_CANONICAL_SCHEMA, RECALL_CANONICAL_SCHEMA,
     SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
     EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
     GRAPH_QUERY_SCHEMA, GRAPH_LINK_SCHEMA,
@@ -1475,6 +1521,10 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_triple_add(args)
             elif tool_name == "mnemosyne_triple_query":
                 return self._handle_triple_query(args)
+            elif tool_name == "mnemosyne_remember_canonical":
+                return self._handle_remember_canonical(args)
+            elif tool_name == "mnemosyne_recall_canonical":
+                return self._handle_recall_canonical(args)
             elif tool_name == "mnemosyne_scratchpad_write":
                 return self._handle_scratchpad_write(args)
             elif tool_name == "mnemosyne_scratchpad_read":
@@ -1910,6 +1960,84 @@ class MnemosyneMemoryProvider(MemoryProvider):
         results = query_triples(subject=subject, predicate=predicate, object=obj,
                                 db_path=self._beam.db_path)
         return json.dumps({"count": len(results), "results": results})
+
+    def _canonical_owner(self) -> str:
+        """Owner id for canonical reads/writes: the active profile identity.
+
+        Derived internally and never taken from tool args, so a profile cannot
+        read or write another profile's canonical bank — owner isolation is
+        enforced by construction. Falls back to "default" when no profile
+        identity is set (single-profile / non-persona deployments)."""
+        return (getattr(self, "_agent_identity", None) or "").strip() or "default"
+
+    def _handle_remember_canonical(self, args: Dict[str, Any]) -> str:
+        category = (args.get("category") or "").strip()
+        name = (args.get("name") or "").strip()
+        body = (args.get("body") or "").strip()
+        if not category or not name:
+            return json.dumps({"error": "category and name are required"})
+        if not body:
+            return json.dumps({"error": "body is required"})
+        source = args.get("source") or "canonical_tool"
+        try:
+            confidence = float(args.get("confidence", 1.0))
+        except (TypeError, ValueError):
+            confidence = 1.0
+        owner_id = self._canonical_owner()
+        row = self._beam.canonical.remember(
+            owner_id, category, name, body,
+            source=source, confidence=confidence,
+        )
+        status = row.pop("status", "stored")
+        self._audit_event(
+            "remember_canonical", bank="canonical",
+            source_tool="mnemosyne_remember_canonical",
+            metadata={"category": category, "name": name, "status": status,
+                      "version": row.get("version")},
+        )
+        return json.dumps({
+            "status": status,
+            "owner_id": owner_id,
+            "category": category,
+            "name": name,
+            "version": row.get("version"),
+            "body_preview": body[:120],
+        })
+
+    def _handle_recall_canonical(self, args: Dict[str, Any]) -> str:
+        category = (args.get("category") or "").strip()
+        name = (args.get("name") or "").strip()
+        query = (args.get("query") or "").strip()
+        include_history = bool(args.get("include_history", False))
+        try:
+            limit = int(args.get("limit", 10))
+        except (TypeError, ValueError):
+            limit = 10
+        owner_id = self._canonical_owner()
+        store = self._beam.canonical
+
+        # Free-text search mode.
+        if query:
+            results = store.search(owner_id, query, limit=limit)
+            return json.dumps({"mode": "search", "owner_id": owner_id,
+                               "query": query, "count": len(results),
+                               "results": results})
+        # Exact slot read (optionally with history).
+        if category and name:
+            if include_history:
+                results = store.history(owner_id, category, name)
+                return json.dumps({"mode": "history", "owner_id": owner_id,
+                                   "category": category, "name": name,
+                                   "count": len(results), "results": results})
+            row = store.recall(owner_id, category, name)
+            return json.dumps({"mode": "recall", "owner_id": owner_id,
+                               "category": category, "name": name,
+                               "found": row is not None, "result": row})
+        # List mode (whole bank, or one category).
+        results = store.list(owner_id, category=category or None)
+        return json.dumps({"mode": "list", "owner_id": owner_id,
+                           "category": category or None,
+                           "count": len(results), "results": results})
 
     def _handle_scratchpad_write(self, args: Dict[str, Any]) -> str:
         content = args.get("content", "").strip()

--- a/integrations/hermes/src/mnemosyne_hermes/tools.py
+++ b/integrations/hermes/src/mnemosyne_hermes/tools.py
@@ -273,6 +273,51 @@ TRIPLE_QUERY_SCHEMA = {
     },
 }
 
+REMEMBER_CANONICAL_SCHEMA = {
+    "name": "mnemosyne_remember_canonical",
+    "description": (
+        "Store a CANONICAL (single-source-of-truth) self-fact for the current "
+        "profile. Each (category, name) slot holds exactly one current value: "
+        "restating the same body is a no-op, and a new body supersedes the old "
+        "one (kept as history). Use for stable identity cards — name, voice, "
+        "stable preferences, relationships — that must not contradict themselves "
+        "over time. Scoped privately to this profile. For relational facts use "
+        "mnemosyne_triple_add; for episodic recall use mnemosyne_remember."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "category": {"type": "string", "description": "Slot group, e.g. 'identity', 'voice', 'preference'"},
+            "name": {"type": "string", "description": "Slot key within the category, e.g. 'name', 'pronouns'"},
+            "body": {"type": "string", "description": "The authoritative free-text value for this slot"},
+            "source": {"type": "string", "description": "Optional provenance label", "default": ""},
+            "confidence": {"type": "number", "description": "Optional 0..1 confidence", "default": 1.0},
+        },
+        "required": ["category", "name", "body"],
+    },
+}
+
+RECALL_CANONICAL_SCHEMA = {
+    "name": "mnemosyne_recall_canonical",
+    "description": (
+        "Read CANONICAL self-facts for the current profile. With category+name: "
+        "return the single authoritative value for that slot. With category "
+        "only: list that category's slots. With query: substring-search the "
+        "profile's canonical values. With nothing: list all canonical slots. "
+        "Set include_history=true to also return superseded versions of a slot."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "category": {"type": "string", "default": ""},
+            "name": {"type": "string", "default": ""},
+            "query": {"type": "string", "description": "Substring search across the profile's canonical values", "default": ""},
+            "include_history": {"type": "boolean", "description": "Include superseded versions (requires category+name)", "default": False},
+            "limit": {"type": "integer", "description": "Max results for query/list modes", "default": 10},
+        },
+    },
+}
+
 SCRATCHPAD_WRITE_SCHEMA = {
     "name": "mnemosyne_scratchpad_write",
     "description": "Write a temporary note to the Mnemosyne scratchpad.",
@@ -454,6 +499,7 @@ ALL_TOOL_SCHEMAS = [
     REMEMBER_SCHEMA, RECALL_SCHEMA, SHARED_REMEMBER_SCHEMA, SHARED_RECALL_SCHEMA,
     SHARED_FORGET_SCHEMA, SHARED_STATS_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
     INVALIDATE_SCHEMA, VALIDATE_SCHEMA, GET_SCHEMA, TRIPLE_ADD_SCHEMA, TRIPLE_QUERY_SCHEMA,
+    REMEMBER_CANONICAL_SCHEMA, RECALL_CANONICAL_SCHEMA,
     SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
     EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
     GRAPH_QUERY_SCHEMA, GRAPH_LINK_SCHEMA,

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1978,6 +1978,13 @@ class BeamMemory:
         from mnemosyne.core.annotations import AnnotationStore
         self.annotations = AnnotationStore(db_path=self.db_path, conn=self.conn)
 
+        # Owner-scoped canonical (single-source-of-truth) facts (issue #256).
+        # Shares this BeamMemory's thread-local connection like AnnotationStore.
+        # Lazily wired and additive — opening an existing DB just creates the
+        # canonical_facts table on first init; nothing else changes.
+        from mnemosyne.core.canonical import CanonicalStore
+        self.canonical = CanonicalStore(db_path=self.db_path, conn=self.conn)
+
         # Phase 3: Episodic graph (shared connection)
         self.episodic_graph = None
         if EpisodicGraph is not None:

--- a/mnemosyne/core/canonical.py
+++ b/mnemosyne/core/canonical.py
@@ -1,0 +1,563 @@
+"""
+Mnemosyne CanonicalStore
+========================
+Owner-scoped single-source-of-truth ("canonical") facts.
+
+Motivation (issue #256)
+-----------------------
+Long-running companion personas need *identity consistency over time*: a
+persona's stable self-facts ("my name is X", "I speak in Y register") must not
+contradict themselves months apart. Stored as ordinary working/episodic
+entries those facts have no uniqueness guarantee — restating one accumulates
+near-duplicates, and a later change coexists with the stale value rather than
+superseding it, so recall surfaces conflicting copies.
+
+The TripleStore already solves this for clean relational ``(subject, predicate,
+object)`` facts via ``valid_until`` supersession. CanonicalStore brings the same
+single-current-truth discipline to *free-text identity cards* that do not reduce
+to one S-P-O triple, and adds the missing **owner scope**: a
+``UNIQUE(owner_id, category, name)`` slot that holds exactly one current value.
+
+Two orthogonal axes
+-------------------
+"Canonical-ness" (a uniqueness/upsert discipline) is independent of
+"shared-ness" (who can read it). CanonicalStore fills the *private + canonical*
+cell:
+
+    |                     | free-text / episodic        | canonical (single truth)  |
+    | private (one owner) | per-profile lived recall    | CanonicalStore (this file)|
+    | shared (all owners) | the shared surface          | (out of scope)            |
+
+Owner isolation is automatic: every read and write is keyed by ``owner_id``, so
+two personas each get their own namespace and a non-persona profile simply has
+none. They can still exchange memory through the shared surface, which this does
+not touch.
+
+Design
+------
+- **One table + a partial unique index** — no new dependency, no FTS table.
+  ``canonical_facts`` holds both the current value and its superseded history;
+  a partial unique index over ``(owner_id, category, name) WHERE valid_until IS
+  NULL`` guarantees exactly one *current* row per slot while letting historical
+  rows accumulate in the same table (mirrors the TripleStore ``valid_until``
+  pattern, with an owner dimension added).
+- **Upsert-in-place** — ``remember`` closes the prior current row (stamps
+  ``valid_until``) and inserts the new value with ``version + 1``. Re-storing an
+  identical body is a no-op, so restating a stable fact never accumulates
+  duplicates.
+- **Point lookup** — ``recall`` is an indexed ``(owner_id, category, name)``
+  read of the single current row; cheaper than hybrid vector search for a
+  known-key identity read.
+
+This complements, not replaces, episodic memory and the TripleStore: relational
+facts still belong in triples; free-text identity cards get a deduped
+authoritative slot here.
+"""
+
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Optional
+
+
+# Default DB location. Mirrors BeamMemory's default (the main mnemosyne.db) so a
+# standalone CanonicalStore() lands in the same database the provider wires it
+# into via a shared connection. Resolved at call time so MNEMOSYNE_DATA_DIR is
+# honored without importing beam (avoids a circular import).
+def _default_db_path() -> Path:
+    data_dir = os.environ.get("MNEMOSYNE_DATA_DIR")
+    base = Path(data_dir) if data_dir else (Path.home() / ".hermes" / "mnemosyne" / "data")
+    return base / "mnemosyne.db"
+
+
+def _now() -> str:
+    """ISO timestamp used for valid_from / valid_until. Second precision is
+    enough for an identity store and keeps history rows human-readable."""
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _get_conn(db_path: Optional[Path] = None) -> sqlite3.Connection:
+    path = Path(db_path) if db_path else _default_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_canonical(db_path: Optional[Path] = None) -> None:
+    """Create the canonical_facts table and indexes if absent.
+
+    Idempotent. Safe on databases that already have the table. Opens and
+    closes its own connection; does not leak file descriptors.
+    """
+    conn = _get_conn(db_path)
+    try:
+        _init_canonical_with_conn(conn)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def _init_canonical_with_conn(conn: sqlite3.Connection) -> None:
+    """Run schema DDL on an existing connection. Caller owns conn lifetime."""
+    cursor = conn.cursor()
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS canonical_facts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            owner_id TEXT NOT NULL,
+            category TEXT NOT NULL,
+            name TEXT NOT NULL,
+            body TEXT NOT NULL,
+            source TEXT,
+            confidence REAL DEFAULT 1.0,
+            version INTEGER NOT NULL DEFAULT 1,
+            valid_from TEXT NOT NULL,
+            valid_until TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    # Exactly-one-current-value-per-slot. A PARTIAL unique index (WHERE
+    # valid_until IS NULL) is what reconciles "single source of truth" with
+    # "keep history in the same table": only the live row participates in the
+    # constraint, superseded rows (valid_until set) are unconstrained. Using a
+    # unique INDEX rather than a table constraint lets pre-existing tables
+    # acquire the guarantee on next init via IF NOT EXISTS — no migration.
+    cursor.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_canonical_current "
+        "ON canonical_facts(owner_id, category, name) WHERE valid_until IS NULL"
+    )
+    # Slot history reads ("all versions of this fact") and point lookups.
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_canonical_slot "
+        "ON canonical_facts(owner_id, category, name)"
+    )
+    # Owner/category listing ("the persona's whole self-card set").
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_canonical_owner_category "
+        "ON canonical_facts(owner_id, category)"
+    )
+
+    conn.commit()
+
+
+class CanonicalStore:
+    """
+    Owner-scoped single-source-of-truth facts.
+
+    Each ``(owner_id, category, name)`` slot holds exactly one current value;
+    re-storing the same body is a no-op, and storing a new body supersedes the
+    old one (preserved as history).
+
+    Example:
+        >>> store = CanonicalStore()
+        >>> store.remember("jessi", "identity", "name", "My name is Jessi.")
+        >>> store.remember("jessi", "identity", "name", "My name is Jessi.")  # no-op
+        >>> store.recall("jessi", "identity", "name")["body"]
+        'My name is Jessi.'
+        >>> store.remember("jessi", "identity", "name", "I go by Jess now.")  # supersede
+        >>> store.recall("jessi", "identity", "name")["body"]
+        'I go by Jess now.'
+        >>> [h["body"] for h in store.history("jessi", "identity", "name")]
+        ['I go by Jess now.', 'My name is Jessi.']
+
+    Owner isolation is enforced on every method — a read or write for one
+    ``owner_id`` never sees or touches another's rows.
+    """
+
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        conn: Optional[sqlite3.Connection] = None,
+    ):
+        """Create a CanonicalStore handle.
+
+        When ``conn`` is provided the store reuses that connection — this is how
+        BeamMemory shares its thread-local connection with the store, avoiding a
+        per-call file-descriptor cost. The caller owns the connection's
+        lifetime. When ``conn`` is None, CanonicalStore opens its own connection.
+        """
+        self.db_path = db_path or _default_db_path()
+        if conn is not None:
+            self.conn = conn
+            _init_canonical_with_conn(conn)
+        else:
+            init_canonical(self.db_path)
+            self.conn = _get_conn(self.db_path)
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def remember(
+        self,
+        owner_id: str,
+        category: str,
+        name: str,
+        body: str,
+        source: str = "",
+        confidence: float = 1.0,
+    ) -> Dict:
+        """Upsert the canonical value for ``(owner_id, category, name)``.
+
+        - If the slot is empty, insert version 1.
+        - If the current body is identical, no-op (returns the existing row
+          unchanged) so restating a stable fact never accumulates duplicates.
+        - Otherwise supersede: stamp ``valid_until`` on the current row and
+          insert the new body with ``version + 1``.
+
+        Returns the resulting current row as a dict, with an added
+        ``status`` key: ``"created"``, ``"unchanged"``, or ``"updated"``.
+
+        Raises ``ValueError`` if owner_id / category / name / body is empty —
+        the slot key and value must all be non-blank for the uniqueness
+        guarantee to be meaningful.
+        """
+        if not (owner_id and category and name):
+            raise ValueError("owner_id, category, and name are required")
+        if not body or not body.strip():
+            raise ValueError("body is required and cannot be blank")
+
+        cursor = self.conn.cursor()
+        # BEGIN IMMEDIATE so the read-current + supersede + insert sequence is
+        # atomic against a concurrent writer racing on the same slot (the
+        # partial unique index would otherwise reject a second live row, but we
+        # want a clean transaction rather than an IntegrityError).
+        cursor.execute("BEGIN IMMEDIATE")
+        try:
+            current = cursor.execute(
+                "SELECT * FROM canonical_facts "
+                "WHERE owner_id = ? AND category = ? AND name = ? "
+                "AND valid_until IS NULL",
+                (owner_id, category, name),
+            ).fetchone()
+
+            if current is not None and current["body"] == body:
+                self.conn.commit()
+                row = dict(current)
+                row["status"] = "unchanged"
+                return row
+
+            now = _now()
+            # Version climbs monotonically from the slot's whole history, so it
+            # keeps increasing even across a forget()+re-remember() gap (where
+            # there is no current row to read a version from). status reflects
+            # whether a live value was superseded: "created" when the slot had
+            # no current value (brand-new or previously retired), else "updated".
+            prior_max = cursor.execute(
+                "SELECT MAX(version) FROM canonical_facts "
+                "WHERE owner_id = ? AND category = ? AND name = ?",
+                (owner_id, category, name),
+            ).fetchone()[0]
+            version = (prior_max or 0) + 1
+            if current is None:
+                status = "created"
+            else:
+                cursor.execute(
+                    "UPDATE canonical_facts SET valid_until = ? WHERE id = ?",
+                    (now, current["id"]),
+                )
+                status = "updated"
+
+            cursor.execute(
+                """
+                INSERT INTO canonical_facts
+                    (owner_id, category, name, body, source, confidence,
+                     version, valid_from, valid_until)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                """,
+                (owner_id, category, name, body, source, confidence, version, now),
+            )
+            new_id = cursor.lastrowid
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
+
+        row = dict(
+            self.conn.execute(
+                "SELECT * FROM canonical_facts WHERE id = ?", (new_id,)
+            ).fetchone()
+        )
+        row["status"] = status
+        return row
+
+    def forget(self, owner_id: str, category: str, name: str) -> bool:
+        """Retire a canonical slot without replacing it.
+
+        Stamps ``valid_until`` on the current row (preserving it as history),
+        mirroring TripleStore.end() — there is then no current value for the
+        slot. Returns True if a current row was retired, False if the slot was
+        already empty. Auditable: nothing is deleted.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "UPDATE canonical_facts SET valid_until = ? "
+            "WHERE owner_id = ? AND category = ? AND name = ? "
+            "AND valid_until IS NULL",
+            (_now(), owner_id, category, name),
+        )
+        self.conn.commit()
+        return cursor.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def recall(self, owner_id: str, category: str, name: str) -> Optional[Dict]:
+        """Return the single current value for a slot, or None if unset."""
+        row = self.conn.execute(
+            "SELECT * FROM canonical_facts "
+            "WHERE owner_id = ? AND category = ? AND name = ? "
+            "AND valid_until IS NULL",
+            (owner_id, category, name),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def list(self, owner_id: str, category: Optional[str] = None) -> List[Dict]:
+        """All current canonical values for an owner, optionally one category.
+
+        Ordered by ``(category, name)`` so a persona's self-card set reads
+        stably.
+        """
+        if category is None:
+            rows = self.conn.execute(
+                "SELECT * FROM canonical_facts "
+                "WHERE owner_id = ? AND valid_until IS NULL "
+                "ORDER BY category, name",
+                (owner_id,),
+            ).fetchall()
+        else:
+            rows = self.conn.execute(
+                "SELECT * FROM canonical_facts "
+                "WHERE owner_id = ? AND category = ? AND valid_until IS NULL "
+                "ORDER BY name",
+                (owner_id, category),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def history(self, owner_id: str, category: str, name: str) -> List[Dict]:
+        """All versions of a slot (current first, then superseded), newest-first."""
+        rows = self.conn.execute(
+            "SELECT * FROM canonical_facts "
+            "WHERE owner_id = ? AND category = ? AND name = ? "
+            "ORDER BY version DESC",
+            (owner_id, category, name),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def search(self, owner_id: str, query: str, limit: int = 10) -> List[Dict]:
+        """Owner-scoped substring search over current canonical values.
+
+        Matches ``query`` (case-insensitive) against body, name, and category
+        of the owner's *current* rows. A LIKE scan is the right tool here: the
+        per-owner set is small (identity cards, not a memory firehose), and it
+        keeps the store at "one table + a unique index" — no FTS dependency. For
+        known-key reads use ``recall`` instead; this is the fuzzy fallback that
+        lets full-text lookups span canonical entries.
+        """
+        if not query or not query.strip():
+            return []
+        like = f"%{query.strip()}%"
+        rows = self.conn.execute(
+            "SELECT * FROM canonical_facts "
+            "WHERE owner_id = ? AND valid_until IS NULL "
+            "AND (body LIKE ? COLLATE NOCASE "
+            "     OR name LIKE ? COLLATE NOCASE "
+            "     OR category LIKE ? COLLATE NOCASE) "
+            "ORDER BY category, name LIMIT ?",
+            (owner_id, like, like, like, int(limit)),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Export / import (parity with TripleStore / AnnotationStore)
+    # ------------------------------------------------------------------
+
+    def export_all(self) -> List[Dict]:
+        """Export every row (current + history) as a list of dicts."""
+        rows = self.conn.execute(
+            """
+            SELECT id, owner_id, category, name, body, source, confidence,
+                   version, valid_from, valid_until, created_at
+            FROM canonical_facts
+            ORDER BY id
+            """
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def import_all(self, rows: List[Dict], force: bool = False) -> Dict:
+        """Import canonical rows from a list of dicts.
+
+        Mirrors TripleStore/AnnotationStore.import_all semantics:
+
+        - **No id collision**: insert with the imported ``id``
+          (``stats["inserted"]``).
+        - **Id collision + identical content**: skip (``stats["skipped"]``).
+        - **Id collision + different content**: insert with a fresh
+          auto-assigned id (``stats["imported_renumbered"]``).
+        - **No id supplied**: insert with a fresh id (``stats["inserted"]``).
+        - ``force=True``: on id collision, overwrite
+          (``stats["overwritten"]``).
+
+        A renumber INSERT that would create a *second live row* for an existing
+        slot (partial unique index on ``(owner_id, category, name) WHERE
+        valid_until IS NULL``) raises IntegrityError; we catch it and bucket the
+        row into ``stats["skipped"]`` — the slot is already represented in the
+        destination. Sum of stats equals ``len(rows)``.
+        """
+        stats = {"inserted": 0, "skipped": 0, "overwritten": 0,
+                 "imported_renumbered": 0}
+        cursor = self.conn.cursor()
+
+        _CONTENT_FIELDS = ("owner_id", "category", "name", "body", "source",
+                           "confidence", "version", "valid_from", "valid_until",
+                           "created_at")
+        _INSERT_DEFAULTS = {"source": "imported", "confidence": 1.0, "version": 1}
+
+        def _normalized(item):
+            return {
+                f: item.get(f) if item.get(f) is not None else _INSERT_DEFAULTS.get(f)
+                for f in _CONTENT_FIELDS
+            }
+
+        seen_ids = set()
+        for item in rows:
+            row_id = item.get("id")
+            if row_id is not None:
+                if row_id in seen_ids:
+                    raise ValueError(
+                        f"import_all: duplicate id {row_id!r} in the imported "
+                        f"batch. Deduplicate the input before calling."
+                    )
+                seen_ids.add(row_id)
+
+        cursor.execute("BEGIN IMMEDIATE")
+        try:
+            existing = cursor.execute(
+                "SELECT id, owner_id, category, name, body, source, confidence, "
+                "version, valid_from, valid_until, created_at FROM canonical_facts"
+            ).fetchall()
+            existing_snapshot = {
+                r[0]: dict(zip(_CONTENT_FIELDS, r[1:])) for r in existing
+            }
+
+            def _insert_with_id(item, row_id):
+                cursor.execute(
+                    """
+                    INSERT INTO canonical_facts
+                        (id, owner_id, category, name, body, source, confidence,
+                         version, valid_from, valid_until, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        row_id, item.get("owner_id"), item.get("category"),
+                        item.get("name"), item.get("body"),
+                        item.get("source", "imported"),
+                        item.get("confidence", 1.0), item.get("version", 1),
+                        item.get("valid_from") or _now(), item.get("valid_until"),
+                        item.get("created_at"),
+                    ),
+                )
+
+            def _insert_without_id(item):
+                cursor.execute(
+                    """
+                    INSERT INTO canonical_facts
+                        (owner_id, category, name, body, source, confidence,
+                         version, valid_from, valid_until, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        item.get("owner_id"), item.get("category"),
+                        item.get("name"), item.get("body"),
+                        item.get("source", "imported"),
+                        item.get("confidence", 1.0), item.get("version", 1),
+                        item.get("valid_from") or _now(), item.get("valid_until"),
+                        item.get("created_at"),
+                    ),
+                )
+
+            explicit_no_collision = []
+            no_id = []
+            collisions = []
+            for item in rows:
+                row_id = item.get("id")
+                if row_id is None:
+                    no_id.append(item)
+                elif row_id in existing_snapshot:
+                    collisions.append(item)
+                else:
+                    explicit_no_collision.append(item)
+
+            for item in explicit_no_collision:
+                try:
+                    _insert_with_id(item, item["id"])
+                    stats["inserted"] += 1
+                except sqlite3.IntegrityError:
+                    stats["skipped"] += 1
+            for item in no_id:
+                try:
+                    _insert_without_id(item)
+                    stats["inserted"] += 1
+                except sqlite3.IntegrityError:
+                    stats["skipped"] += 1
+
+            for item in collisions:
+                row_id = item["id"]
+                existing_content = existing_snapshot[row_id]
+                if force:
+                    cursor.execute(
+                        "DELETE FROM canonical_facts WHERE id = ?", (row_id,)
+                    )
+                    _insert_with_id(item, row_id)
+                    stats["overwritten"] += 1
+                    continue
+                if _normalized(item) == existing_content:
+                    stats["skipped"] += 1
+                    continue
+                try:
+                    _insert_without_id(item)
+                    stats["imported_renumbered"] += 1
+                except sqlite3.IntegrityError:
+                    stats["skipped"] += 1
+
+            self.conn.commit()
+        except Exception:
+            self.conn.rollback()
+            raise
+        return stats
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience functions (mirror triples.py / annotations.py shape)
+# ---------------------------------------------------------------------------
+
+def remember_canonical(
+    owner_id: str,
+    category: str,
+    name: str,
+    body: str,
+    source: str = "",
+    confidence: float = 1.0,
+    db_path: Optional[Path] = None,
+) -> Dict:
+    """Upsert a canonical fact without instantiating CanonicalStore manually."""
+    store = CanonicalStore(db_path=db_path)
+    return store.remember(owner_id, category, name, body,
+                          source=source, confidence=confidence)
+
+
+def recall_canonical(
+    owner_id: str,
+    category: str,
+    name: str,
+    db_path: Optional[Path] = None,
+) -> Optional[Dict]:
+    """Read a single canonical fact without instantiating CanonicalStore."""
+    store = CanonicalStore(db_path=db_path)
+    return store.recall(owner_id, category, name)

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -570,6 +570,85 @@ def _handle_triple_query(arguments: Dict[str, Any]) -> Dict[str, Any]:
     return {"results_count": len(results), "results": results, "store": "triples"}
 
 
+def _canonical_owner(arguments: Dict[str, Any]) -> str:
+    """Owner id for canonical ops over the MCP surface.
+
+    The shared tool schema does not expose owner_id (so an LLM can't target
+    another owner's bank); over MCP the owner is a deployment-level setting via
+    MNEMOSYNE_DEFAULT_OWNER, defaulting to "default" for single-owner use."""
+    return (os.environ.get("MNEMOSYNE_DEFAULT_OWNER") or "default").strip() or "default"
+
+
+def _handle_remember_canonical(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Handle mnemosyne_remember_canonical tool call."""
+    from mnemosyne.core.canonical import CanonicalStore
+
+    category = (arguments.get("category") or "").strip()
+    name = (arguments.get("name") or "").strip()
+    body = (arguments.get("body") or "").strip()
+    if not category or not name:
+        return {"error": "category and name are required"}
+    if not body:
+        return {"error": "body is required"}
+
+    bank = _resolve_bank(arguments)
+    mem = _create_instance(bank=bank)
+    store = getattr(mem.beam, "canonical", None)
+    if store is None:
+        db_path = mem.beam.db_path if hasattr(mem.beam, "db_path") else mem.db_path
+        store = CanonicalStore(db_path=db_path, conn=mem.beam.conn)
+
+    owner_id = _canonical_owner(arguments)
+    row = store.remember(
+        owner_id, category, name, body,
+        source=arguments.get("source", "canonical_tool"),
+        confidence=arguments.get("confidence", 1.0),
+    )
+    status = row.pop("status", "stored")
+    return {"status": status, "owner_id": owner_id, "category": category,
+            "name": name, "version": row.get("version"), "store": "canonical"}
+
+
+def _handle_recall_canonical(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Handle mnemosyne_recall_canonical tool call."""
+    from mnemosyne.core.canonical import CanonicalStore
+
+    category = (arguments.get("category") or "").strip()
+    name = (arguments.get("name") or "").strip()
+    query = (arguments.get("query") or "").strip()
+    include_history = bool(arguments.get("include_history", False))
+    try:
+        limit = int(arguments.get("limit", 10))
+    except (TypeError, ValueError):
+        limit = 10
+
+    bank = _resolve_bank(arguments)
+    mem = _create_instance(bank=bank)
+    store = getattr(mem.beam, "canonical", None)
+    if store is None:
+        db_path = mem.beam.db_path if hasattr(mem.beam, "db_path") else mem.db_path
+        store = CanonicalStore(db_path=db_path, conn=mem.beam.conn)
+    owner_id = _canonical_owner(arguments)
+
+    if query:
+        results = store.search(owner_id, query, limit=limit)
+        return {"mode": "search", "owner_id": owner_id, "query": query,
+                "results_count": len(results), "results": results, "store": "canonical"}
+    if category and name:
+        if include_history:
+            results = store.history(owner_id, category, name)
+            return {"mode": "history", "owner_id": owner_id, "category": category,
+                    "name": name, "results_count": len(results),
+                    "results": results, "store": "canonical"}
+        row = store.recall(owner_id, category, name)
+        return {"mode": "recall", "owner_id": owner_id, "category": category,
+                "name": name, "found": row is not None, "result": row,
+                "store": "canonical"}
+    results = store.list(owner_id, category=category or None)
+    return {"mode": "list", "owner_id": owner_id, "category": category or None,
+            "results_count": len(results), "results": results, "store": "canonical"}
+
+
 def _handle_scratchpad_write(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_scratchpad_write tool call."""
     content = arguments.get("content", "").strip()
@@ -760,6 +839,8 @@ _TOOL_HANDLERS = {
     "mnemosyne_get": _handle_get,
     "mnemosyne_triple_add": _handle_triple_add,
     "mnemosyne_triple_query": _handle_triple_query,
+    "mnemosyne_remember_canonical": _handle_remember_canonical,
+    "mnemosyne_recall_canonical": _handle_recall_canonical,
     "mnemosyne_scratchpad_write": _handle_scratchpad_write,
     "mnemosyne_scratchpad_read": _handle_scratchpad_read,
     "mnemosyne_scratchpad_clear": _handle_scratchpad_clear,

--- a/tests/test_canonical.py
+++ b/tests/test_canonical.py
@@ -1,0 +1,355 @@
+"""
+Tests for Mnemosyne CanonicalStore (issue #256).
+
+CanonicalStore is the owner-scoped single-source-of-truth layer: each
+(owner_id, category, name) slot holds exactly one current value, restating a
+value is a no-op, and a new value supersedes the old one (kept as history).
+
+These tests pin the contract:
+- Upsert-in-place: identical body is a no-op; new body bumps version + supersedes.
+- Exactly one current row per slot (partial unique index enforcement).
+- Owner isolation: one owner never sees/touches another's slots.
+- History, list, and substring search read paths.
+- Export/import round-trip parity with the sibling stores.
+- BeamMemory wires `self.canonical` on the shared connection.
+- The Hermes provider tools round-trip and derive owner from the profile.
+"""
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# ImportError until CanonicalStore lands — red against main, green after.
+from mnemosyne.core.canonical import (
+    CanonicalStore,
+    init_canonical,
+    remember_canonical,
+    recall_canonical,
+)
+
+
+class _TempDBTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.db_path = Path(self.tmp.name)
+        self.store = CanonicalStore(db_path=self.db_path)
+
+    def tearDown(self):
+        try:
+            self.store.conn.close()
+        except Exception:
+            pass
+        try:
+            os.unlink(self.tmp.name)
+        except OSError:
+            pass
+
+
+class TestUpsertSemantics(_TempDBTest):
+    def test_create_then_recall(self):
+        row = self.store.remember("jessi", "identity", "name", "My name is Jessi.")
+        self.assertEqual(row["status"], "created")
+        self.assertEqual(row["version"], 1)
+        got = self.store.recall("jessi", "identity", "name")
+        self.assertEqual(got["body"], "My name is Jessi.")
+        self.assertIsNone(got["valid_until"])
+
+    def test_identical_body_is_noop(self):
+        self.store.remember("jessi", "identity", "name", "My name is Jessi.")
+        row = self.store.remember("jessi", "identity", "name", "My name is Jessi.")
+        self.assertEqual(row["status"], "unchanged")
+        self.assertEqual(row["version"], 1)
+        # Exactly one row total — no duplicate accumulated.
+        self.assertEqual(len(self.store.history("jessi", "identity", "name")), 1)
+
+    def test_new_body_supersedes_and_versions(self):
+        self.store.remember("jessi", "identity", "name", "My name is Jessi.")
+        row = self.store.remember("jessi", "identity", "name", "I go by Jess now.")
+        self.assertEqual(row["status"], "updated")
+        self.assertEqual(row["version"], 2)
+        # Current value is the new one.
+        self.assertEqual(self.store.recall("jessi", "identity", "name")["body"],
+                         "I go by Jess now.")
+        hist = self.store.history("jessi", "identity", "name")
+        self.assertEqual([h["body"] for h in hist],
+                         ["I go by Jess now.", "My name is Jessi."])
+        # The superseded row is closed; the current one is open.
+        self.assertIsNone(hist[0]["valid_until"])
+        self.assertIsNotNone(hist[1]["valid_until"])
+
+    def test_exactly_one_current_row_invariant(self):
+        """The partial unique index permits only one live row per slot."""
+        for body in ("a body value", "b body value", "c body value"):
+            self.store.remember("jessi", "identity", "name", body)
+        cur = self.store.conn.execute(
+            "SELECT COUNT(*) FROM canonical_facts "
+            "WHERE owner_id=? AND category=? AND name=? AND valid_until IS NULL",
+            ("jessi", "identity", "name"),
+        ).fetchone()[0]
+        self.assertEqual(cur, 1)
+        # History retains every version.
+        self.assertEqual(len(self.store.history("jessi", "identity", "name")), 3)
+
+    def test_direct_duplicate_live_row_rejected(self):
+        """Defense-in-depth: a hand-inserted second live row violates the index."""
+        self.store.remember("jessi", "identity", "name", "first body value")
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.store.conn.execute(
+                "INSERT INTO canonical_facts "
+                "(owner_id, category, name, body, version, valid_from, valid_until) "
+                "VALUES (?,?,?,?,?,?,NULL)",
+                ("jessi", "identity", "name", "sneaky dup", 99, "2026-01-01"),
+            )
+            self.store.conn.commit()
+        self.store.conn.rollback()
+
+    def test_blank_inputs_rejected(self):
+        with self.assertRaises(ValueError):
+            self.store.remember("jessi", "identity", "name", "   ")
+        with self.assertRaises(ValueError):
+            self.store.remember("jessi", "", "name", "body value here")
+
+
+class TestForget(_TempDBTest):
+    def test_forget_retires_current_keeps_history(self):
+        self.store.remember("jessi", "identity", "name", "My name is Jessi.")
+        self.assertTrue(self.store.forget("jessi", "identity", "name"))
+        self.assertIsNone(self.store.recall("jessi", "identity", "name"))
+        # Row preserved as history (auditable), not deleted.
+        self.assertEqual(len(self.store.history("jessi", "identity", "name")), 1)
+
+    def test_forget_empty_slot_returns_false(self):
+        self.assertFalse(self.store.forget("jessi", "identity", "ghost"))
+
+    def test_remember_after_forget_starts_fresh_current(self):
+        self.store.remember("jessi", "identity", "name", "My name is Jessi.")
+        self.store.forget("jessi", "identity", "name")
+        row = self.store.remember("jessi", "identity", "name", "Reborn as Jess.")
+        self.assertEqual(self.store.recall("jessi", "identity", "name")["body"],
+                         "Reborn as Jess.")
+        # version keeps climbing across the gap.
+        self.assertEqual(row["version"], 2)
+
+
+class TestOwnerIsolation(_TempDBTest):
+    def test_same_slot_different_owners_coexist(self):
+        self.store.remember("jessi", "identity", "name", "I am Jessi.")
+        self.store.remember("atlas", "identity", "name", "I am Atlas.")
+        self.assertEqual(self.store.recall("jessi", "identity", "name")["body"], "I am Jessi.")
+        self.assertEqual(self.store.recall("atlas", "identity", "name")["body"], "I am Atlas.")
+
+    def test_list_is_owner_scoped(self):
+        self.store.remember("jessi", "identity", "name", "I am Jessi.")
+        self.store.remember("atlas", "identity", "name", "I am Atlas.")
+        jessi = self.store.list("jessi")
+        self.assertEqual(len(jessi), 1)
+        self.assertEqual(jessi[0]["owner_id"], "jessi")
+
+    def test_search_is_owner_scoped(self):
+        self.store.remember("jessi", "identity", "name", "I am Jessi the cartographer.")
+        self.store.remember("atlas", "identity", "name", "I am Atlas the cartographer.")
+        hits = self.store.search("jessi", "cartographer")
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["owner_id"], "jessi")
+
+
+class TestListAndSearch(_TempDBTest):
+    def test_list_all_and_by_category(self):
+        self.store.remember("jessi", "identity", "name", "I am Jessi.")
+        self.store.remember("jessi", "identity", "pronouns", "she/her")
+        self.store.remember("jessi", "voice", "register", "warm and direct")
+        self.assertEqual(len(self.store.list("jessi")), 3)
+        ident = self.store.list("jessi", category="identity")
+        self.assertEqual({r["name"] for r in ident}, {"name", "pronouns"})
+
+    def test_search_matches_body_name_category(self):
+        self.store.remember("jessi", "voice", "register", "warm and direct")
+        self.assertTrue(self.store.search("jessi", "warm"))       # body
+        self.assertTrue(self.store.search("jessi", "register"))   # name
+        self.assertTrue(self.store.search("jessi", "voice"))      # category
+        self.assertEqual(self.store.search("jessi", "nonexistent"), [])
+
+    def test_search_excludes_superseded(self):
+        self.store.remember("jessi", "voice", "register", "icy and terse")
+        self.store.remember("jessi", "voice", "register", "warm and direct")
+        # Old value must not surface in search.
+        self.assertEqual(self.store.search("jessi", "icy"), [])
+        self.assertTrue(self.store.search("jessi", "warm"))
+
+    def test_search_blank_query_returns_empty(self):
+        self.store.remember("jessi", "voice", "register", "warm")
+        self.assertEqual(self.store.search("jessi", "   "), [])
+
+
+class TestExportImport(_TempDBTest):
+    def test_round_trip(self):
+        self.store.remember("jessi", "identity", "name", "I am Jessi.")
+        self.store.remember("jessi", "identity", "name", "I am Jess.")  # creates history
+        self.store.remember("jessi", "voice", "register", "warm")
+        exported = self.store.export_all()
+        self.assertEqual(len(exported), 3)
+
+        # Fresh DB, import.
+        other = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        other.close()
+        try:
+            dst = CanonicalStore(db_path=Path(other.name))
+            stats = dst.import_all(exported)
+            self.assertEqual(stats["inserted"], 3)
+            self.assertEqual(sum(stats.values()), 3)
+            self.assertEqual(dst.recall("jessi", "identity", "name")["body"], "I am Jess.")
+            self.assertEqual(len(dst.history("jessi", "identity", "name")), 2)
+            dst.conn.close()
+        finally:
+            os.unlink(other.name)
+
+    def test_idempotent_reimport_skips(self):
+        self.store.remember("jessi", "identity", "name", "I am Jessi.")
+        exported = self.store.export_all()
+        stats = self.store.import_all(exported)
+        # Re-importing the same export into the same DB is a no-op.
+        self.assertEqual(stats["skipped"], len(exported))
+
+
+class TestModuleConvenience(_TempDBTest):
+    def test_module_level_functions(self):
+        remember_canonical("jessi", "identity", "name", "I am Jessi.", db_path=self.db_path)
+        got = recall_canonical("jessi", "identity", "name", db_path=self.db_path)
+        self.assertEqual(got["body"], "I am Jessi.")
+
+    def test_init_is_idempotent(self):
+        init_canonical(self.db_path)
+        init_canonical(self.db_path)  # no error on second call
+
+
+class TestBeamWiring(unittest.TestCase):
+    """CanonicalStore is reachable as beam.canonical on the shared connection."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.db_path = Path(self.tmp.name)
+
+    def tearDown(self):
+        try:
+            os.unlink(self.tmp.name)
+        except OSError:
+            pass
+
+    def test_beam_exposes_canonical_sharing_connection(self):
+        from mnemosyne.core.beam import BeamMemory
+        beam = BeamMemory(session_id="t", db_path=self.db_path)
+        try:
+            self.assertTrue(hasattr(beam, "canonical"))
+            # Same connection object — no extra file descriptor.
+            self.assertIs(beam.canonical.conn, beam.conn)
+            row = beam.canonical.remember("jessi", "identity", "name", "I am Jessi.")
+            self.assertEqual(row["status"], "created")
+            self.assertEqual(
+                beam.canonical.recall("jessi", "identity", "name")["body"],
+                "I am Jessi.",
+            )
+        finally:
+            try:
+                beam.conn.close()
+            except Exception:
+                pass
+
+
+class TestProviderTools(unittest.TestCase):
+    """The two Hermes provider tools round-trip and isolate by profile."""
+
+    def setUp(self):
+        from hermes_memory_provider import MnemosyneMemoryProvider
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.db_path = Path(self.tmp.name)
+        from mnemosyne.core.beam import BeamMemory
+        self.provider = MnemosyneMemoryProvider()
+        self.provider._beam = BeamMemory(session_id="t", db_path=self.db_path)
+        self.provider._agent_identity = "jessi"
+
+    def tearDown(self):
+        try:
+            self.provider._beam.conn.close()
+        except Exception:
+            pass
+        try:
+            os.unlink(self.tmp.name)
+        except OSError:
+            pass
+
+    def test_remember_and_recall_roundtrip(self):
+        out = json.loads(self.provider.handle_tool_call(
+            "mnemosyne_remember_canonical",
+            {"category": "identity", "name": "name", "body": "My name is Jessi."},
+        ))
+        self.assertEqual(out["status"], "created")
+        self.assertEqual(out["owner_id"], "jessi")
+
+        got = json.loads(self.provider.handle_tool_call(
+            "mnemosyne_recall_canonical",
+            {"category": "identity", "name": "name"},
+        ))
+        self.assertEqual(got["mode"], "recall")
+        self.assertTrue(got["found"])
+        self.assertEqual(got["result"]["body"], "My name is Jessi.")
+
+    def test_recall_search_mode(self):
+        self.provider.handle_tool_call(
+            "mnemosyne_remember_canonical",
+            {"category": "voice", "name": "register", "body": "warm and direct"},
+        )
+        got = json.loads(self.provider.handle_tool_call(
+            "mnemosyne_recall_canonical", {"query": "warm"},
+        ))
+        self.assertEqual(got["mode"], "search")
+        self.assertEqual(got["count"], 1)
+
+    def test_recall_history_mode(self):
+        for body in ("icy and terse", "warm and direct"):
+            self.provider.handle_tool_call(
+                "mnemosyne_remember_canonical",
+                {"category": "voice", "name": "register", "body": body},
+            )
+        got = json.loads(self.provider.handle_tool_call(
+            "mnemosyne_recall_canonical",
+            {"category": "voice", "name": "register", "include_history": True},
+        ))
+        self.assertEqual(got["mode"], "history")
+        self.assertEqual(got["count"], 2)
+
+    def test_owner_defaults_and_isolates_by_profile(self):
+        self.provider.handle_tool_call(
+            "mnemosyne_remember_canonical",
+            {"category": "identity", "name": "name", "body": "I am Jessi."},
+        )
+        # Switch profile → different owner bank, nothing visible.
+        self.provider._agent_identity = "atlas"
+        got = json.loads(self.provider.handle_tool_call(
+            "mnemosyne_recall_canonical", {"category": "identity", "name": "name"},
+        ))
+        self.assertEqual(got["owner_id"], "atlas")
+        self.assertFalse(got["found"])
+
+    def test_missing_required_fields(self):
+        out = json.loads(self.provider.handle_tool_call(
+            "mnemosyne_remember_canonical", {"category": "identity", "name": "name"},
+        ))
+        self.assertIn("error", out)
+
+    def test_schemas_exposed(self):
+        names = {s["name"] for s in self.provider.get_tool_schemas()}
+        self.assertIn("mnemosyne_remember_canonical", names)
+        self.assertIn("mnemosyne_recall_canonical", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -21,9 +21,11 @@ class TestToolSchemas:
     """Verify tool schemas match MCP spec and are valid JSON."""
 
     def test_all_tools_present(self):
-        """All 23 tools must be defined."""
+        """All 25 tools must be defined."""
         names = [t["name"] for t in TOOLS]
-        assert len(names) == 23
+        assert len(names) == 25
+        assert "mnemosyne_remember_canonical" in names
+        assert "mnemosyne_recall_canonical" in names
         assert "mnemosyne_remember" in names
         assert "mnemosyne_recall" in names
         assert "mnemosyne_sleep" in names
@@ -301,9 +303,9 @@ class TestMCPIntegration:
         assert hasattr(mcp_tools, "handle_tool_call")
 
     def test_get_tool_definitions_returns_all(self):
-        """get_tool_definitions returns all 23 tools."""
+        """get_tool_definitions returns all 25 tools."""
         tools = get_tool_definitions()
-        assert len(tools) == 23
+        assert len(tools) == 25
         names = [t["name"] for t in tools]
         assert "mnemosyne_remember" in names
 

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -52,7 +52,13 @@ class TestToolRegistration:
     def test_all_tools_registered(self, tmp_path):
         provider = _provider(tmp_path)
         names = _tool_names(provider)
-        assert len(names) == 23, f"Expected 23 tools, got {len(names)}"
+        assert len(names) == 25, f"Expected 25 tools, got {len(names)}"
+
+    def test_canonical_tools_present(self, tmp_path):
+        provider = _provider(tmp_path)
+        names = _tool_names(provider)
+        for tool in ("remember_canonical", "recall_canonical"):
+            assert f"mnemosyne_{tool}" in names
 
     def test_new_8_tools_present(self, tmp_path):
         provider = _provider(tmp_path)


### PR DESCRIPTION
Closes #256.

## Summary

Adds an **owner-scoped canonical-fact layer** — the missing *private + canonical* cell from the matrix in #256. Each `(owner_id, category, name)` slot holds exactly **one** current value, giving long-running personas identity consistency over time: restating a stable self-fact is a no-op (no duplicate accumulation), and a new value supersedes the old one rather than coexisting with it.

This is the piece that lets the **shared surface go back to being used exactly as intended** (cross-profile sharing) — canonical-ness and shared-ness are orthogonal, and this PR adds only the top-right cell.

## Design

Per the issue's own constraint — *"zero new dependencies — one SQLite table + a unique index"* — this is implemented with **one table + a partial unique index**, no FTS table:

- `canonical_facts(id, owner_id, category, name, body, source, confidence, version, valid_from, valid_until, created_at)`.
- `CREATE UNIQUE INDEX … ON canonical_facts(owner_id, category, name) WHERE valid_until IS NULL` — the partial index reconciles *"single source of truth"* with *"keep history in the same table"*: only the live row participates in the constraint, superseded rows accumulate unconstrained. This mirrors `TripleStore`'s `valid_until` supersession, with an `owner_id` dimension added.
- `remember()` is upsert-in-place: identical body → no-op; new body → stamp `valid_until` on the current row, insert the new value with `version + 1`.
- `recall()` is an indexed point lookup of the single current row — cheaper than hybrid vector search for a known-key identity read.

`CanonicalStore` follows the `AnnotationStore` template exactly (shared-connection or standalone construction, `init_*` / `_init_*_with_conn`, `export_all`/`import_all` parity with the sibling stores, module-level convenience functions).

## What's included

- **`mnemosyne/core/canonical.py`** — `CanonicalStore` with `remember`, `recall`, `list`, `history`, `search` (owner-scoped substring), `forget` (retire-as-history), and export/import.
- **`BeamMemory`** exposes `self.canonical` on its shared thread-local connection (no extra file descriptor), alongside `self.annotations`.
- **Two new tools** — `mnemosyne_remember_canonical` and `mnemosyne_recall_canonical` — on both the Hermes provider (`hermes_memory_provider`) and the MCP surface (`mnemosyne.mcp_tools` / `mnemosyne_hermes.tools`). Tool count 23 → 25. `recall_canonical` covers exact-slot read, category / whole-bank listing, version history, and owner-scoped search, so full-text lookups span canonical entries **without touching the default `mnemosyne_recall` path** (zero behavior change).
- **Owner isolation by construction:** the provider derives `owner_id` from the active profile identity and never reads it from tool args, so a profile cannot read or write another profile's canonical bank. (Over MCP the owner is a deployment setting, `MNEMOSYNE_DEFAULT_OWNER`.)

## Backward compatibility

Fully additive and opt-in. `canonical_facts` is created lazily on first init; existing tables, tools, and recall output are unchanged. The shared surface is untouched.

## Tests

`tests/test_canonical.py` (27 cases): upsert / no-op / supersession + versioning, partial-unique-index enforcement (incl. a hand-inserted duplicate live row rejected), owner isolation across `recall`/`list`/`search`, list/search/history read paths, `forget` semantics, export/import round-trip + idempotent re-import, `BeamMemory` wiring (shared connection), and provider tool round-trip incl. owner defaulting/isolation. Existing provider + MCP tool-registration counts updated 23 → 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
