### PR TITLE
Push recall filters into working-memory vector search

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -26,7 +26,7 @@ import math
 
 logger = logging.getLogger(__name__)
 from datetime import datetime, timedelta, timezone
-from typing import List, Dict, Optional, Any, Set, Union
+from typing import List, Dict, Optional, Any, Set, Union, Tuple
 from pathlib import Path
 
 
@@ -2087,7 +2087,9 @@ def _fts_search_working(conn: sqlite3.Connection, query: str, k: int = 20) -> Li
     return [{"id": r["id"], "rank": r["rank"]} for r in rows]
 
 
-def _wm_vec_search(conn: sqlite3.Connection, query_embedding, k: int = 20) -> List[Dict]:
+def _wm_vec_search(conn: sqlite3.Connection, query_embedding, k: int = 20,
+                   *, where_sql: Optional[str] = None,
+                   where_params: Tuple[Any, ...] = ()) -> List[Dict]:
     """Vector search against working_memory via memory_embeddings table.
     Returns list of dicts with 'id' (memory_id) and 'sim' (cosine similarity)."""
     if np is None:
@@ -2096,14 +2098,16 @@ def _wm_vec_search(conn: sqlite3.Connection, query_embedding, k: int = 20) -> Li
     try:
         # BEAM mode: scan up to 500K rows for broad vector recall on large benchmark datasets
         _vec_limit = 500000 if _BEAM_MODE else 50000
-        cursor.execute("""
+        if where_sql is None:
+            where_sql = "wm.superseded_by IS NULL AND (wm.valid_until IS NULL OR wm.valid_until > ?)"
+            where_params = (datetime.now().isoformat(),)
+        cursor.execute(f"""
             SELECT wm.id, me.embedding_json
             FROM memory_embeddings me
             JOIN working_memory wm ON me.memory_id = wm.id
-            WHERE wm.superseded_by IS NULL
-              AND (wm.valid_until IS NULL OR wm.valid_until > ?)
+            WHERE {where_sql}
             LIMIT ?
-        """, (datetime.now().isoformat(), _vec_limit))
+        """, (*where_params, _vec_limit))
     except Exception:
         return []
     rows = cursor.fetchall()
@@ -4683,32 +4687,9 @@ class BeamMemory:
         wm_ids = {r["id"] for r in wm_fts}
         wm_ranks = {r["id"]: r["rank"] for r in wm_fts}
 
-        # ---- Working memory (vector search) ----
-        wm_vec_sims = {}
-        if embeddings_available:
-            try:
-                emb_result = _get_query_embedding()
-                if emb_result is not None:
-                    wm_vec = _wm_vec_search(self.conn, emb_result,
-                                              k=max(top_k, 20) if _BEAM_MODE else max(top_k * 3, 50))
-                    for vr in wm_vec:
-                        wm_vec_sims[vr["id"]] = vr["sim"]
-                        wm_ids.add(vr["id"])  # Merge vector results with FTS5 results
-            except Exception:
-                logger.info("Regex extraction failed, skipping", exc_info=True)
-        # Track whether the FTS+vec layer produced any candidates
-        # at all (signal source for the truly_empty gate later).
-        if wm_ids:
-            _wm_had_candidates = True
-        # If both FTS and vec produced nothing, the WM fallback at
-        # the else-branch below fires. Recording the fallback signal
-        # uses a boolean (per-call), not a per-row count -- that
-        # avoids double-counting against the kept-row accumulators.
-        _wm_fallback_used = not wm_ids
-        if _wm_fallback_used:
-            _recall_diag.record_fallback_used(wm=True)
-
-        # Build temporal filter clause for working memory
+        # Build temporal/filter clause for working memory before vector search
+        # so _wm_vec_search can push the same recall filters into SQL instead
+        # of scanning broad memory_embeddings rows and filtering later.
         wm_where_clauses = [
             "(valid_until IS NULL OR valid_until > ?)",
             "superseded_by IS NULL"
@@ -4756,6 +4737,33 @@ class BeamMemory:
             wm_params.append(channel_id)
         
         wm_where = " AND ".join(wm_where_clauses)
+
+        # ---- Working memory (vector search) ----
+        wm_vec_sims = {}
+        if embeddings_available:
+            try:
+                emb_result = _get_query_embedding()
+                if emb_result is not None:
+                    wm_vec = _wm_vec_search(self.conn, emb_result,
+                                              k=max(top_k, 20) if _BEAM_MODE else max(top_k * 3, 50),
+                                              where_sql=wm_where,
+                                              where_params=tuple(wm_params))
+                    for vr in wm_vec:
+                        wm_vec_sims[vr["id"]] = vr["sim"]
+                        wm_ids.add(vr["id"])  # Merge vector results with FTS5 results
+            except Exception:
+                logger.info("Regex extraction failed, skipping", exc_info=True)
+        # Track whether the FTS+vec layer produced any candidates
+        # at all (signal source for the truly_empty gate later).
+        if wm_ids:
+            _wm_had_candidates = True
+        # If both FTS and vec produced nothing, the WM fallback at
+        # the else-branch below fires. Recording the fallback signal
+        # uses a boolean (per-call), not a per-row count -- that
+        # avoids double-counting against the kept-row accumulators.
+        _wm_fallback_used = not wm_ids
+        if _wm_fallback_used:
+            _recall_diag.record_fallback_used(wm=True)
 
         if wm_ids:
             placeholders = ",".join("?" * len(wm_ids))

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from datetime import datetime, timedelta
 
 from mnemosyne.core import beam as beam_module
-from mnemosyne.core.beam import BeamMemory, init_beam, _find_memories_by_fact
+from mnemosyne.core.beam import BeamMemory, init_beam, _find_memories_by_fact, _wm_vec_search
 from mnemosyne.core.memory import Mnemosyne
 
 
@@ -55,6 +55,57 @@ def test_recall_computes_query_embedding_once_per_call(temp_db, monkeypatch):
     beam.recall("cache this query", top_k=5)
 
     assert calls == ["cache this query"]
+
+
+def test_wm_vec_search_pushes_recall_filters_before_vector_decode(temp_db, monkeypatch):
+    np = pytest.importorskip("numpy")
+    beam = BeamMemory(session_id="target-session", db_path=temp_db)
+    now = datetime.now().isoformat()
+    conn = beam.conn
+    conn.executemany(
+        """
+        INSERT INTO working_memory
+            (id, content, source, timestamp, session_id, scope, channel_id, author_id, author_type, veracity, memory_type)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("target", "target vector memory", "chat", now, "target-session", "session", "chan-a", "alice", "human", "stated", "preference"),
+            ("other-session", "other session memory", "chat", now, "other-session", "session", "chan-b", "bob", "human", "stated", "preference"),
+            ("other-source", "wrong source memory", "cron", now, "target-session", "session", "chan-a", "alice", "human", "stated", "preference"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        [
+            ("target", "[1.0, 0.0, 0.0]", "test"),
+            ("other-session", "[1.0, 0.0, 0.0]", "test"),
+            ("other-source", "[1.0, 0.0, 0.0]", "test"),
+        ],
+    )
+    conn.commit()
+
+    decoded = []
+    real_loads = beam_module.json.loads
+
+    def counting_loads(value):
+        decoded.append(value)
+        return real_loads(value)
+
+    monkeypatch.setattr(beam_module.json, "loads", counting_loads)
+
+    results = _wm_vec_search(
+        conn,
+        np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        k=10,
+        where_sql=(
+            "(valid_until IS NULL OR valid_until > ?) AND superseded_by IS NULL "
+            "AND (session_id = ? OR scope = 'global') AND source = ? AND channel_id = ?"
+        ),
+        where_params=(now, "target-session", "chat", "chan-a"),
+    )
+
+    assert [r["id"] for r in results] == ["target"]
+    assert decoded == ["[1.0, 0.0, 0.0]"]
 
 
 class TestFactAnnotationMatching:


### PR DESCRIPTION
## Summary

- Add optional SQL filter pushdown to `_wm_vec_search()`.
- Build the working-memory recall filter before vector search and pass it into `_wm_vec_search()`.
- This narrows the `memory_embeddings` scan before JSON vector decode / NumPy cosine scoring.
- Keep PR #298's per-call query embedding cache in place.

## Scope

This is the second, narrower-scan part of #292. It does not add a dedicated sqlite-vec table for working memory; that can remain a later optimization.

## Tests

- `pytest tests/test_beam.py::test_recall_computes_query_embedding_once_per_call tests/test_beam.py::test_wm_vec_search_pushes_recall_filters_before_vector_decode -q`
- `pytest tests/test_beam.py tests/test_configurable_scoring.py tests/test_beam_e3_additive_sleep.py -q`
- Result: `122 passed, 1 skipped`

Note: I also attempted the full local suite in a minimal local venv; collection initially needed the Hermes integration installed, then the full run hit unrelated `tests/test_mnemosyne_stats.py` local DB setup failures (`no such table: working_memory`) and timed out. The focused recall/beam suites above pass locally; CI should be the clean-environment arbiter.

Fixes part of #292.
