### PR TITLE
fix(beam): score fact_recall hits by query relevance, return full triple as content

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6076,34 +6076,48 @@ class BeamMemory:
                         fts_rows.append({"rowid": row["rowid"], "rank": 0})
 
         if fts_rows:
-            fact_ids = [r["rowid"] for r in fts_rows[:top_k]]
-            placeholders = ",".join("?" * len(fact_ids))
+            # Keep the FTS relevance ORDER and each fact's rank position so the
+            # score can reflect how well the fact matches the *query*, not just how
+            # confident we are it is true. (Previously the rows were re-ordered by
+            # confidence and the FTS rank was discarded, so every fact for a query
+            # scored at its stored confidence and outranked relevance-scored
+            # memories in the merged result.)
+            ranked_ids = [r["rowid"] for r in fts_rows[:top_k]]
+            rank_pos = {rid: i for i, rid in enumerate(ranked_ids)}
+            placeholders = ",".join("?" * len(ranked_ids))
             try:
                 cursor.execute(f"""
-                    SELECT fact_id, subject, predicate, object,
+                    SELECT rowid, fact_id, subject, predicate, object,
                            timestamp, confidence
                     FROM facts
                     WHERE rowid IN ({placeholders})
-                    ORDER BY confidence DESC
-                    LIMIT ?
-                """, (*fact_ids, top_k))
+                """, (*ranked_ids,))
                 fact_rows = cursor.fetchall()
             except Exception:
                 fact_rows = []
 
+            n = max(len(ranked_ids), 1)
             for raw_row in fact_rows:
                 row = dict(raw_row)
                 confidence = row.get("confidence")
-                subject = row.get("subject")
-                predicate = row.get("predicate")
-                obj = row.get("object")
-                fact_text = obj if obj else f"{subject} {predicate} {obj}"
+                confidence = confidence if confidence is not None else 0.5
+                subject = row.get("subject") or ""
+                predicate = row.get("predicate") or ""
+                obj = row.get("object") or ""
+                # Full subject-predicate-object triple: a bare object is
+                # meaningless once merged into general recall output.
+                fact_text = " ".join(p for p in (subject, predicate, obj) if p).strip() or obj
+                # Relevance from the FTS rank position (top hit -> ~1.0, decaying),
+                # combined with confidence. Replaces the flat per-fact confidence
+                # that made every hit score identically.
+                pos = rank_pos.get(row["rowid"], n - 1)
+                relevance = 1.0 - (pos / n)
                 results.append({
                     "content": fact_text,
-                    "score": confidence if confidence is not None else 0.5,
+                    "score": relevance * confidence,
                     "fact_id": row["fact_id"],
-                    "subject": subject if subject is not None else "",
-                    "predicate": predicate if predicate is not None else "",
+                    "subject": subject,
+                    "predicate": predicate,
                 })
 
         # --- Source 2: consolidated_facts (sleep-consolidated LLM triples) ---

--- a/tests/test_fact_recall_ranking.py
+++ b/tests/test_fact_recall_ranking.py
@@ -1,0 +1,58 @@
+"""Tests for fact_recall() ranking + content (raw `facts` source).
+
+Covers the fix where fact hits were scored by a flat stored confidence (the FTS
+rank was discarded) and surfaced with only the object as content. After the fix:
+
+  * content is the full subject-predicate-object triple, and
+  * the score reflects FTS relevance (rank position) combined with confidence,
+    so two equal-confidence facts no longer collapse to the same score.
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from mnemosyne.core.beam import BeamMemory
+
+
+def _insert_fact(beam, fact_id, subject, predicate, obj, confidence):
+    beam.conn.execute(
+        "INSERT INTO facts (fact_id, session_id, subject, predicate, object, "
+        "timestamp, source_msg_id, confidence) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (fact_id, "test", subject, predicate, obj,
+         "2026-01-01T00:00:00", "msg1", confidence),
+    )
+    beam.conn.commit()
+
+
+def test_fact_recall_full_triple_content_and_relevance_scoring():
+    with tempfile.TemporaryDirectory() as tmp:
+        beam = BeamMemory(session_id="test", db_path=str(Path(tmp) / "facts.db"))
+
+        # Two facts with the SAME confidence, both matching the query term.
+        _insert_fact(beam, "f1", "python", "is", "a language", 0.6)
+        _insert_fact(beam, "f2", "java", "is", "a language too", 0.6)
+
+        results = beam.fact_recall("language", top_k=10)
+
+        assert len(results) == 2, results
+
+        # content is the full subject-predicate-object triple, not the bare object.
+        contents = {r["content"] for r in results}
+        assert "python is a language" in contents, contents
+        assert "java is a language too" in contents, contents
+        assert "a language" not in contents  # never the bare object alone
+        # subject is preserved in every hit's content.
+        assert all(r["content"].startswith(r["subject"]) for r in results)
+
+        # Equal confidence, but the score is no longer a flat constant: FTS rank
+        # position now differentiates the two hits (pre-fix both were 0.6).
+        scores = [round(r["score"], 6) for r in results]
+        assert len(set(scores)) > 1, f"expected relevance-differentiated scores, got {scores}"
+        # scores stay within (0, confidence]; relevance in (0, 1].
+        assert all(0.0 < s <= 0.6 + 1e-9 for s in scores), scores
+
+
+if __name__ == "__main__":  # allow direct execution without pytest
+    test_fact_recall_full_triple_content_and_relevance_scoring()
+    print("ok")


### PR DESCRIPTION
## What

`fact_recall()` (the raw `facts` source) queries `fts_facts ORDER BY rank` (bm25
relevance) but then re-selects the rows `ORDER BY confidence DESC` and scores them by
the stored `confidence` — discarding query relevance. Because facts written by the
same path share a confidence, every fact for a query collapses to one score and
**outranks the relevance-scored episodic/working memories** in merged recall. The
merged `content` is also just the fact's object (e.g. `"hiking"`), meaningless out of
context.

General issue — affects any consumer that enables `MNEMOSYNE_FACT_RECALL_ENABLED`.

## Change

In `fact_recall()` Source 1: preserve the FTS rank order and each fact's rank
position, derive a bounded relevance from the position (top hit → ~1.0, decaying),
combine it with confidence (`relevance * confidence`), and build `content` from the
full subject-predicate-object triple. The existing `results.sort(...score)[:top_k]`
then orders by the relevance-aware score; the `recall()` integration's ×0.9 discount
still applies.

## Notes

- **Rank-position decay** (`1 - pos/n`) rather than the raw bm25 value: bounded to
  `[0, 1]` so it composes with confidence, dependency-free, and preserves the FTS
  ordering (the part that matters).
- **LIKE fallback** keeps working — those rows carry `rank=0` and are scored by
  position, a strict improvement over the flat score.
- **Source 2 (`consolidated_facts`)** left as-is here (already full-triple content;
  its confidence-only score is a smaller follow-up) to keep this focused.
- **No API/signature change**; behavior unchanged when the feature is disabled (default).

## Tests

Adds `tests/test_fact_recall_ranking.py`: two equal-confidence facts matching the same
query now return full-triple content (not the bare object) and get
relevance-differentiated scores instead of collapsing to one value.

## Risk

Low. Confined to the opt-in `fact_recall` path; no schema or API change; default-off
behavior unchanged.

Fixes #309
