### PR TITLE
perf: split get_context hot path queries

### DIFF
--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -1,3 +1,48 @@
-"""Mnemosyne — local-first, zero-cloud memory for AI agents."""
+"""
+Mnemosyne - The Zero-Dependency AI Memory System
+
+A native, sub-millisecond memory system for AI agents using SQLite.
+No HTTP, no servers, no API keys — just Python and SQLite.
+
+Example:
+    >>> from mnemosyne import remember, recall
+    >>> remember("User prefers dark mode", importance=0.9)
+    >>> results = recall("user preferences")
+"""
 
 __version__ = "3.7.0"
+__author__ = "Abdias J"
+__license__ = "MIT"
+
+# Lazy imports to allow mnemosyne.install to run without heavy deps
+# (e.g. numpy is not yet installed during first-time setup)
+_lazy_exports = {
+    "Mnemosyne": (".core.memory", "Mnemosyne"),
+    "remember": (".core.memory", "remember"),
+    "recall": (".core.memory", "recall"),
+    "get_context": (".core.memory", "get_context"),
+    "get_stats": (".core.memory", "get_stats"),
+    "get": (".core.memory", "get"),
+    "forget": (".core.memory", "forget"),
+    "update": (".core.memory", "update"),
+}
+
+
+def __getattr__(name: str):
+    if name in _lazy_exports:
+        mod_path, attr_name = _lazy_exports[name]
+        mod = __import__(f"mnemosyne{mod_path}", fromlist=[attr_name])
+        return getattr(mod, attr_name)
+    raise AttributeError(f"module 'mnemosyne' has no attribute '{name}'")
+
+
+__all__ = list(_lazy_exports.keys())
+
+# Conditionally expose MCP server if mcp package is installed
+try:
+    import mcp  # noqa: F401
+
+    _lazy_exports["run_mcp_server"] = (".mcp_server", "run_mcp_server")
+    __all__.append("run_mcp_server")
+except ImportError:
+    pass  # MCP is optional — core works without it

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -836,6 +836,12 @@ def init_beam(db_path: Path = None):
         ON episodic_memory(scope, importance) WHERE superseded_by IS NULL""")
     cursor.execute("""CREATE INDEX IF NOT EXISTS idx_wm_session_recall
         ON working_memory(session_id, last_recalled) WHERE valid_until IS NULL""")
+    cursor.execute("""CREATE INDEX IF NOT EXISTS idx_wm_context_session
+        ON working_memory(session_id, importance DESC, timestamp DESC)
+        WHERE superseded_by IS NULL""")
+    cursor.execute("""CREATE INDEX IF NOT EXISTS idx_wm_context_global
+        ON working_memory(scope, importance DESC, timestamp DESC)
+        WHERE superseded_by IS NULL""")
     cursor.execute("""CREATE INDEX IF NOT EXISTS idx_mem_emb_type
         ON memory_embeddings(memory_id, model)""")
 
@@ -3054,19 +3060,40 @@ class BeamMemory:
 
         cursor = self.conn.cursor()
         now = datetime.now().isoformat()
-        cursor.execute("""
-            SELECT id, content, source, timestamp, importance, scope
+        # Keep the original ordering contract (global memories first, then
+        # session-local memories; each group by importance and recency) while
+        # avoiding the previous ``session_id = ? OR scope = 'global'`` query.
+        # Splitting this hot path lets SQLite use simple partial indexes for
+        # each branch instead of scanning working_memory and building a temp
+        # B-tree for the CASE-based ORDER BY.
+        select_cols = "id, content, source, timestamp, importance, scope, last_recalled"
+        common_predicate = "(valid_until IS NULL OR valid_until > ?) AND superseded_by IS NULL"
+
+        cursor.execute(f"""
+            SELECT {select_cols}
             FROM working_memory
-            WHERE (session_id = ? OR scope = 'global')
-              AND (valid_until IS NULL OR valid_until > ?)
-              AND superseded_by IS NULL
-            ORDER BY
-                CASE WHEN scope = 'global' THEN 0 ELSE 1 END,
-                importance DESC,
-                timestamp DESC
+            WHERE scope = 'global'
+              AND {common_predicate}
+            ORDER BY importance DESC, timestamp DESC
             LIMIT ?
-        """, (self.session_id, now, limit))
-        rows = [dict(row) for row in cursor.fetchall()]
+        """, (now, limit))
+        global_rows = [dict(row) for row in cursor.fetchall()]
+
+        session_rows = []
+        if limit < 0 or len(global_rows) < limit:
+            session_limit = limit if limit < 0 else limit - len(global_rows)
+            cursor.execute(f"""
+                SELECT {select_cols}
+                FROM working_memory
+                WHERE session_id = ?
+                  AND (scope IS NULL OR scope != 'global')
+                  AND {common_predicate}
+                ORDER BY importance DESC, timestamp DESC
+                LIMIT ?
+            """, (self.session_id, now, session_limit))
+            session_rows = [dict(row) for row in cursor.fetchall()]
+
+        rows = global_rows + session_rows
         if not rows:
             return rows
 
@@ -3076,15 +3103,7 @@ class BeamMemory:
         now_dt = datetime.now()
         bump_delta = timedelta(hours=WM_BUMP_CAP_HOURS)
         for row in rows:
-            # Read current values for this item
-            cursor.execute(
-                "SELECT last_recalled FROM working_memory WHERE id = ?",
-                (row["id"],)
-            )
-            cur = cursor.fetchone()
-            if cur is None:
-                continue
-            old_ts = cur["last_recalled"]
+            old_ts = row.pop("last_recalled", None)
             if old_ts is None:
                 new_last = now_dt
             else:

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -102,6 +102,14 @@ class TestBeamSchema:
         assert "fts_episodes" in tables
         conn.close()
 
+    def test_context_indexes_created(self, temp_db):
+        init_beam(temp_db)
+        conn = sqlite3.connect(temp_db)
+        indexes = {r[1] for r in conn.execute("PRAGMA index_list(working_memory)").fetchall()}
+        assert "idx_wm_context_session" in indexes
+        assert "idx_wm_context_global" in indexes
+        conn.close()
+
     def test_vec_type_probe_does_not_rollback_schema_ddl(self, temp_db, monkeypatch):
         """Vector capability probing must not undo unrelated schema DDL.
 
@@ -133,6 +141,112 @@ class TestWorkingMemory:
         ctx = beam.get_context(limit=5)
         assert len(ctx) == 1
         assert ctx[0]["content"] == "Prefers Neovim"
+
+    def test_get_context_keeps_global_first_then_session_order(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        now = datetime.now()
+        rows = [
+            ("session-high", "session high", "conversation", (now - timedelta(minutes=1)).isoformat(), "s1", 0.99, "session"),
+            ("global-low", "global low", "preference", (now - timedelta(minutes=2)).isoformat(), "other", 0.10, "global"),
+            ("global-high", "global high", "preference", now.isoformat(), "other", 0.80, "global"),
+            ("session-low", "session low", "conversation", (now - timedelta(minutes=3)).isoformat(), "s1", 0.10, "session"),
+            ("other-session", "other session", "conversation", now.isoformat(), "s2", 1.00, "session"),
+        ]
+        beam.conn.executemany(
+            """
+            INSERT INTO working_memory
+                (id, content, source, timestamp, session_id, importance, scope)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        beam.conn.commit()
+
+        ctx = beam.get_context(limit=4)
+        assert [row["id"] for row in ctx] == [
+            "global-high",
+            "global-low",
+            "session-high",
+            "session-low",
+        ]
+        assert all("last_recalled" not in row for row in ctx)
+
+    def test_get_context_limit_minus_one_preserves_unbounded_sqlite_limit(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        now = datetime.now().isoformat()
+        for i in range(3):
+            beam.conn.execute(
+                """
+                INSERT INTO working_memory
+                    (id, content, source, timestamp, session_id, importance, scope)
+                VALUES (?, ?, 'conversation', ?, 's1', ?, 'session')
+                """,
+                (f"m{i}", f"memory {i}", now, i / 10),
+            )
+        beam.conn.commit()
+
+        ctx = beam.get_context(limit=-1)
+        assert len(ctx) == 3
+
+    def test_get_context_query_shapes_use_context_indexes(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        now = datetime.now().isoformat()
+        for i in range(20):
+            beam.conn.execute(
+                """
+                INSERT INTO working_memory
+                    (id, content, source, timestamp, session_id, importance, scope)
+                VALUES (?, ?, 'conversation', ?, ?, ?, ?)
+                """,
+                (
+                    f"m{i}",
+                    f"memory {i}",
+                    now,
+                    "s1" if i % 2 else "s2",
+                    i / 20,
+                    "global" if i % 5 == 0 else "session",
+                ),
+            )
+        beam.conn.commit()
+
+        global_plan = "\n".join(
+            row[3]
+            for row in beam.conn.execute(
+                """
+                EXPLAIN QUERY PLAN
+                SELECT id, content, source, timestamp, importance, scope, last_recalled
+                FROM working_memory
+                WHERE scope = 'global'
+                  AND (valid_until IS NULL OR valid_until > ?)
+                  AND superseded_by IS NULL
+                ORDER BY importance DESC, timestamp DESC
+                LIMIT ?
+                """,
+                (now, 10),
+            ).fetchall()
+        )
+        session_plan = "\n".join(
+            row[3]
+            for row in beam.conn.execute(
+                """
+                EXPLAIN QUERY PLAN
+                SELECT id, content, source, timestamp, importance, scope, last_recalled
+                FROM working_memory
+                WHERE session_id = ?
+                  AND (scope IS NULL OR scope != 'global')
+                  AND (valid_until IS NULL OR valid_until > ?)
+                  AND superseded_by IS NULL
+                ORDER BY importance DESC, timestamp DESC
+                LIMIT ?
+                """,
+                ("s1", now, 10),
+            ).fetchall()
+        )
+
+        assert "idx_wm_context_global" in global_plan
+        assert "idx_wm_context_session" in session_plan
+        assert "USE TEMP B-TREE" not in global_plan
+        assert "USE TEMP B-TREE" not in session_plan
 
     def test_trim_old_memories(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)


### PR DESCRIPTION
## Summary

- split `BeamMemory.get_context()` into separate global/session queries so SQLite can use straightforward indexes instead of the previous `OR` + `CASE` ordering shape
- add partial context indexes for global and session lookups
- keep the public ordering contract: global memories first, then session memories; both groups sorted by importance and recency
- avoid the per-row `SELECT last_recalled` by selecting it in the initial queries and removing it from returned rows before returning

Closes #291.

## Verification

```text
env PYTHONPATH=$PWD uv run --no-project \
  --with pytest --with pytest-asyncio --with pyyaml --with numpy --with python-dotenv \
  python -m pytest tests/test_beam.py tests/test_beam_e3_additive_sleep.py tests/test_pre_experiment_fidelity.py -q

121 passed in 94.51s (0:01:34)
```

Added tests cover:

- context indexes are created
- global-first/session ordering is preserved
- `limit=-1` keeps SQLite's unbounded-limit behavior
- representative query shapes use the new context indexes without a temp B-tree
