### PR TITLE
Cache recall query embedding per call

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4625,6 +4625,27 @@ class BeamMemory:
         # ---- Configurable hybrid scoring setup (Phase 4) ----
         vw, fw, iw = _normalize_weights(vec_weight, fts_weight, importance_weight)
 
+        # Query embeddings are used by several recall subpaths. Compute the
+        # vector at most once per recall() call, then reuse it for working
+        # memory vector search, binary-vector scoring, and episodic vector
+        # search.
+        embeddings_available = _embeddings.available()
+        query_embedding = None
+        query_embedding_computed = False
+
+        def _get_query_embedding():
+            nonlocal query_embedding, query_embedding_computed
+            if not embeddings_available:
+                return None
+            if not query_embedding_computed:
+                query_embedding_computed = True
+                try:
+                    query_embedding = _embeddings.embed_query(query)
+                except Exception:
+                    logger.info("Query embedding failed, skipping vector recall paths", exc_info=True)
+                    query_embedding = None
+            return query_embedding
+
         # ---- Temporal scoring setup ----
         parsed_query_time = _parse_query_time(query_time)
         if temporal_halflife is not None:
@@ -4664,9 +4685,9 @@ class BeamMemory:
 
         # ---- Working memory (vector search) ----
         wm_vec_sims = {}
-        if _embeddings.available():
+        if embeddings_available:
             try:
-                emb_result = _embeddings.embed_query(query)
+                emb_result = _get_query_embedding()
                 if emb_result is not None:
                     wm_vec = _wm_vec_search(self.conn, emb_result,
                                               k=max(top_k, 20) if _BEAM_MODE else max(top_k * 3, 50))
@@ -5103,8 +5124,8 @@ class BeamMemory:
         # ---- Pre-compute query binary vector (Phase 5 binary voice) ----
         query_bv = None
         query_emb_for_bv = None
-        if _embeddings.available() and _mib is not None:
-            emb_result = _embeddings.embed_query(query)
+        if embeddings_available and _mib is not None:
+            emb_result = _get_query_embedding()
             if emb_result is not None:
                 query_emb_for_bv = emb_result
                 query_bv = _mib(emb_result)
@@ -5112,8 +5133,8 @@ class BeamMemory:
         # ---- Episodic memory (vec + FTS5 hybrid) ----
         vec_results = {}
         max_distance = 0.0
-        if _embeddings.available():
-            emb_result = _embeddings.embed_query(query)
+        if embeddings_available:
+            emb_result = _get_query_embedding()
             if emb_result is not None:
                 if _vec_available(self.conn):
                     vec_rows = _vec_search(self.conn, emb_result.tolist(), k=max(top_k * 3, 20))

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -35,6 +35,28 @@ class _FakeBeam:
         self.annotations = _FakeAnnotations(rows)
 
 
+def test_recall_computes_query_embedding_once_per_call(temp_db, monkeypatch):
+    np = pytest.importorskip("numpy")
+    beam = BeamMemory(session_id="embed-cache-test", db_path=temp_db)
+    calls = []
+
+    monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
+
+    def fake_embed_query(query):
+        calls.append(query)
+        return np.array([1.0, 0.0, 0.0], dtype=np.float32)
+
+    monkeypatch.setattr(beam_module._embeddings, "embed_query", fake_embed_query)
+    monkeypatch.setattr(beam_module, "_wm_vec_search", lambda conn, emb, k=20: [])
+    monkeypatch.setattr(beam_module, "_vec_available", lambda conn: False)
+    monkeypatch.setattr(beam_module, "_in_memory_vec_search", lambda conn, emb, k=20: [])
+    monkeypatch.setattr(beam_module, "_mib", lambda emb: b"\x00")
+
+    beam.recall("cache this query", top_k=5)
+
+    assert calls == ["cache this query"]
+
+
 class TestFactAnnotationMatching:
     def test_strict_fact_match_ignores_stopword_only_matches(self, monkeypatch):
         monkeypatch.setenv("MNEMOSYNE_STRICT_FACT_MATCH", "1")


### PR DESCRIPTION
## Summary

- Cache the query embedding once per `recall()` call.
- Reuse that embedding for working-memory vector search, binary-vector scoring, and episodic vector search.
- Add a regression test that asserts `embed_query()` is called only once during recall.

## Scope

This is the low-risk first PR from #292. The working-memory vector filter pushdown remains a separate follow-up.

## Tests

- `pytest tests/test_beam.py::test_recall_computes_query_embedding_once_per_call -q`
- `pytest tests/test_beam.py -q`
- `pytest tests/test_configurable_scoring.py tests/test_beam_e3_additive_sleep.py -q`
- Combined: `121 passed, 1 skipped`

Fixes part of #292.
