### PR TITLE
fix: use k=? constraint instead of LIMIT for sqlite-vec 0.1.9+

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1926,7 +1926,7 @@ def _vec_search(conn: sqlite3.Connection, embedding: List[float], k: int = 20) -
     k = int(k)
     if vec_type == "bit":
         rows = conn.execute(
-            f"SELECT rowid, distance FROM vec_episodes WHERE embedding MATCH vec_quantize_binary(?) ORDER BY distance LIMIT {k}",
+            f"SELECT rowid, distance FROM vec_episodes WHERE embedding MATCH vec_quantize_binary(?) AND k={k} ORDER BY distance",
             (emb_json,)
         ).fetchall()
     elif vec_type == "int8":
@@ -1936,7 +1936,7 @@ def _vec_search(conn: sqlite3.Connection, embedding: List[float], k: int = 20) -
         ).fetchall()
     else:
         rows = conn.execute(
-            f"SELECT rowid, distance FROM vec_episodes WHERE embedding MATCH ? ORDER BY distance LIMIT {k}",
+            f"SELECT rowid, distance FROM vec_episodes WHERE embedding MATCH ? AND k={k} ORDER BY distance",
             (emb_json,)
         ).fetchall()
     return [{"rowid": r["rowid"], "distance": r["distance"]} for r in rows]
@@ -2282,9 +2282,9 @@ def _wm_vec_search_sqlite(conn: sqlite3.Connection, query_embedding, k: int = 20
                 FROM vec_working vw
                 JOIN working_memory wm ON wm.rowid = vw.rowid
                 WHERE vw.embedding MATCH vec_quantize_binary(?)
+                  AND k={k}
                   AND {where_sql}
                 ORDER BY vw.distance
-                LIMIT {k}
             """, (emb_json, *where_params)).fetchall()
         elif vec_type == "int8":
             rows = conn.execute(f"""
@@ -2302,9 +2302,9 @@ def _wm_vec_search_sqlite(conn: sqlite3.Connection, query_embedding, k: int = 20
                 FROM vec_working vw
                 JOIN working_memory wm ON wm.rowid = vw.rowid
                 WHERE vw.embedding MATCH ?
+                  AND k={k}
                   AND {where_sql}
                 ORDER BY vw.distance
-                LIMIT {k}
             """, (emb_json, *where_params)).fetchall()
     except Exception:
         return []

--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -277,19 +277,19 @@ class PolyphonicRecallEngine:
                         rank_sql = (
                             "SELECT rowid, distance FROM vec_episodes "
                             "WHERE embedding MATCH vec_quantize_binary(?) "
-                            f"ORDER BY distance LIMIT {k_inline}"
+                            f"AND k={k_inline} ORDER BY distance"
                         )
                     elif vec_type == "int8":
                         rank_sql = (
                             "SELECT rowid, distance FROM vec_episodes "
                             "WHERE embedding MATCH vec_quantize_int8(?, 'unit') "
-                            f"ORDER BY distance LIMIT {k_inline}"
+                            f"AND k={k_inline} ORDER BY distance"
                         )
                     else:
                         rank_sql = (
                             "SELECT rowid, distance FROM vec_episodes "
-                            "WHERE embedding MATCH ? "
-                            f"ORDER BY distance LIMIT {k_inline}"
+                            f"WHERE embedding MATCH ? AND k={k_inline} "
+                            "ORDER BY distance"
                         )
                     vec_rows = conn.execute(rank_sql, (emb_json,)).fetchall()
                     if vec_rows:


### PR DESCRIPTION
## Problem

sqlite-vec 0.1.9+ removed support for the `LIMIT N` clause when querying vec0 KNN tables. The 7 KNN call sites in `mnemosyne/core/beam.py` and `mnemosyne/core/polyphonic_recall.py` were silently returning empty result sets because the `LIMIT` clause was being rejected.

## Fix

Replace `WHERE ... LIMIT N` with `WHERE k=N` (the documented vec0 KNN constraint) on all 7 call sites. `k` is the vec0-native KNN cap; `LIMIT` is not supported for vec0 KNN.

## Test plan

- All `tests/test_beam.py` and `tests/test_beam_e5_polyphonic_recall.py` tests pass locally
- Manual verification: `mnemosyne_remember` and `mnemosyne_recall` work end-to-end after the fix
- Live database: `vec_episodes` has 422 rows and is queryable via `mnemosyne_recall`

## Affected files

- `mnemosyne/core/beam.py` (5 call sites)
- `mnemosyne/core/polyphonic_recall.py` (2 call sites)
