### PR TITLE
fix(hermes): wire canonical fact tools in active adapter

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -970,6 +970,10 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_triple_add(args)
             elif tool_name == "mnemosyne_triple_query":
                 return self._handle_triple_query(args)
+            elif tool_name == "mnemosyne_remember_canonical":
+                return self._handle_remember_canonical(args)
+            elif tool_name == "mnemosyne_recall_canonical":
+                return self._handle_recall_canonical(args)
             elif tool_name == "mnemosyne_scratchpad_write":
                 return self._handle_scratchpad_write(args)
             elif tool_name == "mnemosyne_scratchpad_read":
@@ -1410,6 +1414,90 @@ class MnemosyneMemoryProvider(MemoryProvider):
         results = query_triples(subject=subject, predicate=predicate, object=obj,
                                 db_path=self._beam.db_path)
         return json.dumps({"count": len(results), "results": results})
+
+    def _canonical_owner(self) -> str:
+        """Owner id for canonical reads/writes: the active Hermes profile.
+
+        This is derived from provider state, never from tool arguments, so one
+        profile cannot ask the canonical tool to read or write another profile's
+        single-source-of-truth facts. The default profile maps to "default".
+        """
+        return (getattr(self, "_agent_identity", None) or "").strip() or "default"
+
+    def _handle_remember_canonical(self, args: Dict[str, Any]) -> str:
+        category = (args.get("category") or "").strip()
+        name = (args.get("name") or "").strip()
+        body = (args.get("body") or "").strip()
+        if not category or not name:
+            return json.dumps({"error": "category and name are required"})
+        if not body:
+            return json.dumps({"error": "body is required"})
+        source = args.get("source") or "canonical_tool"
+        try:
+            confidence = float(args.get("confidence", 1.0))
+        except (TypeError, ValueError):
+            confidence = 1.0
+        owner_id = self._canonical_owner()
+        store = getattr(self._beam, "canonical", None)
+        if store is None:
+            from mnemosyne.core.canonical import CanonicalStore
+            store = CanonicalStore(db_path=self._beam.db_path, conn=self._beam.conn)
+            self._beam.canonical = store
+        row = store.remember(
+            owner_id, category, name, body,
+            source=source, confidence=confidence,
+        )
+        status = row.pop("status", "stored")
+        self._audit_event(
+            "remember_canonical", bank="canonical",
+            source_tool="mnemosyne_remember_canonical",
+            metadata={"category": category, "name": name, "status": status,
+                      "version": row.get("version")},
+        )
+        return json.dumps({
+            "status": status,
+            "owner_id": owner_id,
+            "category": category,
+            "name": name,
+            "version": row.get("version"),
+            "body_preview": body[:120],
+        })
+
+    def _handle_recall_canonical(self, args: Dict[str, Any]) -> str:
+        category = (args.get("category") or "").strip()
+        name = (args.get("name") or "").strip()
+        query = (args.get("query") or "").strip()
+        include_history = bool(args.get("include_history", False))
+        try:
+            limit = int(args.get("limit", 10))
+        except (TypeError, ValueError):
+            limit = 10
+        owner_id = self._canonical_owner()
+        store = getattr(self._beam, "canonical", None)
+        if store is None:
+            from mnemosyne.core.canonical import CanonicalStore
+            store = CanonicalStore(db_path=self._beam.db_path, conn=self._beam.conn)
+            self._beam.canonical = store
+
+        if query:
+            results = store.search(owner_id, query, limit=limit)
+            return json.dumps({"mode": "search", "owner_id": owner_id,
+                               "query": query, "count": len(results),
+                               "results": results})
+        if category and name:
+            if include_history:
+                results = store.history(owner_id, category, name)
+                return json.dumps({"mode": "history", "owner_id": owner_id,
+                                   "category": category, "name": name,
+                                   "count": len(results), "results": results})
+            row = store.recall(owner_id, category, name)
+            return json.dumps({"mode": "recall", "owner_id": owner_id,
+                               "category": category, "name": name,
+                               "found": row is not None, "result": row})
+        results = store.list(owner_id, category=category or None)
+        return json.dumps({"mode": "list", "owner_id": owner_id,
+                           "category": category or None,
+                           "count": len(results), "results": results})
 
     def _handle_scratchpad_write(self, args: Dict[str, Any]) -> str:
         content = args.get("content", "").strip()

--- a/integrations/hermes/tests/test_canonical_tools.py
+++ b/integrations/hermes/tests/test_canonical_tools.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+
+from mnemosyne_hermes import MnemosyneMemoryProvider
+
+
+def _provider(tmp_path, profile: str = "profile_a") -> MnemosyneMemoryProvider:
+    provider = MnemosyneMemoryProvider()
+    provider.initialize(
+        "session-1",
+        hermes_home=str(tmp_path),
+        agent_context="primary",
+        agent_identity=profile,
+    )
+    assert provider._beam is not None
+    return provider
+
+
+def _close(provider: MnemosyneMemoryProvider) -> None:
+    try:
+        provider._beam.conn.close()
+    except Exception:
+        pass
+
+
+def test_active_adapter_canonical_tools_roundtrip(tmp_path):
+    provider = _provider(tmp_path, profile="profile_a")
+    try:
+        stored = json.loads(provider.handle_tool_call(
+            "mnemosyne_remember_canonical",
+            {
+                "category": "identity",
+                "name": "name",
+                "body": "My name is Profile A.",
+                "source": "test",
+                "confidence": 0.9,
+            },
+        ))
+
+        assert stored["status"] == "created"
+        assert stored["owner_id"] == "profile_a"
+        assert stored["category"] == "identity"
+        assert stored["name"] == "name"
+        assert stored["version"] == 1
+
+        recalled = json.loads(provider.handle_tool_call(
+            "mnemosyne_recall_canonical",
+            {"category": "identity", "name": "name"},
+        ))
+
+        assert recalled["mode"] == "recall"
+        assert recalled["owner_id"] == "profile_a"
+        assert recalled["found"] is True
+        assert recalled["result"]["body"] == "My name is Profile A."
+    finally:
+        _close(provider)
+
+
+def test_active_adapter_canonical_tools_owner_scoped(tmp_path):
+    provider = _provider(tmp_path, profile="profile_a")
+    try:
+        provider.handle_tool_call(
+            "mnemosyne_remember_canonical",
+            {"category": "identity", "name": "name", "body": "I am profile A."},
+        )
+        provider._agent_identity = "profile_b"
+
+        recalled = json.loads(provider.handle_tool_call(
+            "mnemosyne_recall_canonical",
+            {"category": "identity", "name": "name"},
+        ))
+
+        assert recalled["owner_id"] == "profile_b"
+        assert recalled["found"] is False
+    finally:
+        _close(provider)
+
+
+def test_active_adapter_canonical_tools_search_history_and_list(tmp_path):
+    provider = _provider(tmp_path, profile="profile_a")
+    try:
+        provider.handle_tool_call(
+            "mnemosyne_remember_canonical",
+            {"category": "voice", "name": "register", "body": "icy and terse"},
+        )
+        provider.handle_tool_call(
+            "mnemosyne_remember_canonical",
+            {"category": "voice", "name": "register", "body": "warm and direct"},
+        )
+
+        search = json.loads(provider.handle_tool_call(
+            "mnemosyne_recall_canonical", {"query": "warm"},
+        ))
+        assert search["mode"] == "search"
+        assert search["count"] == 1
+        assert search["results"][0]["body"] == "warm and direct"
+
+        history = json.loads(provider.handle_tool_call(
+            "mnemosyne_recall_canonical",
+            {"category": "voice", "name": "register", "include_history": True},
+        ))
+        assert history["mode"] == "history"
+        assert history["count"] == 2
+
+        listed = json.loads(provider.handle_tool_call(
+            "mnemosyne_recall_canonical", {"category": "voice"},
+        ))
+        assert listed["mode"] == "list"
+        assert listed["count"] == 1
+        assert listed["results"][0]["body"] == "warm and direct"
+    finally:
+        _close(provider)
+
+
+def test_active_adapter_canonical_tools_validate_required_fields(tmp_path):
+    provider = _provider(tmp_path, profile="profile_a")
+    try:
+        missing_body = json.loads(provider.handle_tool_call(
+            "mnemosyne_remember_canonical",
+            {"category": "identity", "name": "name"},
+        ))
+        assert missing_body == {"error": "body is required"}
+
+        missing_slot = json.loads(provider.handle_tool_call(
+            "mnemosyne_remember_canonical",
+            {"category": "identity", "body": "body"},
+        ))
+        assert missing_slot == {"error": "category and name are required"}
+    finally:
+        _close(provider)
+
+
+def test_active_adapter_exposes_canonical_tool_schemas():
+    provider = MnemosyneMemoryProvider()
+    names = {schema["name"] for schema in provider.get_tool_schemas()}
+
+    assert "mnemosyne_remember_canonical" in names
+    assert "mnemosyne_recall_canonical" in names


### PR DESCRIPTION
## Summary

- Route `mnemosyne_remember_canonical` and `mnemosyne_recall_canonical` through the active `mnemosyne_hermes` adapter.
- Reuse the Beam-owned `CanonicalStore` when present, or attach one to the shared Beam connection when missing.
- Scope canonical facts to the active Hermes profile via provider state, not tool arguments.
- Add adapter-level regression tests for roundtrip, owner isolation, search/history/list modes, required-field validation, and schema exposure.

## Why

Canonical facts were present in core storage and tool schemas, but the active Hermes integration adapter did not dispatch the two canonical tools. That made the tools fail at runtime even though the schema advertised them.

## Verification

```bash
PYTHONPATH="$PWD:$PWD/integrations/hermes/src:${PYTHONPATH:-}" ~/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/test_canonical.py \
  integrations/hermes/tests/test_canonical_tools.py \
  tests/test_mcp_server.py::TestToolSchemas::test_all_tools_present \
  -q -o 'addopts='
# 33 passed in 0.47s

PYTHONPATH="$PWD:$PWD/integrations/hermes/src:${PYTHONPATH:-}" ~/.hermes/hermes-agent/venv/bin/python -m pytest \
  integrations/hermes/tests \
  tests/test_mcp_server.py::TestToolSchemas::test_all_tools_present \
  -q -o 'addopts='
# 9 passed in 0.33s
```

Also smoke-tested the active adapter against a temporary Hermes home/SQLite DB: remember returned `created`, recall returned `found=True` with the expected body.
