### PR TITLE
fix(hermes): use full import path for Mnemosyne in profile isolation

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -687,7 +687,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 # directory creation, canonical path resolution, and isolates
                 # memories per Hermes profile.
                 bank_name = self._resolve_profile_bank()
-                from mnemosyne import Mnemosyne
+                from mnemosyne.core.memory import Mnemosyne
                 mem = Mnemosyne(
                     session_id=self._session_id,
                     bank=bank_name,


### PR DESCRIPTION
## Problem

When Hermes profile isolation is enabled, `hermes mnemosyne recall` (and all memory tools) crash on session start:

```
ImportError: cannot import name 'Mnemosyne' from 'mnemosyne'
```

`__init__.py:690` uses a shorthand import that fails with `mnemosyne-memory` >= 3.7.0 because the `Mnemosyne` class is not re-exported at the package level.

## Fix

Change line 690 from:

```python
from mnemosyne import Mnemosyne
```

to:

```python
from mnemosyne.core.memory import Mnemosyne
```

All other call sites in this file (lines 1533, 1571) already use the correct full path. This was the only outlier.

## Environment

- `mnemosyne-hermes` 0.1.8
- `mnemosyne-memory` 3.7.0
- Hermes v2026.6.5
- macOS, Python 3.11.15

## Reproduction

1. Enable profile isolation (default Hermes profile setup)
2. Run `hermes mnemosyne stats` or any memory tool
3. ImportError on session start

Related to #305