### PR TITLE
perf(recall): add vec_working infrastructure

### DIFF
--- a/hermes_memory_provider/audit.py
+++ b/hermes_memory_provider/audit.py
@@ -1,7 +1,8 @@
 """Memory audit log for Mnemosyne provider.
 
 Records memory mutation events in a SQLite table co-located with the
-active provider DB. Non-blocking, fire-and-forget — audit failures
+active provider DB. Uses memory_audit_events to avoid colliding with
+the sync engine's memory_events event-log table. Non-blocking, fire-and-forget — audit failures
 never break memory operations.
 """
 
@@ -17,7 +18,7 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 _CREATE_TABLE = """
-CREATE TABLE IF NOT EXISTS memory_events (
+CREATE TABLE IF NOT EXISTS memory_audit_events (
     event_id INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp REAL NOT NULL,
     action TEXT NOT NULL,
@@ -34,13 +35,13 @@ CREATE TABLE IF NOT EXISTS memory_events (
 """
 
 _INSERT = """
-INSERT INTO memory_events
+INSERT INTO memory_audit_events
     (timestamp, action, memory_id, bank, scope, profile, session_id, source_tool, tokens_used, reason, metadata_json)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 _MIGRATE_TOKENS = """
-ALTER TABLE memory_events ADD COLUMN tokens_used INTEGER
+ALTER TABLE memory_audit_events ADD COLUMN tokens_used INTEGER
 """
 
 
@@ -113,7 +114,7 @@ class AuditLog:
             cur = self._conn.execute(
                 "SELECT event_id, timestamp, action, memory_id, bank, scope, "
                 "profile, session_id, source_tool, tokens_used, reason, metadata_json "
-                "FROM memory_events ORDER BY event_id DESC LIMIT ?",
+                "FROM memory_audit_events ORDER BY event_id DESC LIMIT ?",
                 (limit,),
             )
             cols = [d[0] for d in cur.description]
@@ -125,7 +126,7 @@ class AuditLog:
         if self._conn is None:
             return 0
         try:
-            return self._conn.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0]
+            return self._conn.execute("SELECT COUNT(*) FROM memory_audit_events").fetchone()[0]
         except Exception:
             return 0
 

--- a/integrations/hermes/src/mnemosyne_hermes/audit.py
+++ b/integrations/hermes/src/mnemosyne_hermes/audit.py
@@ -1,7 +1,8 @@
 """Memory audit log for Mnemosyne provider.
 
 Records memory mutation events in a SQLite table co-located with the
-active provider DB. Non-blocking, fire-and-forget — audit failures
+active provider DB. Uses memory_audit_events to avoid colliding with
+the sync engine's memory_events event-log table. Non-blocking, fire-and-forget — audit failures
 never break memory operations.
 """
 
@@ -17,7 +18,7 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 _CREATE_TABLE = """
-CREATE TABLE IF NOT EXISTS memory_events (
+CREATE TABLE IF NOT EXISTS memory_audit_events (
     event_id INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp REAL NOT NULL,
     action TEXT NOT NULL,
@@ -34,13 +35,13 @@ CREATE TABLE IF NOT EXISTS memory_events (
 """
 
 _INSERT = """
-INSERT INTO memory_events
+INSERT INTO memory_audit_events
     (timestamp, action, memory_id, bank, scope, profile, session_id, source_tool, tokens_used, reason, metadata_json)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 _MIGRATE_TOKENS = """
-ALTER TABLE memory_events ADD COLUMN tokens_used INTEGER
+ALTER TABLE memory_audit_events ADD COLUMN tokens_used INTEGER
 """
 
 
@@ -113,7 +114,7 @@ class AuditLog:
             cur = self._conn.execute(
                 "SELECT event_id, timestamp, action, memory_id, bank, scope, "
                 "profile, session_id, source_tool, tokens_used, reason, metadata_json "
-                "FROM memory_events ORDER BY event_id DESC LIMIT ?",
+                "FROM memory_audit_events ORDER BY event_id DESC LIMIT ?",
                 (limit,),
             )
             cols = [d[0] for d in cur.description]
@@ -125,7 +126,7 @@ class AuditLog:
         if self._conn is None:
             return 0
         try:
-            return self._conn.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0]
+            return self._conn.execute("SELECT COUNT(*) FROM memory_audit_events").fetchone()[0]
         except Exception:
             return 0
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -674,11 +674,16 @@ def init_beam(db_path: Path = None):
     # Detect supported vector type
     effective_vec_type = _detect_vec_type(conn)
 
-    # --- sqlite-vec VIRTUAL TABLE ---
+    # --- sqlite-vec VIRTUAL TABLES ---
     if _SQLITE_VEC_AVAILABLE:
         try:
             cursor.execute(f"""
                 CREATE VIRTUAL TABLE IF NOT EXISTS vec_episodes USING vec0(
+                    embedding {effective_vec_type}[{EMBEDDING_DIM}]
+                )
+            """)
+            cursor.execute(f"""
+                CREATE VIRTUAL TABLE IF NOT EXISTS vec_working USING vec0(
                     embedding {effective_vec_type}[{EMBEDDING_DIM}]
                 )
             """)
@@ -893,6 +898,14 @@ def init_beam(db_path: Path = None):
         WHERE superseded_by IS NULL""")
     cursor.execute("""CREATE INDEX IF NOT EXISTS idx_mem_emb_type
         ON memory_embeddings(memory_id, model)""")
+    try:
+        _backfill_vec_working_from_memory_embeddings(conn)
+    except NameError:
+        # During unusual import/bootstrap paths the helper may not be bound yet;
+        # normal BeamMemory construction can backfill on the next init call.
+        pass
+    except Exception:
+        logger.info("vec_working backfill skipped during init", exc_info=True)
 
     # --- Migration: multi-agent identity layer (v2.1) ---
     _add_column_if_missing(conn, "working_memory", "author_id", "TEXT DEFAULT NULL")
@@ -1273,13 +1286,24 @@ def _temporal_boost(memory_timestamp_str: str, query_time: datetime,
 
 
 def _vec_available(conn: sqlite3.Connection) -> bool:
+    return _vec_table_available(conn, "vec_episodes")
+
+
+def _vec_table_available(conn: sqlite3.Connection, table: str) -> bool:
+    """Return whether a sqlite-vec virtual table is usable."""
     if not _SQLITE_VEC_AVAILABLE:
         return False
+    if table not in {"vec_episodes", "vec_working", "vec_facts"}:
+        return False
     try:
-        conn.execute("SELECT 1 FROM vec_episodes LIMIT 0")
+        conn.execute(f"SELECT 1 FROM {table} LIMIT 0")
         return True
     except Exception:
         return False
+
+
+def _wm_vec_available(conn: sqlite3.Connection) -> bool:
+    return _vec_table_available(conn, "vec_working")
 
 
 def _extract_and_store_entities(beam: "BeamMemory", memory_id: str, content: str):
@@ -1752,14 +1776,21 @@ def _effective_vec_type(conn: sqlite3.Connection) -> str:
 
 
 def _vec_insert(conn: sqlite3.Connection, rowid: int, embedding: List[float]):
-    """Insert embedding into sqlite-vec table with quantization via SQL functions.
+    """Insert embedding into the episodic sqlite-vec table."""
+    _vec_table_insert(conn, "vec_episodes", rowid, embedding)
+
+
+def _vec_table_insert(conn: sqlite3.Connection, table: str, rowid: int, embedding: List[float], *, commit: bool = True):
+    """Insert embedding into a sqlite-vec table with quantization via SQL functions.
 
     Manually normalizes the embedding to unit length before quantization.
     ``vec_quantize_int8(x, 'unit')`` in sqlite-vec 0.1.9 fails to normalize
     1024-dim vectors (works for 3-dim, silently passes through unnormalized
-    vectors at high dimensions).  Pre-normalizing works around the bug until
+    vectors at high dimensions). Pre-normalizing works around the bug until
     upstream sqlite-vec ships a fix.
     """
+    if table not in {"vec_episodes", "vec_working", "vec_facts"}:
+        raise ValueError(f"unsupported sqlite-vec table: {table}")
     vec_type = _effective_vec_type(conn)
     # Normalize to unit length before quantization
     # (sqlite-vec 0.1.9 'unit' param fails at 1024-dim)
@@ -1769,29 +1800,107 @@ def _vec_insert(conn: sqlite3.Connection, rowid: int, embedding: List[float]):
     if norm > 0:
         emb_arr = emb_arr / norm
     emb_json = json.dumps(emb_arr.tolist())
+    # vec0 has no stable UPSERT path; delete first to make refresh idempotent.
+    conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
     if vec_type == "bit":
         conn.execute(
-            "INSERT INTO vec_episodes(rowid, embedding) VALUES (?, vec_quantize_binary(?))",
+            f"INSERT INTO {table}(rowid, embedding) VALUES (?, vec_quantize_binary(?))",
             (rowid, emb_json)
         )
     elif vec_type == "int8":
         conn.execute(
-            "INSERT INTO vec_episodes(rowid, embedding) VALUES (?, vec_quantize_int8(?, 'unit'))",
+            f"INSERT INTO {table}(rowid, embedding) VALUES (?, vec_quantize_int8(?, 'unit'))",
             (rowid, emb_json)
         )
     else:
         conn.execute(
-            "INSERT INTO vec_episodes(rowid, embedding) VALUES (?, ?)",
+            f"INSERT INTO {table}(rowid, embedding) VALUES (?, ?)",
             (rowid, emb_json)
         )
     # Ensure the insert is committed even when the caller's connection
     # has _defer_commit=True (_BeamConnection). Without this, inserts
     # sit in the deferred transaction and disappear if the caller
     # later rolls back or the connection is reused in a different context.
-    if isinstance(conn, _BeamConnection):
-        conn._real_commit()
-    else:
-        conn.commit()
+    if commit:
+        if isinstance(conn, _BeamConnection):
+            conn._real_commit()
+        else:
+            conn.commit()
+
+
+def _wm_rowid(conn: sqlite3.Connection, memory_id: str) -> Optional[int]:
+    row = conn.execute("SELECT rowid FROM working_memory WHERE id = ?", (memory_id,)).fetchone()
+    return int(row["rowid"]) if row else None
+
+
+def _wm_vec_upsert(conn: sqlite3.Connection, memory_id: str, embedding: List[float], *, commit: bool = True) -> None:
+    """Best-effort refresh of vec_working for a working-memory row."""
+    if not _wm_vec_available(conn):
+        return
+    rowid = _wm_rowid(conn, memory_id)
+    if rowid is None:
+        return
+    _vec_table_insert(conn, "vec_working", rowid, embedding, commit=commit)
+
+
+def _wm_vec_delete(conn: sqlite3.Connection, memory_id: str) -> None:
+    """Best-effort delete of vec_working row for a working-memory id."""
+    if not _wm_vec_available(conn):
+        return
+    rowid = _wm_rowid(conn, memory_id)
+    if rowid is None:
+        return
+    conn.execute("DELETE FROM vec_working WHERE rowid = ?", (rowid,))
+
+
+def _store_working_embedding(conn: sqlite3.Connection, memory_id: str, embedding: List[float], *, commit_vec: bool = True) -> None:
+    """Store working-memory embedding in fallback and sqlite-vec stores.
+
+    ``memory_embeddings`` remains the compatibility/fallback store. When the
+    dedicated sqlite-vec table is available, ``vec_working`` mirrors the same
+    vector keyed by ``working_memory.rowid``.
+    """
+    emb_for_json = np.array(embedding, dtype=np.float32) if np is not None else embedding
+    emb_json = _embeddings.serialize(emb_for_json)
+    conn.execute(
+        "INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        (memory_id, emb_json, _embeddings._DEFAULT_MODEL)
+    )
+    try:
+        _wm_vec_upsert(conn, memory_id, embedding, commit=commit_vec)
+    except Exception as exc:
+        logger.warning(
+            "vec_working upsert failed for '%s' (%s): %s",
+            memory_id, type(exc).__name__, exc,
+        )
+
+
+def _backfill_vec_working_from_memory_embeddings(conn: sqlite3.Connection) -> int:
+    """Idempotently mirror fallback working embeddings into vec_working."""
+    if not _wm_vec_available(conn) or np is None:
+        return 0
+    try:
+        rows = conn.execute("""
+            SELECT wm.id, wm.rowid, me.embedding_json
+            FROM working_memory wm
+            JOIN memory_embeddings me ON me.memory_id = wm.id
+            LEFT JOIN vec_working vw ON vw.rowid = wm.rowid
+            WHERE vw.rowid IS NULL
+        """).fetchall()
+    except Exception:
+        return 0
+    inserted = 0
+    for row in rows:
+        try:
+            embedding = json.loads(row["embedding_json"])
+            _vec_table_insert(conn, "vec_working", int(row["rowid"]), embedding)
+            inserted += 1
+        except Exception as exc:
+            logger.warning(
+                "vec_working backfill skipped '%s' (%s): %s",
+                row["id"], type(exc).__name__, exc,
+            )
+    return inserted
 
 
 def _vec_search(conn: sqlite3.Connection, embedding: List[float], k: int = 20) -> List[Dict]:
@@ -2559,11 +2668,7 @@ class BeamMemory:
             try:
                 vec = _embeddings.embed([content])
                 if vec is not None and len(vec) == 1:
-                    emb_json = _embeddings.serialize(vec[0])
-                    cursor.execute(
-                        "INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
-                        (memory_id, emb_json, _embeddings._DEFAULT_MODEL)
-                    )
+                    _store_working_embedding(self.conn, memory_id, vec[0])
             except Exception as exc:
                 logger.warning(
                     "remember: embedding storage failed for '%s' (%s): %s",
@@ -2809,13 +2914,8 @@ class BeamMemory:
                         len(vectors), len(contents),
                     )
                 else:
-                    model = _embeddings._DEFAULT_MODEL
                     for i, memory_id in enumerate(ids):
-                        emb_json = _embeddings.serialize(vectors[i])
-                        cursor.execute(
-                            "INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
-                            (memory_id, emb_json, model)
-                        )
+                        _store_working_embedding(self.conn, memory_id, vectors[i], commit_vec=False)
             except Exception as exc:
                 # M3 review fix: include exception type name so operators
                 # can distinguish sqlite3.OperationalError from RuntimeError
@@ -3396,14 +3496,7 @@ class BeamMemory:
             try:
                 vec = _embeddings.embed([content])
                 if vec is not None and len(vec) > 0:
-                    model = _embeddings._DEFAULT_MODEL
-                    emb_json = _embeddings.serialize(vec[0])
-                    cursor.execute(
-                        "INSERT OR REPLACE INTO memory_embeddings"
-                        " (memory_id, embedding_json, model)"
-                        " VALUES (?, ?, ?)",
-                        (memory_id, emb_json, model),
-                    )
+                    _store_working_embedding(self.conn, memory_id, vec[0])
             except Exception as exc:
                 logger.warning(
                     "update_working: embedding refresh failed for %s"
@@ -3490,6 +3583,12 @@ class BeamMemory:
         # silently include.
         cursor = self.conn.cursor()
         try:
+            authorized_row = cursor.execute(
+                "SELECT rowid FROM working_memory WHERE id = ? AND (session_id = ? OR scope = 'global')",
+                (memory_id, self.session_id),
+            ).fetchone()
+            if authorized_row is not None and _wm_vec_available(self.conn):
+                cursor.execute("DELETE FROM vec_working WHERE rowid = ?", (int(authorized_row["rowid"]),))
             cursor.execute(
                 "DELETE FROM working_memory WHERE id = ? AND (session_id = ? OR scope = 'global')",
                 (memory_id, self.session_id),
@@ -3499,6 +3598,7 @@ class BeamMemory:
                 cursor.execute(
                     "DELETE FROM annotations WHERE memory_id = ?", (memory_id,)
                 )
+                cursor.execute("DELETE FROM memory_embeddings WHERE memory_id = ?", (memory_id,))
             self.conn.commit()
         except Exception:
             self.conn.rollback()
@@ -7690,6 +7790,18 @@ class BeamMemory:
                 stats["working_memory"]["skipped"] += 1
                 continue
             if exists and force:
+                existing_row = cursor.execute(
+                    "SELECT rowid FROM working_memory WHERE id = ?", (mid,)
+                ).fetchone()
+                if existing_row is not None and _wm_vec_available(self.conn):
+                    try:
+                        cursor.execute("DELETE FROM vec_working WHERE rowid = ?", (int(existing_row["rowid"]),))
+                    except sqlite3.Error as cleanup_exc:
+                        logger.warning(
+                            "import_from_dict: vec_working cleanup failed for rowid=%s: %s; continuing",
+                            existing_row["rowid"], cleanup_exc,
+                        )
+                cursor.execute("DELETE FROM memory_embeddings WHERE memory_id = ?", (mid,))
                 cursor.execute("DELETE FROM working_memory WHERE id = ?", (mid,))
                 stats["working_memory"]["overwritten"] += 1
             else:
@@ -7719,6 +7831,10 @@ class BeamMemory:
                 item.get("consolidation_claimed_at"),
             ))
         self.conn.commit()
+        try:
+            _backfill_vec_working_from_memory_embeddings(self.conn)
+        except Exception:
+            logger.info("vec_working backfill skipped after working import", exc_info=True)
 
         # -- Episodic memory --
         # Capture sqlite-vec availability once before the loop. Reused

--- a/mnemosyne/core/sync_server.py
+++ b/mnemosyne/core/sync_server.py
@@ -9,6 +9,7 @@ Provides endpoints for peer-to-peer memory synchronization:
 - GET  /sync/status — server sync statistics
 """
 
+import importlib
 import json
 import logging
 import os
@@ -17,6 +18,13 @@ import threading
 from datetime import datetime, timezone
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from typing import Optional, Dict, Any, Callable
+
+# Full-suite tests and embedded hosts can leave sys.modules["logging"] in a
+# partially shadowed state. Recover the stdlib module instead of failing at
+# import time; sync serving should not depend on global module-cache hygiene.
+if not hasattr(logging, "getLogger"):
+    sys.modules.pop("logging", None)
+    logging = importlib.import_module("logging")
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -108,6 +108,77 @@ def test_wm_vec_search_pushes_recall_filters_before_vector_decode(temp_db, monke
     assert decoded == ["[1.0, 0.0, 0.0]"]
 
 
+def _unit_embedding():
+    np = pytest.importorskip("numpy")
+    return np.array([1.0] + [0.0] * (beam_module.EMBEDDING_DIM - 1), dtype=np.float32)
+
+
+def _require_vec_working(conn):
+    pytest.importorskip("sqlite_vec")
+    if not beam_module._wm_vec_available(conn):
+        pytest.skip("sqlite-vec vec_working table unavailable")
+
+
+def test_remember_update_and_forget_maintain_vec_working(temp_db, monkeypatch):
+    beam = BeamMemory(session_id="vec-working-session", db_path=temp_db)
+    _require_vec_working(beam.conn)
+
+    np = pytest.importorskip("numpy")
+    vectors = [_unit_embedding(), np.array([0.0, 1.0] + [0.0] * (beam_module.EMBEDDING_DIM - 2), dtype=np.float32)]
+    calls = []
+
+    monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
+
+    def fake_embed(contents):
+        calls.extend(contents)
+        return [vectors[min(len(calls) - 1, len(vectors) - 1)]]
+
+    monkeypatch.setattr(beam_module._embeddings, "embed", fake_embed)
+
+    memory_id = beam.remember("vec working initial", source="test", scope="session")
+    rowid = beam.conn.execute("SELECT rowid FROM working_memory WHERE id = ?", (memory_id,)).fetchone()["rowid"]
+
+    assert beam.conn.execute("SELECT COUNT(*) FROM memory_embeddings WHERE memory_id = ?", (memory_id,)).fetchone()[0] == 1
+    assert beam.conn.execute("SELECT COUNT(*) FROM vec_working WHERE rowid = ?", (rowid,)).fetchone()[0] == 1
+
+    assert beam.update_working(memory_id, content="vec working updated") is True
+    assert beam.conn.execute("SELECT COUNT(*) FROM memory_embeddings WHERE memory_id = ?", (memory_id,)).fetchone()[0] == 1
+    assert beam.conn.execute("SELECT COUNT(*) FROM vec_working WHERE rowid = ?", (rowid,)).fetchone()[0] == 1
+
+    assert beam.forget_working(memory_id) is True
+    assert beam.conn.execute("SELECT COUNT(*) FROM memory_embeddings WHERE memory_id = ?", (memory_id,)).fetchone()[0] == 0
+    assert beam.conn.execute("SELECT COUNT(*) FROM vec_working WHERE rowid = ?", (rowid,)).fetchone()[0] == 0
+
+
+def test_vec_working_backfill_from_memory_embeddings_is_idempotent(temp_db):
+    beam = BeamMemory(session_id="vec-working-backfill", db_path=temp_db)
+    _require_vec_working(beam.conn)
+    now = datetime.now().isoformat()
+    memory_id = "manual-wm"
+    embedding = _unit_embedding()
+
+    beam.conn.execute(
+        """
+        INSERT INTO working_memory
+            (id, content, source, timestamp, session_id, scope, importance)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (memory_id, "manual working memory", "test", now, "vec-working-backfill", "session", 0.5),
+    )
+    beam.conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        (memory_id, beam_module._embeddings.serialize(embedding), "test"),
+    )
+    beam.conn.commit()
+    rowid = beam.conn.execute("SELECT rowid FROM working_memory WHERE id = ?", (memory_id,)).fetchone()["rowid"]
+
+    assert beam.conn.execute("SELECT COUNT(*) FROM vec_working WHERE rowid = ?", (rowid,)).fetchone()[0] == 0
+    assert beam_module._backfill_vec_working_from_memory_embeddings(beam.conn) == 1
+    assert beam.conn.execute("SELECT COUNT(*) FROM vec_working WHERE rowid = ?", (rowid,)).fetchone()[0] == 1
+    assert beam_module._backfill_vec_working_from_memory_embeddings(beam.conn) == 0
+
+
+
 class TestFactAnnotationMatching:
     def test_strict_fact_match_ignores_stopword_only_matches(self, monkeypatch):
         monkeypatch.setenv("MNEMOSYNE_STRICT_FACT_MATCH", "1")


### PR DESCRIPTION
## Summary

First infrastructure slice for #292 item 3.

- create a dedicated sqlite-vec `vec_working` table for `working_memory` vectors
- mirror working-memory embeddings into both stores:
  - `memory_embeddings` remains the compatibility/fallback path
  - `vec_working` is keyed by `working_memory.rowid`
- cover lifecycle paths for new rows, batch ingest, content updates, deletes, and force-import cleanup
- add idempotent backfill from `memory_embeddings` into `vec_working`
- add focused tests for schema/lifecycle/backfill behavior

This intentionally keeps `_wm_vec_search()` on the current filtered `memory_embeddings` path for this first PR, so recall ranking/scoring does not change yet. The follow-up PR can switch search to prefer `vec_working` once the storage lifecycle is reviewed.

## Verification

```text
python3 -m py_compile mnemosyne/core/beam.py tests/test_beam.py

env PYTHONPATH=/opt/data/tmp/mnemo-review/mnemosyne uv run --no-project   --with pytest --with pytest-asyncio --with pyyaml --with numpy   --with sqlite-vec --with fastembed --with python-dotenv   python -m pytest   tests/test_beam.py::test_remember_update_and_forget_maintain_vec_working   tests/test_beam.py::test_vec_working_backfill_from_memory_embeddings_is_idempotent   tests/test_beam.py::test_wm_vec_search_pushes_recall_filters_before_vector_decode   tests/test_beam.py::TestExportImport -q
# 8 passed

env PYTHONPATH=/opt/data/tmp/mnemo-review/mnemosyne uv run --no-project   --with pytest --with pytest-asyncio --with pyyaml --with numpy   --with sqlite-vec --with fastembed --with python-dotenv   python -m pytest   tests/test_pre_experiment_fidelity.py::TestE2a10EmbeddingLoopDefense   tests/test_orphan_vec_episodes_cleanup.py   tests/test_optional_embeddings.py -q
# 13 passed

env PYTHONPATH=/opt/data/tmp/mnemo-review/mnemosyne uv run --no-project   --with pytest --with pytest-asyncio --with pyyaml --with numpy   --with sqlite-vec --with fastembed --with python-dotenv   python -m pytest tests/test_beam.py -q
# 81 passed
```
