### PR TITLE
perf(entities): skip levenshtein when length ratio rules out a match

### DIFF
--- a/mnemosyne/core/entities.py
+++ b/mnemosyne/core/entities.py
@@ -212,9 +212,21 @@ def find_similar_entities(entity: str, known_entities: List[str], threshold: flo
     Returns list of (entity_name, similarity_score) tuples, sorted by score descending.
     """
     matches: List[Tuple[str, float]] = []
+    entity_len = len(entity.strip())
     for known in known_entities:
         if known == entity:
             matches.append((known, 1.0))
+            continue
+        # Cheap upper bound before the O(n*m) levenshtein in similarity():
+        # the edit-distance score is capped at min_len/max_len and the
+        # prefix/substring bonuses at 0.7 + ratio*0.3, so when the length
+        # ratio alone puts every branch below the threshold the pair can
+        # never match. Critical when callers pass long free-text queries
+        # against thousands of short entity names.
+        known_len = len(known.strip())
+        max_len = max(entity_len, known_len, 1)
+        ratio = min(entity_len, known_len) / max_len
+        if ratio < threshold and (0.7 + ratio * 0.3) < threshold:
             continue
         sim = similarity(entity, known)
         if sim >= threshold:


### PR DESCRIPTION
## Problem

`find_similar_entities()` computes pure-Python levenshtein against every known entity. `BeamMemory.recall()` calls `_find_memories_by_entity(self, query)` with the **full recall query** as `entity_name` (beam.py, entity-aware recall section), so a long chat message gets edit-distanced against the entire entity store.

On a real deployment this froze the host agent completely: with 7,282 distinct `mentions` entities, a single 18,549-char message spent **12.4 minutes** inside the scan, holding the GIL the whole time. Every network call in sibling threads timed out, so it presented as provider/API failures rather than a memory-layer issue. Caught via py-spy:

```
levenshtein_distance (mnemosyne/core/entities.py)
similarity (mnemosyne/core/entities.py)
find_similar_entities (mnemosyne/core/entities.py)
_find_memories_by_entity (mnemosyne/core/beam.py)
recall (mnemosyne/core/beam.py)
prefetch (mnemosyne/__init__.py)
```

## Fix

Add a cheap length-ratio gate before calling `similarity()`. The score from the levenshtein branch is bounded above by `min_len/max_len`, and the prefix/substring bonuses cap at `0.7 + ratio*0.3`, so when both bounds fall below `threshold` the pair can never match and the O(n*m) work is skipped.

This is exact, not approximate: no pair that could reach the threshold is skipped, so results are unchanged.

## Results

Measured against the production entity store above:

| case | before | after |
|---|---|---|
| 18,549-char query x 7,282 entities | 12.4 min | 3 ms |
| short entity probes (8 names) | baseline | byte-identical results |

All 92 entity-related tests pass (`pytest -k "entit or similar or levenshtein"`).

## Follow-up worth considering

The gate makes it harmless, but `recall()` passing the whole query string as an entity name is the underlying oddity. Extracting entity candidates from the query first (e.g. via `extract_entities_regex`) and matching those individually would make the entity-aware recall path both cheaper and semantically cleaner. Happy to take a swing at that in a separate PR if you agree with the direction.