### PR TITLE
fix: harden Hermes prefetch injection selection

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sys
 import threading
 from dataclasses import dataclass
@@ -133,7 +134,23 @@ _PREFETCH_FRAGMENT_STOPWORDS = frozenset({
 })
 _PREFETCH_MIN_FRAGMENT_CHARS = 8   # lone tokens shorter than this are dropped
 _PREFETCH_OVERFETCH = 16           # recall more, then filter junk and cap
-_PREFETCH_TOP_K = 8                # final injected count (unchanged behavior)
+_PREFETCH_TOP_K = 5                # final injected count: compact, relevance-first
+
+# Prompt-usefulness filter for automatic memory-context injection. Manual recall
+# tools can stay broad; prefetch is silently injected into every model call, so
+# it should be conservative and favor distilled memories over raw transcript.
+_PREFETCH_RAW_PREFIXES = ("[USER]", "[ASSISTANT]", "[IDENTITY]")
+_PREFETCH_EXCLUDED_PREFIXES = ("[ASSISTANT]",)
+_PREFETCH_RAW_SOURCES = {"conversation"}
+_PREFETCH_DISTILLED_SOURCES = {
+    "preference", "correction", "fact", "identity", "insight", "sleep_consolidation",
+}
+_PREFETCH_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_./:-]*", re.IGNORECASE)
+_PREFETCH_DEDUP_STOPWORDS = _PREFETCH_FRAGMENT_STOPWORDS | frozenset({
+    "about", "after", "before", "because", "could", "from", "have", "into",
+    "like", "more", "need", "needs", "than", "them", "they", "want", "wants",
+    "when", "where", "which", "while", "would", "yourself",
+})
 
 
 def _is_low_quality_prefetch(content: str) -> bool:
@@ -148,37 +165,139 @@ def _is_low_quality_prefetch(content: str) -> bool:
     return False
 
 
+def _strip_prefetch_prefix(content: str) -> str:
+    c = (content or "").strip()
+    upper = c.upper()
+    for prefix in _PREFETCH_RAW_PREFIXES:
+        if upper.startswith(prefix):
+            return c[len(prefix):].strip()
+    return c
+
+
+def _prefetch_tokens(content: str) -> Set[str]:
+    c = _strip_prefetch_prefix(content).lower()
+    tokens: Set[str] = set()
+    for token in _PREFETCH_TOKEN_RE.findall(c):
+        if len(token) <= 2 or token in _PREFETCH_DEDUP_STOPWORDS:
+            continue
+        tokens.add(token)
+    return tokens
+
+
+def _prefetch_topic_signal(row: Dict[str, Any]) -> float:
+    """Best available non-importance relevance signal for a recall row."""
+    signal = max(
+        float(row.get("keyword_score") or 0.0),
+        float(row.get("fts_score") or 0.0),
+        float(row.get("dense_score") or 0.0),
+    )
+    # Fact/entity matches are explicit relevance signals even when recall() did
+    # not fill keyword/FTS scores for that path.
+    if row.get("fact_match") or row.get("entity_match"):
+        signal = max(signal, 0.20)
+    return signal
+
+
+def _prefetch_source_quality(row: Dict[str, Any]) -> float:
+    """Relative usefulness multiplier for injected memory.
+
+    Distilled memories are better prompt context than raw transcript snippets;
+    assistant transcript snippets should not be injected at all by default.
+    """
+    content = (row.get("content") or "").strip()
+    upper = content.upper()
+    source = str(row.get("source") or "").lower()
+
+    if upper.startswith(_PREFETCH_EXCLUDED_PREFIXES):
+        return 0.0
+
+    quality = 1.0
+    if source in _PREFETCH_DISTILLED_SOURCES:
+        quality *= 1.12
+    if source in _PREFETCH_RAW_SOURCES:
+        quality *= 0.72
+    if upper.startswith("[USER]"):
+        quality *= 0.68
+    elif upper.startswith("[IDENTITY]"):
+        quality *= 0.80
+    elif source.startswith("memoria_source"):
+        quality *= 0.90
+    return quality
+
+
+def _prefetch_is_raw(row: Dict[str, Any]) -> bool:
+    content = (row.get("content") or "").strip().upper()
+    source = str(row.get("source") or "").lower()
+    return source in _PREFETCH_RAW_SOURCES or content.startswith("[USER]") or content.startswith("[IDENTITY]")
+
+
+def _prefetch_adjusted_score(row: Dict[str, Any]) -> float:
+    score = float(row.get("score") or 0.0)
+    signal = _prefetch_topic_signal(row)
+    importance = min(max(float(row.get("importance") or 0.0), 0.0), 1.0)
+    return (score * 0.65 + signal * 0.35 + importance * 0.05) * _prefetch_source_quality(row)
+
+
+def _semantic_dedup_prefetch(rows: List[Dict[str, Any]], threshold: float = 0.72) -> List[Dict[str, Any]]:
+    """Collapse near-duplicate memory rows, keeping the best-ranked variant."""
+    kept: List[Dict[str, Any]] = []
+    kept_tokens: List[Set[str]] = []
+    for row in rows:
+        tokens = _prefetch_tokens(row.get("content", ""))
+        if not tokens:
+            continue
+        duplicate = False
+        for existing in kept_tokens:
+            overlap = len(tokens & existing)
+            if not overlap:
+                continue
+            jaccard = overlap / max(len(tokens | existing), 1)
+            containment = overlap / max(min(len(tokens), len(existing)), 1)
+            if jaccard >= threshold or containment >= 0.86:
+                duplicate = True
+                break
+        if duplicate:
+            continue
+        kept.append(row)
+        kept_tokens.append(tokens)
+    return kept
+
+
 # ---------------------------------------------------------------------------
 # Prefetch profiles
 #
 # A profile is a named bundle of the prefetch knobs (recall breadth, weights,
-# temporal decay, relevance thresholds, the low-quality filter + dedup toggles,
-# and which registered sources to merge). The built-in `general` profile
-# reproduces the prior hardcoded behavior exactly, so existing deployments see no
-# change. Operators select a profile via MNEMOSYNE_PREFETCH_PROFILE; libraries can
-# register their own with register_profile().
+# temporal decay, relevance thresholds, source quality filtering + dedup toggles,
+# and which registered sources to merge). Operators select a profile via
+# MNEMOSYNE_PREFETCH_PROFILE; libraries can register their own with
+# register_profile().
 # ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
 class PrefetchProfile:
     name: str
-    top_k: int = 8
+    top_k: int = _PREFETCH_TOP_K
     importance_weight: Optional[float] = None   # None -> recall() default
     vec_weight: Optional[float] = None
     fts_weight: Optional[float] = None
     temporal_weight: float = 0.2
     temporal_halflife: float = 48
-    min_score: float = 0.15
-    min_importance: float = 0.5
+    min_score: float = 0.20
+    min_importance: float = 0.65
+    min_topic_signal: float = 0.08
+    raw_min_topic_signal: float = 0.18
     content_char_limit: int = 0                  # 0 -> use env / untruncated
     drop_low_quality: bool = True
     dedup: bool = True
+    semantic_dedup: bool = True
+    exclude_assistant: bool = True
     sources: Tuple[str, ...] = ("bank",)         # which registered sources to merge
 
 
 _BUILTIN_PROFILES: Dict[str, PrefetchProfile] = {
-    # Exact prior behavior — the default.
+    # Default per-turn injection: compact, relevance-first, and conservative
+    # about raw transcript snippets.
     "general": PrefetchProfile(name="general"),
     # Favor recent, high-importance memories; same filter/dedup defaults.
     "social-chat": PrefetchProfile(
@@ -1419,7 +1538,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
     def _prefetch_bank(self, query: str, session_id: str, profile: "PrefetchProfile") -> str:
         """The built-in memory-bank source: hybrid recall with temporal weighting,
         relevance + low-quality filtering, scoped to author_id when available.
-        Parameterized by *profile*; with ``general`` this is the legacy behavior."""
+        Parameterized by *profile*."""
         try:
             import os
             author_id = self._beam.author_id or os.environ.get("MNEMOSYNE_AUTHOR_ID")
@@ -1430,7 +1549,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 temporal_halflife=profile.temporal_halflife,
             )
             # Pass tuning weights only when the profile sets them, so the default
-            # profile preserves recall()'s own defaults exactly.
+            # profile still lets recall() resolve its own weights.
             if profile.importance_weight is not None:
                 recall_kwargs["importance_weight"] = profile.importance_weight
             if profile.vec_weight is not None:
@@ -1450,15 +1569,29 @@ class MnemosyneMemoryProvider(MemoryProvider):
             results = self._beam.recall(**recall_kwargs)
             if not results:
                 return ""
-            # Filter out low-relevance results to prevent context pollution
-            # Only include memories with score above threshold or high importance
-            filtered = [
-                r for r in results
-                if (r.get("score", 0) >= profile.min_score
-                    or r.get("importance", 0) >= profile.min_importance)
-                and not (profile.drop_low_quality
-                         and _is_low_quality_prefetch(r.get("content", "")))
-            ]
+            # Filter out low-relevance results to prevent context pollution.
+            # Importance alone is not enough for silent injection: a memory must
+            # also have a real topical signal. Raw transcript rows need a
+            # stronger topical signal than distilled facts/preferences.
+            filtered = []
+            for r in results:
+                if profile.drop_low_quality and _is_low_quality_prefetch(r.get("content", "")):
+                    continue
+                if profile.exclude_assistant and _prefetch_source_quality(r) <= 0:
+                    continue
+                signal = _prefetch_topic_signal(r)
+                score = float(r.get("score") or 0.0)
+                importance = float(r.get("importance") or 0.0)
+                required_signal = profile.raw_min_topic_signal if _prefetch_is_raw(r) else profile.min_topic_signal
+                if signal < required_signal:
+                    continue
+                if score < profile.min_score and importance < profile.min_importance:
+                    continue
+                filtered.append(r)
+
+            filtered.sort(key=_prefetch_adjusted_score, reverse=True)
+            if profile.semantic_dedup:
+                filtered = _semantic_dedup_prefetch(filtered)
             # Cap back to the intended injection size after over-fetch+filter.
             filtered = filtered[:profile.top_k]
             if not filtered:
@@ -1470,11 +1603,14 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     r.get("content", ""),
                     content_limit,
                 )
+                content = " ".join(content.split())
                 ts = r.get("timestamp", "")[:16] if r.get("timestamp") else ""
                 imp = r.get("importance", 0.0)
                 trust = r.get("trust_tier", "STATED")
                 trust_tag = f" [{trust}]" if trust != "STATED" else ""
-                lines.append(f"  [{ts}] (importance {imp:.2f}){trust_tag} {content}")
+                source = str(r.get("source") or "").strip()
+                source_tag = f", source {source}" if source and source != "conversation" else ""
+                lines.append(f"  [{ts}] (importance {imp:.2f}{source_tag}){trust_tag} {content}")
             return "\n".join(lines)
         except Exception as e:
             logger.debug("Mnemosyne prefetch failed: %s", e)

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sys
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 from datetime import datetime
 
 # Mnemosyne core is installed via pip (mnemosyne-memory>=3.1 dependency).
@@ -91,6 +92,125 @@ def _format_prefetch_content(content: str, limit: int) -> str:
     return f"{cut}..."
 
 
+_PREFETCH_TOP_K = 5
+_PREFETCH_MIN_FRAGMENT_CHARS = 8
+_PREFETCH_FRAGMENT_STOPWORDS = frozenset({
+    "a", "an", "and", "are", "as", "be", "but", "by", "do", "for", "go",
+    "hi", "how", "i", "if", "in", "is", "it", "me", "my", "no", "of", "ok",
+    "on", "or", "so", "the", "to", "u", "we", "what", "why", "yes", "you",
+})
+_PREFETCH_RAW_PREFIXES = ("[USER]", "[ASSISTANT]", "[IDENTITY]")
+_PREFETCH_EXCLUDED_PREFIXES = ("[ASSISTANT]",)
+_PREFETCH_RAW_SOURCES = {"conversation"}
+_PREFETCH_DISTILLED_SOURCES = {
+    "preference", "correction", "fact", "identity", "insight", "sleep_consolidation",
+}
+_PREFETCH_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_./:-]*", re.IGNORECASE)
+_PREFETCH_DEDUP_STOPWORDS = _PREFETCH_FRAGMENT_STOPWORDS | frozenset({
+    "about", "after", "before", "because", "could", "from", "have", "into",
+    "like", "more", "need", "needs", "than", "them", "they", "want", "wants",
+    "when", "where", "which", "while", "would", "yourself",
+})
+
+
+def _is_low_quality_prefetch(content: str) -> bool:
+    c = (content or "").strip()
+    if not c:
+        return True
+    if len(c.split()) <= 1 and (
+        len(c) <= _PREFETCH_MIN_FRAGMENT_CHARS or c.lower() in _PREFETCH_FRAGMENT_STOPWORDS
+    ):
+        return True
+    return False
+
+
+def _strip_prefetch_prefix(content: str) -> str:
+    c = (content or "").strip()
+    upper = c.upper()
+    for prefix in _PREFETCH_RAW_PREFIXES:
+        if upper.startswith(prefix):
+            return c[len(prefix):].strip()
+    return c
+
+
+def _prefetch_tokens(content: str) -> Set[str]:
+    c = _strip_prefetch_prefix(content).lower()
+    tokens: Set[str] = set()
+    for token in _PREFETCH_TOKEN_RE.findall(c):
+        if len(token) <= 2 or token in _PREFETCH_DEDUP_STOPWORDS:
+            continue
+        tokens.add(token)
+    return tokens
+
+
+def _prefetch_topic_signal(row: Dict[str, Any]) -> float:
+    signal = max(
+        float(row.get("keyword_score") or 0.0),
+        float(row.get("fts_score") or 0.0),
+        float(row.get("dense_score") or 0.0),
+    )
+    if row.get("fact_match") or row.get("entity_match"):
+        signal = max(signal, 0.20)
+    return signal
+
+
+def _prefetch_source_quality(row: Dict[str, Any]) -> float:
+    content = (row.get("content") or "").strip()
+    upper = content.upper()
+    source = str(row.get("source") or "").lower()
+    if upper.startswith(_PREFETCH_EXCLUDED_PREFIXES):
+        return 0.0
+    quality = 1.0
+    if source in _PREFETCH_DISTILLED_SOURCES:
+        quality *= 1.12
+    if source in _PREFETCH_RAW_SOURCES:
+        quality *= 0.72
+    if upper.startswith("[USER]"):
+        quality *= 0.68
+    elif upper.startswith("[IDENTITY]"):
+        quality *= 0.80
+    elif source.startswith("memoria_source"):
+        quality *= 0.90
+    return quality
+
+
+def _prefetch_is_raw(row: Dict[str, Any]) -> bool:
+    content = (row.get("content") or "").strip().upper()
+    source = str(row.get("source") or "").lower()
+    return source in _PREFETCH_RAW_SOURCES or content.startswith("[USER]") or content.startswith("[IDENTITY]")
+
+
+def _prefetch_adjusted_score(row: Dict[str, Any]) -> float:
+    score = float(row.get("score") or 0.0)
+    signal = _prefetch_topic_signal(row)
+    importance = min(max(float(row.get("importance") or 0.0), 0.0), 1.0)
+    return (score * 0.65 + signal * 0.35 + importance * 0.05) * _prefetch_source_quality(row)
+
+
+def _semantic_dedup_prefetch(rows: List[Dict[str, Any]], threshold: float = 0.72) -> List[Dict[str, Any]]:
+    kept: List[Dict[str, Any]] = []
+    kept_tokens: List[Set[str]] = []
+    for row in rows:
+        tokens = _prefetch_tokens(row.get("content", ""))
+        if not tokens:
+            continue
+        duplicate = False
+        for existing in kept_tokens:
+            overlap = len(tokens & existing)
+            if not overlap:
+                continue
+            jaccard = overlap / max(len(tokens | existing), 1)
+            containment = overlap / max(min(len(tokens), len(existing)), 1)
+            if jaccard >= threshold or containment >= 0.86:
+                duplicate = True
+                break
+        if duplicate:
+            continue
+        kept.append(row)
+        kept_tokens.append(tokens)
+    return kept
+
+
 def _sync_turn_user_limit() -> int:
     """Return the per-turn user content truncation limit.
 
@@ -154,6 +274,8 @@ def _parse_env_float(key: str, default: float) -> float:
 class MnemosyneMemoryProvider(MemoryProvider):
     """Mnemosyne native memory — local SQLite with vector + FTS5 hybrid search."""
 
+    _VALID_SYNC_ROLES: frozenset = frozenset({"user", "assistant"})
+
     # How long on_session_end will wait for sleep/consolidation to finish before
     # giving up and letting the daemon thread continue in the background. Tests
     # may shorten this to keep the suite fast. Override via MNEMOSYNE_SESSION_END_TIMEOUT.
@@ -189,6 +311,11 @@ class MnemosyneMemoryProvider(MemoryProvider):
         self._auto_sleep_threshold = 50
         self._auto_sleep_enabled = os.environ.get("MNEMOSYNE_AUTO_SLEEP_ENABLED", "").strip().lower() in ("1", "true", "yes", "on")
         self._ignore_patterns: List[str] = []  # Regex patterns to filter from memory
+        self._sync_roles: Set[str] = set(self._VALID_SYNC_ROLES)
+        _sync_env = os.environ.get("MNEMOSYNE_SYNC_ROLES")
+        if _sync_env is not None:
+            _parsed_roles = {r.strip().lower() for r in _sync_env.split(",") if r.strip()}
+            self._sync_roles = _parsed_roles & self._VALID_SYNC_ROLES
         self._skip_contexts = {"cron", "flush", "subagent", "background", "skill_loop"}  # Agent contexts to skip
         # Allow override via MNEMOSYNE_SKIP_CONTEXTS env var.
         # Set to empty string to skip nothing (enable all contexts).
@@ -351,6 +478,21 @@ class MnemosyneMemoryProvider(MemoryProvider):
             shared_surface_path = self._read_config_key("shared_surface_path")
         if shared_surface_path:
             self._shared_surface_path = Path(str(shared_surface_path)).expanduser()
+
+        # sync_roles: controls which turn roles are autosaved. User-only
+        # autosave configurations avoid assistant transcript noise in automatic
+        # memory-context injection.
+        _sync_raw = kwargs.get("sync_roles")
+        if _sync_raw is None:
+            _sync_raw = self._read_config_key("sync_roles")
+        if _sync_raw is not None:
+            if isinstance(_sync_raw, str):
+                parsed = {r.strip().lower() for r in _sync_raw.split(",") if r.strip()}
+            elif isinstance(_sync_raw, (list, tuple, set)):
+                parsed = {str(r).strip().lower() for r in _sync_raw if str(r).strip()}
+            else:
+                parsed = set()
+            self._sync_roles = parsed & self._VALID_SYNC_ROLES
 
         # skip_contexts: kwargs > config.yaml > env var (already set in __init__)
         _skip_raw = kwargs.get("skip_contexts")
@@ -641,7 +783,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             import os
             author_id = self._beam.author_id or os.environ.get("MNEMOSYNE_AUTHOR_ID")
             recall_kwargs: Dict[str, Any] = dict(
-                query=query, top_k=8,
+                query=query, top_k=max(_PREFETCH_TOP_K * 2, 16),
                 temporal_weight=0.2, temporal_halflife=48,
             )
             # Only pass author_id when explicitly non-empty.  Passing an empty
@@ -657,15 +799,28 @@ class MnemosyneMemoryProvider(MemoryProvider):
             results = self._beam.recall(**recall_kwargs)
             if not results:
                 return ""
-            # Filter out low-relevance results to prevent context pollution
-            # Only include memories with score above threshold or high importance
-            MIN_SCORE_THRESHOLD = 0.15
-            MIN_IMPORTANCE_THRESHOLD = 0.5
-            filtered = [
-                r for r in results
-                if r.get("score", 0) >= MIN_SCORE_THRESHOLD
-                or r.get("importance", 0) >= MIN_IMPORTANCE_THRESHOLD
-            ]
+            # Filter out low-relevance results to prevent context pollution.
+            # Importance alone is not enough for silent injection: a memory must
+            # also have a real topical signal. Raw transcript rows need a
+            # stronger topical signal than distilled facts/preferences.
+            filtered = []
+            for r in results:
+                if _is_low_quality_prefetch(r.get("content", "")):
+                    continue
+                if _prefetch_source_quality(r) <= 0:
+                    continue
+                signal = _prefetch_topic_signal(r)
+                score = float(r.get("score") or 0.0)
+                importance = float(r.get("importance") or 0.0)
+                required_signal = 0.18 if _prefetch_is_raw(r) else 0.08
+                if signal < required_signal:
+                    continue
+                if score < 0.20 and importance < 0.65:
+                    continue
+                filtered.append(r)
+
+            filtered.sort(key=_prefetch_adjusted_score, reverse=True)
+            filtered = _semantic_dedup_prefetch(filtered)[:_PREFETCH_TOP_K]
             if not filtered:
                 return ""
             lines = ["## Mnemosyne Context"]
@@ -675,11 +830,14 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     r.get("content", ""),
                     content_limit,
                 )
+                content = " ".join(content.split())
                 ts = r.get("timestamp", "")[:16] if r.get("timestamp") else ""
                 imp = r.get("importance", 0.0)
                 trust = r.get("trust_tier", "STATED")
                 trust_tag = f" [{trust}]" if trust != "STATED" else ""
-                lines.append(f"  [{ts}] (importance {imp:.2f}){trust_tag} {content}")
+                source = str(r.get("source") or "").strip()
+                source_tag = f", source {source}" if source and source != "conversation" else ""
+                lines.append(f"  [{ts}] (importance {imp:.2f}{source_tag}){trust_tag} {content}")
             return "\n".join(lines)
         except Exception as e:
             logger.debug("Mnemosyne prefetch failed: %s", e)
@@ -693,7 +851,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if not self._beam or self._agent_context in self._skip_contexts:
             return
         try:
-            if user_content and len(user_content) > 5 and not self._should_filter(user_content):
+            if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
                 user_limit = _sync_turn_user_limit()
                 uc = user_content[:user_limit] if user_limit > 0 else user_content
                 self._beam.remember(
@@ -704,7 +862,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 )
                 # Check for identity-significant signals in user content
                 self._capture_identity_signals(user_content)
-            if assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
+            if "assistant" in self._sync_roles and assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
                 assistant_limit = _sync_turn_assistant_limit()
                 ac = assistant_content[:assistant_limit] if assistant_limit > 0 else assistant_content
                 self._beam.remember(

--- a/integrations/hermes/tests/test_prefetch_hardening.py
+++ b/integrations/hermes/tests/test_prefetch_hardening.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from mnemosyne_hermes import MnemosyneMemoryProvider
+
+
+class FakeBeam:
+    author_id = "test-author"
+
+    def __init__(self, results=None):
+        self.results = results or []
+        self.writes = []
+
+    def recall(self, **kwargs):
+        self.last_kwargs = kwargs
+        return self.results
+
+    def remember(self, **kwargs):
+        self.writes.append(kwargs)
+
+
+def _provider(results):
+    p = MnemosyneMemoryProvider()
+    p._beam = FakeBeam(results)
+    p._agent_context = "primary"
+    return p
+
+
+def test_prefetch_excludes_assistant_transcript_rows():
+    p = _provider([
+        {"content": "[ASSISTANT] stale answer that should not inject", "source": "conversation",
+         "timestamp": "2026-06-11T09:00:00Z", "importance": 1.0, "score": 1.0,
+         "keyword_score": 1.0, "trust_tier": "STATED"},
+        {"content": "Mnemosyne injection should prefer distilled correction memories.",
+         "source": "correction", "timestamp": "2026-06-11T09:01:00Z",
+         "importance": 0.8, "score": 0.7, "keyword_score": 0.7, "trust_tier": "STATED"},
+    ])
+
+    block = p.prefetch("Mnemosyne injection correction")
+
+    assert "distilled correction" in block
+    assert "[ASSISTANT]" not in block
+
+
+def test_prefetch_requires_topic_signal_not_importance_only():
+    p = _provider([
+        {"content": "[USER] unrelated minecraft watcher cleanup", "source": "conversation",
+         "timestamp": "2026-06-10T11:33:00Z", "importance": 0.99, "score": 0.9,
+         "keyword_score": 0.02, "trust_tier": "STATED"},
+        {"content": "Mnemosyne memory-context injection should be selected by topical relevance.",
+         "source": "correction", "timestamp": "2026-06-11T09:01:00Z",
+         "importance": 0.7, "score": 0.6, "keyword_score": 0.6, "trust_tier": "STATED"},
+    ])
+
+    block = p.prefetch("make Mnemosyne memory-context injection more relevant")
+
+    assert "topical relevance" in block
+    assert "minecraft watcher" not in block
+
+
+def test_sync_roles_can_disable_assistant_autosave():
+    p = MnemosyneMemoryProvider()
+    p._beam = FakeBeam()
+    p._agent_context = "primary"
+    p._sync_roles = {"user"}
+
+    p.sync_turn("please remember user side", "assistant side should not be stored")
+
+    written = [w["content"] for w in p._beam.writes]
+    assert any(c.startswith("[USER]") for c in written)
+    assert not any(c.startswith("[ASSISTANT]") for c in written)

--- a/tests/test_prefetch_content_truncation.py
+++ b/tests/test_prefetch_content_truncation.py
@@ -21,6 +21,8 @@ class FakeBeam:
                 "timestamp": "2026-05-14T12:00:00Z",
                 "importance": 0.9,
                 "score": 0.9,
+                "keyword_score": 0.9,
+                "source": "correction",
                 "trust_tier": "STATED",
             }
         ]

--- a/tests/test_prefetch_low_quality.py
+++ b/tests/test_prefetch_low_quality.py
@@ -35,12 +35,12 @@ class FakeBeam:
         return [
             # bare fragments scoring high on keyword match — must be filtered out
             {"content": "what", "timestamp": "2026-05-14T12:00:00Z",
-             "importance": 0.1, "score": 0.63, "trust_tier": "STATED"},
+             "importance": 0.1, "score": 0.63, "keyword_score": 0.63, "trust_tier": "STATED"},
             {"content": "still", "timestamp": "2026-05-14T12:00:00Z",
-             "importance": 0.1, "score": 0.62, "trust_tier": "STATED"},
+             "importance": 0.1, "score": 0.62, "keyword_score": 0.62, "trust_tier": "STATED"},
             # a real, sentence-length memory scoring lower — must survive
             {"content": "Paris is the capital of France", "timestamp": "2026-05-14T12:00:00Z",
-             "importance": 0.6, "score": 0.40, "trust_tier": "STATED"},
+             "importance": 0.6, "score": 0.40, "keyword_score": 0.40, "trust_tier": "STATED"},
         ]
 
 

--- a/tests/test_prefetch_profiles.py
+++ b/tests/test_prefetch_profiles.py
@@ -1,8 +1,8 @@
 """Tests for selectable prefetch profiles + the generic source-extension hook.
 
-The default `general` profile must reproduce prior behavior exactly; other
-profiles only change the documented knobs. The source registry lets a caller
-merge extra retrieval inputs without the core knowing what they are.
+The default `general` profile is the normal conservative injection profile;
+other profiles only change the documented knobs. The source registry lets a
+caller merge extra retrieval inputs without the core knowing what they are.
 """
 from __future__ import annotations
 
@@ -46,7 +46,7 @@ def test_unknown_profile_falls_back_to_general():
 def test_general_is_the_default_and_passes_no_tuning_weights():
     p = _provider("general", [
         {"content": "Paris is the capital of France", "timestamp": "2026-05-14T12:00:00Z",
-         "importance": 0.9, "score": 0.9, "trust_tier": "STATED"},
+         "importance": 0.9, "score": 0.9, "keyword_score": 0.9, "trust_tier": "STATED"},
     ])
     block = p.prefetch("capital of France")
     assert block.startswith("## Mnemosyne Context")
@@ -59,7 +59,7 @@ def test_general_is_the_default_and_passes_no_tuning_weights():
 def test_social_chat_passes_its_tuning_to_recall():
     p = _provider("social-chat", [
         {"content": "the team ships on Friday", "timestamp": "2026-05-14T12:00:00Z",
-         "importance": 0.9, "score": 0.4, "trust_tier": "STATED"},
+         "importance": 0.9, "score": 0.4, "keyword_score": 0.4, "trust_tier": "STATED"},
     ])
     p.prefetch("when do we ship")
     assert p._beam.last_kwargs["importance_weight"] == 0.6
@@ -72,7 +72,7 @@ def test_social_chat_passes_its_tuning_to_recall():
 def test_registered_source_is_merged():
     p = _provider("general", [
         {"content": "Paris is the capital of France", "timestamp": "2026-05-14T12:00:00Z",
-         "importance": 0.9, "score": 0.9, "trust_tier": "STATED"},
+         "importance": 0.9, "score": 0.9, "keyword_score": 0.9, "trust_tier": "STATED"},
     ])
     register_profile(PrefetchProfile(name="t-merge", sources=("bank", "dummy")))
     p._prefetch_profile = "t-merge"
@@ -93,7 +93,7 @@ def test_bank_source_cannot_be_overridden():
 def test_dedup_collapses_duplicate_content_across_sources():
     p = _provider("general", [
         {"content": "Mount Everest is the tallest mountain", "timestamp": "2026-05-14T12:00:00Z",
-         "importance": 0.9, "score": 0.9, "trust_tier": "STATED"},
+         "importance": 0.9, "score": 0.9, "keyword_score": 0.9, "trust_tier": "STATED"},
     ])
     register_profile(PrefetchProfile(name="t-dedup", sources=("bank", "dummy"), dedup=True))
     p._prefetch_profile = "t-dedup"
@@ -110,8 +110,87 @@ def test_env_content_chars_override_beats_profile(monkeypatch):
     long_content = "Mount Everest " * 10 + "tail"
     p = _provider("general", [
         {"content": long_content, "timestamp": "2026-05-14T12:00:00Z",
-         "importance": 0.9, "score": 0.9, "trust_tier": "STATED"},
+         "importance": 0.9, "score": 0.9, "keyword_score": 0.9, "trust_tier": "STATED"},
     ])
     block = p.prefetch("everest")
     assert "tail" not in block          # truncated by the env limit
     assert block.rstrip().endswith("...")
+
+
+# --- Mnemosyne injection hardening ------------------------------------------
+
+def test_prefetch_excludes_assistant_transcript_rows_by_default():
+    p = _provider("general", [
+        {"content": "[ASSISTANT] You should always mention the old injected block",
+         "timestamp": "2026-06-11T09:00:00Z", "source": "conversation",
+         "importance": 1.0, "score": 1.0, "keyword_score": 1.0, "trust_tier": "STATED"},
+        {"content": "Mnemosyne injection should prefer distilled correction memories.",
+         "timestamp": "2026-06-11T09:01:00Z", "source": "correction",
+         "importance": 0.8, "score": 0.7, "keyword_score": 0.7, "trust_tier": "STATED"},
+    ])
+
+    block = p.prefetch("Mnemosyne injection correction")
+
+    assert "distilled correction" in block
+    assert "[ASSISTANT]" not in block
+
+
+def test_prefetch_does_not_let_importance_alone_inject_weak_raw_chat():
+    p = _provider("general", [
+        {"content": "[USER] unrelated bi weekly reminder and minecraft watcher cleanup",
+         "timestamp": "2026-06-10T11:33:00Z", "source": "conversation",
+         "importance": 0.99, "score": 0.9, "keyword_score": 0.02, "trust_tier": "STATED"},
+        {"content": "Mnemosyne memory-context injection should be selected by topical relevance.",
+         "timestamp": "2026-06-11T09:01:00Z", "source": "correction",
+         "importance": 0.7, "score": 0.6, "keyword_score": 0.6, "trust_tier": "STATED"},
+    ])
+
+    block = p.prefetch("make Mnemosyne memory-context injection more relevant")
+
+    assert "topical relevance" in block
+    assert "minecraft watcher" not in block
+
+
+def test_prefetch_semantic_dedup_keeps_distilled_variant_over_raw_duplicate():
+    p = _provider("general", [
+        {"content": "[USER] I want Mnemosyne injection relevance hardening and better memory selection",
+         "timestamp": "2026-06-11T09:00:00Z", "source": "conversation",
+         "importance": 0.3, "score": 0.95, "keyword_score": 0.75, "trust_tier": "STATED"},
+        {"content": "Operators want Mnemosyne injection relevance hardening and better memory selection.",
+         "timestamp": "2026-06-11T09:01:00Z", "source": "correction",
+         "importance": 0.85, "score": 0.75, "keyword_score": 0.75, "trust_tier": "STATED"},
+    ])
+
+    block = p.prefetch("Mnemosyne injection relevance hardening")
+
+    assert "Operators want Mnemosyne" in block
+    assert "[USER] I want Mnemosyne" not in block
+
+
+def test_prefetch_default_caps_injection_to_five_relevance_sorted_rows():
+    unique_terms = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"]
+    rows = [
+        {"content": f"Relevant distilled memory about {term}", "timestamp": f"2026-06-11T09:0{i}:00Z",
+         "source": "fact", "importance": 0.7, "score": 0.6 + i * 0.01,
+         "keyword_score": 0.6, "trust_tier": "STATED"}
+        for i, term in enumerate(unique_terms)
+    ]
+    p = _provider("general", rows)
+
+    block = p.prefetch("relevant distilled memory")
+
+    injected = [line for line in block.splitlines() if "Relevant distilled memory" in line]
+    assert len(injected) == 5
+
+
+def test_prefetch_collapses_content_newlines_inside_memory_rows():
+    p = _provider("general", [
+        {"content": "Mnemosyne injection first line\nsecond line should stay in the same injected row",
+         "timestamp": "2026-06-11T09:01:00Z", "source": "correction",
+         "importance": 0.8, "score": 0.7, "keyword_score": 0.7, "trust_tier": "STATED"},
+    ])
+
+    block = p.prefetch("Mnemosyne injection line")
+
+    assert "first line second line" in block
+    assert len(block.splitlines()) == 2


### PR DESCRIPTION
## Summary
- Tightens Hermes/Mnemosyne automatic prefetch injection so default context is compact and relevance-first.
- Requires topical signal before injecting recalled memories, with stricter handling for raw conversation snippets.
- Excludes assistant transcript snippets from automatic injection, semantically deduplicates results, and caps injected rows at 5.
- Collapses embedded newlines in injected rows and includes source labels for non-conversation memories.
- Adds `sync_roles` handling to the packaged Hermes adapter so deployments can disable assistant autosave.

## Validation
- `python -m pytest tests/test_prefetch_profiles.py tests/test_prefetch_low_quality.py tests/test_prefetch_content_truncation.py tests/test_hermes_memory_provider_thread_isolation.py integrations/hermes/tests/test_prefetch_hardening.py -q -o 'addopts='`
- `git diff --check`
