### PR TITLE
fix(recall): tighten fact matching for broad queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Fact recall no longer treats one plain shared word as relevance for broad
+  queries.** Single-token fact matches are now limited to lookup-style queries or
+  distinctive structured identifiers, preventing unrelated high-importance facts
+  from surfacing on conversational glue words while preserving direct lookups.
+
 - **Holographic import CLI no longer demands an API key.** Holographic is a local
   SQLite importer (no API key needed) but the generic provider path checked for
   `--api-key` on every non-`hindsight` provider. Added `--db-path` and `--min-trust`

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1369,6 +1369,10 @@ _FACT_MATCH_STOPWORDS: Set[str] = {
     "should", "that", "the", "their", "there", "this", "to", "totally", "unrelated",
     "use", "uses", "was", "we", "what", "when", "where", "which", "who", "why",
     "with", "you", "your",
+    # Conversational glue/pronouns. These caused broad requests like "do not reply
+    # to them" to fact-match unrelated policies via overlaps such as "not/they".
+    "again", "into", "not", "please", "somewhere", "supposed", "them", "then",
+    "they", "whatever",
 }
 
 # Unicode-aware recall tokenization.
@@ -1576,11 +1580,16 @@ def _strict_fact_matches(query: str, fact_text: str) -> bool:
     if len(overlap) == 1:
         token = next(iter(overlap))
         # Long structured tokens (paths/domains/identifiers) are very distinctive
+        # even inside a longer query.
         if len(token) >= 8 and any(c in token for c in (".", "/", ":", "-", "_")):
             return True
-        # Medium tokens (5+ chars) that passed the stopword filter are significant
-        # enough for single-token fact queries like "hermes", "python", "react"
-        return len(token) >= 5
+        # Medium tokens (5+ chars) are useful for direct lookup-style fact queries
+        # like "hermes" or "python". They are NOT enough for broad natural-language
+        # queries: one shared word such as "public", "context", or "reply" should
+        # not cause an unrelated high-importance fact to enter recall.
+        if len(query_tokens) <= 2:
+            return len(token) >= 5
+        return False
 
     return False
 

--- a/tests/test_recall_precision_regressions.py
+++ b/tests/test_recall_precision_regressions.py
@@ -137,6 +137,85 @@ class TestRecallPrecisionRegressions(unittest.TestCase):
         self.assertIn("database adapter timeout", joined)
         self.assertNotIn("orchid care dashboard", joined)
 
+    def test_fact_recall_requires_more_than_one_plain_token_for_broad_queries(self):
+        """Fact annotations must not leak unrelated rows on one shared plain word."""
+        unrelated_id = self.beam.remember(
+            "Public release notes should describe implementation and validation only.",
+            source="imported_fixture",
+            importance=0.99,
+            scope="global",
+            veracity="stated",
+        )
+        self.beam.annotations.add_many(
+            memory_id=unrelated_id,
+            kind="fact",
+            values=["Public release notes should describe implementation and validation only"],
+            source="imported_fixture",
+        )
+        relevant_id = self.beam.remember(
+            "Runtime context blocks are metadata and should be ignored unless directly requested.",
+            source="imported_fixture",
+            importance=0.2,
+            scope="global",
+            veracity="stated",
+        )
+        self.beam.annotations.add_many(
+            memory_id=relevant_id,
+            kind="fact",
+            values=["Runtime context blocks are metadata and should be ignored unless directly requested"],
+            source="imported_fixture",
+        )
+
+        results = self.beam.recall(
+            "Please fix runtime context so you do not reply to the context block",
+            top_k=5,
+        )
+        joined = "\n".join(r["content"] for r in results).lower()
+        self.assertIn("runtime context blocks", joined)
+        self.assertNotIn("public release notes", joined)
+
+    def test_fact_recall_ignores_pronoun_glue_overlaps_for_broad_queries(self):
+        """Words like not/them/they are not enough to fact-match a row."""
+        unrelated_id = self.beam.remember(
+            "Preserve critical services and data; do not stop or kill them.",
+            source="imported_fixture",
+            importance=0.99,
+            scope="global",
+            veracity="stated",
+        )
+        self.beam.annotations.add_many(
+            memory_id=unrelated_id,
+            kind="fact",
+            values=["Preserve critical services and data; do not stop or kill them"],
+            source="imported_fixture",
+        )
+
+        results = self.beam.recall(
+            "Please add a reminder to not reply to them and treat them as context",
+            top_k=5,
+        )
+        joined = "\n".join(r["content"] for r in results).lower()
+        self.assertNotIn("preserve critical services", joined)
+
+    def test_direct_single_token_fact_lookup_still_works(self):
+        memory_id = self.beam.remember(
+            "HermesBridge is the codename for the localhost memory adapter.",
+            source="imported_fixture",
+            importance=0.6,
+            scope="global",
+            veracity="stated",
+        )
+        self.beam.annotations.add_many(
+            memory_id=memory_id,
+            kind="fact",
+            values=["HermesBridge is the localhost memory adapter codename"],
+            source="imported_fixture",
+        )
+
+        results = self.beam.recall("HermesBridge", top_k=3)
+        self.assertTrue(results)
+        self.assertIn("HermesBridge", results[0]["content"])
+
     def test_memoria_date_or_sequence_fact_does_not_force_top_slot(self):
         results = self.beam.recall("Where is the Orion runner jar and how should it bind?", top_k=5)
         self.assertTrue(results)


### PR DESCRIPTION
## Description

Tightens fact-annotation recall so broad natural-language queries cannot match unrelated memories on a single plain shared word.

Previously, `_strict_fact_matches()` allowed one medium-length token overlap to count as a fact match for any query length. That made broad conversational prompts susceptible to unrelated high-importance facts if they shared a weak word. This change keeps single-token fact matches for short lookup-style queries and distinctive structured identifiers, while requiring stronger evidence for broad queries.

Also expands the fact-match stopword set for conversational glue/pronouns that should not carry recall relevance.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / performance
- [x] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Existing tests still pass: `python3 -m pytest tests/test_recall_precision_regressions.py tests/test_multilingual_local_recall.py tests/test_fact_recall_integration.py tests/test_hermes_memory_provider_unified_recall.py tests/test_c4_recall_diagnostics.py tests/test_temporal_recall.py tests/test_benchmark_pure_recall_gate.py tests/test_prefetch_profiles.py tests/test_prefetch_low_quality.py -q -o 'addopts='`
  - `124 passed, 4 subtests passed`
- [x] New tests added for the bug fix
- [x] Manual verification: `git diff --check`

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py` — not bumped for this small bug fix
- [x] `CHANGELOG.md` updated with a brief entry
- [ ] README updated if user-facing behavior changed — not applicable
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency
