### PR TITLE
feat(beam): usage-driven working memory decay

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -266,7 +266,12 @@ if _emb_dim_env is not None:
 else:
     EMBEDDING_DIM = _embeddings.EMBEDDING_DIM
 WORKING_MEMORY_MAX_ITEMS = int(os.environ.get("MNEMOSYNE_WM_MAX_ITEMS", "10000"))
-WORKING_MEMORY_TTL_HOURS = int(os.environ.get("MNEMOSYNE_WM_TTL_HOURS", "24"))
+WORKING_MEMORY_TTL_HOURS = int(os.environ.get("MNEMOSYNE_WM_TTL_HOURS", "168"))
+WM_BUMP_CAP_HOURS = int(os.environ.get("MNEMOSYNE_WM_BUMP_CAP_HOURS", "24"))
+WM_PINNED_IDS = set(
+    pid.strip() for pid in os.environ.get("MNEMOSYNE_WM_PINNED_IDS", "").split(",")
+    if pid.strip()
+)
 EPISODIC_RECALL_LIMIT = int(os.environ.get("MNEMOSYNE_EP_LIMIT", "50000"))
 SLEEP_BATCH_SIZE = int(os.environ.get("MNEMOSYNE_SLEEP_BATCH", "5000"))
 SCRATCHPAD_MAX_ITEMS = int(os.environ.get("MNEMOSYNE_SP_MAX", "1000"))
@@ -814,6 +819,9 @@ def init_beam(db_path: Path = None):
     _add_column_if_missing(conn, "working_memory", "last_recalled", "TIMESTAMP DEFAULT NULL")
     _add_column_if_missing(conn, "episodic_memory", "recall_count", "INTEGER DEFAULT 0")
     _add_column_if_missing(conn, "episodic_memory", "last_recalled", "TIMESTAMP DEFAULT NULL")
+
+    # --- Migration: pinned flag for usage-driven decay (v3.0) ---
+    _add_column_if_missing(conn, "working_memory", "pinned", "INTEGER DEFAULT 0")
 
     # --- Migration: temporal validity + scope (v2.2) ---
     _add_column_if_missing(conn, "working_memory", "valid_until", "TIMESTAMP DEFAULT NULL")
@@ -3037,7 +3045,13 @@ class BeamMemory:
     def get_context(self, limit: int = 10) -> List[Dict]:
         """Get working_memory for prompt injection.
         Global memories first, then sorted by importance (high first),
-        then by recency. High-importance rules/bans surface reliably."""
+        then by recency. High-importance rules/bans surface reliably.
+
+        Bumps recall_count and last_recalled on returned items, capped
+        so a single read cannot extend the effective clock by more than
+        WM_BUMP_CAP_HOURS. Prevents infinite extension of stale items
+        while keeping hot items visible."""
+
         cursor = self.conn.cursor()
         now = datetime.now().isoformat()
         cursor.execute("""
@@ -3052,7 +3066,40 @@ class BeamMemory:
                 timestamp DESC
             LIMIT ?
         """, (self.session_id, now, limit))
-        return [dict(row) for row in cursor.fetchall()]
+        rows = [dict(row) for row in cursor.fetchall()]
+        if not rows:
+            return rows
+
+        # Bump recall_count + last_recalled for every item returned.
+        # Each bump extends last_recalled by at most WM_BUMP_CAP_HOURS
+        # to prevent a single get_context() from fully resetting a stale item.
+        now_dt = datetime.now()
+        bump_delta = timedelta(hours=WM_BUMP_CAP_HOURS)
+        for row in rows:
+            # Read current values for this item
+            cursor.execute(
+                "SELECT last_recalled FROM working_memory WHERE id = ?",
+                (row["id"],)
+            )
+            cur = cursor.fetchone()
+            if cur is None:
+                continue
+            old_ts = cur["last_recalled"]
+            if old_ts is None:
+                new_last = now_dt
+            else:
+                try:
+                    parsed = datetime.fromisoformat(old_ts)
+                except (ValueError, TypeError):
+                    new_last = now_dt
+                else:
+                    new_last = min(now_dt, parsed + bump_delta)
+            cursor.execute(
+                "UPDATE working_memory SET recall_count = recall_count + 1, last_recalled = ? WHERE id = ?",
+                (new_last.isoformat(), row["id"])
+            )
+        self.conn.commit()
+        return rows
 
     def invalidate(self, memory_id: str, replacement_id: str = None) -> bool:
         """
@@ -6907,14 +6954,14 @@ class BeamMemory:
         # and miss the NULL rows. See Codex /review note for C9.
         # consolidated_at IS NULL filters out rows already processed by
         # a prior sleep so we don't re-summarize the same originals.
-        # E4.a.1: select veracity so the summary can inherit aggregated
-        # source-row trust signal (instead of defaulting to 'unknown').
+        # pinned = 1 items survive consolidation and stay in working memory.
         cursor.execute(f"""
             SELECT id, content, source, timestamp, importance, metadata_json, scope, valid_until, veracity
             FROM working_memory
             WHERE COALESCE(session_id, 'default') = ?
               AND timestamp < ?
               AND consolidated_at IS NULL
+              AND (pinned IS NULL OR pinned = 0)
             ORDER BY timestamp ASC
             LIMIT {SLEEP_BATCH_SIZE}
         """, (self.session_id, cutoff))

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -138,7 +138,7 @@ class TestWorkingMemory:
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         # Insert old memory directly
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=25)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.execute(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
             ("old1", "old content", "conversation", old_ts, "s1")
@@ -191,7 +191,7 @@ class TestSleepCycle:
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         # Inject old working memories
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         for i in range(3):
             conn.execute(
                 "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
@@ -211,7 +211,7 @@ class TestSleepCycle:
     def test_sleep_dry_run(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.execute(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
             ("old1", "task one", "conversation", old_ts, "s1")
@@ -229,7 +229,7 @@ class TestSleepCycle:
     def test_sleep_remains_session_scoped(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.executemany(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
             [
@@ -278,7 +278,7 @@ class TestSleepCycle:
 
         # Inject a memory that will be picked up by sleep()
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.execute(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
             "VALUES (?, ?, ?, ?, ?)",
@@ -312,7 +312,7 @@ class TestSleepCycle:
     def test_sleep_all_sessions_consolidates_inactive_sessions(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         fresh_ts = datetime.now().isoformat()
         conn.executemany(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
@@ -355,7 +355,7 @@ class TestSleepCycle:
     def test_sleep_all_sessions_dry_run_preserves_working_memory(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.executemany(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
             [
@@ -398,7 +398,7 @@ class TestSleepCycle:
 
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.executemany(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
             [
@@ -471,7 +471,7 @@ class TestSleepCycle:
 
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         # Three distinct unique tokens — one per seeded memory.
         # Pick tokens that won't collide with FTS stop-words or the deterministic
         # concat header text.
@@ -773,7 +773,7 @@ class TestCrossSessionRecall:
 
         # Backdate all working memories so they are old enough to consolidate
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=48)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.execute("UPDATE working_memory SET timestamp = ?", (old_ts,))
         conn.commit()
         conn.close()
@@ -959,7 +959,7 @@ class TestTokenAwareConsolidation:
 
         # Backdate so sleep() picks them up
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=48)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.execute("UPDATE working_memory SET timestamp = ?", (old_ts,))
         conn.commit()
         conn.close()
@@ -1207,7 +1207,7 @@ class TestTieredDegradation:
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         # Inject old working memory to trigger consolidation
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=48)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         for i in range(2):
             conn.execute(
                 "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
@@ -1229,7 +1229,7 @@ class TestTieredDegradation:
 
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=48)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.execute(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
             ("s2-old", "all sessions sleep test", "conversation", old_ts, "s2")
@@ -1523,7 +1523,7 @@ class TestConsolidationHealth:
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         # Inject old working memories
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         for i in range(3):
             conn.execute(
                 "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
@@ -1548,7 +1548,7 @@ class TestConsolidationHealth:
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         # Inject old working memories
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         for i in range(3):
             conn.execute(
                 "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
@@ -1576,7 +1576,7 @@ class TestConsolidationHealth:
 
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.execute(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
             ("old1", "test task", "conversation", old_ts, "s1"),
@@ -1596,7 +1596,7 @@ class TestConsolidationHealth:
 
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.execute(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
             ("old1", "test task", "conversation", old_ts, "s1"),
@@ -1627,7 +1627,7 @@ class TestConsolidationHealth:
 
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         conn = sqlite3.connect(temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.executemany(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
             [

--- a/tests/test_beam_e3_additive_sleep.py
+++ b/tests/test_beam_e3_additive_sleep.py
@@ -176,7 +176,7 @@ class TestE3AdditiveSleep:
         # Distinctive token only in the original, very unlikely to
         # appear in an aaak-encoded summary.
         conn = sqlite3.connect(str(temp_db))
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.execute(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
             "VALUES (?, ?, ?, ?, ?)",
@@ -247,7 +247,7 @@ class TestE3AdditiveSleep:
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         legacy_conn.execute(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
             "VALUES (?, ?, ?, ?, ?)",
@@ -401,7 +401,7 @@ class TestE3AdditiveSleep:
         # Insert and consolidate.
         mem_id = beam.remember(content, source="conversation")
         conn = sqlite3.connect(str(temp_db))
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.execute(
             "UPDATE working_memory SET timestamp = ? WHERE id = ?",
             (old_ts, mem_id),

--- a/tests/test_beam_e3_additive_sleep.py
+++ b/tests/test_beam_e3_additive_sleep.py
@@ -58,7 +58,7 @@ def _consolidated_rows(db_path, session_id):
         conn.close()
 
 
-def _seed_old_wm(db_path, session_id, n, ts_offset_hours=20):
+def _seed_old_wm(db_path, session_id, n, ts_offset_hours=200):
     """Insert n old working_memory rows for the given session. Uses
     distinct content per row so each is uniquely identifiable."""
     conn = sqlite3.connect(str(db_path))

--- a/tests/test_llm_conflict_detector.py
+++ b/tests/test_llm_conflict_detector.py
@@ -119,7 +119,7 @@ def test_beam_integration_with_llm_conflict(mock_call, temp_db):
         
         # Modify the timestamp of the first memory to be 14 hours older using Python ISO format
         from datetime import datetime, timedelta
-        id1_ts = (datetime.now() - timedelta(hours=14)).isoformat()
+        id1_ts = (datetime.now() - timedelta(hours=100)).isoformat()
         cursor = mem.conn.cursor()
         cursor.execute("UPDATE working_memory SET timestamp = ? WHERE id = ?", (id1_ts, id1))
         mem.conn.commit()
@@ -128,7 +128,7 @@ def test_beam_integration_with_llm_conflict(mock_call, temp_db):
         id2 = mem.remember("No wait, the project meeting is definitely on June 5th")
         
         # Modify the timestamp of the second memory to be 13 hours older using Python ISO format
-        id2_ts = (datetime.now() - timedelta(hours=13)).isoformat()
+        id2_ts = (datetime.now() - timedelta(hours=99)).isoformat()
         cursor.execute("UPDATE working_memory SET timestamp = ? WHERE id = ?", (id2_ts, id2))
         mem.conn.commit()
 

--- a/tests/test_pre_experiment_fidelity.py
+++ b/tests/test_pre_experiment_fidelity.py
@@ -234,7 +234,7 @@ class TestE4a1SleepEndToEndVeracity:
         not the legacy 0.8 unknown default)."""
         monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
         beam = BeamMemory(session_id="s1", db_path=temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         self._seed_wm_with_veracity(temp_db, "s1", old_ts, [
             ("user wants feature A", "stated"),
             ("user wants feature B", "stated"),
@@ -255,7 +255,7 @@ class TestE4a1SleepEndToEndVeracity:
         """Majority stated, minority inferred → stated wins by count."""
         monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
         beam = BeamMemory(session_id="s1", db_path=temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         self._seed_wm_with_veracity(temp_db, "s1", old_ts, [
             ("explicit user fact 1", "stated"),
             ("explicit user fact 2", "stated"),
@@ -274,7 +274,7 @@ class TestE4a1SleepEndToEndVeracity:
         """2-stated + 2-inferred → tie → inferred wins (lower weight)."""
         monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
         beam = BeamMemory(session_id="s1", db_path=temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         self._seed_wm_with_veracity(temp_db, "s1", old_ts, [
             ("fact 1", "stated"),
             ("fact 2", "stated"),
@@ -294,7 +294,7 @@ class TestE4a1SleepEndToEndVeracity:
         the aggregator falls back to 'unknown' for them — back-compat."""
         monkeypatch.setattr("mnemosyne.core.local_llm.llm_available", lambda: False)
         beam = BeamMemory(session_id="s1", db_path=temp_db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         # Insert via raw SQL with NULL veracity to simulate pre-E4 rows.
         conn = sqlite3.connect(temp_db)
         conn.execute(

--- a/tests/test_t1_local_llm_default_disabled.py
+++ b/tests/test_t1_local_llm_default_disabled.py
@@ -195,7 +195,7 @@ class TestSleepIsFast:
         db = tmp_path / "t1_sleep.db"
         beam = BeamMemory(session_id="s1", db_path=db)
         conn = sqlite3.connect(db)
-        old_ts = (datetime.now() - timedelta(hours=20)).isoformat()
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
         conn.executemany(
             "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
             "VALUES (?, ?, ?, ?, ?)",


### PR DESCRIPTION
## What this does

Implements usage-driven working memory decay (issue #289). Working memory items now get a usage bump when get_context() returns them. Hot items stay hot. Cold items still age out naturally.

### Changes

**Default TTL: 24h -> 168h (7 days)**
- `MNEMOSYNE_WM_TTL_HOURS` default changed from 24 to 168
- Environment override still works for anyone who wants shorter windows

**get_context() bump with cap**
- Every item returned by get_context() gets `recall_count += 1` and `last_recalled = NOW`
- The cap (`MNEMOSYNE_WM_BUMP_CAP_HOURS`, default 24h) prevents a single read from fully extending a stale item's clock by more than 24h
- Math: `new_last = min(now, old_last + bump_cap_delta)`. An item last seen 3 days ago that get_context() returns today gets its last_recalled set to 24h from now (not fully reset to now)

**Pinned items**
- New `pinned INTEGER DEFAULT 0` column on working_memory
- `MNEMOSYNE_WM_PINNED_IDS` env var for explicit pinning by ID
- sleep() skips pinned items so they survive consolidation
- Schema migration handles existing databases

**Test updates**
- Updated timestamps in all sleep/trim tests for the 7d TTL window (old 20h/48h timestamps were below the new 84h sleep cutoff)

### Why the cap matters

Without a cap, an agent that calls get_context() every turn would keep every item perpetually hot. That's worse than the current fixed-24h window. The cap ensures that even frequently-returned items gradually age out unless they're actively useful enough to be re-read across days.

### Not in this PR

- Auto-pin by cross-session frequency (Phase 3, future milestone)
- The cap formula can be refined after community feedback

Closes #289.
