### PR TITLE
fix(diagnose): downgrade optional local LLM fallback

### DIFF
--- a/mnemosyne/diagnose.py
+++ b/mnemosyne/diagnose.py
@@ -9,6 +9,7 @@ Never includes memory content, user queries, or API keys.
 Supports --fix mode: auto-installs missing dependencies.
 """
 
+import importlib.metadata
 import json
 import os
 import subprocess
@@ -88,25 +89,42 @@ def run_diagnostics() -> Dict:
     # --- Mnemosyne package ---
     try:
         import mnemosyne
-        log("package", "mnemosyne_version", mnemosyne.__version__)
+        version = getattr(mnemosyne, "__version__", None)
+        if not version:
+            version = importlib.metadata.version("mnemosyne-memory")
+        log("package", "mnemosyne_version", str(version))
     except Exception as e:
         log("package", "mnemosyne_version", "ERROR", str(e))
 
     # --- Core dependencies ---
-    deps = {
+    required_deps = {
         "fastembed": "fastembed",
         "sqlite_vec": "sqlite_vec",
         "numpy": "numpy",
-        "ctransformers": "ctransformers",
         "huggingface_hub": "huggingface_hub",
     }
-    for name, module in deps.items():
+    optional_deps = {
+        # Optional local-GGUF fallback only. Host/remote LLM paths and the
+        # non-LLM fallback work without it, so absence should not fail the
+        # installation health check.
+        "ctransformers": "ctransformers",
+    }
+    for name, module in required_deps.items():
         try:
             mod = __import__(module)
             ver = getattr(mod, "__version__", "unknown")
             log("deps", name, "OK", f"version={ver}")
         except ImportError:
             log("deps", name, "MISSING")
+        except Exception as e:
+            log("deps", name, "ERROR", str(e))
+    for name, module in optional_deps.items():
+        try:
+            mod = __import__(module)
+            ver = getattr(mod, "__version__", "unknown")
+            log("deps", name, "OK", f"version={ver}")
+        except ImportError:
+            log("deps", name, "OPTIONAL", "optional local-GGUF fallback dependency not installed")
         except Exception as e:
             log("deps", name, "ERROR", str(e))
 
@@ -180,10 +198,11 @@ def run_diagnostics() -> Dict:
             f.write(json.dumps(entry) + "\n")
 
     # --- Build summary ---
+    non_failure_statuses = ("OK", "YES", "set", "OPTIONAL")
     summary = {
         "log_path": str(log_path),
         "checks_total": len(entries),
-        "checks_passed": sum(1 for e in entries if e["status"] in ("OK", "YES", "set")),
+        "checks_passed": sum(1 for e in entries if e["status"] in non_failure_statuses),
         "checks_failed": sum(1 for e in entries if e["status"] in ("MISSING", "NO", "ERROR")),
         "key_findings": [],
         "fixable": [],

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -1,0 +1,31 @@
+import mnemosyne
+
+from mnemosyne import diagnose
+
+
+def _entry(summary, check):
+    return next(item for item in summary["entries"] if item["check"] == check)
+
+
+def test_diagnose_version_falls_back_to_distribution_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(diagnose, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.delattr(mnemosyne, "__version__", raising=False)
+    monkeypatch.setattr(diagnose.importlib.metadata, "version", lambda name: "9.9.9" if name == "mnemosyne-memory" else "0")
+
+    summary = diagnose.run_diagnostics()
+
+    assert _entry(summary, "mnemosyne_version")["status"] == "9.9.9"
+
+
+def test_diagnose_treats_ctransformers_as_optional(tmp_path, monkeypatch):
+    monkeypatch.setattr(diagnose, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+
+    summary = diagnose.run_diagnostics()
+    ctransformers = _entry(summary, "ctransformers")
+
+    assert ctransformers["status"] in {"OK", "OPTIONAL"}
+    if ctransformers["status"] == "OPTIONAL":
+        assert "local-GGUF fallback" in ctransformers["detail"]
+    assert ctransformers["status"] not in {"MISSING", "ERROR"}


### PR DESCRIPTION
## Summary
- fall back to package distribution metadata when `mnemosyne.__version__` is not exposed by the active import path
- classify `ctransformers` as an optional local-GGUF fallback dependency instead of a failed core dependency
- count optional dependency absence as non-failing diagnostic status
- add regression coverage for both cases

## Validation
- `PYTHONPATH="$PWD:$PWD/integrations/hermes/src:${PYTHONPATH:-}" ~/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_diagnose_optional_deps.py tests/test_hermes_memory_provider_diagnose_active_db.py -q -o 'addopts='`
