### PR TITLE
fix(hermes): route prompt to structured memory tools

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -752,10 +752,17 @@ class MnemosyneMemoryProvider(MemoryProvider):
             # (working / init-failed-visible / skip-context-silent).
             return (
                 "# Mnemosyne Memory\n"
-                "Active (native local memory). Use mnemosyne_remember to store ANY "
-                "durable fact, preference, identity, or insight. Use mnemosyne_recall to search. "
-                "Use mnemosyne_shared_* tools for manual shared surface CRUD. "
-                "The legacy memory tool is deprecated for durable storage — Mnemosyne is primary."
+                "Active native local memory. Mnemosyne is primary; the legacy memory tool is deprecated for durable storage.\n"
+                "Use mnemosyne_recall for durable facts/preferences before asking the user to repeat old context.\n"
+                "Before writing durable memory, choose the narrowest layer: "
+                "mnemosyne_remember for ordinary facts/preferences/insights; "
+                "mnemosyne_remember_canonical for stable single-source-of-truth identity/profile slots; "
+                "mnemosyne_triple_add for explicit subject-predicate-object or temporal relationships; "
+                "mnemosyne_graph_link/query for relationships between existing memories; "
+                "mnemosyne_validate/invalidate/update/forget for provenance, corrections, stale facts, and cleanup; "
+                "mnemosyne_scratchpad_* for temporary working notes; "
+                "mnemosyne_shared_* only for compact cross-agent stable metadata, never raw conversation.\n"
+                "Prefer compact, declarative, non-imperative memories. Do not save one-off task progress."
             )
         # C27: when init failed (as opposed to a deliberate skip-context),
         # surface the failure in the system prompt so the agent -- and through

--- a/integrations/hermes/tests/test_system_prompt.py
+++ b/integrations/hermes/tests/test_system_prompt.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from mnemosyne_hermes import MnemosyneMemoryProvider
+
+
+def test_system_prompt_routes_to_structured_mnemosyne_surfaces():
+    provider = MnemosyneMemoryProvider()
+    provider._beam = object()
+
+    block = provider.system_prompt_block()
+
+    assert "Mnemosyne is primary" in block
+    assert "legacy memory tool is deprecated" in block
+    assert "mnemosyne_recall" in block
+    assert "mnemosyne_remember for ordinary facts/preferences/insights" in block
+    assert "mnemosyne_remember_canonical" in block
+    assert "mnemosyne_triple_add" in block
+    assert "mnemosyne_graph_link/query" in block
+    assert "mnemosyne_validate/invalidate/update/forget" in block
+    assert "mnemosyne_scratchpad_*" in block
+    assert "mnemosyne_shared_*" in block
+    assert "Do not save one-off task progress" in block


### PR DESCRIPTION
## Summary

- Expand the Hermes adapter system prompt from basic remember/recall guidance into explicit Mnemosyne memory-layer routing.
- Nudge agents to use canonical facts, triples, graph links, validation/invalidation, scratchpad, and shared surface appropriately.
- Add a regression test so the structured-memory routing prompt does not silently narrow again.

## Why

The old prompt mentioned `mnemosyne_remember`, `mnemosyne_recall`, and `mnemosyne_shared_*`, which biases Hermes agents toward the simplest memory operations even though the adapter exposes richer structured memory tools.

This keeps the prompt concise while making the intended routing explicit.

## Tests

```bash
cd integrations/hermes
~/.hermes/hermes-agent/venv/bin/python -m py_compile src/mnemosyne_hermes/__init__.py tests/test_system_prompt.py
~/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_system_prompt.py tests/test_canonical_tools.py tests/test_prefetch_hardening.py -q -o 'addopts='
```

Result: `9 passed`.
