### PR TITLE
fix(triples): restore temporal-triple lifecycle regressed after #246

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -623,7 +623,10 @@ TRIPLE_ADD_SCHEMA = {
     "name": "mnemosyne_triple_add",
     "description": (
         "Add a temporal fact triple (subject, predicate, object) to the knowledge graph. "
-        "Example: ('user', 'prefers', 'neovim'). Use for structured relationships."
+        "Example: ('user', 'prefers', 'neovim'). Use for structured relationships. "
+        "By default a new triple supersedes any prior fact with the same subject+predicate; "
+        "set supersede=false for multi-valued facts that should coexist "
+        "(e.g. ('user','speaks','English') and ('user','speaks','Spanish'))."
     ),
     "parameters": {
         "type": "object",
@@ -632,20 +635,47 @@ TRIPLE_ADD_SCHEMA = {
             "predicate": {"type": "string"},
             "object": {"type": "string"},
             "valid_from": {"type": "string", "description": "ISO date YYYY-MM-DD", "default": ""},
+            "valid_until": {"type": "string", "description": "Optional ISO expiry date YYYY-MM-DD.", "default": ""},
+            "source": {"type": "string", "description": "Provenance label.", "default": ""},
+            "confidence": {"type": "number", "description": "0.0-1.0 (default 1.0).", "default": 1.0},
+            "supersede": {"type": "boolean", "description": "If false, do not close prior same subject+predicate triples (multi-valued).", "default": True},
         },
         "required": ["subject", "predicate", "object"],
     },
 }
 
+TRIPLE_END_SCHEMA = {
+    "name": "mnemosyne_triple_end",
+    "description": (
+        "Expire a fact in the knowledge graph WITHOUT replacing it (e.g. a relationship "
+        "that simply ended). Closes all open triples for subject+predicate, or only the one "
+        "matching object when given. Use mnemosyne_triple_add instead when a new value replaces the old."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "subject": {"type": "string"},
+            "predicate": {"type": "string"},
+            "object": {"type": "string", "description": "Optional: end only this exact triple; omit to end all open subject+predicate triples.", "default": ""},
+            "valid_until": {"type": "string", "description": "ISO date YYYY-MM-DD the fact ended (default: today).", "default": ""},
+        },
+        "required": ["subject", "predicate"],
+    },
+}
+
 TRIPLE_QUERY_SCHEMA = {
     "name": "mnemosyne_triple_query",
-    "description": "Query the temporal knowledge graph for facts matching subject/predicate/object patterns.",
+    "description": (
+        "Query the temporal knowledge graph for facts matching subject/predicate/object patterns. "
+        "Subject match is case-insensitive. Pass as_of to query facts valid on a past date."
+    ),
     "parameters": {
         "type": "object",
         "properties": {
             "subject": {"type": "string", "default": ""},
             "predicate": {"type": "string", "default": ""},
             "object": {"type": "string", "default": ""},
+            "as_of": {"type": "string", "description": "ISO date YYYY-MM-DD; query facts valid as of this date (default: today).", "default": ""},
         },
     },
 }
@@ -876,6 +906,7 @@ ALL_TOOL_SCHEMAS = [
     REMEMBER_SCHEMA, RECALL_SCHEMA, SHARED_REMEMBER_SCHEMA, SHARED_RECALL_SCHEMA,
     SHARED_FORGET_SCHEMA, SHARED_STATS_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
     INVALIDATE_SCHEMA, VALIDATE_SCHEMA, GET_SCHEMA, TRIPLE_ADD_SCHEMA, TRIPLE_QUERY_SCHEMA,
+    TRIPLE_END_SCHEMA,
     REMEMBER_CANONICAL_SCHEMA, RECALL_CANONICAL_SCHEMA,
     SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
     EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
@@ -1736,6 +1767,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_get(args)
             elif tool_name == "mnemosyne_triple_add":
                 return self._handle_triple_add(args)
+            elif tool_name == "mnemosyne_triple_end":
+                return self._handle_triple_end(args)
             elif tool_name == "mnemosyne_triple_query":
                 return self._handle_triple_query(args)
             elif tool_name == "mnemosyne_remember_canonical":
@@ -2164,18 +2197,37 @@ class MnemosyneMemoryProvider(MemoryProvider):
         valid_from = args.get("valid_from", None) or None
         if not all([subject, predicate, obj]):
             return json.dumps({"error": "subject, predicate, and object are required"})
+        valid_until = args.get("valid_until", None) or None
+        source = args.get("source", "") or "inferred"
+        confidence = args.get("confidence", 1.0)
+        supersede = args.get("supersede", True)
         add_triple, _ = _get_triple_module()
         triple_id = add_triple(subject, predicate, obj, valid_from=valid_from,
+                               valid_until=valid_until, source=source,
+                               confidence=confidence, supersede=supersede,
                                db_path=self._beam.db_path)
         return json.dumps({"status": "stored", "triple_id": triple_id})
+
+    def _handle_triple_end(self, args: Dict[str, Any]) -> str:
+        subject = args.get("subject", "")
+        predicate = args.get("predicate", "")
+        if not all([subject, predicate]):
+            return json.dumps({"error": "subject and predicate are required"})
+        obj = args.get("object", "") or None
+        valid_until = args.get("valid_until", None) or None
+        from mnemosyne.core.triples import end_triple
+        n = end_triple(subject, predicate, object=obj, valid_until=valid_until,
+                       db_path=self._beam.db_path)
+        return json.dumps({"status": "ended", "count": n})
 
     def _handle_triple_query(self, args: Dict[str, Any]) -> str:
         subject = args.get("subject", "") or None
         predicate = args.get("predicate", "") or None
         obj = args.get("object", "") or None
+        as_of = args.get("as_of", "") or None
         _, query_triples = _get_triple_module()
         results = query_triples(subject=subject, predicate=predicate, object=obj,
-                                db_path=self._beam.db_path)
+                                as_of=as_of, db_path=self._beam.db_path)
         return json.dumps({"count": len(results), "results": results})
 
     def _canonical_owner(self) -> str:

--- a/mnemosyne/core/triples.py
+++ b/mnemosyne/core/triples.py
@@ -141,29 +141,61 @@ class TripleStore:
     
     def add(self, subject: str, predicate: str, object: str,
             valid_from: str = None, source: str = "inferred",
-            confidence: float = 1.0) -> int:
+            confidence: float = 1.0, valid_until: str = None,
+            supersede: bool = True) -> int:
         """
-        Add a temporal triple. Automatically closes previous matching triples.
+        Add a temporal triple.
+
+        supersede=True (default): close any open triple sharing
+        (subject, predicate) before inserting — single-valued semantics
+        (the historical behavior).
+        supersede=False: insert without closing priors, so a subject can hold
+        multiple simultaneous values for one predicate (multi-valued facts,
+        e.g. ('user','speaks','English') + ('user','speaks','Spanish')).
+        valid_until: optional explicit expiry date (ISO YYYY-MM-DD) for the row.
         """
         valid_from = valid_from or datetime.now().isoformat()[:10]
-        
-        # Invalidate previous triples for same (subject, predicate)
+
         cursor = self.conn.cursor()
+        # supersede flag gates the auto-close;
+        # multi-valued predicates pass supersede=False to keep prior values open.
+        if supersede:
+            cursor.execute("""
+                UPDATE triples
+                SET valid_until = ?
+                WHERE subject = ? AND predicate = ? AND valid_until IS NULL
+            """, (valid_from, subject, predicate))
+
+        # Insert new triple (now carries optional explicit valid_until)
         cursor.execute("""
-            UPDATE triples
-            SET valid_until = ?
-            WHERE subject = ? AND predicate = ? AND valid_until IS NULL
-        """, (valid_from, subject, predicate))
-        
-        # Insert new triple
-        cursor.execute("""
-            INSERT INTO triples (subject, predicate, object, valid_from, source, confidence)
-            VALUES (?, ?, ?, ?, ?, ?)
-        """, (subject, predicate, object, valid_from, source, confidence))
-        
+            INSERT INTO triples (subject, predicate, object, valid_from, valid_until, source, confidence)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, (subject, predicate, object, valid_from, valid_until, source, confidence))
+
         self.conn.commit()
         return cursor.lastrowid
-    
+
+    def end(self, subject: str, predicate: str, object: str = None,
+            valid_until: str = None) -> int:
+        """
+        Expire open triples WITHOUT replacing
+        them. Closes all open triples for (subject, predicate), or only the one
+        matching `object` when supplied. Returns the number of rows closed.
+        """
+        valid_until = valid_until or datetime.now().isoformat()[:10]
+        conditions = ["subject = ?", "predicate = ?", "valid_until IS NULL"]
+        params = [subject, predicate]
+        if object is not None:
+            conditions.append("object = ?")
+            params.append(object)
+        cursor = self.conn.cursor()
+        cursor.execute(
+            f"UPDATE triples SET valid_until = ? WHERE {' AND '.join(conditions)}",
+            [valid_until, *params],
+        )
+        self.conn.commit()
+        return cursor.rowcount
+
     def query(self, subject: str = None, predicate: str = None,
               object: str = None, as_of: str = None) -> List[Dict]:
         """
@@ -176,7 +208,7 @@ class TripleStore:
         params = []
         
         if subject:
-            conditions.append("subject = ?")
+            conditions.append("subject = ? COLLATE NOCASE")  # case-insensitive subject
             params.append(subject)
         if predicate:
             conditions.append("predicate = ?")
@@ -475,14 +507,27 @@ class TripleStore:
 
 def add_triple(subject: str, predicate: str, object: str,
                valid_from: str = None, source: str = "inferred",
-               confidence: float = 1.0, db_path: Path = None) -> int:
+               confidence: float = 1.0, db_path: Path = None,
+               valid_until: str = None, supersede: bool = True) -> int:
     """
     Add a temporal triple without instantiating TripleStore manually.
     Optional db_path aligns with BEAM memory database when used from Hermes.
+    valid_until/supersede passthrough (see TripleStore.add).
     """
     store = TripleStore(db_path=db_path)
     return store.add(subject, predicate, object,
-                     valid_from=valid_from, source=source, confidence=confidence)
+                     valid_from=valid_from, source=source, confidence=confidence,
+                     valid_until=valid_until, supersede=supersede)
+
+
+def end_triple(subject: str, predicate: str, object: str = None,
+               valid_until: str = None, db_path: Path = None) -> int:
+    """
+    Expire open triples without replacing them (see
+    TripleStore.end). Returns the number of rows closed.
+    """
+    store = TripleStore(db_path=db_path)
+    return store.end(subject, predicate, object=object, valid_until=valid_until)
 
 
 def query_triples(subject: str = None, predicate: str = None,

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -52,7 +52,7 @@ class TestToolRegistration:
     def test_all_tools_registered(self, tmp_path):
         provider = _provider(tmp_path)
         names = _tool_names(provider)
-        assert len(names) == 25, f"Expected 25 tools, got {len(names)}"
+        assert len(names) == 26, f"Expected 26 tools, got {len(names)}"
 
     def test_canonical_tools_present(self, tmp_path):
         provider = _provider(tmp_path)

--- a/tests/test_triples_lifecycle.py
+++ b/tests/test_triples_lifecycle.py
@@ -1,0 +1,66 @@
+"""Tests for the temporal triple lifecycle: explicit valid_until, the supersede
+flag (multi-valued facts), end() (expire without replace), as_of historical
+queries, and case-insensitive subject matching.
+"""
+
+from pathlib import Path
+
+from mnemosyne.core.triples import add_triple, end_triple, query_triples
+
+
+def _objs(rows):
+    return sorted(r["object"] for r in rows)
+
+
+def test_supersede_default_closes_prior(tmp_path: Path):
+    db = tmp_path / "triples.db"
+    add_triple("alice", "city", "NYC", valid_from="2025-01-01", db_path=db)
+    add_triple("alice", "city", "LA", valid_from="2026-01-01", db_path=db)
+    # only the newest value is open now
+    assert _objs(query_triples(subject="alice", predicate="city", db_path=db)) == ["LA"]
+
+
+def test_as_of_returns_historical_value(tmp_path: Path):
+    db = tmp_path / "triples.db"
+    add_triple("alice", "city", "NYC", valid_from="2025-01-01", db_path=db)
+    add_triple("alice", "city", "LA", valid_from="2026-01-01", db_path=db)
+    assert _objs(query_triples(subject="alice", predicate="city",
+                               as_of="2025-06-01", db_path=db)) == ["NYC"]
+
+
+def test_supersede_false_allows_multivalued(tmp_path: Path):
+    db = tmp_path / "triples.db"
+    add_triple("user", "speaks", "English", supersede=False, db_path=db)
+    add_triple("user", "speaks", "Spanish", supersede=False, db_path=db)
+    assert _objs(query_triples(subject="user", predicate="speaks", db_path=db)) == ["English", "Spanish"]
+
+
+def test_explicit_valid_until_expires(tmp_path: Path):
+    db = tmp_path / "triples.db"
+    add_triple("project", "status", "active", valid_until="2026-12-31", db_path=db)
+    assert _objs(query_triples(subject="project", predicate="status", db_path=db)) == ["active"]
+    assert query_triples(subject="project", predicate="status", as_of="2027-01-15", db_path=db) == []
+
+
+def test_end_by_object_then_by_subject_predicate(tmp_path: Path):
+    db = tmp_path / "triples.db"
+    add_triple("user", "speaks", "English", supersede=False, db_path=db)
+    add_triple("user", "speaks", "Spanish", supersede=False, db_path=db)
+    assert end_triple("user", "speaks", "English", db_path=db) == 1
+    assert _objs(query_triples(subject="user", predicate="speaks", db_path=db)) == ["Spanish"]
+    assert end_triple("user", "speaks", db_path=db) == 1
+    assert query_triples(subject="user", predicate="speaks", db_path=db) == []
+
+
+def test_subject_match_is_case_insensitive(tmp_path: Path):
+    db = tmp_path / "triples.db"
+    add_triple("Alice", "city", "LA", db_path=db)
+    assert _objs(query_triples(subject="alice", predicate="city", db_path=db)) == ["LA"]
+    assert _objs(query_triples(subject="ALICE", predicate="city", db_path=db)) == ["LA"]
+
+
+def test_add_triple_backcompat(tmp_path: Path):
+    db = tmp_path / "triples.db"
+    # old-style call without any of the new kwargs still works
+    add_triple("bob", "likes", "tea", db_path=db)
+    assert _objs(query_triples(subject="bob", predicate="likes", db_path=db)) == ["tea"]


### PR DESCRIPTION
## Summary

The temporal-triple lifecycle added in #246 (merged 2026-06-08, merge commit `63fbb48`) is no longer present on `main` — `mnemosyne/core/triples.py` and `hermes_memory_provider/__init__.py` are back to their pre-#246 base. A later merge on `main` appears to have reverted it (likely a branch cut before #246 that overwrote `triples.py` on merge), so the lifecycle is **absent from the v3.5.0 and v3.6.0 releases** even though #246 shows as merged.

This re-applies #246; the diff applies cleanly to current `main`.

### `TripleStore` (`mnemosyne/core/triples.py`)
- `add(..., valid_until=None, supersede=True)` — `supersede=False` skips the auto-close so a `(subject, predicate)` can hold multiple simultaneous values (e.g. `('user','speaks','English')` + `('user','speaks','Spanish')`); `valid_until` sets an explicit expiry on insert.
- new `end(subject, predicate, object=None, valid_until=None)` — expire open triples **without** replacing them; returns the count closed.
- `query` subject match is case-insensitive (`COLLATE NOCASE`).
- module-level `add_triple` gains the `valid_until`/`supersede` passthrough; new `end_triple`.

### Provider (`hermes_memory_provider/__init__.py`)
- `mnemosyne_triple_add` gains `valid_until` / `source` / `confidence` / `supersede`.
- new `mnemosyne_triple_end` tool.
- `mnemosyne_triple_query` gains `as_of`.

**Default behavior is unchanged** — `add` still supersedes by default (single-valued); everything new is additive / opt-in.

### Tests

Re-adds `tests/test_triples_lifecycle.py` from #246 — covers multi-valued coexistence, `end` expiry, default supersede, explicit `valid_until`, `as_of` history, and case-insensitive subject. All pass:

```
7 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
