### PR TITLE
fix(cli): respect HERMES_HOME for data directory

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -12,10 +12,21 @@ import json
 from pathlib import Path
 from typing import NoReturn
 
-# Data directory - respects MNEMOSYNE_DATA_DIR env var
-DATA_DIR = os.environ.get("MNEMOSYNE_DATA_DIR") or str(
-    Path.home() / ".hermes" / "mnemosyne" / "data"
-)
+def _default_data_dir() -> str:
+    """Resolve the default data directory used by the CLI.
+
+    Keep the standalone CLI aligned with Hermes integrations:
+    MNEMOSYNE_DATA_DIR wins, then HERMES_HOME/mnemosyne/data, then the
+    historical ~/.hermes/mnemosyne/data fallback.
+    """
+    if data_dir := os.environ.get("MNEMOSYNE_DATA_DIR"):
+        return data_dir
+    if hermes_home := os.environ.get("HERMES_HOME"):
+        return str(Path(hermes_home).expanduser() / "mnemosyne" / "data")
+    return str(Path.home() / ".hermes" / "mnemosyne" / "data")
+
+
+DATA_DIR = _default_data_dir()
 os.makedirs(DATA_DIR, exist_ok=True)
 
 

--- a/scripts/mnemosyne-stats.py
+++ b/scripts/mnemosyne-stats.py
@@ -18,10 +18,15 @@ import sqlite3, sys, json
 from pathlib import Path
 from datetime import datetime
 
-DB_PATH = Path(
-    os.environ.get("MNEMOSYNE_DATA_DIR")
-    or Path.home() / ".hermes" / "mnemosyne" / "data"
-) / "mnemosyne.db"
+def _default_data_dir() -> Path:
+    if data_dir := os.environ.get("MNEMOSYNE_DATA_DIR"):
+        return Path(data_dir)
+    if hermes_home := os.environ.get("HERMES_HOME"):
+        return Path(hermes_home).expanduser() / "mnemosyne" / "data"
+    return Path.home() / ".hermes" / "mnemosyne" / "data"
+
+
+DB_PATH = _default_data_dir() / "mnemosyne.db"
 WIKI_PATH = Path.home() / "wiki"
 SNAPSHOT_DIR = Path.home() / ".hermes" / "mnemosyne" / "stats"
 W = 60

--- a/tests/test_cli_data_dir_resolution.py
+++ b/tests/test_cli_data_dir_resolution.py
@@ -1,0 +1,58 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_cli(args, tmp_path, extra_env):
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["MNEMOSYNE_NO_EMBEDDINGS"] = "1"
+    env.pop("MNEMOSYNE_DATA_DIR", None)
+    env.pop("HERMES_HOME", None)
+    env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "mnemosyne.cli", *args],
+        cwd=str(ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_cli_uses_hermes_home_when_data_dir_is_unset(tmp_path):
+    hermes_home = tmp_path / "custom-hermes-home"
+    expected_db = hermes_home / "mnemosyne" / "data" / "mnemosyne.db"
+    default_home_db = tmp_path / "home" / ".hermes" / "mnemosyne" / "data" / "mnemosyne.db"
+
+    result = _run_cli(["stats"], tmp_path, {"HERMES_HOME": str(hermes_home)})
+
+    assert result.returncode == 0, result.stderr
+    assert f"DB path: {expected_db}" in result.stdout
+    assert expected_db.exists()
+    assert not default_home_db.exists()
+
+
+def test_cli_mnemosyne_data_dir_overrides_hermes_home(tmp_path):
+    hermes_home = tmp_path / "custom-hermes-home"
+    data_dir = tmp_path / "explicit-mnemosyne-data"
+    expected_db = data_dir / "mnemosyne.db"
+    hermes_home_db = hermes_home / "mnemosyne" / "data" / "mnemosyne.db"
+
+    result = _run_cli(
+        ["stats"],
+        tmp_path,
+        {
+            "HERMES_HOME": str(hermes_home),
+            "MNEMOSYNE_DATA_DIR": str(data_dir),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"DB path: {expected_db}" in result.stdout
+    assert expected_db.exists()
+    assert not hermes_home_db.exists()

--- a/tests/test_mnemosyne_stats.py
+++ b/tests/test_mnemosyne_stats.py
@@ -23,8 +23,16 @@ def _safe_count(db, table):
         return 0
 
 
+def _expected_data_dir() -> Path:
+    if data_dir := os.environ.get("MNEMOSYNE_DATA_DIR"):
+        return Path(data_dir)
+    if hermes_home := os.environ.get("HERMES_HOME"):
+        return Path(hermes_home).expanduser() / "mnemosyne" / "data"
+    return Path.home() / ".hermes" / "mnemosyne" / "data"
+
+
 SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "mnemosyne-stats.py"
-DB_PATH = Path.home() / ".hermes" / "mnemosyne" / "data" / "mnemosyne.db"
+DB_PATH = _expected_data_dir() / "mnemosyne.db"
 SNAP_DIR = Path.home() / ".hermes" / "mnemosyne" / "stats"
 WIKI_PATH = Path.home() / "wiki"
 
@@ -119,12 +127,15 @@ def test_json_mode_uses_mnemosyne_data_dir(tmp_path):
     assert payload["working_memory"]["total"] == 1
 
 
-def test_json_mode_empty_mnemosyne_data_dir_falls_back_to_default(tmp_path):
+def test_json_mode_uses_hermes_home_when_data_dir_unset(tmp_path):
     home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-home"
+    hermes_db = hermes_home / "mnemosyne" / "data" / "mnemosyne.db"
     default_db = home / ".hermes" / "mnemosyne" / "data" / "mnemosyne.db"
     env = os.environ.copy()
     env["HOME"] = str(home)
-    env["MNEMOSYNE_DATA_DIR"] = ""
+    env["HERMES_HOME"] = str(hermes_home)
+    env.pop("MNEMOSYNE_DATA_DIR", None)
     env["MNEMOSYNE_NO_EMBEDDINGS"] = "1"
 
     store = subprocess.run(
@@ -136,7 +147,8 @@ def test_json_mode_empty_mnemosyne_data_dir_falls_back_to_default(tmp_path):
         timeout=30,
     )
     assert store.returncode == 0, store.stderr
-    assert default_db.exists()
+    assert hermes_db.exists()
+    assert not default_db.exists()
 
     stats = subprocess.run(
         [sys.executable, str(SCRIPT), "--json"],


### PR DESCRIPTION
## Summary

This makes the standalone CLI use the same default Mnemosyne data directory as the Hermes integration.

Before this, `mnemosyne stats` ignored `HERMES_HOME` unless `MNEMOSYNE_DATA_DIR` was also set. In a Hermes install with `HERMES_HOME=/opt/data`, that meant the CLI could read an empty `~/.hermes/mnemosyne/data` database while the active provider was using `/opt/data/mnemosyne/data`.

The new order is:

1. `MNEMOSYNE_DATA_DIR`
2. `HERMES_HOME/mnemosyne/data`
3. `~/.hermes/mnemosyne/data`

I applied the same fallback to `scripts/mnemosyne-stats.py`, since it had the same default-path behavior.

## Testing

```bash
uv run --no-project \
  --with pytest --with pyyaml --with numpy --with sqlite-vec --with fastembed \
  --with python-dotenv --with cryptography --with requests \
  python -m pytest -q \
  tests/test_cli_data_dir_resolution.py \
  tests/test_cli_stats.py \
  tests/test_cli_errors.py \
  tests/test_cli_operation_failures.py \
  tests/test_cli_usage_errors.py \
  tests/test_mnemosyne_stats.py
```

Result:

```text
58 passed in 79.27s
```