### PR TITLE
docs: update unreleased release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ## [Unreleased]
 
+### Added
+
+- **Sleep orphan-claim recovery** (issue #293). Added `reclaim_orphans()`
+  to clear stale consolidation claims when `sleep()` was interrupted after
+  claiming working-memory rows but before writing an episodic summary.
+
 ### Changed
 
 - **Lower prefetch noise from raw conversation turns.** sync_turn() now writes
@@ -14,6 +20,12 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
   (was 0.2). This increases the bar for raw conversation turns to surface in
   prefetch recall, reducing irrelevant context pollution. Both provider copies
   (hermes_memory_provider and mnemosyne_hermes) updated identically.
+- **Faster working-memory context retrieval** (issue #291, PR #296).
+  `get_context()` now uses split global/session queries and targeted indexes
+  instead of a broad `OR`/temporary-sort query shape.
+- **Lower recall overhead** (issue #292, PRs #298 and #299). `recall()` now
+  computes the query embedding once per call and pushes working-memory filters
+  into vector candidate selection before JSON vector decode / NumPy scoring.
 
 ## [3.7.0] — 2026-06-13
 

--- a/setup.py
+++ b/setup.py
@@ -67,10 +67,10 @@ setup(
     },
     extras_require={
         "llm": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20"],
-        "embeddings": ["fastembed>=0.3.0"],
+        "embeddings": ["fastembed>=0.3.0", "sqlite-vec>=0.1.0"],
         "mcp": ["mcp>=1.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
         "openclaw": ["openclaw>=0.1.0; python_version >= '3.10'"],
-        "all": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "mcp>=1.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'", "openclaw>=0.1.0; python_version >= '3.10'"],
+        "all": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "sqlite-vec>=0.1.0", "mcp>=1.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
         "dev": ["pytest>=7.0", "build", "twine"],
     },
     entry_points={


### PR DESCRIPTION
## Summary

- document the post-v3.7.0 working-memory context, sleep orphan recovery, and recall overhead improvements in `CHANGELOG.md`
- align `setup.py` extras with `pyproject.toml` so the legacy `all` extra excludes `openclaw` and includes `sqlite-vec`
- keep `openclaw` available through its dedicated extra

## Verification

```text
python3 - <<'PY'
import ast, pathlib, tomllib
py = tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['optional-dependencies']
setup_ast = ast.parse(pathlib.Path('setup.py').read_text())
extras = None
for node in ast.walk(setup_ast):
    if isinstance(node, ast.Call) and getattr(node.func, 'id', '') == 'setup':
        for kw in node.keywords:
            if kw.arg == 'extras_require':
                extras = ast.literal_eval(kw.value)
assert 'openclaw>=0.1.0; python_version >= \'3.10\'' not in extras['all']
assert 'sqlite-vec>=0.1.0' in extras['embeddings']
assert 'sqlite-vec>=0.1.0' in extras['all']
print('metadata checks ok')
PY
metadata checks ok
```

```text
python3 -m py_compile setup.py
```
