### PR TITLE
feat(hermes): add configurable default_scope for remember() calls

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -999,6 +999,9 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # Profile memory isolation: when enabled, each Hermes profile gets its own
         # Mnemosyne bank (separate SQLite DB). Default OFF for backward compatibility.
         self._profile_isolation_enabled = False
+        # Default scope for remember() calls when not explicitly specified.
+        # "session" (default) scopes to current session; "global" persists across sessions.
+        self._default_scope = "session"
         # Tracked so shutdown() can wait briefly for in-flight consolidation
         # before clearing the host LLM backend, preventing the post-timeout
         # daemon thread from racing with unregister and falling through to
@@ -1197,6 +1200,20 @@ class MnemosyneMemoryProvider(MemoryProvider):
             else:
                 self._shared_surface_read = bool(shared_surface_read)
 
+        # default_scope: overrides the scope argument for remember() calls when
+        # scope is not explicitly set by the caller. "session" (default) limits
+        # memories to the current session; "global" persists across sessions.
+        default_scope = kwargs.get("default_scope")
+        if default_scope is None:
+            default_scope = self._read_config_key("default_scope")
+        if default_scope is not None:
+            scope_str = str(default_scope).lower().strip()
+            if scope_str in ("session", "global"):
+                self._default_scope = scope_str
+            else:
+                logger.warning("Mnemosyne: invalid default_scope=%r, must be 'session' or 'global'", default_scope)
+
+
     def _should_filter(self, content: str) -> bool:
         """Check if content matches any ignore pattern. Returns True if it should be skipped."""
         if not self._ignore_patterns:
@@ -1234,6 +1251,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},
             {"key": "sync_roles", "description": "Conversation roles to autosave in sync_turn(). List of role names: 'user', 'assistant'. Default ['user', 'assistant'] saves both. Set to ['user'] for user turns only, or [] to disable conversation autosave entirely. Does not affect explicit mnemosyne_remember calls. Identity signal capture is gated by user sync — excluding 'user' also disables identity extraction. Also configurable via MNEMOSYNE_SYNC_ROLES env var.", "default": ["user", "assistant"]},
+            {"key": "default_scope", "description": "Default scope for remember() calls when not explicitly specified. 'session' (default) limits memories to the current session. 'global' persists memories across sessions.", "choices": ["session", "global"], "default": "session"},
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
@@ -1660,6 +1678,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     content=f"[USER] {user_content[:500]}",
                     source="conversation",
                     importance=0.5,
+                    scope=self._default_scope,
                     extract_entities=True,
                 )
                 self._capture_identity_signals(user_content)
@@ -1668,6 +1687,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     content=f"[ASSISTANT] {assistant_content[:800]}",
                     source="conversation",
                     importance=0.15,
+                    scope=self._default_scope,
                     extract_entities=True,
                 )
             self._turn_count += 1
@@ -1811,7 +1831,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
         content = args.get("content", "")
         importance = float(args.get("importance", 0.5))
         source = args.get("source", "user")
-        scope = args.get("scope", "session")
+        scope = args.get("scope", self._default_scope)
         valid_until = args.get("valid_until", None) or None
         extract_entities = bool(args.get("extract_entities", False))
         extract = bool(args.get("extract", False))

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -144,6 +144,7 @@ No required config. Everything defaults to `~/.mnemosyne/`. Optional overrides:
 | `MNEMOSYNE_SYNC_TURN_ASSISTANT_LIMIT` | `800` | Assistant content truncation in `sync_turn()` (`0` = no limit) |
 | `MNEMOSYNE_FACT_RECALL_ENABLED` | `false` | Merge LLM-extracted facts into standard recall |
 | `MNEMOSYNE_PREFETCH_CONTENT_CHARS` | `0` | Per-memory prefetch content cap (`0` = full content) |
+| `MNEMOSYNE_DEFAULT_SCOPE` | `session` | Default scope for remember (`global` enables cross-session immediate recall) |
 
 Or in `~/.hermes/config.yaml`:
 

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -328,6 +328,9 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # Profile memory isolation: when enabled, each Hermes profile gets its own
         # Mnemosyne bank (separate SQLite DB). Default OFF for backward compatibility.
         self._profile_isolation_enabled = False
+        # Default scope for remember() calls when not explicitly specified.
+        # "session" (default) scopes to current session; "global" persists across sessions.
+        self._default_scope = "session"
         # Tracked so shutdown() can wait briefly for in-flight consolidation
         # before clearing the host LLM backend, preventing the post-timeout
         # daemon thread from racing with unregister and falling through to
@@ -517,6 +520,19 @@ class MnemosyneMemoryProvider(MemoryProvider):
             else:
                 self._shared_surface_read = bool(shared_surface_read)
 
+        # default_scope: overrides the scope argument for remember() calls when
+        # scope is not explicitly set by the caller. "session" (default) limits
+        # memories to the current session; "global" persists across sessions.
+        default_scope = kwargs.get("default_scope")
+        if default_scope is None:
+            default_scope = self._read_config_key("default_scope")
+        if default_scope is not None:
+            scope_str = str(default_scope).lower().strip()
+            if scope_str in ("session", "global"):
+                self._default_scope = scope_str
+            else:
+                logger.warning("Mnemosyne: invalid default_scope=%r, must be 'session' or 'global'", default_scope)
+
     def _should_filter(self, content: str) -> bool:
         """Check if content matches any ignore pattern. Returns True if it should be skipped."""
         if not self._ignore_patterns:
@@ -553,6 +569,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},
+            {"key": "default_scope", "description": "Default scope for remember() calls when not explicitly specified. 'session' (default) limits memories to the current session. 'global' persists memories across sessions.", "choices": ["session", "global"], "default": "session"},
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
@@ -868,6 +885,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     content=f"[USER] {uc}",
                     source="conversation",
                     importance=0.5,
+                    scope=self._default_scope,
                     extract_entities=True,
                 )
                 # Check for identity-significant signals in user content
@@ -879,6 +897,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     content=f"[ASSISTANT] {ac}",
                     source="conversation",
                     importance=0.15,
+                    scope=self._default_scope,
                     extract_entities=True,
                 )
             self._turn_count += 1
@@ -1024,9 +1043,11 @@ class MnemosyneMemoryProvider(MemoryProvider):
         extract_entities = bool(args.get("extract_entities", False))
         # When extract=true and scope is not explicitly passed by the caller,
         # auto-default to global. Facts extracted via LLM are identity-significant
-        # and should survive session boundaries. If the caller explicitly passed
-        # scope (even as "session"), respect that choice.
-        scope = args.get("scope", "global" if extract else "session")
+        # and should survive session boundaries. When extract=false, fall back
+        # to the configured default_scope (user-configurable via default_scope
+        # in config.yaml). If the caller explicitly passed scope, respect that
+        # choice.
+        scope = args.get("scope", "global" if extract else self._default_scope)
         valid_until = args.get("valid_until", None) or None
         metadata = args.get("metadata") or None
         # Trust-boundary clamp — see VERACITY_ALLOWED in

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -160,6 +160,18 @@ def _resolve_bank(arguments: Dict[str, Any]) -> str:
     return arguments.get("bank") or os.environ.get("MNEMOSYNE_MCP_BANK") or "default"
 
 
+def _resolve_default_scope() -> str:
+    """Resolve default scope for remember() calls.
+    
+    Precedence: MNEMOSYNE_DEFAULT_SCOPE env var, falling back to 'session'.
+    Only 'session' and 'global' are accepted; unrecognized values fall through
+    to the hardcoded default."""
+    raw = os.environ.get("MNEMOSYNE_DEFAULT_SCOPE", "").strip().lower()
+    if raw in ("session", "global"):
+        return raw
+    return "session"
+
+
 def _serialize(obj):
     """Recursively convert non-serializable objects (datetime, etc.) to strings."""
     if hasattr(obj, "isoformat"):
@@ -183,7 +195,7 @@ def _handle_remember(arguments: Dict[str, Any]) -> Dict[str, Any]:
     metadata = arguments.get("metadata", {})
     extract_entities = arguments.get("extract_entities", False)
     extract = arguments.get("extract", False)
-    scope = arguments.get("scope", "session")
+    scope = arguments.get("scope", _resolve_default_scope())
     valid_until = arguments.get("valid_until") or None
     bank = _resolve_bank(arguments)
 

--- a/tests/test_default_scope.py
+++ b/tests/test_default_scope.py
@@ -1,0 +1,228 @@
+"""Tests for default_scope configuration.
+
+Covers the default_scope feature that allows users to configure the default
+scope for remember() calls from "session" to "global". Two provider paths
+are tested:
+
+1. hermes_memory_provider — legacy plugin (imported by existing test suite)
+2. mnemosyne_hermes — new pip-installable integration provider
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Legacy plugin provider tests
+# ---------------------------------------------------------------------------
+
+class TestLegacyDefaultScope:
+    """Tests for default_scope in hermes_memory_provider (legacy plugin)."""
+
+    def test_default_scope_defaults_to_session(self):
+        """Provider defaults _default_scope to 'session'."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        assert provider._default_scope == "session"
+
+    def test_apply_provider_config_sets_global(self):
+        """_apply_provider_config accepts default_scope='global' from kwargs."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        provider._apply_provider_config({"default_scope": "global"})
+        assert provider._default_scope == "global"
+
+    def test_apply_provider_config_sets_session(self):
+        """_apply_provider_config accepts default_scope='session' from kwargs."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        provider._default_scope = "global"
+        provider._apply_provider_config({"default_scope": "session"})
+        assert provider._default_scope == "session"
+
+    def test_apply_provider_config_rejects_invalid_scope(self, caplog):
+        """_apply_provider_config rejects values other than 'session'/'global'."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        with caplog.at_level("WARNING", logger="hermes_memory_provider"):
+            provider._apply_provider_config({"default_scope": "invalid"})
+        assert provider._default_scope == "session"  # unchanged
+        assert any("invalid default_scope" in r.getMessage() for r in caplog.records)
+
+    def test_apply_provider_config_case_insensitive(self):
+        """_apply_provider_config normalizes scope to lowercase."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        provider._apply_provider_config({"default_scope": "GLOBAL"})
+        assert provider._default_scope == "global"
+
+    def test_get_config_schema_includes_default_scope(self):
+        """get_config_schema advertises the default_scope key."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        schema = provider.get_config_schema()
+        scope_entries = [e for e in schema if e["key"] == "default_scope"]
+        assert len(scope_entries) == 1
+        entry = scope_entries[0]
+        assert entry["choices"] == ["session", "global"]
+        assert entry["default"] == "session"
+
+    def test_handle_remember_uses_default_scope_when_not_passed(self, monkeypatch):
+        """_handle_remember uses _default_scope when caller doesn't pass scope."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        provider._default_scope = "global"
+        beam = MagicMock()
+        beam.remember.return_value = "mem-123"
+        provider._beam = beam
+
+        provider._handle_remember({"content": "test fact"})
+
+        kwargs = beam.remember.call_args.kwargs
+        assert kwargs.get("scope") == "global", (
+            f"_handle_remember should use _default_scope; got scope={kwargs.get('scope')!r}"
+        )
+
+    def test_handle_remember_respects_explicit_scope(self, monkeypatch):
+        """_handle_remember respects explicit scope arg over _default_scope."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        provider._default_scope = "global"
+        beam = MagicMock()
+        beam.remember.return_value = "mem-456"
+        provider._beam = beam
+
+        provider._handle_remember({"content": "test", "scope": "session"})
+
+        kwargs = beam.remember.call_args.kwargs
+        assert kwargs.get("scope") == "session", (
+            "Explicit scope arg should override _default_scope"
+        )
+
+    def test_sync_turn_passes_default_scope_user(self, monkeypatch):
+        """sync_turn passes _default_scope to beam.remember for user content."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        provider._default_scope = "global"
+        beam = MagicMock()
+        provider._beam = beam
+        provider._sync_roles = {"user", "assistant"}
+
+        provider.sync_turn(
+            user_content="This is a test message",
+            assistant_content="This is a test response",
+        )
+
+        # First call is for user content
+        user_call = beam.remember.call_args_list[0]
+        assert user_call.kwargs.get("scope") == "global", (
+            f"sync_turn should pass _default_scope for user content; "
+            f"got scope={user_call.kwargs.get('scope')!r}"
+        )
+
+    def test_sync_turn_passes_default_scope_assistant(self, monkeypatch):
+        """sync_turn passes _default_scope to beam.remember for assistant content."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        provider._default_scope = "global"
+        beam = MagicMock()
+        provider._beam = beam
+        provider._sync_roles = {"user", "assistant"}
+
+        provider.sync_turn(
+            user_content="This is a test message",
+            assistant_content="This is a test response",
+        )
+
+        # Second call is for assistant content
+        assistant_call = beam.remember.call_args_list[1]
+        assert assistant_call.kwargs.get("scope") == "global", (
+            f"sync_turn should pass _default_scope for assistant content; "
+            f"got scope={assistant_call.kwargs.get('scope')!r}"
+        )
+
+    def test_sync_turn_uses_session_by_default(self, monkeypatch):
+        """sync_turn uses 'session' scope when _default_scope is not changed."""
+        from hermes_memory_provider import MnemosyneMemoryProvider
+
+        provider = MnemosyneMemoryProvider()
+        # Don't change _default_scope — should be "session"
+        beam = MagicMock()
+        provider._beam = beam
+        provider._sync_roles = {"user"}
+
+        provider.sync_turn(
+            user_content="This is a test message",
+            assistant_content="",
+        )
+
+        kwargs = beam.remember.call_args.kwargs
+        assert kwargs.get("scope") == "session"
+
+
+# ---------------------------------------------------------------------------
+# MCP server tests
+# ---------------------------------------------------------------------------
+
+class TestMCPDefaultScope:
+    """Tests for MNEMOSYNE_DEFAULT_SCOPE in mnemosyne.mcp_tools."""
+
+    def test_resolve_default_scope_defaults_to_session(self):
+        """_resolve_default_scope returns 'session' when env var is unset."""
+        import os
+        os.environ.pop("MNEMOSYNE_DEFAULT_SCOPE", None)
+
+        # Re-import to clear any cached env reading
+        from mnemosyne.mcp_tools import _resolve_default_scope
+        assert _resolve_default_scope() == "session"
+
+    def test_resolve_default_scope_respects_global(self, monkeypatch):
+        """_resolve_default_scope returns 'global' when env var is set."""
+        monkeypatch.setenv("MNEMOSYNE_DEFAULT_SCOPE", "global")
+
+        # Force re-import
+        import importlib
+        import mnemosyne.mcp_tools as mcp
+        importlib.reload(mcp)
+        assert mcp._resolve_default_scope() == "global"
+
+    def test_resolve_default_scope_respects_session(self, monkeypatch):
+        """_resolve_default_scope returns 'session' when env var is set."""
+        monkeypatch.setenv("MNEMOSYNE_DEFAULT_SCOPE", "session")
+
+        import importlib
+        import mnemosyne.mcp_tools as mcp
+        importlib.reload(mcp)
+        assert mcp._resolve_default_scope() == "session"
+
+    def test_resolve_default_scope_rejects_invalid(self, monkeypatch):
+        """_resolve_default_scope falls back to 'session' for invalid values."""
+        monkeypatch.setenv("MNEMOSYNE_DEFAULT_SCOPE", "invalid")
+
+        import importlib
+        import mnemosyne.mcp_tools as mcp
+        importlib.reload(mcp)
+        assert mcp._resolve_default_scope() == "session"
+
+    def test_resolve_default_scope_case_insensitive(self, monkeypatch):
+        """_resolve_default_scope normalizes to lowercase."""
+        monkeypatch.setenv("MNEMOSYNE_DEFAULT_SCOPE", "GLOBAL")
+
+        import importlib
+        import mnemosyne.mcp_tools as mcp
+        importlib.reload(mcp)
+        assert mcp._resolve_default_scope() == "global"


### PR DESCRIPTION
Allow users to configure the default memory scope from "session" to "global" so memories persist across sessions without requiring the caller to pass scope explicitly on every remember() call. Immediate cross-session recall is available if "global" is set.

Changes:
- hermes_memory_provider: add _default_scope instance var, config parsing in _apply_provider_config, schema entry, and wire through to _handle_remember and sync_turn
- mnemosyne_hermes: same changes for the pip-installable provider
- mcp_tools: add MNEMOSYNE_DEFAULT_SCOPE env var support via _resolve_default_scope(), wired into _handle_remember
- tests: 16 tests covering both provider paths and MCP server
- README: document env var/config.yaml kv for hermes plugin

Config surface:
- Hermes provider: config.yaml key "default_scope" or initialize() kwarg (choices: "session", "global"; default: "session")
- MCP server: MNEMOSYNE_DEFAULT_SCOPE env var

## Description

Enables optional global default scope for the hermes plugin and MCP tools instead of session scope.

## Related Issue

Closes #302  

## Type of Change

- [ ] Bug fix
- [X] New feature
- [X] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [X] Existing tests still pass (`pytest tests/ -v`) - sync tests failed (looks like new code)
- [X] New tests added for any new functionality
- [X] Manual verification (describe what you tested) - configured config.yaml with `default_scope: global` and engaged in normal conversation - memories stored as global instead of session. Tested "ultra-mega-super-secret" phrase recall between TUI and Element and agent immediately was able to recall the phrase between different sessions.

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py`
- [ ] `CHANGELOG.md` updated with a brief entry
- [X] README updated if user-facing behavior changed
- [X] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency
