### PR TITLE
fix(prefetch): always inject per-contact identity, independent of recall query

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1331,9 +1331,90 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 block = ""
             if block:
                 blocks.append(block)
+        # Per-contact identity memories must surface on EVERY turn, independent
+        # of the semantic recall query. Routing them through recall is a latent
+        # bug: a short/generic opener ("Hi", a nickname) does not match the
+        # identity text, so it never enters recall's top_k window and the
+        # importance filter never sees it -- the agent then loses track of who
+        # it is talking to. Inject them deterministically at the FRONT, scoped
+        # strictly to the active session_id, deduplicated against whatever
+        # recall already surfaced. No identity rows == no-op (legacy behavior).
+        identity_block = self._prefetch_identity(blocks, profile)
+        if identity_block:
+            blocks.insert(0, identity_block)
         if profile.dedup:
             blocks = _dedup_blocks(blocks)
         return "\n\n".join(b for b in blocks if b)
+
+    def _prefetch_identity(self, existing_blocks: List[str], profile: "PrefetchProfile") -> str:
+        """Render the always-inject identity block for the active session.
+
+        Pulls identity memories straight from the active ``session_id`` (see
+        ``_identity_fichas``) and renders them in the same format as the memory
+        bank, tagged ``[IDENTITY]``. Rows whose content already appears in the
+        blocks recall produced are dropped, so a query that *does* match the
+        identity never yields a duplicate. Returns ``""`` when there is nothing
+        to inject.
+        """
+        rows = self._identity_fichas()
+        if not rows:
+            return ""
+        already = "\n".join(existing_blocks)
+        content_limit = _prefetch_content_char_limit() or profile.content_char_limit
+        lines: List[str] = ["## Mnemosyne Context"]
+        seen: set = set()
+        for r in rows:
+            content = r.get("content", "")
+            if not content or content in seen:
+                continue
+            disp = _format_prefetch_content(content, content_limit)
+            # Dedup against anything recall already surfaced (raw or truncated).
+            if content in already or disp in already:
+                continue
+            seen.add(content)
+            ts = r.get("timestamp", "")[:16] if r.get("timestamp") else ""
+            imp = r.get("importance", 0.95)
+            lines.append(f"  [{ts}] (importance {imp:.2f}) [IDENTITY] {disp}")
+        if len(lines) <= 1:
+            return ""
+        return "\n".join(lines)
+
+    def _identity_fichas(self) -> List[Dict[str, Any]]:
+        """Return ALL identity memories for the ACTIVE session, deterministically.
+
+        Identity memories (source='identity') answer "who am I talking to?" and
+        must be injected on every turn regardless of the user's message. Routing
+        them through semantic recall is a latent bug: a short/generic opener does
+        not match the identity text, so it never enters recall's top_k window and
+        the importance filter never sees it. This pulls them straight from the
+        active session_id with a direct, query-independent SQL read. Strictly
+        session-scoped, so there is zero cross-session leakage.
+        """
+        out: List[Dict[str, Any]] = []
+        beam = self._beam
+        if beam is None:
+            return out
+        try:
+            cur = beam.conn.cursor()
+            cur.execute(
+                "SELECT content, importance, timestamp FROM working_memory "
+                "WHERE source='identity' AND session_id=? "
+                "ORDER BY importance DESC, timestamp DESC",
+                (beam.session_id,),
+            )
+            for content, importance, timestamp in cur.fetchall():
+                if not content:
+                    continue
+                out.append({
+                    "content": content,
+                    "importance": importance if importance is not None else 0.95,
+                    "timestamp": timestamp or "",
+                    "source": "identity",
+                    "_always_inject": True,
+                })
+        except Exception as e:
+            logger.debug("Mnemosyne identity read failed (non-fatal): %s", e)
+        return out
 
     def _prefetch_bank(self, query: str, session_id: str, profile: "PrefetchProfile") -> str:
         """The built-in memory-bank source: hybrid recall with temporal weighting,

--- a/tests/test_prefetch_identity_always_inject.py
+++ b/tests/test_prefetch_identity_always_inject.py
@@ -1,0 +1,131 @@
+"""Tests for always-inject, query-independent identity prefetch.
+
+Per-contact identity memories (source='identity') answer "who am I talking
+to?" and must surface on EVERY turn, regardless of the user's message. Routing
+them through semantic recall is a latent bug: a short/generic opener ("Hi", a
+nickname) does not match the identity text, so it never enters recall's top_k
+window and the importance filter never sees it -- the agent then loses track of
+who it is talking to. These tests prove identity injection is:
+
+  (a) deterministic on a generic query that does NOT semantically match it,
+  (b) strictly session-scoped (session A's identity never leaks into session B),
+  (c) deduplicated (a query that DOES match the identity yields no duplicate).
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from hermes_memory_provider import MnemosyneMemoryProvider
+
+
+def _insert_identity(beam, content, session_id, importance=0.95):
+    """Insert an identity row directly into working_memory for *session_id*."""
+    beam.conn.execute(
+        "INSERT INTO working_memory "
+        "(id, content, source, timestamp, session_id, importance) "
+        "VALUES (?, ?, 'identity', ?, ?, ?)",
+        (
+            f"id-{session_id}-{abs(hash(content)) % 10**9}",
+            content,
+            "2026-05-14T12:00:00Z",
+            session_id,
+            importance,
+        ),
+    )
+    beam.conn.commit()
+
+
+@pytest.fixture
+def provider_factory():
+    """Yield a factory that builds a provider bound to a beam for a session_id,
+    sharing one temp DB so cross-session isolation can be exercised."""
+    from mnemosyne.core.beam import BeamMemory
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "mnemosyne.db")
+        beams = []
+
+        def make(session_id):
+            beam = BeamMemory(session_id=session_id, db_path=db_path)
+            beams.append(beam)
+            p = MnemosyneMemoryProvider()
+            p._beam = beam
+            p._prefetch_profile = "general"
+            p._agent_context = "test"
+            p._skip_contexts = set()
+            return p
+
+        yield make
+
+        for b in beams:
+            try:
+                b.conn.close()
+            except Exception:
+                pass
+
+
+def test_identity_surfaces_on_non_matching_generic_query(provider_factory):
+    """An identity row is injected even when the query does NOT match it."""
+    p = provider_factory("session-A")
+    _insert_identity(
+        p._beam,
+        "Contact A is the lead engineer on the payments team.",
+        "session-A",
+    )
+    # A short, generic opener with zero semantic overlap with the identity.
+    block = p.prefetch("Hi")
+    assert "[IDENTITY]" in block
+    assert "Contact A is the lead engineer on the payments team." in block
+
+
+def test_identity_does_not_leak_across_sessions(provider_factory):
+    """Identity stored under session A must never appear in session B prefetch."""
+    pa = provider_factory("session-A")
+    _insert_identity(
+        pa._beam,
+        "Contact A is the lead engineer on the payments team.",
+        "session-A",
+    )
+
+    pb = provider_factory("session-B")
+    block_b = pb.prefetch("Hi")
+    assert "Contact A" not in block_b
+    assert "[IDENTITY]" not in block_b
+
+    # Sanity: session A still sees its own identity.
+    block_a = pa.prefetch("Hi")
+    assert "Contact A is the lead engineer on the payments team." in block_a
+
+
+def test_no_duplicate_when_query_matches_identity(provider_factory):
+    """When recall ALSO surfaces the identity, it must not be injected twice."""
+    p = provider_factory("session-A")
+    identity_text = "Contact A is the lead engineer on the payments team."
+    _insert_identity(p._beam, identity_text, "session-A")
+
+    # Force recall to return the very same identity content (simulating a query
+    # that DOES semantically match), so the dedup path is exercised.
+    def fake_recall(**kwargs):
+        return [{
+            "content": identity_text,
+            "timestamp": "2026-05-14T12:00:00Z",
+            "importance": 0.95,
+            "score": 0.9,
+            "trust_tier": "STATED",
+        }]
+
+    p._beam.recall = fake_recall
+    block = p.prefetch("who is the lead engineer on payments")
+    # The identity content appears exactly once across the whole block.
+    assert block.count(identity_text) == 1
+
+
+def test_no_identity_rows_is_a_noop(provider_factory):
+    """With no identity rows, behavior is unchanged (no [IDENTITY] block)."""
+    p = provider_factory("session-A")
+    p._beam.recall = lambda **kwargs: []
+    block = p.prefetch("Hi")
+    assert "[IDENTITY]" not in block


### PR DESCRIPTION
## The bug: semantic-recall-gated identity → wrong identity on short openers

Per-contact identity memories (`source='identity'`, session-scoped, high
importance ~0.95, one silo per session) answer the question *"who am I talking
to?"*. The Claude Code memory provider surfaces context via
`MnemosyneMemoryProvider.prefetch()`, which is profile-driven and ultimately
calls `_prefetch_bank()` → `self._beam.recall(query=user_message, top_k=...)`.

The problem: identity memories **only surface if they win SEMANTIC recall**
against the user's message. When a user sends a short/generic message ("Hi",
"Hola", "thanks", or just a nickname), there is no semantic match to the
identity text (e.g. "Contact A is the lead engineer on the payments team"), so:

1. the identity memory never enters recall's `top_k` window,
2. the importance filter (which runs **after** recall) never sees it,
3. the agent loses track of who it's talking to and defaults to the wrong
   identity.

Reproduced deterministically: a generic opener yields a prefetch context with
no identity, even though a high-importance identity row exists for the active
session.

## The fix: deterministic, query-independent, session-scoped injection

Add a query-**independent** identity injection to `prefetch()`:

- **`_identity_fichas()`** — reads ALL identity rows for the **active**
  `session_id` straight from `working_memory` with a direct SQL read
  (`WHERE source='identity' AND session_id=?`), ordered by importance then
  recency. Strictly session-scoped, so there is **zero cross-session leakage**.
  Wrapped in try/except → non-fatal on any error.
- **`_prefetch_identity()`** — renders those rows in the **same format as the
  memory bank**, tagged `[IDENTITY]`:
  `  [{ts}] (importance {imp:.2f}) [IDENTITY] {content}`, deduplicated against
  whatever recall already surfaced (so a query that *does* match the identity
  never produces a duplicate).
- In `prefetch()`, the identity block is merged to the **FRONT** of the
  returned context, kept behind the existing
  `if not self._beam or self._agent_context in self._skip_contexts: return ""`
  guard.

The owner/empty-identity case (no identity rows) is a strict **no-op** —
existing behavior is preserved exactly. The change is additive and minimal.

## Tests

`tests/test_prefetch_identity_always_inject.py` proves:

- **(a)** an identity row surfaces on a generic query (`"Hi"`) that does NOT
  semantically match it;
- **(b)** identity stored under session A does **not** leak into session B's
  prefetch (and session A still sees its own);
- **(c)** no duplicate when a query DOES match the identity (recall + always-inject);
- **(d)** the no-identity-rows case is a no-op (no `[IDENTITY]` block).

Local run (new + existing prefetch/provider/identity/isolation suites):

```
tests/test_prefetch_identity_always_inject.py ....                 [ 4 passed ]
tests/test_prefetch_profiles.py / _content_truncation / _low_quality   [27 passed total]
tests/test_hermes_memory_provider.py + identity + multi_agent_identity
  + thread_isolation                                                [81 passed]
```

`python -c "import ast; ast.parse(open('hermes_memory_provider/__init__.py').read())"` → OK.

No private user data, real contact names, phone numbers, or chat IDs are
included — generic placeholders ("Contact A", "session-A") are used throughout.
