### PR TITLE
fix: Russian FTS5 fallback for inflected Cyrillic recall

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1846,6 +1846,167 @@ def _cjk_like_search(conn: sqlite3.Connection, query: str, k: int = 20, working:
     return [{result_key: rid, "rank": -score} for rid, score in scored[:k]]
 
 
+# ---------------------------------------------------------------------------
+# Cyrillic FTS5 fallback (Russian)
+#
+# Russian is morphologically rich: a single lemma produces many inflected
+# surface forms (тёмная / тёмную / тёмной, встреча / встречи / встречу).
+# The default unicode61 FTS5 tokenizer has no built-in stemmer for Russian,
+# so direct FTS5 queries match only the exact surface form.
+#
+# When a Russian query produces zero FTS5 results, we fall back to a
+# LIKE-based scan and rank candidates by trigram Jaccard similarity
+# between query and content words. This mirrors _cjk_like_search
+# (issue #168) but with n-gram scoring, which is significantly more
+# discriminative for inflected languages than the single-character
+# coverage used for CJK.
+#
+# NOTE: the regex [а-яёА-ЯЁ] covers Russian and some Cyrillic neighbours
+# (Ukrainian, Bulgarian, etc.) but does NOT include Serbian/Mongolian
+# Cyrillic characters (ђ ћ џ њ љ ө ү). These can be added later if needed.
+#
+# No new dependencies, no schema migration, no FTS5 changes. The fallback
+# activates only when FTS5 returns zero rows AND the query contains
+# Cyrillic characters.
+#
+# Priority: if a query contains both CJK and Cyrillic, the CJK fallback
+# takes precedence (checked first). This is unlikely in practice but
+# documented here for clarity.
+# ---------------------------------------------------------------------------
+
+_CYRILLIC_CHAR_RE = re.compile(r"[а-яёА-ЯЁ]")
+
+
+def _has_cyrillic(text: str) -> bool:
+    """True if text contains at least one Russian/Cyrillic character.
+
+    Matches [а-яёА-ЯЁ] which covers Russian and some neighbours but
+    not Serbian/Mongolian Cyrillic — see module-level note.
+    """
+    return bool(_CYRILLIC_CHAR_RE.search(text))
+
+
+def _ngrams(s: str, n: int = 3) -> set:
+    """Return the set of length-n sliding n-grams of s.
+
+    For strings shorter than n, returns the whole string as a single
+    n-gram to keep the Jaccard math well-defined.
+    """
+    if len(s) < n:
+        return {s}
+    return {s[i:i + n] for i in range(len(s) - n + 1)}
+
+
+def _cyrillic_score(query: str, content: str, n: int = 3) -> float:
+    """Trigram Jaccard score in [0, 1] for Russian/Cyrillic recall.
+
+    For each query word, find the best-matching content word by Jaccard
+    similarity of their character n-gram sets. Return the mean across
+    query words. Words shorter than 3 characters are ignored to avoid
+    noisy matches on stop words and punctuation.
+
+    N-gram sets are computed once per unique word and cached in a dict
+    to avoid redundant recomputation when the same content word is
+    compared against multiple query words.
+    """
+    q_words = [
+        w for w in re.findall(r"[а-яёa-z0-9]+", query.lower()) if len(w) >= 3
+    ]
+    c_words = [
+        w for w in re.findall(r"[а-яёa-z0-9]+", content.lower()) if len(w) >= 3
+    ]
+    if not q_words or not c_words:
+        return 0.0
+    # Cache n-gram sets to avoid recomputing the same word multiple times.
+    ng_cache: dict = {}
+    total = 0.0
+    for qw in q_words:
+        if qw not in ng_cache:
+            ng_cache[qw] = _ngrams(qw, n)
+        q_ng = ng_cache[qw]
+        best = 0.0
+        for cw in c_words:
+            if cw not in ng_cache:
+                ng_cache[cw] = _ngrams(cw, n)
+            c_ng = ng_cache[cw]
+            union = q_ng | c_ng
+            if not union:
+                continue
+            jacc = len(q_ng & c_ng) / len(union)
+            if jacc > best:
+                best = jacc
+        total += best
+    return total / len(q_words)
+
+
+def _cyrillic_like_search(
+    conn: sqlite3.Connection, query: str, k: int = 20, working: bool = False,
+) -> List[Dict]:
+    """LIKE-based FTS5 fallback for Russian/Cyrillic text.
+
+    Candidate generation: scan ``working_memory``/``episodic_memory`` for
+    rows whose content contains any 4+ character word from the query as
+    a substring. Re-rank the candidate set by trigram Jaccard similarity
+    so that inflected forms of the same lemma (тёмная/тёмную/тёмной)
+    receive comparable scores regardless of which surface form appears
+    in the stored text.
+
+    The candidate-generation LIMIT is ``k * 5`` to keep the Python-side
+    scoring bounded; this matches the CJK fallback's behaviour.
+    """
+    if not _has_cyrillic(query):
+        return []
+    if working:
+        table, id_col = "working_memory", "id"
+    else:
+        table, id_col = "episodic_memory", "rowid"
+
+    # SQLite's default LOWER() and LIKE are ASCII-only, so they cannot
+    # case-fold Cyrillic letters (Т ≠ т, Ё ≠ ё). Register a Python
+    # UDF on the connection that performs a real Unicode lower(). It
+    # is safe to register the same name multiple times — SQLite will
+    # overwrite the previous function with the same name and arity.
+    conn.create_function("_py_lower", 1, lambda s: s.lower() if isinstance(s, str) else s)
+
+    # Use a 4-character prefix for LIKE matching. Query words and
+    # stored content are inflected forms of the same lemma (тёмная
+    # vs тёмную), so the 4-char prefix is the most reliable cheap
+    # over-selector that still prunes the candidate set down to a
+    # trigram-scoring-sized slice.
+    q_words = [
+        w for w in re.findall(r"[а-яёa-z0-9]+", query.lower()) if len(w) >= 4
+    ]
+    if not q_words:
+        return []
+
+    conditions = " OR ".join(
+        ["_py_lower(content) LIKE ? ESCAPE '\\'"] * len(q_words)
+    )
+    params = [f"%{w[:4].lower()}%" for w in q_words]
+    try:
+        all_rows = conn.execute(
+            f"SELECT {id_col}, content FROM {table} WHERE {conditions} LIMIT ?",
+            params + [k * 5],
+        ).fetchall()
+    except Exception:
+        return []
+
+    if not all_rows:
+        return []
+
+    scored = []
+    for row in all_rows:
+        rid = row[id_col]
+        content = row["content"]
+        score = _cyrillic_score(query, content)
+        if score > 0:
+            scored.append((rid, score))
+
+    scored.sort(key=lambda x: x[1], reverse=True)
+    result_key = "id" if working else "rowid"
+    return [{result_key: rid, "rank": -score} for rid, score in scored[:k]]
+
+
 def _fts_search(conn: sqlite3.Connection, query: str, k: int = 20) -> List[Dict]:
     """Search FTS5 episodes and return rowids with ranks.
 
@@ -1859,6 +2020,13 @@ def _fts_search(conn: sqlite3.Connection, query: str, k: int = 20) -> List[Dict]
         # Fall back to LIKE-based CJK search.
         if _has_cjk(query):
             return _cjk_like_search(conn, query, k=k, working=False)
+        # Cyrillic text (Russian) also produces zero FTS terms because
+        # the default unicode61 tokenizer has no built-in stemmer for
+        # inflected Cyrillic surface forms.
+        # NOTE: CJK is checked first — if a query contains both CJK and
+        # Cyrillic (unlikely), the CJK fallback takes precedence.
+        if _has_cyrillic(query):
+            return _cyrillic_like_search(conn, query, k=k, working=False)
         return []
     fts_query = " OR ".join(terms)
     rows = conn.execute(
@@ -1867,6 +2035,8 @@ def _fts_search(conn: sqlite3.Connection, query: str, k: int = 20) -> List[Dict]
     ).fetchall()
     if not rows and _has_cjk(query):
         return _cjk_like_search(conn, query, k=k, working=False)
+    if not rows and _has_cyrillic(query):
+        return _cyrillic_like_search(conn, query, k=k, working=False)
     return [{"rowid": r["rowid"], "rank": r["rank"]} for r in rows]
 
 
@@ -1876,6 +2046,8 @@ def _fts_search_working(conn: sqlite3.Connection, query: str, k: int = 20) -> Li
     if not terms:
         if _has_cjk(query):
             return _cjk_like_search(conn, query, k=k, working=True)
+        if _has_cyrillic(query):
+            return _cyrillic_like_search(conn, query, k=k, working=True)
         return []
     fts_query = " OR ".join(terms)
     rows = conn.execute(
@@ -1884,6 +2056,8 @@ def _fts_search_working(conn: sqlite3.Connection, query: str, k: int = 20) -> Li
     ).fetchall()
     if not rows and _has_cjk(query):
         return _cjk_like_search(conn, query, k=k, working=True)
+    if not rows and _has_cyrillic(query):
+        return _cyrillic_like_search(conn, query, k=k, working=True)
     return [{"id": r["id"], "rank": r["rank"]} for r in rows]
 
 

--- a/tests/test_cyrillic_fts.py
+++ b/tests/test_cyrillic_fts.py
@@ -1,0 +1,352 @@
+"""
+Tests for the Cyrillic (Russian) FTS5 fallback added alongside this file.
+
+Background: the default unicode61 FTS5 tokenizer has no built-in stemmer
+for inflected Russian surface forms (тёмная/тёмную/тёмной, встреча/
+встречи/встречу), so a Russian query with one inflection matches only
+that exact surface form. The fallback in ``_cyrillic_like_search`` is
+triggered when FTS5 returns zero rows for a query that contains at least
+one Cyrillic character. It scans ``working_memory``/``episodic_memory``
+with LIKE and re-ranks candidates by trigram Jaccard similarity.
+
+These tests pin the contract:
+
+- _has_cyrillic detects Russian and other Cyrillic scripts covered by
+  [а-яёА-ЯЁ] (Ukrainian, Bulgarian, etc. — but NOT Serbian/Mongolian)
+- _ngrams produces the expected set for short and long strings
+- _cyrillic_score is 0 for non-overlapping content and high for
+  matching inflections of the same lemma
+- _cyrillic_like_search returns rows in score-descending order and
+  reaches across grammatical cases (nominative vs accusative vs
+  prepositional, etc.)
+- _fts_search / _fts_search_working route Cyrillic queries to the
+  fallback when FTS5 returns nothing
+"""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core import beam as beam_module
+from mnemosyne.core.beam import (
+    init_beam,
+    _has_cyrillic,
+    _ngrams,
+    _cyrillic_score,
+    _cyrillic_like_search,
+    _fts_search,
+    _fts_search_working,
+)
+
+
+# ---------------------------------------------------------------------------
+# Detection and primitives
+# ---------------------------------------------------------------------------
+
+class TestHasCyrillic:
+    def test_empty(self):
+        assert _has_cyrillic("") is False
+
+    def test_pure_ascii(self):
+        assert _has_cyrillic("hello world") is False
+        assert _has_cyrillic("User prefers dark mode") is False
+
+    def test_pure_latin_with_accents(self):
+        # Latin diacritics are not Cyrillic
+        assert _has_cyrillic("café déjà vu") is False
+
+    def test_pure_cyrillic(self):
+        assert _has_cyrillic("тёмная") is True
+        assert _has_cyrillic("встреча") is True
+        assert _has_cyrillic("українська") is True
+        assert _has_cyrillic("български") is True
+
+    def test_mixed_ru_en(self):
+        assert _has_cyrillic("backend Python — это бэкенд") is True
+        assert _has_cyrillic("dark mode тёмная тема") is True
+
+    def test_case_insensitive(self):
+        # Uppercase Cyrillic letters must also trigger
+        assert _has_cyrillic("ТЁМНАЯ") is True
+        assert _has_cyrillic("Русский") is True
+
+    def test_yo_letter(self):
+        # ё / Ё are explicitly included in the regex
+        assert _has_cyrillic("ёжик") is True
+        assert _has_cyrillic("ЁЖИК") is True
+
+
+class TestNgrams:
+    def test_short_string_returns_whole(self):
+        # Strings shorter than n are returned as a single n-gram
+        assert _ngrams("ab", 3) == {"ab"}
+        assert _ngrams("кот", 3) == {"кот"}
+
+    def test_exact_length(self):
+        # Length == n: exactly one n-gram
+        assert _ngrams("тём", 3) == {"тём"}
+
+    def test_longer_string(self):
+        # Sliding window over "тёмная" (6 chars, n=3): 4 trigrams
+        assert _ngrams("тёмная", 3) == {"тём", "ёмн", "мна", "ная"}
+
+    def test_unique_ngrams(self):
+        # The set deduplicates repeated n-grams
+        assert _ngrams("аааа", 3) == {"ааа"}
+
+
+# ---------------------------------------------------------------------------
+# Trigram Jaccard scoring
+# ---------------------------------------------------------------------------
+
+class TestCyrillicScore:
+    def test_empty_inputs(self):
+        assert _cyrillic_score("", "") == 0.0
+        assert _cyrillic_score("тёмная", "") == 0.0
+        assert _cyrillic_score("", "тёмная") == 0.0
+
+    def test_identical_strings(self):
+        # Trigram Jaccard of a string with itself is 1.0
+        assert _cyrillic_score("тёмная", "тёмная") == pytest.approx(1.0)
+
+    def test_inflection_overlap(self):
+        # Different cases of the same lemma should overlap heavily:
+        # "тёмная" trigrams {тём, ёмн, мна, ная}
+        # "тёмную"  trigrams {тём, ёмн, мну, ную}
+        # shared = {тём, ёмн} -> 2 / (4 + 4 - 2) = 0.333
+        s = _cyrillic_score("тёмная", "тёмную")
+        assert 0.25 <= s <= 0.4
+
+    def test_unrelated_words_score_low(self):
+        # "тёмная" vs "встреча" share no trigrams at all -> 0
+        assert _cyrillic_score("тёмная", "встреча") == 0.0
+
+    def test_yo_vs_e_collapses(self):
+        # We deliberately do NOT collapse ё -> е; the regex preserves
+        # the user's exact spelling. Trigrams differ, so the score is
+        # the same as for any unrelated substitution.
+        s_with_yo = _cyrillic_score("ёжик", "ёжики")
+        s_with_e = _cyrillic_score("ежик", "ежики")
+        # Both should be the same since the logic is symmetric
+        assert s_with_yo == pytest.approx(s_with_e)
+        # And both should be reasonably high
+        assert s_with_yo > 0.3
+
+    def test_short_query_words_ignored(self):
+        # 1-2 char words are skipped to avoid stop-word noise
+        # "а" alone: 0 valid query words -> 0
+        assert _cyrillic_score("а", "автобус") == 0.0
+        # "он" is 2 chars: still skipped
+        assert _cyrillic_score("он", "автобус") == 0.0
+
+    def test_mixed_script_query(self):
+        # Latin words also pass through the regex [а-яёa-z0-9]
+        # and participate in the Jaccard computation
+        s = _cyrillic_score("backend Python", "Backend на Python")
+        assert s > 0.5  # strong overlap
+
+    def test_punctuation_does_not_disturb(self):
+        # Punctuation between words must not affect scoring
+        s1 = _cyrillic_score("тёмная, тема!", "Тёмная тема оформления.")
+        s2 = _cyrillic_score("тёмная тема", "Тёмная тема оформления")
+        assert s1 == pytest.approx(s2)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: fallback through _fts_search
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test_cyrillic.db"
+        init_beam(db_path)
+        yield db_path
+
+
+def _seed_working(db_path: Path, rows: list[tuple[str, str, float]]) -> None:
+    """Insert a few rows into working_memory (and fts_working mirror).
+
+    rows: list of (id, content, importance) tuples
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        for mid, content, importance in rows:
+            conn.execute(
+                "INSERT INTO working_memory (id, content, importance) VALUES (?, ?, ?)",
+                (mid, content, importance),
+            )
+            conn.execute(
+                "INSERT INTO fts_working (id, content) VALUES (?, ?)",
+                (mid, content),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_episodic(db_path: Path, rows: list[tuple[str, str, float]]) -> None:
+    """Insert a few rows into episodic_memory (and fts_episodes mirror).
+
+    rows: list of (id, content, importance) tuples. The id is a TEXT
+    unique identifier (separate from the implicit rowid).
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        for mid, content, importance in rows:
+            conn.execute(
+                "INSERT INTO episodic_memory (id, content, importance) VALUES (?, ?, ?)",
+                (mid, content, importance),
+            )
+            conn.execute(
+                "INSERT INTO fts_episodes (rowid, content) VALUES ((SELECT rowid FROM episodic_memory WHERE id = ?), ?)",
+                (mid, content),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _open(db_path: Path) -> sqlite3.Connection:
+    """Open a connection with dict-like row access.
+
+    ``_fts_search`` and friends index rows by column name (``r["id"]``),
+    so tests must use ``sqlite3.Row`` factory.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+class TestCyrillicLikeSearchWorking:
+    """Verify _cyrillic_like_search against working_memory."""
+
+    def test_finds_inflected_form(self, temp_db):
+        # Stored: "тёмную" (accusative) and "тёмной" (prepositional).
+        # Query: "тёмная" (nominative) — the inflection NOT in the DB.
+        # Direct FTS5 would return zero. Fallback must find both.
+        _seed_working(temp_db, [
+            ("m1", "Пользователь предпочитает тёмную тему оформления", 0.9),
+            ("m2", "Тёмная комната была неуютной", 0.5),
+            ("m3", "Совершенно посторонний текст про погоду", 0.5),
+        ])
+        conn = _open(temp_db)
+        try:
+            results = _cyrillic_like_search(conn, "тёмная", k=5, working=True)
+        finally:
+            conn.close()
+        ids = [r["id"] for r in results]
+        # Both m1 and m2 must surface (their surface forms are inflections
+        # of the same lemma as the query).
+        assert "m1" in ids
+        assert "m2" in ids
+        # m3 has no overlap with the query -> must NOT appear.
+        assert "m3" not in ids
+
+    def test_returns_empty_for_latin_query(self, temp_db):
+        # Cyrillic fallback must not engage on non-Cyrillic text
+        _seed_working(temp_db, [
+            ("m1", "User prefers dark mode", 0.9),
+        ])
+        conn = _open(temp_db)
+        try:
+            results = _cyrillic_like_search(conn, "dark mode", k=5, working=True)
+        finally:
+            conn.close()
+        assert results == []
+
+    def test_returns_empty_when_no_candidates(self, temp_db):
+        # Cyrillic query against Cyrillic-free corpus -> 0
+        _seed_working(temp_db, [
+            ("m1", "User prefers dark mode", 0.9),
+        ])
+        conn = _open(temp_db)
+        try:
+            results = _cyrillic_like_search(conn, "тёмная", k=5, working=True)
+        finally:
+            conn.close()
+        assert results == []
+
+    def test_ranking_is_descending(self, temp_db):
+        _seed_working(temp_db, [
+            ("m1", "Встреча с клиентом в пятницу", 0.5),  # exact match
+            ("m2", "Встречи бывают продуктивными", 0.5),  # only "встреч"
+            ("m3", "Шум в коридоре", 0.5),                # no overlap
+        ])
+        conn = _open(temp_db)
+        try:
+            results = _cyrillic_like_search(conn, "встреча пятница", k=5, working=True)
+        finally:
+            conn.close()
+        # m1 should beat m2; m3 should not appear (score 0)
+        ids = [r["id"] for r in results]
+        assert "m1" in ids
+        if "m2" in ids:
+            assert ids.index("m1") < ids.index("m2")
+        assert "m3" not in ids
+
+
+class TestCyrillicLikeSearchEpisodic:
+    """Verify _cyrillic_like_search against episodic_memory."""
+
+    def test_finds_across_grammatical_cases(self, temp_db):
+        # Stored accusative, queried with prepositional: "в тёмной"
+        _seed_episodic(temp_db, [
+            ("ep1", "Пользователь предпочитает тёмную тему", 0.9),
+            ("ep2", "Светлая комната была уютной", 0.5),
+        ])
+        conn = _open(temp_db)
+        try:
+            results = _cyrillic_like_search(
+                conn, "тёмной", k=5, working=False,
+            )
+        finally:
+            conn.close()
+        rowids = [r["rowid"] for r in results]
+        assert 1 in rowids
+        assert 2 not in rowids  # irrelevant
+
+
+class TestFtsSearchRoutesCyrillic:
+    """End-to-end: _fts_search routes Cyrillic queries to the fallback."""
+
+    def test_working_memory_fallback(self, temp_db):
+        # Seed only via the FTS5 mirror so that FTS5's MATCH must be the
+        # path that returns zero. We use a stored surface form different
+        # from the query surface form to provoke the fallback.
+        _seed_working(temp_db, [
+            ("m1", "Пользователь предпочитает тёмную тему", 0.9),
+        ])
+        conn = _open(temp_db)
+        try:
+            rows = _fts_search_working(conn, "тёмная", k=5)
+        finally:
+            conn.close()
+        assert any(r["id"] == "m1" for r in rows)
+
+    def test_episodic_fallback(self, temp_db):
+        _seed_episodic(temp_db, [
+            ("ep1", "Пользователь предпочитает тёмную тему", 0.9),
+        ])
+        conn = _open(temp_db)
+        try:
+            rows = _fts_search(conn, "тёмная", k=5)
+        finally:
+            conn.close()
+        assert any(r["rowid"] == 1 for r in rows)
+
+    def test_latin_query_does_not_trigger_cyrillic_fallback(self, temp_db):
+        # Sanity: a Latin-only query against a Cyrillic-free corpus
+        # should return rows via the normal FTS5 path, not via our
+        # Cyrillic fallback.
+        _seed_working(temp_db, [
+            ("m1", "User prefers dark mode interfaces", 0.9),
+        ])
+        conn = _open(temp_db)
+        try:
+            rows = _fts_search_working(conn, "dark mode", k=5)
+        finally:
+            conn.close()
+        assert any(r["id"] == "m1" for r in rows)


### PR DESCRIPTION
Like the CJK fallback added in issue #168, this routes Russian (and other `[а-яё]`-covered Cyrillic) queries to a LIKE-based candidate scan re-ranked by trigram Jaccard similarity when the default unicode61 FTS5 tokenizer returns zero rows.

The default tokenizer has no built-in stemmer for inflected Russian surface forms, so a single-lemma query would otherwise only match the exact surface form in storage.

**Structure** (mirrors the CJK fallback):
- `_has_cyrillic` detects the script — covers Russian and some Cyrillic neighbours, but **not** Serbian/Mongolian Cyrillic (ђ ћ џ њ љ ө ү). Documented for future extension.
- `_ngrams` + `_cyrillic_score` provide the trigram Jaccard ranking signal
- `_cyrillic_like_search` wires the LIKE-based candidate generation with a `_py_lower` UDF for Unicode-aware case folding (SQLite's default `LOWER()` is ASCII-only)
- Four integration points in `_fts_search` and `_fts_search_working` (empty-terms branch + post-MATCH zero-rows branch, for both episodic and working memory)

**Priority note:** CJK fallback is checked first. If a query contains both CJK and Cyrillic characters (unlikely in practice), the CJK path takes precedence.

**No new dependencies, no schema migration, no FTS5 schema changes, no version bump.**

Includes 27 unit tests covering detection, n-gram scoring, inflection overlap, ranking order, and end-to-end routing through the FTS5 entry points.

Closes #168 family — Cyrillic counterpart of the CJK fallback.