### PR TITLE
feat(diagnose): report vec_working migration coverage

### DIFF
--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -106,9 +106,12 @@ Export all memories to a JSON file
 | `output_path` | `string` | yes |
 
 ### 10. `mnemosyne_diagnose`
-PII-safe diagnostics: deps, DB state, vector readiness
+PII-safe diagnostics: deps, DB state, vector readiness, vec_working coverage
 
-*No parameters*
+| Parameter | Type | Required |
+|-----------|------|----------|
+| `repair_vec_working` | `bool` | no (default: false) |
+| `dry_run` | `bool` | no (default: false) |
 
 ### 11. `mnemosyne_stats`
 Memory statistics: working count, episodic count, BEAM tiers

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -840,8 +840,22 @@ IMPORT_SCHEMA = {
 
 DIAGNOSE_SCHEMA = {
     "name": "mnemosyne_diagnose",
-    "description": "Run PII-safe diagnostics on Mnemosyne installation. Checks dependencies, database state, and vector search readiness. Never includes memory content or API keys.",
-    "parameters": {"type": "object", "properties": {}},
+    "description": "Run PII-safe diagnostics on Mnemosyne installation. Checks dependencies, database state, vector search readiness, and optional vec_working migration coverage. Never includes memory content or API keys.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repair_vec_working": {
+                "type": "boolean",
+                "description": "If true, idempotently backfill missing vec_working rows from memory_embeddings.",
+                "default": False,
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "If true with repair_vec_working, report what would be repaired without writing.",
+                "default": False,
+            },
+        },
+    },
 }
 
 GRAPH_QUERY_SCHEMA = {
@@ -2411,7 +2425,9 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
     def _handle_diagnose(self, args: Dict[str, Any]) -> str:
         from mnemosyne.diagnose import run_diagnostics
-        result = run_diagnostics()
+        repair_requested = bool(args.get("repair_vec_working", False))
+        dry_run = bool(args.get("dry_run", False))
+        result = run_diagnostics(repair_vec_working=repair_requested, dry_run=dry_run)
 
         # run_diagnostics() reports Mnemosyne's legacy/default DB path. When
         # Hermes profile isolation is enabled, the active provider may use a
@@ -2441,6 +2457,19 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     "facts": cur.execute("SELECT COUNT(*) FROM facts").fetchone()[0],
                 }
                 con.close()
+                try:
+                    from mnemosyne.core.beam import repair_vec_working as _repair_vec_working, vec_working_coverage
+                    if repair_requested and self._beam is not None:
+                        result["active_provider_vec_working_repair"] = _repair_vec_working(
+                            self._beam.conn, dry_run=dry_run
+                        )
+                        result["active_provider_vec_working"] = result[
+                            "active_provider_vec_working_repair"
+                        ].get("after", {})
+                    elif self._beam is not None:
+                        result["active_provider_vec_working"] = vec_working_coverage(self._beam.conn)
+                except Exception as exc:
+                    result["active_provider_vec_working_error"] = str(exc)
             except Exception as exc:
                 result["active_provider_counts_error"] = str(exc)
 

--- a/integrations/hermes/src/mnemosyne_hermes/tools.py
+++ b/integrations/hermes/src/mnemosyne_hermes/tools.py
@@ -438,8 +438,22 @@ IMPORT_SCHEMA = {
 
 DIAGNOSE_SCHEMA = {
     "name": "mnemosyne_diagnose",
-    "description": "Run PII-safe diagnostics on Mnemosyne installation. Checks dependencies, database state, and vector search readiness. Never includes memory content or API keys.",
-    "parameters": {"type": "object", "properties": {}},
+    "description": "Run PII-safe diagnostics on Mnemosyne installation. Checks dependencies, database state, vector search readiness, and optional vec_working migration coverage. Never includes memory content or API keys.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "repair_vec_working": {
+                "type": "boolean",
+                "description": "If true, idempotently backfill missing vec_working rows from memory_embeddings.",
+                "default": False,
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "If true with repair_vec_working, report what would be repaired without writing.",
+                "default": False,
+            },
+        },
+    },
 }
 
 GRAPH_QUERY_SCHEMA = {

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -154,11 +154,12 @@ def cmd_diagnose(args):
     """Run PII-safe diagnostics. Use --fix to auto-install missing dependencies."""
     fix_mode = "--fix" in args
     dry_run = "--dry-run" in args
+    repair_vec_working = "--repair-vec-working" in args
     clean_args = [a for a in args if not a.startswith("--")]
 
     try:
         from mnemosyne.diagnose import run_diagnostics, auto_fix
-        result = run_diagnostics()
+        result = run_diagnostics(repair_vec_working=repair_vec_working, dry_run=dry_run)
         print("\nMnemosyne Diagnostics\n")
         print(f"  Checks passed: {result.get('checks_passed', 0)}/{result.get('checks_total', 0)}")
         if result.get("key_findings"):
@@ -168,7 +169,10 @@ def cmd_diagnose(args):
         else:
             print("\n  No issues detected")
 
-        if fix_mode or dry_run:
+        if repair_vec_working:
+            print("\n  vec_working repair requested")
+
+        if fix_mode or (dry_run and not repair_vec_working):
             print("\n--- Auto-fix ---")
             fix_result = auto_fix(result.get("entries", []), dry_run=dry_run)
             if fix_result["fixed"]:
@@ -624,7 +628,7 @@ def run_cli():
         print("  delete <id>                            Delete a memory")
         print("  stats                                  Show statistics")
         print("  sleep                                  Run consolidation")
-        print("  diagnose [--fix] [--dry-run]           Run diagnostics (--fix auto-installs deps)")
+        print("  diagnose [--fix] [--dry-run] [--repair-vec-working]  Run diagnostics / optional repairs")
         print("  export [--include-sync-events] [file.json]    Export memories")
         print("  import <file.json>                     Import memories")
         print("  import-hindsight <file|url> [bank]     Import Hindsight memories")

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1903,6 +1903,128 @@ def _backfill_vec_working_from_memory_embeddings(conn: sqlite3.Connection) -> in
     return inserted
 
 
+def vec_working_coverage(conn: sqlite3.Connection) -> Dict[str, Any]:
+    """Return PII-safe coverage counters for the working-memory vector table.
+
+    This is intentionally count-only: no memory IDs, content, embeddings, or
+    queries are exposed. It helps operators verify old DBs after upgrading to
+    the dedicated ``vec_working`` sqlite-vec table without requiring a manual
+    DB conversion.
+    """
+    coverage: Dict[str, Any] = {
+        "sqlite_vec_package_available": bool(_SQLITE_VEC_AVAILABLE),
+        "vec_working_available": False,
+        "vec_type": "none",
+        "working_memory_rows": 0,
+        "working_embedding_rows": 0,
+        "vec_working_rows": 0,
+        "missing_vec_working_rows": 0,
+        "orphan_vec_working_rows": 0,
+        "status": "unavailable",
+    }
+    try:
+        coverage["working_memory_rows"] = int(
+            conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0]
+        )
+    except Exception as exc:
+        coverage["status"] = "error"
+        coverage["error"] = f"working_memory count failed: {type(exc).__name__}: {exc}"
+        return coverage
+
+    try:
+        coverage["working_embedding_rows"] = int(conn.execute("""
+            SELECT COUNT(*)
+            FROM working_memory wm
+            JOIN memory_embeddings me ON me.memory_id = wm.id
+        """).fetchone()[0])
+    except Exception as exc:
+        coverage["memory_embeddings_error"] = f"{type(exc).__name__}: {exc}"
+
+    try:
+        coverage["vec_working_available"] = bool(_wm_vec_available(conn))
+    except Exception as exc:
+        coverage["vec_working_error"] = f"{type(exc).__name__}: {exc}"
+        coverage["vec_working_available"] = False
+
+    if not coverage["vec_working_available"]:
+        if coverage["working_memory_rows"] == 0:
+            coverage["status"] = "empty"
+        elif coverage["working_embedding_rows"] > 0:
+            coverage["status"] = "fallback_only"
+        else:
+            coverage["status"] = "no_vectors"
+        return coverage
+
+    try:
+        coverage["vec_type"] = _effective_vec_type(conn)
+    except Exception:
+        coverage["vec_type"] = "unknown"
+
+    try:
+        coverage["vec_working_rows"] = int(
+            conn.execute("SELECT COUNT(*) FROM vec_working").fetchone()[0]
+        )
+    except Exception as exc:
+        coverage["vec_working_rows_error"] = f"{type(exc).__name__}: {exc}"
+
+    try:
+        coverage["missing_vec_working_rows"] = int(conn.execute("""
+            SELECT COUNT(*)
+            FROM working_memory wm
+            JOIN memory_embeddings me ON me.memory_id = wm.id
+            LEFT JOIN vec_working vw ON vw.rowid = wm.rowid
+            WHERE vw.rowid IS NULL
+        """).fetchone()[0])
+    except Exception as exc:
+        coverage["missing_vec_working_rows_error"] = f"{type(exc).__name__}: {exc}"
+
+    try:
+        coverage["orphan_vec_working_rows"] = int(conn.execute("""
+            SELECT COUNT(*)
+            FROM vec_working vw
+            LEFT JOIN working_memory wm ON wm.rowid = vw.rowid
+            WHERE wm.rowid IS NULL
+        """).fetchone()[0])
+    except Exception as exc:
+        coverage["orphan_vec_working_rows_error"] = f"{type(exc).__name__}: {exc}"
+
+    if coverage["working_embedding_rows"] == 0:
+        coverage["status"] = "no_vectors" if coverage["working_memory_rows"] else "empty"
+    elif coverage["missing_vec_working_rows"] == 0:
+        coverage["status"] = "complete"
+    else:
+        coverage["status"] = "partial"
+    return coverage
+
+
+def repair_vec_working(conn: sqlite3.Connection, *, dry_run: bool = False) -> Dict[str, Any]:
+    """Backfill missing vec_working rows from memory_embeddings.
+
+    The operation is idempotent and preserves ``memory_embeddings`` as the
+    compatibility store. ``dry_run`` reports the current gap without writing.
+    """
+    before = vec_working_coverage(conn)
+    result: Dict[str, Any] = {"before": before, "dry_run": dry_run, "inserted": 0}
+    if dry_run:
+        result["status"] = "dry_run"
+        result["after"] = before
+        return result
+    if not before.get("vec_working_available"):
+        result["status"] = "skipped"
+        result["reason"] = "vec_working unavailable"
+        result["after"] = before
+        return result
+    try:
+        result["inserted"] = _backfill_vec_working_from_memory_embeddings(conn)
+        conn.commit()
+        result["status"] = "repaired"
+    except Exception as exc:
+        result["status"] = "error"
+        result["error"] = f"{type(exc).__name__}: {exc}"
+    result["after"] = vec_working_coverage(conn)
+    return result
+
+
 def _vec_search(conn: sqlite3.Connection, embedding: List[float], k: int = 20) -> List[Dict]:
     """Search sqlite-vec and return rowids with distances.
 

--- a/mnemosyne/diagnose.py
+++ b/mnemosyne/diagnose.py
@@ -62,10 +62,16 @@ def _safe_env(name: str) -> str:
     return "set" if val else "unset"
 
 
-def run_diagnostics() -> Dict:
+def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False) -> Dict:
     """
     Run full diagnostic scan and write PII-safe log.
     Returns summary dict for display.
+
+    Args:
+        repair_vec_working: If true, idempotently backfill missing rows in the
+            dedicated working-memory sqlite-vec table from memory_embeddings.
+        dry_run: With repair_vec_working, report what would be repaired without
+            writing.
     """
     log_path = _log_path()
     entries: List[Dict] = []
@@ -177,6 +183,25 @@ def run_diagnostics() -> Dict:
         log("db", "episodic_vectors", str(ep.get("vectors", 0)))
         log("db", "episodic_vec_type", ep.get("vec_type", "none"))
         log("db", "db_path", stats.get("database", "unknown"))
+
+        try:
+            from mnemosyne.core.beam import repair_vec_working as _repair_vec_working, vec_working_coverage
+            if repair_vec_working:
+                vec_working = _repair_vec_working(mem.beam.conn, dry_run=dry_run)
+                after = vec_working.get("after", {})
+                log("db", "vec_working_repair_status", vec_working.get("status", "unknown"))
+                log("db", "vec_working_repair_inserted", str(vec_working.get("inserted", 0)))
+            else:
+                after = vec_working_coverage(mem.beam.conn)
+                vec_working = None
+            log("db", "vec_working_status", after.get("status", "unknown"))
+            log("db", "vec_working_available", "YES" if after.get("vec_working_available") else "NO")
+            log("db", "vec_working_rows", str(after.get("vec_working_rows", 0)))
+            log("db", "vec_working_missing", str(after.get("missing_vec_working_rows", 0)))
+            log("db", "vec_working_orphans", str(after.get("orphan_vec_working_rows", 0)))
+            log("db", "working_embedding_rows", str(after.get("working_embedding_rows", 0)))
+        except Exception as exc:
+            log("db", "vec_working_coverage", "ERROR", str(exc))
     except Exception as e:
         log("db", "stats", "ERROR", str(e))
 
@@ -214,6 +239,12 @@ def run_diagnostics() -> Dict:
     vec_ok = any(e["check"] == "sqlite_vec_available" and e["status"] == "YES" for e in entries)
     ep_vec = next((e for e in entries if e["check"] == "episodic_vectors"), None)
     ep_vec_type = next((e for e in entries if e["check"] == "episodic_vec_type"), None)
+    vec_working_status = next((e for e in entries if e["check"] == "vec_working_status"), None)
+    vec_working_missing = next((e for e in entries if e["check"] == "vec_working_missing"), None)
+    vec_working_rows = next((e for e in entries if e["check"] == "vec_working_rows"), None)
+    working_embedding_rows = next((e for e in entries if e["check"] == "working_embedding_rows"), None)
+    vec_working_repair_status = next((e for e in entries if e["check"] == "vec_working_repair_status"), None)
+    vec_working_repair_inserted = next((e for e in entries if e["check"] == "vec_working_repair_inserted"), None)
 
     if not embed_ok:
         summary["key_findings"].append("fastembed not available - install with: pip install mnemosyne-memory[embeddings]")
@@ -233,6 +264,29 @@ def run_diagnostics() -> Dict:
             # the ANN index only matters at much larger scale.
             msg += " - the sqlite-vec ANN index is not in use (extension not loadable); the fallback is fine at small/medium scale"
         summary["key_findings"].append(msg)
+
+    if vec_working_repair_status:
+        inserted = vec_working_repair_inserted["status"] if vec_working_repair_inserted else "0"
+        action = "would insert" if dry_run else "inserted"
+        summary["key_findings"].append(
+            f"vec_working repair {vec_working_repair_status['status']}: {action} {inserted} rows"
+        )
+    if vec_working_status:
+        missing = int(vec_working_missing["status"]) if vec_working_missing else 0
+        rows = vec_working_rows["status"] if vec_working_rows else "0"
+        fallback_rows = working_embedding_rows["status"] if working_embedding_rows else "0"
+        if vec_working_status["status"] == "complete":
+            summary["key_findings"].append(
+                f"Working-memory sqlite-vec coverage complete: vec_working rows={rows}, fallback embeddings={fallback_rows}"
+            )
+        elif missing > 0:
+            summary["key_findings"].append(
+                f"vec_working is missing {missing} backfillable working-memory vectors - run: mnemosyne diagnose --repair-vec-working"
+            )
+        elif vec_working_status["status"] == "fallback_only":
+            summary["key_findings"].append(
+                "Working-memory vector recall is using memory_embeddings fallback; sqlite-vec vec_working is unavailable"
+            )
 
     return summary
 
@@ -286,13 +340,14 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Mnemosyne diagnostics")
     parser.add_argument("--fix", action="store_true", help="Auto-install missing dependencies")
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be fixed without installing")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be fixed/repaired without writing")
+    parser.add_argument("--repair-vec-working", action="store_true", help="Backfill missing vec_working rows from memory_embeddings")
     args = parser.parse_args()
 
-    result = run_diagnostics()
+    result = run_diagnostics(repair_vec_working=args.repair_vec_working, dry_run=args.dry_run)
     print(json.dumps(result, indent=2))
 
-    if args.fix or args.dry_run:
+    if args.fix or (args.dry_run and not args.repair_vec_working):
         fix_result = auto_fix(result.get("entries", []), dry_run=args.dry_run)
         print("\n--- Auto-fix ---")
         print(json.dumps(fix_result, indent=2))

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -753,7 +753,10 @@ def _handle_import(arguments: Dict[str, Any]) -> Dict[str, Any]:
 def _handle_diagnose(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_diagnose tool call."""
     from mnemosyne.diagnose import run_diagnostics
-    result = run_diagnostics()
+    result = run_diagnostics(
+        repair_vec_working=bool(arguments.get("repair_vec_working", False)),
+        dry_run=bool(arguments.get("dry_run", False)),
+    )
     db_path = None
     try:
         mem = _create_instance()

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -30,7 +30,7 @@ ALL_TOOL_SCHEMAS = [
     {"name": "mnemosyne_invalidate", "description": "Mark a memory as expired/superseded", "params": {"memory_id": "string", "replacement_id": "string="}},
     {"name": "mnemosyne_import", "description": "Import memories from JSON file or provider (Hindsight, Mem0)", "params": {"input_path": "string=", "provider": "string=", "api_key": "string=", "user_id": "string=", "agent_id": "string=", "base_url": "string=", "dry_run": "bool=false", "channel_id": "string=", "force": "bool=false"}},
     {"name": "mnemosyne_export", "description": "Export all memories to a JSON file", "params": {"output_path": "string"}},
-    {"name": "mnemosyne_diagnose", "description": "PII-safe diagnostics: deps, DB state, vector readiness", "params": {}},
+    {"name": "mnemosyne_diagnose", "description": "PII-safe diagnostics: deps, DB state, vector readiness, vec_working coverage", "params": {"repair_vec_working": "bool=false", "dry_run": "bool=false"}},
     {"name": "mnemosyne_stats", "description": "Memory statistics: working count, episodic count, BEAM tiers", "params": {}},
     {"name": "mnemosyne_sleep", "description": "Run consolidation cycle (compress old working memories)", "params": {"all_sessions": "bool=false", "dry_run": "bool=false"}},
     {"name": "mnemosyne_triple_add", "description": "Add a fact triple to the knowledge graph", "params": {"subject": "string", "predicate": "string", "object": "string", "valid_from": "string="}},

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -258,6 +258,80 @@ def test_wm_vec_search_falls_back_when_vec_working_missing_row(temp_db):
     assert results[0]["sim"] == pytest.approx(1.0)
 
 
+def test_vec_working_coverage_reports_missing_and_repair_fills_gap(temp_db):
+    beam = BeamMemory(session_id="vec-working-coverage", db_path=temp_db)
+    _require_vec_working(beam.conn)
+    now = datetime.now().isoformat()
+    memory_id = "coverage-gap"
+    embedding = _unit_embedding()
+
+    beam.conn.execute(
+        """
+        INSERT INTO working_memory
+            (id, content, source, timestamp, session_id, scope, importance)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (memory_id, "coverage vector gap", "test", now, "vec-working-coverage", "session", 0.5),
+    )
+    beam.conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        (memory_id, beam_module._embeddings.serialize(embedding), "test"),
+    )
+    beam.conn.commit()
+
+    before = beam_module.vec_working_coverage(beam.conn)
+    assert before["vec_working_available"] is True
+    assert before["working_memory_rows"] == 1
+    assert before["working_embedding_rows"] == 1
+    assert before["vec_working_rows"] == 0
+    assert before["missing_vec_working_rows"] == 1
+    assert before["status"] == "partial"
+
+    dry_run = beam_module.repair_vec_working(beam.conn, dry_run=True)
+    assert dry_run["status"] == "dry_run"
+    assert dry_run["inserted"] == 0
+    assert dry_run["after"]["missing_vec_working_rows"] == 1
+
+    repaired = beam_module.repair_vec_working(beam.conn)
+    assert repaired["status"] == "repaired"
+    assert repaired["inserted"] == 1
+    assert repaired["after"]["missing_vec_working_rows"] == 0
+    assert repaired["after"]["vec_working_rows"] == 1
+    assert repaired["after"]["status"] == "complete"
+
+    second = beam_module.repair_vec_working(beam.conn)
+    assert second["inserted"] == 0
+    assert second["after"]["status"] == "complete"
+
+
+def test_vec_working_coverage_reports_fallback_only_when_table_unavailable(temp_db, monkeypatch):
+    beam = BeamMemory(session_id="vec-working-unavailable", db_path=temp_db)
+    now = datetime.now().isoformat()
+    beam.conn.execute(
+        """
+        INSERT INTO working_memory
+            (id, content, source, timestamp, session_id, scope, importance)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("fallback-only", "fallback only vector", "test", now, "vec-working-unavailable", "session", 0.5),
+    )
+    beam.conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        ("fallback-only", beam_module._embeddings.serialize(_unit_embedding()), "test"),
+    )
+    beam.conn.commit()
+    monkeypatch.setattr(beam_module, "_wm_vec_available", lambda _conn: False)
+
+    coverage = beam_module.vec_working_coverage(beam.conn)
+    assert coverage["vec_working_available"] is False
+    assert coverage["working_embedding_rows"] == 1
+    assert coverage["status"] == "fallback_only"
+
+    repair = beam_module.repair_vec_working(beam.conn)
+    assert repair["status"] == "skipped"
+    assert repair["reason"] == "vec_working unavailable"
+
+
 
 class TestFactAnnotationMatching:
     def test_strict_fact_match_ignores_stopword_only_matches(self, monkeypatch):

--- a/tests/test_hermes_memory_provider_diagnose_active_db.py
+++ b/tests/test_hermes_memory_provider_diagnose_active_db.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+from mnemosyne.core import beam as beam_module
 from mnemosyne.core.beam import BeamMemory
 from hermes_memory_provider import MnemosyneMemoryProvider
 
@@ -25,7 +28,7 @@ def test_diagnose_reports_active_provider_db_path_and_counts(tmp_path, monkeypat
     legacy_path = tmp_path / "legacy" / "mnemosyne.db"
     monkeypatch.setattr(
         "mnemosyne.diagnose.run_diagnostics",
-        lambda: {
+        lambda **_kwargs: {
             "checks_total": 1,
             "checks_passed": 1,
             "key_findings": [],
@@ -58,7 +61,7 @@ def test_diagnose_without_active_beam_keeps_base_diagnostics(monkeypatch):
     provider = MnemosyneMemoryProvider()
     monkeypatch.setattr(
         "mnemosyne.diagnose.run_diagnostics",
-        lambda: {"checks_total": 1, "key_findings": ["base finding"]},
+        lambda **_kwargs: {"checks_total": 1, "key_findings": ["base finding"]},
     )
 
     result = json.loads(provider._handle_diagnose({}))
@@ -72,7 +75,7 @@ def test_diagnose_reports_count_error_without_failing(tmp_path, monkeypatch):
     provider._beam.conn.commit()
     monkeypatch.setattr(
         "mnemosyne.diagnose.run_diagnostics",
-        lambda: {"checks_total": 1, "key_findings": []},
+        lambda **_kwargs: {"checks_total": 1, "key_findings": []},
     )
 
     result = json.loads(provider._handle_diagnose({}))
@@ -80,3 +83,43 @@ def test_diagnose_reports_count_error_without_failing(tmp_path, monkeypatch):
     assert result["active_provider_db_path"] == str(db_path)
     assert "active_provider_counts_error" in result
     assert "no such table: facts" in result["active_provider_counts_error"]
+
+
+
+def test_diagnose_can_repair_active_provider_vec_working_gap(tmp_path, monkeypatch):
+    provider, _db_path = _provider_with_beam(tmp_path)
+    np = pytest.importorskip("numpy")
+    np  # keep importorskip side effect explicit
+    pytest.importorskip("sqlite_vec")
+    if not beam_module._wm_vec_available(provider._beam.conn):
+        pytest.skip("sqlite-vec vec_working table unavailable")
+    now = "2026-01-01T00:00:00"
+    memory_id = "active-gap"
+    embedding = np.array([1.0] + [0.0] * (beam_module.EMBEDDING_DIM - 1), dtype=np.float32)
+    provider._beam.conn.execute(
+        """
+        INSERT INTO working_memory
+            (id, content, source, timestamp, session_id, scope, importance)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (memory_id, "active provider vector gap", "test", now, "diagnose-test", "session", 0.5),
+    )
+    provider._beam.conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        (memory_id, beam_module._embeddings.serialize(embedding), "test"),
+    )
+    provider._beam.conn.commit()
+    monkeypatch.setattr(
+        "mnemosyne.diagnose.run_diagnostics",
+        lambda **_kwargs: {"checks_total": 1, "key_findings": [], "entries": []},
+    )
+
+    dry_run = json.loads(provider._handle_diagnose({"repair_vec_working": True, "dry_run": True}))
+    assert dry_run["active_provider_vec_working_repair"]["status"] == "dry_run"
+    assert dry_run["active_provider_vec_working"]["missing_vec_working_rows"] == 1
+
+    repaired = json.loads(provider._handle_diagnose({"repair_vec_working": True}))
+    assert repaired["active_provider_vec_working_repair"]["status"] == "repaired"
+    assert repaired["active_provider_vec_working_repair"]["inserted"] == 1
+    assert repaired["active_provider_vec_working"]["missing_vec_working_rows"] == 0
+    assert repaired["active_provider_vec_working"]["status"] == "complete"


### PR DESCRIPTION
## Summary

Follow-up to #292 / #306 for upgrade/operator transparency.

- add PII-safe `vec_working` coverage counters:
  - `working_embedding_rows`
  - `vec_working_rows`
  - `vec_working_missing`
  - `vec_working_orphans`
  - coverage status (`complete`, `partial`, `fallback_only`, etc.)
- add idempotent repair/backfill helper that mirrors missing working-memory embeddings from `memory_embeddings` into `vec_working`
- expose repair through:
  - `mnemosyne diagnose --repair-vec-working`
  - `--dry-run`
  - Hermes/MCP `mnemosyne_diagnose` schema (`repair_vec_working`, `dry_run`)
- preserve `memory_embeddings` as the compatibility/fallback store
- update generated tool schema docs

## Why

Old DBs do **not** need a manual conversion when upgrading to the new sqlite-vec `vec_working` path. This PR makes that visible and repairable: operators can diagnose whether backfill completed and trigger an idempotent repair if needed.

## Verification

```text
python3 scripts/generate-docs.py
python3 scripts/verify-docs.py
python3 -m py_compile mnemosyne/core/beam.py mnemosyne/diagnose.py mnemosyne/cli.py mnemosyne/mcp_tools.py hermes_memory_provider/__init__.py integrations/hermes/src/mnemosyne_hermes/tools.py scripts/generate-docs.py tests/test_beam.py tests/test_hermes_memory_provider_diagnose_active_db.py

env PYTHONPATH=/opt/data/tmp/mnemo-review/mnemosyne:integrations/hermes/src uv run --no-project \
  --with pytest --with pytest-asyncio --with pyyaml --with numpy --with sqlite-vec \
  --with fastembed --with python-dotenv --with cryptography --with mcp \
  python -m pytest tests/test_beam.py tests/test_hermes_memory_provider_diagnose_active_db.py \
  tests/test_provider_all_15_tools.py::TestDiagnose tests/test_mcp_server.py \
  tests/test_diagnose_optional_deps.py -q
# 118 passed
```
