### PR TITLE
fix: reclaim stale consolidation orphan claims

### DIFF
--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -25,6 +25,7 @@ _lazy_exports = {
     "get": (".core.memory", "get"),
     "forget": (".core.memory", "forget"),
     "update": (".core.memory", "update"),
+    "reclaim_orphans": (".core.memory", "reclaim_orphans"),
 }
 
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -599,6 +599,12 @@ def init_beam(db_path: Path = None):
             (datetime.now().isoformat(),),
         )
 
+    try:
+        cursor.execute("ALTER TABLE working_memory ADD COLUMN consolidation_claimed_at TEXT")
+    except sqlite3.OperationalError as exc:
+        if "duplicate column" not in str(exc).lower():
+            raise
+
     # Partial index for the sleep eligibility predicate. Sleep scans
     # WHERE session_id = ? AND timestamp < ? AND consolidated_at IS NULL
     # on every cycle; once consolidated rows accumulate the predicate
@@ -608,6 +614,11 @@ def init_beam(db_path: Path = None):
         "CREATE INDEX IF NOT EXISTS idx_wm_unconsolidated "
         "ON working_memory(session_id, timestamp) "
         "WHERE consolidated_at IS NULL"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_wm_consolidation_claims "
+        "ON working_memory(consolidation_claimed_at) "
+        "WHERE consolidation_claimed_at IS NOT NULL"
     )
 
     # --- SCRATCHPAD ---
@@ -2442,7 +2453,8 @@ class BeamMemory:
                     memory_type = COALESCE(?, memory_type),
                     veracity = CASE WHEN ? != 'unknown' THEN ? ELSE veracity END,
                     trust_tier = COALESCE(?, trust_tier),
-                    consolidated_at = NULL
+                    consolidated_at = NULL,
+                    consolidation_claimed_at = NULL
                 WHERE id = ? AND session_id = ?
             """, (importance, datetime.now().isoformat(), source,
                   valid_until, scope,
@@ -6938,6 +6950,103 @@ class BeamMemory:
     # ------------------------------------------------------------------
     # Consolidation / Sleep
     # ------------------------------------------------------------------
+    def reclaim_orphans(
+        self,
+        dry_run: bool = False,
+        stale_after_seconds: int = 3600,
+        limit: int = 1000,
+    ) -> Dict:
+        """Clear stale sleep claims that have no episodic summary.
+
+        sleep() claims working rows by setting ``consolidated_at`` before it
+        writes the episodic summary. A process crash in that narrow window can
+        leave rows permanently skipped by later sleep() runs. This maintenance
+        helper finds old claims whose id does not appear in any
+        ``episodic_memory.summary_of`` CSV token and clears the marker so a
+        later sleep pass can summarize them.
+        """
+        stale_after_seconds = max(0, int(stale_after_seconds))
+        limit = max(0, int(limit))
+        cutoff = (datetime.now() - timedelta(seconds=stale_after_seconds)).isoformat()
+        if limit == 0:
+            return {
+                "status": "dry_run" if dry_run else "no_op",
+                "stale_after_seconds": stale_after_seconds,
+                "cutoff": cutoff,
+                "candidates": 0,
+                "reclaimed": 0,
+                "candidate_ids": [],
+            }
+
+        cursor = self.conn.cursor()
+        orphan_query = """
+            SELECT wm.id
+            FROM working_memory wm
+            WHERE wm.consolidated_at IS NOT NULL
+              AND wm.consolidation_claimed_at IS NOT NULL
+              AND wm.consolidation_claimed_at < ?
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM episodic_memory em
+                  WHERE instr(',' || COALESCE(em.summary_of, '') || ',',
+                              ',' || wm.id || ',') > 0
+              )
+            ORDER BY wm.consolidated_at ASC
+            LIMIT ?
+        """
+        cursor.execute(orphan_query, (cutoff, limit))
+        candidate_ids = [row["id"] for row in cursor.fetchall()]
+        if not candidate_ids:
+            return {
+                "status": "dry_run" if dry_run else "no_op",
+                "stale_after_seconds": stale_after_seconds,
+                "cutoff": cutoff,
+                "candidates": 0,
+                "reclaimed": 0,
+                "candidate_ids": [],
+            }
+
+        if dry_run:
+            return {
+                "status": "dry_run",
+                "stale_after_seconds": stale_after_seconds,
+                "cutoff": cutoff,
+                "candidates": len(candidate_ids),
+                "reclaimed": 0,
+                "candidate_ids": candidate_ids,
+            }
+
+        placeholders = ",".join("?" * len(candidate_ids))
+        cursor.execute(
+            f"""
+            UPDATE working_memory
+            SET consolidated_at = NULL,
+                consolidation_claimed_at = NULL
+            WHERE id IN ({placeholders})
+              AND consolidated_at IS NOT NULL
+              AND consolidation_claimed_at IS NOT NULL
+              AND consolidation_claimed_at < ?
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM episodic_memory em
+                  WHERE instr(',' || COALESCE(em.summary_of, '') || ',',
+                              ',' || working_memory.id || ',') > 0
+              )
+            """,
+            (*candidate_ids, cutoff),
+        )
+        reclaimed = cursor.rowcount
+        self.conn.commit()
+        logger.info("reclaim_orphans: reclaimed=%d candidates=%d", reclaimed, len(candidate_ids))
+        return {
+            "status": "reclaimed" if reclaimed else "no_op",
+            "stale_after_seconds": stale_after_seconds,
+            "cutoff": cutoff,
+            "candidates": len(candidate_ids),
+            "reclaimed": reclaimed,
+            "candidate_ids": candidate_ids,
+        }
+
     def sleep(self, dry_run: bool = False, force: bool = False) -> Dict:
         """
         Consolidate old working_memory for this session into episodic summaries.
@@ -7008,9 +7117,9 @@ class BeamMemory:
             ids_to_claim = [row["id"] for row in rows]
             placeholders = ",".join("?" * len(ids_to_claim))
             cursor.execute(
-                f"UPDATE working_memory SET consolidated_at = ? "
+                f"UPDATE working_memory SET consolidated_at = ?, consolidation_claimed_at = ? "
                 f"WHERE id IN ({placeholders}) AND consolidated_at IS NULL",
-                (now_iso, *ids_to_claim),
+                (now_iso, now_iso, *ids_to_claim),
             )
             claimed_ids = set()
             if cursor.rowcount == len(ids_to_claim):
@@ -7165,6 +7274,12 @@ class BeamMemory:
                         "source": source,
                         "llm_used": llm_succeeded
                     }
+                )
+                group_placeholders = ",".join("?" * len(ids))
+                cursor.execute(
+                    f"UPDATE working_memory SET consolidation_claimed_at = NULL "
+                    f"WHERE id IN ({group_placeholders})",
+                    tuple(ids),
                 )
             consolidated_ids.extend(ids)
             summaries_created += 1
@@ -7428,7 +7543,8 @@ class BeamMemory:
         cursor.execute("""
             SELECT id, content, source, timestamp, session_id, importance,
                    metadata_json, valid_until, superseded_by, scope,
-                   recall_count, last_recalled, created_at, veracity, consolidated_at
+                   recall_count, last_recalled, created_at, veracity,
+                   consolidated_at, consolidation_claimed_at
             FROM working_memory
             ORDER BY session_id, timestamp
         """)
@@ -7520,8 +7636,8 @@ class BeamMemory:
                 INSERT INTO working_memory
                 (id, content, source, timestamp, session_id, importance, metadata_json,
                  valid_until, superseded_by, scope, recall_count, last_recalled, created_at,
-                 veracity, consolidated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 veracity, consolidated_at, consolidation_claimed_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 mid, item.get("content"), item.get("source"), item.get("timestamp"),
                 item.get("session_id", "default"), item.get("importance", 0.5),
@@ -7533,6 +7649,7 @@ class BeamMemory:
                 # treated as "not yet consolidated" so the next sleep
                 # cycle on the importing DB processes them normally.
                 item.get("consolidated_at"),
+                item.get("consolidation_claimed_at"),
             ))
         self.conn.commit()
 

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -565,6 +565,16 @@ class Mnemosyne:
         """Run consolidation sleep cycle across all sessions with eligible old working memories."""
         return self.beam.sleep_all_sessions(dry_run=dry_run, force=force)
 
+    def reclaim_orphans(self, dry_run: bool = False,
+                        stale_after_seconds: int = 3600,
+                        limit: int = 1000) -> Dict:
+        """Clear stale sleep claims that have no episodic summary."""
+        return self.beam.reclaim_orphans(
+            dry_run=dry_run,
+            stale_after_seconds=stale_after_seconds,
+            limit=limit,
+        )
+
     def scratchpad_write(self, content: str) -> str:
         """Write to scratchpad."""
         return self.beam.scratchpad_write(content)
@@ -843,6 +853,16 @@ def sleep(dry_run: bool = False, force: bool = False, bank: str = None) -> Dict:
 def sleep_all_sessions(dry_run: bool = False, force: bool = False, bank: str = None) -> Dict:
     """Run consolidation sleep cycle across all sessions using the global instance"""
     return _get_default(bank).sleep_all_sessions(dry_run=dry_run, force=force)
+
+
+def reclaim_orphans(dry_run: bool = False, stale_after_seconds: int = 3600,
+                    limit: int = 1000, bank: str = None) -> Dict:
+    """Clear stale sleep claims that have no episodic summary using the global instance."""
+    return _get_default(bank).reclaim_orphans(
+        dry_run=dry_run,
+        stale_after_seconds=stale_after_seconds,
+        limit=limit,
+    )
 
 
 def scratchpad_write(content: str, bank: str = None) -> str:

--- a/tests/test_beam_e3_additive_sleep.py
+++ b/tests/test_beam_e3_additive_sleep.py
@@ -443,6 +443,166 @@ class TestE3AdditiveSleep:
             f"claim failed. result_a={result_a}, result_b={result_b}"
         )
 
+    def test_reclaim_orphans_clears_stale_claim_without_summary(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=1)
+        stale_claim = (datetime.now() - timedelta(hours=2)).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute(
+            "UPDATE working_memory SET consolidated_at = ?, consolidation_claimed_at = ? WHERE id = ?",
+            (stale_claim, stale_claim, "e3-s1-0"),
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.reclaim_orphans(stale_after_seconds=1)
+
+        assert result["status"] == "reclaimed"
+        assert result["reclaimed"] == 1
+        assert result["candidate_ids"] == ["e3-s1-0"]
+        assert _consolidated_rows(temp_db, "s1")[0][1] is None
+
+    def test_reclaim_orphans_preserves_referenced_claims_and_avoids_partial_matches(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
+        stale_claim = (datetime.now() - timedelta(hours=2)).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.executemany(
+            """
+            INSERT INTO working_memory (id, content, source, timestamp, session_id, consolidated_at, consolidation_claimed_at)
+            VALUES (?, ?, 'conversation', ?, 's1', ?, ?)
+            """,
+            [
+                ("wm1", "orphan", old_ts, stale_claim, stale_claim),
+                ("wm10", "referenced", old_ts, stale_claim, stale_claim),
+            ],
+        )
+        conn.execute(
+            """
+            INSERT INTO episodic_memory (id, content, source, timestamp, session_id, summary_of)
+            VALUES ('ep1', 'summary', 'sleep_consolidation', ?, 's1', 'wm10')
+            """,
+            (datetime.now().isoformat(),),
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.reclaim_orphans(stale_after_seconds=1)
+
+        assert result["reclaimed"] == 1
+        rows = dict(_consolidated_rows(temp_db, "s1"))
+        assert rows["wm1"] is None
+        assert rows["wm10"] == stale_claim
+
+    def test_reclaim_orphans_respects_stale_threshold(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
+        stale_claim = (datetime.now() - timedelta(hours=2)).isoformat()
+        fresh_claim = datetime.now().isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.executemany(
+            """
+            INSERT INTO working_memory (id, content, source, timestamp, session_id, consolidated_at, consolidation_claimed_at)
+            VALUES (?, ?, 'conversation', ?, 's1', ?, ?)
+            """,
+            [
+                ("stale", "stale orphan", old_ts, stale_claim, stale_claim),
+                ("fresh", "fresh claim", old_ts, fresh_claim, fresh_claim),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.reclaim_orphans(stale_after_seconds=60)
+
+        assert result["reclaimed"] == 1
+        rows = dict(_consolidated_rows(temp_db, "s1"))
+        assert rows["stale"] is None
+        assert rows["fresh"] == fresh_claim
+
+    def test_reclaim_orphans_dry_run_writes_nothing(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=1)
+        stale_claim = (datetime.now() - timedelta(hours=2)).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute(
+            "UPDATE working_memory SET consolidated_at = ?, consolidation_claimed_at = ? WHERE id = ?",
+            (stale_claim, stale_claim, "e3-s1-0"),
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.reclaim_orphans(dry_run=True, stale_after_seconds=1)
+
+        assert result["status"] == "dry_run"
+        assert result["candidates"] == 1
+        assert result["reclaimed"] == 0
+        assert _consolidated_rows(temp_db, "s1")[0][1] == stale_claim
+
+    def test_reclaim_orphans_ignores_legacy_backfill_without_claim_marker(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=1)
+        stale_backfill = (datetime.now() - timedelta(hours=2)).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute(
+            "UPDATE working_memory SET consolidated_at = ?, consolidation_claimed_at = NULL WHERE id = ?",
+            (stale_backfill, "e3-s1-0"),
+        )
+        conn.commit()
+        conn.close()
+
+        result = beam.reclaim_orphans(stale_after_seconds=1)
+
+        assert result["status"] == "no_op"
+        assert result["reclaimed"] == 0
+        assert _consolidated_rows(temp_db, "s1")[0][1] == stale_backfill
+
+    def test_successful_sleep_clears_claim_marker(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=1)
+
+        result = beam.sleep(dry_run=False)
+
+        assert result["items_consolidated"] == 1
+        conn = sqlite3.connect(str(temp_db))
+        marker = conn.execute(
+            "SELECT consolidation_claimed_at FROM working_memory WHERE id = 'e3-s1-0'"
+        ).fetchone()[0]
+        conn.close()
+        assert marker is None
+
+    def test_manual_reclaim_then_sleep_all_sessions_consolidates_orphan(self, temp_db, monkeypatch):
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: False
+        )
+        beam = BeamMemory(session_id="maintenance", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=1)
+        stale_claim = (datetime.now() - timedelta(hours=2)).isoformat()
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute(
+            "UPDATE working_memory SET consolidated_at = ?, consolidation_claimed_at = ? WHERE id = ?",
+            (stale_claim, stale_claim, "e3-s1-0"),
+        )
+        conn.commit()
+        conn.close()
+
+        reclaim = beam.reclaim_orphans(stale_after_seconds=1)
+        result = beam.sleep_all_sessions(dry_run=False, force=True)
+
+        assert reclaim["reclaimed"] == 1
+        assert result["items_consolidated"] == 1
+        conn = sqlite3.connect(str(temp_db))
+        summary_of = conn.execute(
+            "SELECT summary_of FROM episodic_memory WHERE source = 'sleep_consolidation'"
+        ).fetchone()[0]
+        final = conn.execute(
+            "SELECT consolidated_at, consolidation_claimed_at FROM working_memory WHERE id = 'e3-s1-0'"
+        ).fetchone()
+        conn.close()
+        assert summary_of == "e3-s1-0"
+        assert final[0] is not None
+        assert final[1] is None
+
     def test_export_import_preserves_consolidated_at(self, temp_db):
         """Backup round-trip must preserve consolidated_at so the
         importing DB doesn't re-summarize already-slept rows on next


### PR DESCRIPTION
## Summary

- add a crash-recovery marker for sleep claims: `working_memory.consolidation_claimed_at`
- add `reclaim_orphans()` to clear stale sleep claims that never produced an episodic summary
- expose the helper via `BeamMemory`, `Mnemosyne`, module-level API, and top-level `mnemosyne.reclaim_orphans`
- keep reclaim manual/explicit rather than automatically running it from `sleep_all_sessions()`
- preserve legacy E3 backfill behavior by only reclaiming rows with an explicit claim marker

Closes #293.

## Safety notes

`reclaim_orphans()` only clears rows where:

- `consolidated_at IS NOT NULL`
- `consolidation_claimed_at IS NOT NULL`
- the claim is older than `stale_after_seconds` (default: 3600)
- no `episodic_memory.summary_of` CSV token references the working-memory id

Successful `sleep()` runs now clear `consolidation_claimed_at` after the episodic summary is written, so normal consolidated rows are not candidates for reclaim.

## Verification

```text
python -m pytest tests/test_beam_e3_additive_sleep.py -q
21 passed in 16.09s
```

```text
python -m pytest \
  tests/test_beam.py \
  tests/test_beam_e3_additive_sleep.py \
  tests/test_hermes_memory_provider.py \
  tests/test_hermes_memory_provider_shared_multi_agent.py \
  tests/test_hermes_memory_provider_unified_recall.py \
  tests/test_hermes_memory_provider_validation.py \
  tests/test_mcp_server.py \
  tests/test_outer_package_version.py \
  tests/test_pre_experiment_fidelity.py \
  -q --tb=short
235 passed in 137.53s (0:02:17)
```

Also split the broader local suite into chunks. The only local failures observed were pre-existing/environmental:

- `tests/test_hermes_llm_adapter.py::test_complete_returns_none_when_agent_import_unavailable` sees this Hermes host's real `agent` package
- two `tests/test_mnemosyne_stats.py` assertions open the default home DB directly and fail when no local schema exists

Neither failure is in the reclaim path; the relevant Beam/provider/fidelity suites above pass.
