### PR TITLE
feat(hermes): add bank_id config key for explicit bank selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
+## [3.6.0] — 2026-06-10
+
+### Added
+
+- **Explicit bank selection via `bank_id` config key** (issue #267). New
+  `memory.mnemosyne.bank_id` config key and `MNEMOSYNE_BANK_ID` env var allow
+  overriding the auto-derived bank name from `agent_identity` / `hermes_home`.
+  Useful when the Hermes profile name cannot be changed (e.g. "default") but a
+  specific bank is needed. Precedence: kwargs > config.yaml > env var.
+  Applied to both `hermes_memory_provider` and `integrations/hermes` implementations.
+
 ## [3.5.0] — 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ results = beam.recall("editor preferences", top_k=5)
 | `MNEMOSYNE_IMPORTANCE_WEIGHT` | `0.2` | Importance weight |
 | `MNEMOSYNE_WM_MAX_ITEMS` | `10000` | Working memory limit |
 | `MNEMOSYNE_RECENCY_HALFLIFE` | `168` | Decay halflife in hours |
+| `MNEMOSYNE_BANK_ID` | _(none)_ | Explicit bank name override. Takes priority over auto-derived bank from agent_identity/hermes_home. |
 
 | `MNEMOSYNE_EMBEDDING_API_URL` | `${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}` | Preferred name for custom embedding API endpoint (OpenAI-compatible). Falls back to `OPENROUTER_BASE_URL`. |
 | `MNEMOSYNE_EMBEDDING_API_KEY` | `${OPENROUTER_API_KEY:-${OPENAI_API_KEY:-}}` | Preferred name for embedding API key. Falls back to `OPENROUTER_API_KEY`, then `OPENAI_API_KEY`. |

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -849,6 +849,9 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # Profile memory isolation: when enabled, each Hermes profile gets its own
         # Mnemosyne bank (separate SQLite DB). Default OFF for backward compatibility.
         self._profile_isolation_enabled = False
+        # Explicit bank name override. When set, takes priority over
+        # the auto-derived bank name from agent_identity / hermes_home.
+        self._bank_id: Optional[str] = None
         # Tracked so shutdown() can wait briefly for in-flight consolidation
         # before clearing the host LLM backend, preventing the post-timeout
         # daemon thread from racing with unregister and falling through to
@@ -995,6 +998,19 @@ class MnemosyneMemoryProvider(MemoryProvider):
             else:
                 self._profile_isolation_enabled = bool(profile_isolation)
 
+        # bank_id: explicit bank name override. Takes priority over
+        # the auto-derived bank from agent_identity / hermes_home.
+        # Precedence: kwargs > config.yaml > MNEMOSYNE_BANK_ID env var.
+        bank_id = kwargs.get("bank_id")
+        if bank_id is None:
+            bank_id = self._read_config_key("bank_id")
+        if bank_id is None:
+            bank_id = os.environ.get("MNEMOSYNE_BANK_ID", "").strip() or None
+        if bank_id is not None:
+            sanitized = self._sanitize_bank_name(str(bank_id))
+            if sanitized != "default":
+                self._bank_id = sanitized
+
         shared_surface_path = kwargs.get("shared_surface_path")
         if shared_surface_path is None:
             shared_surface_path = self._read_config_key("shared_surface_path")
@@ -1084,6 +1100,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},
             {"key": "sync_roles", "description": "Conversation roles to autosave in sync_turn(). List of role names: 'user', 'assistant'. Default ['user', 'assistant'] saves both. Set to ['user'] for user turns only, or [] to disable conversation autosave entirely. Does not affect explicit mnemosyne_remember calls. Identity signal capture is gated by user sync — excluding 'user' also disables identity extraction. Also configurable via MNEMOSYNE_SYNC_ROLES env var.", "default": ["user", "assistant"]},
+            {"key": "bank_id", "description": "Explicit bank name override. When set, takes priority over the auto-derived bank from agent_identity / hermes_home. Also settable via MNEMOSYNE_BANK_ID env var. Useful when the profile name cannot be changed (e.g. 'default') but a specific bank is needed.", "default": None},
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
@@ -1144,10 +1161,15 @@ class MnemosyneMemoryProvider(MemoryProvider):
         """Derive a bank name from the active Hermes profile.
 
         Precedence:
-        1. agent_identity (explicit profile name from Hermes)
-        2. hermes_home basename (derived from profile directory)
-        3. Fallback to 'default' (backward-compatible shared DB)
+        1. bank_id explicit override (config key or MNEMOSYNE_BANK_ID env var)
+        2. agent_identity (explicit profile name from Hermes)
+        3. hermes_home basename (derived from profile directory)
+        4. Fallback to 'default' (backward-compatible shared DB)
         """
+        # Explicit override wins
+        if self._bank_id:
+            return self._bank_id
+
         # Try agent_identity first (most reliable)
         identity = getattr(self, "_agent_identity", None) or ""
         if identity and identity.lower() not in ("primary", "default", "none", ""):

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -200,6 +200,9 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # Profile memory isolation: when enabled, each Hermes profile gets its own
         # Mnemosyne bank (separate SQLite DB). Default OFF for backward compatibility.
         self._profile_isolation_enabled = False
+        # Explicit bank name override. When set, takes priority over
+        # the auto-derived bank name from agent_identity / hermes_home.
+        self._bank_id: Optional[str] = None
         # Tracked so shutdown() can wait briefly for in-flight consolidation
         # before clearing the host LLM backend, preventing the post-timeout
         # daemon thread from racing with unregister and falling through to
@@ -346,6 +349,19 @@ class MnemosyneMemoryProvider(MemoryProvider):
             else:
                 self._profile_isolation_enabled = bool(profile_isolation)
 
+        # bank_id: explicit bank name override. Takes priority over
+        # the auto-derived bank from agent_identity / hermes_home.
+        # Precedence: kwargs > config.yaml > MNEMOSYNE_BANK_ID env var.
+        bank_id = kwargs.get("bank_id")
+        if bank_id is None:
+            bank_id = self._read_config_key("bank_id")
+        if bank_id is None:
+            bank_id = os.environ.get("MNEMOSYNE_BANK_ID", "").strip() or None
+        if bank_id is not None:
+            sanitized = self._sanitize_bank_name(str(bank_id))
+            if sanitized != "default":
+                self._bank_id = sanitized
+
         shared_surface_path = kwargs.get("shared_surface_path")
         if shared_surface_path is None:
             shared_surface_path = self._read_config_key("shared_surface_path")
@@ -408,6 +424,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},
+            {"key": "bank_id", "description": "Explicit bank name override. When set, takes priority over the auto-derived bank from agent_identity / hermes_home. Also settable via MNEMOSYNE_BANK_ID env var. Useful when the profile name cannot be changed (e.g. 'default') but a specific bank is needed.", "default": None},
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
@@ -468,10 +485,15 @@ class MnemosyneMemoryProvider(MemoryProvider):
         """Derive a bank name from the active Hermes profile.
 
         Precedence:
-        1. agent_identity (explicit profile name from Hermes)
-        2. hermes_home basename (derived from profile directory)
-        3. Fallback to 'default' (backward-compatible shared DB)
+        1. bank_id explicit override (config key or MNEMOSYNE_BANK_ID env var)
+        2. agent_identity (explicit profile name from Hermes)
+        3. hermes_home basename (derived from profile directory)
+        4. Fallback to 'default' (backward-compatible shared DB)
         """
+        # Explicit override wins
+        if self._bank_id:
+            return self._bank_id
+
         # Try agent_identity first (most reliable)
         identity = getattr(self, "_agent_identity", None) or ""
         if identity and identity.lower() not in ("primary", "default", "none", ""):

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.5.0"
+__version__ = "3.6.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/tests/test_hermes_memory_provider.py
+++ b/tests/test_hermes_memory_provider.py
@@ -649,6 +649,68 @@ class TestResolveProfileBank:
         assert provider._resolve_profile_bank() == "my_profile_v2"
 
 
+class TestResolveProfileBankIdOverride:
+    """Tests for bank_id explicit override in _resolve_profile_bank."""
+
+    def test_bank_id_takes_priority_over_identity(self):
+        provider = MnemosyneMemoryProvider()
+        provider._bank_id = "custom"
+        provider._agent_identity = "sphinx"
+        provider._hermes_home = "/home/user/.hermes/profiles/work"
+        assert provider._resolve_profile_bank() == "custom"
+
+    def test_bank_id_takes_priority_over_hermes_home(self):
+        provider = MnemosyneMemoryProvider()
+        provider._bank_id = "custom"
+        provider._agent_identity = ""
+        provider._hermes_home = "/home/user/.hermes/profiles/work"
+        assert provider._resolve_profile_bank() == "custom"
+
+    def test_bank_id_none_falls_through(self):
+        provider = MnemosyneMemoryProvider()
+        provider._bank_id = None
+        provider._agent_identity = "sphinx"
+        assert provider._resolve_profile_bank() == "sphinx"
+
+    def test_bank_id_empty_string_falls_through(self):
+        provider = MnemosyneMemoryProvider()
+        provider._bank_id = ""
+        provider._agent_identity = "sphinx"
+        assert provider._resolve_profile_bank() == "sphinx"
+
+    def test_bank_id_from_apply_provider_config_kwargs(self):
+        provider = MnemosyneMemoryProvider()
+        provider._hermes_home = ""
+        provider._apply_provider_config({"bank_id": "from_kwargs"})
+        assert provider._bank_id == "from_kwargs"
+
+    def test_bank_id_from_env_var(self, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_BANK_ID", "from_env")
+        provider = MnemosyneMemoryProvider()
+        provider._hermes_home = ""
+        provider._apply_provider_config({})
+        assert provider._bank_id == "from_env"
+
+    def test_bank_id_default_is_sanitized(self):
+        provider = MnemosyneMemoryProvider()
+        provider._hermes_home = ""
+        provider._apply_provider_config({"bank_id": "default"})
+        assert provider._bank_id is None
+
+    def test_bank_id_invalid_chars_are_sanitized(self):
+        provider = MnemosyneMemoryProvider()
+        provider._hermes_home = ""
+        provider._apply_provider_config({"bank_id": "my bank/name"})
+        assert provider._bank_id == "my_bank_name"
+
+    def test_bank_id_in_config_schema(self):
+        provider = MnemosyneMemoryProvider()
+        schema = provider.get_config_schema()
+        bank_id_entry = [e for e in schema if e["key"] == "bank_id"]
+        assert len(bank_id_entry) == 1
+        assert bank_id_entry[0]["default"] is None
+
+
 class TestInitializeProfileIsolation:
     """Tests for initialize() with profile_isolation flag."""
 


### PR DESCRIPTION
## Description

Adds `memory.mnemosyne.bank_id` config key and `MNEMOSYNE_BANK_ID` env var to override the auto-derived bank name in `_resolve_profile_bank()`.

When `profile_isolation` is enabled, the bank name is always derived from `agent_identity` or `hermes_home`. If the profile name maps to "default" (or other filtered values), there is no way to route to a specific bank. This lets users explicitly set a bank name regardless of profile identity.

Precedence: kwargs > config.yaml > `MNEMOSYNE_BANK_ID` env var > existing derivation logic.

## Related Issue

Closes #267

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Existing tests still pass (`pytest tests/ -v`)
- [x] New tests added for any new functionality
- [ ] Manual verification

## Checklist

- [x] Version bumped in `mnemosyne/__init__.py`
- [x] `CHANGELOG.md` updated with a brief entry
- [x] README updated if user-facing behavior changed
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency