### PR TITLE
fix(hermes): scan full __init__.py in is_installed() instead of first 4096 bytes

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -222,7 +222,7 @@ def is_installed(*, hermes_home_path: str | Path | None = None) -> bool:
     if not init_file.is_file():
         return False
     try:
-        source = init_file.read_text(errors="replace")[:4096]
+        source = init_file.read_text(errors="replace")
         return "register_memory_provider" in source or "MnemosyneMemoryProvider" in source
     except Exception:
         return False


### PR DESCRIPTION
## What

`is_installed()` in the Hermes integration only scanned the first 4096 bytes of the plugin `__init__.py` when looking for the `register_memory_provider` / `MnemosyneMemoryProvider` markers. In 0.1.7 those symbols are at byte 9255 and 79437 of an ~80 KB file, so the check never finds them and `mnemosyne-hermes status` reports `Not installed` on a working install, while `install` and Hermes' own `load_memory_provider` both succeed.

## Fix

Read the whole file instead of the first 4 KB (one line).

## Validation

Ubuntu aarch64, Python 3.11.15, mnemosyne-hermes 0.1.7, no other change:

- before: `mnemosyne-hermes status` -> `Not installed (expected symlink at ~/.hermes/plugins/mnemosyne)`
- after: `Installed. Symlink at ~/.hermes/plugins/mnemosyne -> .../mnemosyne_hermes` / `mnemosyne-memory 3.6.0 installed` / `Core library: OK`

The provider already loaded correctly throughout (`load_memory_provider("mnemosyne")` returns `MnemosyneMemoryProvider`, `is_available() == True`); only the status self-check was wrong.

Fixes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
