### PR TITLE
feat(reindex): Phase 1 — synchronous `mnemosyne reindex` to rebuild vectors after a model/dim change

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -585,6 +585,81 @@ def cmd_bank(args):
         _fail(str(e))
 
 
+def cmd_reindex(args):
+    """Rebuild vector indexes from source text with the active embedding model.
+
+    Usage: mnemosyne reindex [--model NAME] [--dry-run] [--yes] [--no-backup]
+
+    Use after changing the embedding model/dimension. Synchronous and blocking —
+    re-embeds working + episodic memory, so it can take minutes on a large DB.
+    Run it with any provider/gateway stopped.
+    """
+    dry_run = "--dry-run" in args
+    assume_yes = "--yes" in args or "-y" in args
+    no_backup = "--no-backup" in args
+
+    # --model has to win before the embedding module is imported: it freezes the
+    # model + dimension from the env at import time.
+    if "--model" in args:
+        try:
+            os.environ["MNEMOSYNE_EMBEDDING_MODEL"] = args[args.index("--model") + 1]
+        except IndexError:
+            _usage("Usage: mnemosyne reindex [--model NAME] [--dry-run] [--yes] [--no-backup]")
+
+    from mnemosyne.core import embeddings as _emb
+
+    mem = _get_memory()
+
+    if dry_run:
+        plan = mem.reindex_vectors(dry_run=True)
+        print("Reindex plan (dry run -- nothing written):")
+        for key in ("model", "dim", "vec_type", "sqlite_vec",
+                    "working_memory", "episodic_memory"):
+            if key in plan:
+                print(f"  {key}: {plan[key]}")
+        return
+
+    print(
+        f"Reindex will re-embed working + episodic memory with "
+        f"'{_emb._DEFAULT_MODEL}' (dim {_emb.EMBEDDING_DIM}) and rebuild the sqlite-vec "
+        f"tables. This is synchronous and may take several minutes on a large DB -- "
+        f"run it with any provider/gateway stopped."
+    )
+    if not assume_yes:
+        try:
+            resp = input("Proceed? [y/N] ").strip().lower()
+        except EOFError:
+            resp = "n"
+        if resp not in ("y", "yes"):
+            print("Aborted.")
+            return
+
+    if not no_backup:
+        try:
+            from mnemosyne.dr.recovery import create_backup
+            backup = create_backup()
+            print(f"Backup created: {backup['backup_path']}")
+        except Exception as e:
+            _fail(f"Backup failed (use --no-backup to skip): {e}")
+
+    import time
+    started = time.time()
+
+    def _progress(store, done, total):
+        print(f"  {store}: {done}/{total}", flush=True)
+
+    try:
+        result = mem.reindex_vectors(progress=_progress)
+    except Exception as e:
+        _fail(str(e))
+
+    print(f"Reindex complete in {time.time() - started:.1f}s:")
+    print(f"  model: {result['model']} (dim {result['dim']})")
+    print(f"  working_memory reindexed: {result.get('working_memory_reindexed', 0)}")
+    print(f"  episodic_memory reindexed: {result.get('episodic_memory_reindexed', 0)}")
+    print(f"  sqlite-vec tables recreated at dim {result['dim']}")
+
+
 COMMANDS = {
     "store": cmd_store,
     "remember": cmd_store,
@@ -604,6 +679,7 @@ COMMANDS = {
     "import-hindsight": cmd_import_hindsight,
     "mcp": cmd_mcp,
     "bank": cmd_bank,
+    "reindex": cmd_reindex,
     "backup": cmd_backup,
     "restore": cmd_restore,
     "verify": cmd_verify,
@@ -633,6 +709,8 @@ def run_cli():
         print("  import <file.json>                     Import memories")
         print("  import-hindsight <file|url> [bank]     Import Hindsight memories")
         print("  bank list|create|delete [name]         Manage memory banks")
+        print("  reindex [--model NAME] [--dry-run] [--yes] [--no-backup]")
+        print("                                      Rebuild vector indexes with the active model")
         print("  backup [output_dir]                    Create database backup")
         print("  restore <backup.db.gz>                 Restore from backup")
         print("  verify [db_path] [--quick]             Verify database integrity")

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2025,6 +2025,124 @@ def repair_vec_working(conn: sqlite3.Connection, *, dry_run: bool = False) -> Di
     return result
 
 
+def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
+                    dry_run: bool = False, progress=None) -> Dict[str, Any]:
+    """Rebuild every vector representation from source text with the ACTIVE
+    embedding model, recreating the sqlite-vec tables at the active dimension.
+
+    Use after changing the embedding model (e.g. via ``MNEMOSYNE_EMBEDDING_MODEL``):
+    the stored vectors are otherwise frozen at the previous model/dimension, so a
+    differently-sized query vector makes sqlite-vec recall raise a dimension error,
+    while the float-JSON and binary voices score against the wrong dimension and
+    silently degrade. It re-embeds ``working_memory`` and ``episodic_memory`` and
+    refreshes every store, reusing the same write helpers the normal store path
+    uses so encodings stay consistent.
+
+    Covered stores: ``memory_embeddings`` (working float JSON) + ``vec_working``,
+    ``episodic_memory.binary_vector`` + ``vec_episodes``, and ``vec_facts`` (no
+    writer yet — recreated empty so its declared dimension can't mismatch a query).
+
+    Synchronous and blocking — re-embedding a large DB can take minutes; run it
+    offline (with any provider/gateway stopped). Idempotent.
+
+    ``dry_run`` returns the plan (model, dim, per-store counts) without writing.
+    ``progress`` is an optional ``callable(store, done, total)`` for reporting.
+    """
+    target_dim = int(_embeddings.EMBEDDING_DIM)
+    vec_type = _effective_vec_type(conn)
+    vec_ok = _vec_available(conn)
+
+    def _count(sql: str) -> int:
+        try:
+            return int(conn.execute(sql).fetchone()[0])
+        except Exception:
+            return 0
+
+    wm_total = _count("SELECT COUNT(*) FROM working_memory "
+                      "WHERE content IS NOT NULL AND length(content) > 0")
+    ep_total = _count("SELECT COUNT(*) FROM episodic_memory "
+                      "WHERE content IS NOT NULL AND length(content) > 0")
+
+    plan: Dict[str, Any] = {
+        "model": _embeddings._DEFAULT_MODEL,
+        "dim": target_dim,
+        "vec_type": vec_type,
+        "sqlite_vec": vec_ok,
+        "working_memory": wm_total,
+        "episodic_memory": ep_total,
+    }
+    if dry_run:
+        plan["dry_run"] = True
+        return plan
+
+    if not _embeddings.available():
+        raise RuntimeError("Embedding model unavailable; cannot reindex vectors.")
+
+    # 1) Recreate the sqlite-vec tables at the active dimension. vec_facts has no
+    #    writer yet but is recreated so its declared dim can't mismatch a query.
+    if vec_ok:
+        for table in ("vec_episodes", "vec_working", "vec_facts"):
+            conn.execute(f"DROP TABLE IF EXISTS {table}")
+            conn.execute(
+                f"CREATE VIRTUAL TABLE {table} USING vec0(embedding {vec_type}[{target_dim}])"
+            )
+        conn.commit()
+
+    # 2) Working memory -> memory_embeddings (+ vec_working), via the shared write
+    #    helper so the float-JSON and sqlite-vec stores stay consistent.
+    wm_done = 0
+    wm_rows = conn.execute(
+        "SELECT id, content FROM working_memory "
+        "WHERE content IS NOT NULL AND length(content) > 0"
+    ).fetchall()
+    for start in range(0, len(wm_rows), batch_size):
+        chunk = wm_rows[start:start + batch_size]
+        vecs = _embeddings.embed([r["content"] for r in chunk])
+        if vecs is None:
+            break
+        for r, vec in zip(chunk, vecs):
+            _store_working_embedding(conn, r["id"], np.asarray(vec).tolist(), commit_vec=False)
+            wm_done += 1
+        conn.commit()
+        if progress:
+            progress("working_memory", wm_done, wm_total)
+
+    # 3) Episodic memory -> vec_episodes + binary_vector (mirrors the episodic
+    #    store path).
+    ep_done = 0
+    ep_rows = conn.execute(
+        "SELECT rowid, content FROM episodic_memory "
+        "WHERE content IS NOT NULL AND length(content) > 0"
+    ).fetchall()
+    for start in range(0, len(ep_rows), batch_size):
+        chunk = ep_rows[start:start + batch_size]
+        vecs = _embeddings.embed([r["content"] for r in chunk])
+        if vecs is None:
+            break
+        for r, vec in zip(chunk, vecs):
+            arr = np.asarray(vec)
+            rowid = int(r["rowid"])
+            if vec_ok:
+                _vec_table_insert(conn, "vec_episodes", rowid, arr.tolist(), commit=False)
+            if _mib is not None:
+                try:
+                    conn.execute(
+                        "UPDATE episodic_memory SET binary_vector = ? WHERE rowid = ?",
+                        (_mib(arr), rowid),
+                    )
+                except Exception:
+                    pass
+            ep_done += 1
+        conn.commit()
+        if progress:
+            progress("episodic_memory", ep_done, ep_total)
+
+    plan["status"] = "reindexed"
+    plan["working_memory_reindexed"] = wm_done
+    plan["episodic_memory_reindexed"] = ep_done
+    return plan
+
+
 def _vec_search(conn: sqlite3.Connection, embedding: List[float], k: int = 20) -> List[Dict]:
     """Search sqlite-vec and return rowids with distances.
 

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -565,6 +565,15 @@ class Mnemosyne:
         """Run consolidation sleep cycle across all sessions with eligible old working memories."""
         return self.beam.sleep_all_sessions(dry_run=dry_run, force=force)
 
+    def reindex_vectors(self, *, batch_size: int = 64, dry_run: bool = False, progress=None) -> Dict:
+        """Rebuild all vector representations from source text with the active model.
+
+        Run after changing the embedding model (and dimension). Synchronous and
+        blocking — run offline. See ``mnemosyne.core.beam.reindex_vectors``.
+        """
+        from mnemosyne.core.beam import reindex_vectors as _reindex
+        return _reindex(self.beam.conn, batch_size=batch_size, dry_run=dry_run, progress=progress)
+
     def reclaim_orphans(self, dry_run: bool = False,
                         stale_after_seconds: int = 3600,
                         limit: int = 1000) -> Dict:

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -1,0 +1,89 @@
+"""Tests for reindex_vectors() — rebuilding vector stores after a model/dim change.
+
+Simulates the motivating bug (sqlite-vec tables stuck at the old dimension after an
+embedding-model swap) by recreating the vec0 tables at a wrong dimension, then
+verifies reindex_vectors() recreates them at the active dimension, repopulates
+working + episodic vectors, refreshes the episodic binary_vector, and leaves recall
+working. Also checks that --dry-run writes nothing.
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from mnemosyne.core.beam import BeamMemory, reindex_vectors, _effective_vec_type
+import mnemosyne.core.embeddings as E
+
+
+def _ddl(conn, table):
+    row = conn.execute("SELECT sql FROM sqlite_master WHERE name = ?", (table,)).fetchone()
+    return row[0] if row and row[0] else ""
+
+
+def test_reindex_rebuilds_all_vector_stores_at_active_dim():
+    if not E.available():
+        import pytest  # type: ignore
+        pytest.skip("embedding model unavailable")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        beam = BeamMemory(session_id="t", db_path=str(Path(tmp) / "m.db"))
+        conn = beam.conn
+
+        # working memory via the public store path (populates working_memory,
+        # memory_embeddings, and vec_working).
+        for text in ("the cat sat on the mat",
+                     "python is a programming language",
+                     "paris is the capital of france"):
+            beam.remember(text)
+
+        # one episodic row with content for reindex to re-embed.
+        conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, importance) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("ep1", "a long sunny day at the beach with friends", "test",
+             "2026-01-01T00:00:00", "t", 0.8),
+        )
+        conn.commit()
+
+        dim = int(E.EMBEDDING_DIM)
+        vt = _effective_vec_type(conn)
+        wrong = 384 if dim != 384 else 256
+
+        # simulate the stale-dimension state after a model swap.
+        for table in ("vec_episodes", "vec_working", "vec_facts"):
+            conn.execute(f"DROP TABLE IF EXISTS {table}")
+            conn.execute(f"CREATE VIRTUAL TABLE {table} USING vec0(embedding {vt}[{wrong}])")
+        conn.commit()
+
+        # dry-run: reports the plan, writes nothing.
+        plan = reindex_vectors(conn, dry_run=True)
+        assert plan["dim"] == dim
+        assert plan["working_memory"] >= 3
+        assert plan["episodic_memory"] >= 1
+        assert f"[{wrong}]" in _ddl(conn, "vec_episodes")  # unchanged by dry-run
+
+        # real reindex.
+        result = reindex_vectors(conn)
+        assert result["status"] == "reindexed"
+        assert result["working_memory_reindexed"] >= 3
+        assert result["episodic_memory_reindexed"] >= 1
+
+        # vec tables recreated at the active dim and repopulated.
+        for table in ("vec_episodes", "vec_working", "vec_facts"):
+            assert f"[{dim}]" in _ddl(conn, table), (table, _ddl(conn, table))
+        assert conn.execute("SELECT COUNT(*) FROM vec_working").fetchone()[0] >= 3
+        assert conn.execute("SELECT COUNT(*) FROM vec_episodes").fetchone()[0] >= 1
+
+        # episodic binary_vector refreshed.
+        assert conn.execute(
+            "SELECT COUNT(*) FROM episodic_memory WHERE binary_vector IS NOT NULL"
+        ).fetchone()[0] >= 1
+
+        # recall works (no dimension error) and the model/dim matches the query path.
+        results = beam.recall("programming language", top_k=5)
+        assert isinstance(results, list)
+
+
+if __name__ == "__main__":  # allow direct execution without pytest
+    test_reindex_rebuilds_all_vector_stores_at_active_dim()
+    print("ok")


### PR DESCRIPTION
Phase 1 of #308 — a synchronous `mnemosyne reindex` that rebuilds every vector representation from source text with the active embedding model. Opened to save you a step; happy to adjust per your review.

## What it does

`reindex_vectors()` (in `core/beam.py`, alongside `repair_vec_working`) re-embeds `working_memory` and `episodic_memory` with the current model and recreates the sqlite-vec tables at the active dimension. It reuses the existing write helpers so encodings stay identical to the normal store path:

- **working:** `memory_embeddings` (float JSON) + `vec_working` — via `_store_working_embedding`
- **episodic:** `episodic_memory.binary_vector` + `vec_episodes` — via `_mib` + `_vec_table_insert`
- **vec_facts:** recreated empty (no writer yet) so its declared dim can't mismatch a query

Good catch on `vec_working` — that's covered (this is the full 5-store set). Exposed as `Mnemosyne.reindex_vectors(...)` and a CLI command:

```
mnemosyne reindex [--model NAME] [--dry-run] [--yes] [--no-backup]
```

Synchronous and blocking, with an up-front "may take several minutes — run with the gateway stopped" warning, auto-backup first (via `dr.recovery.create_backup`), and a per-store progress line. `--dry-run` prints the plan (model, dim, per-store counts) and writes nothing.

## Your design questions

- **Shape / auto-backup / dry-run:** as above — `--model`/`--dry-run`/`--yes`/`--no-backup`, backup-first by default.
- **Atomicity:** currently backup-first + per-batch commits — a crash mid-run is recoverable from the backup, and re-running is idempotent (drops/recreates the vec tables, overwrites the float/binary stores). Glad to switch to staging into temp tables + atomic swap if you'd rather not lean on the backup for Phase 1.
- **Idempotency:** yes — re-running with the same model re-embeds to the same vectors.
- **diagnose/verify dim-mismatch check:** left out here to keep this focused; happy to add a follow-up that flags *configured dim ≠ stored vec-table dim* and points at `reindex`.

## `--model` note

`--model` sets `MNEMOSYNE_EMBEDDING_MODEL` before the embedding module is imported, so `EMBEDDING_DIM` (and the binary packer) pick up the new dimension without a reload. Documented flow is still: swap the model, then `reindex`.

## Tests

`tests/test_reindex_vectors.py` simulates the bug (vec0 tables recreated at a wrong dim), then asserts reindex recreates them at the active dim, repopulates working + episodic vectors, refreshes `binary_vector`, and leaves recall working; plus a `--dry-run` writes-nothing check.

## Scope

Phase 1 only (synchronous). Phase 2 (async + progress/cancellation) is a separate PR per your note.

Refs #308
