### PR TITLE
fix(beam): guard sqlite-vec table creation against embedding-dimension mismatch

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -482,6 +482,34 @@ def _detect_vec_type(conn: sqlite3.Connection) -> str:
     return "float32"
 
 
+def _existing_vec_dim(conn: sqlite3.Connection) -> Optional[int]:
+    """Return the embedding dimension already declared by a sqlite-vec table in
+    this database, or ``None`` if no ``vec0`` table exists yet.
+
+    A ``vec0`` virtual table fixes its dimension at creation time, encoded in its
+    DDL as ``embedding <type>[<dim>]``. When a store already holds vectors, that
+    declared dimension -- not the process's configured ``EMBEDDING_DIM`` -- is the
+    source of truth for what the stored data actually is. Reads only
+    ``sqlite_master`` (no extension required) so it is safe to call before the
+    sqlite-vec tables are (re)created.
+    """
+    try:
+        rows = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' "
+            "AND name IN ('vec_episodes', 'vec_working', 'vec_facts')"
+        ).fetchall()
+    except sqlite3.Error:
+        return None
+    for row in rows:
+        sql = row[0] if row else None
+        if not sql:
+            continue
+        match = re.search(r"\[(\d+)\]", sql)
+        if match:
+            return int(match.group(1))
+    return None
+
+
 def init_beam(db_path: Path = None):
     """Initialize BEAM schema."""
     conn = _get_connection(db_path)
@@ -675,20 +703,48 @@ def init_beam(db_path: Path = None):
     effective_vec_type = _detect_vec_type(conn)
 
     # --- sqlite-vec VIRTUAL TABLES ---
+    # Guard against a dimension mismatch: the dimension of a vec0 table is fixed
+    # at creation time, so if this database already stores vectors at one
+    # dimension and the process is configured (EMBEDDING_DIM, from
+    # MNEMOSYNE_EMBEDDING_DIM or the embedding model) for a different one, creating
+    # a new vec0 table at the configured dimension is silently wrong: every insert
+    # of a real (existing-dimension) vector then fails, and recall reads an
+    # empty/incompatible index. This bites most often when a store written by one
+    # model/dimension is later opened by a process that resolved a different
+    # EMBEDDING_DIM -- e.g. an invocation that did not inherit the same
+    # environment as the writer. Refuse to create mismatched tables, leave any
+    # existing ones untouched, and surface one actionable error instead of
+    # per-row insert noise; recall falls back to the float-JSON voice meanwhile.
+    vec_dim_mismatch = False
     if _SQLITE_VEC_AVAILABLE:
-        try:
-            cursor.execute(f"""
-                CREATE VIRTUAL TABLE IF NOT EXISTS vec_episodes USING vec0(
-                    embedding {effective_vec_type}[{EMBEDDING_DIM}]
-                )
-            """)
-            cursor.execute(f"""
-                CREATE VIRTUAL TABLE IF NOT EXISTS vec_working USING vec0(
-                    embedding {effective_vec_type}[{EMBEDDING_DIM}]
-                )
-            """)
-        except sqlite3.OperationalError:
-            pass  # May already exist or extension not loadable
+        existing_dim = _existing_vec_dim(conn)
+        if existing_dim is not None and existing_dim != EMBEDDING_DIM:
+            vec_dim_mismatch = True
+            logger.error(
+                "Embedding dimension mismatch: this database stores %d-dimensional "
+                "vectors, but the process is configured for %d "
+                "(MNEMOSYNE_EMBEDDING_DIM / embedding model). Not creating "
+                "sqlite-vec tables at the wrong dimension. Set "
+                "MNEMOSYNE_EMBEDDING_DIM / MNEMOSYNE_EMBEDDING_MODEL to match the "
+                "stored data, or run `mnemosyne reindex` to rebuild all vectors at "
+                "the configured dimension.",
+                existing_dim,
+                EMBEDDING_DIM,
+            )
+        else:
+            try:
+                cursor.execute(f"""
+                    CREATE VIRTUAL TABLE IF NOT EXISTS vec_episodes USING vec0(
+                        embedding {effective_vec_type}[{EMBEDDING_DIM}]
+                    )
+                """)
+                cursor.execute(f"""
+                    CREATE VIRTUAL TABLE IF NOT EXISTS vec_working USING vec0(
+                        embedding {effective_vec_type}[{EMBEDDING_DIM}]
+                    )
+                """)
+            except sqlite3.OperationalError:
+                pass  # May already exist or extension not loadable
 
     # --- FTS5 VIRTUAL TABLE for episodic ---
     cursor.execute("""
@@ -898,14 +954,15 @@ def init_beam(db_path: Path = None):
         WHERE superseded_by IS NULL""")
     cursor.execute("""CREATE INDEX IF NOT EXISTS idx_mem_emb_type
         ON memory_embeddings(memory_id, model)""")
-    try:
-        _backfill_vec_working_from_memory_embeddings(conn)
-    except NameError:
-        # During unusual import/bootstrap paths the helper may not be bound yet;
-        # normal BeamMemory construction can backfill on the next init call.
-        pass
-    except Exception:
-        logger.info("vec_working backfill skipped during init", exc_info=True)
+    if not vec_dim_mismatch:
+        try:
+            _backfill_vec_working_from_memory_embeddings(conn)
+        except NameError:
+            # During unusual import/bootstrap paths the helper may not be bound yet;
+            # normal BeamMemory construction can backfill on the next init call.
+            pass
+        except Exception:
+            logger.info("vec_working backfill skipped during init", exc_info=True)
 
     # --- Migration: multi-agent identity layer (v2.1) ---
     _add_column_if_missing(conn, "working_memory", "author_id", "TEXT DEFAULT NULL")
@@ -1003,15 +1060,18 @@ def init_beam(db_path: Path = None):
         END
     """)
 
-    # Vector table for facts (sqlite-vec)
-    try:
-        cursor.execute(f"""
-            CREATE VIRTUAL TABLE IF NOT EXISTS vec_facts USING vec0(
-                embedding {effective_vec_type}[{EMBEDDING_DIM}]
-            )
-        """)
-    except (sqlite3.OperationalError, RuntimeError):
-        pass  # sqlite-vec not available
+    # Vector table for facts (sqlite-vec). Skipped on a dimension mismatch for the
+    # same reason as vec_episodes / vec_working above (see the guard in the
+    # sqlite-vec VIRTUAL TABLES block).
+    if not vec_dim_mismatch:
+        try:
+            cursor.execute(f"""
+                CREATE VIRTUAL TABLE IF NOT EXISTS vec_facts USING vec0(
+                    embedding {effective_vec_type}[{EMBEDDING_DIM}]
+                )
+            """)
+        except (sqlite3.OperationalError, RuntimeError):
+            pass  # sqlite-vec not available
 
     # --- Temporal architecture migration ---
     _add_column_if_missing(conn, "working_memory", "event_date", "TEXT DEFAULT NULL")

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -1,0 +1,90 @@
+"""Tests for the sqlite-vec dimension-consistency guard in init_beam().
+
+The dimension of a sqlite-vec ``vec0`` table is fixed at creation time. If a
+database already stores vectors at one dimension and the process is later
+configured (EMBEDDING_DIM) for a different one, creating a new ``vec0`` table at
+the configured dimension is silently wrong: every insert of a real vector then
+fails and recall reads an empty/incompatible index. init_beam() must detect the
+established dimension from the database and refuse to create mismatched tables,
+leaving existing tables untouched, rather than corrupting the store.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import mnemosyne.core.beam as beam
+
+
+def test_existing_vec_dim_none_on_fresh_db(tmp_path):
+    """A database with no vec0 tables has no established dimension."""
+    conn = beam._get_connection(Path(tmp_path) / "fresh.db")
+    assert beam._existing_vec_dim(conn) is None
+
+
+def test_existing_vec_dim_reads_declared_dimension(tmp_path):
+    """The helper reads the dimension declared in a vec0 table's DDL."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        import pytest  # type: ignore
+
+        pytest.skip("sqlite-vec unavailable")
+    conn = beam._get_connection(Path(tmp_path) / "declared.db")
+    conn.execute("CREATE VIRTUAL TABLE vec_episodes USING vec0(embedding int8[768])")
+    conn.commit()
+    assert beam._existing_vec_dim(conn) == 768
+
+
+def test_init_beam_skips_vec_creation_on_dim_mismatch(tmp_path, monkeypatch):
+    """init_beam() must not create vec0 tables at a dimension that disagrees with
+    vectors already stored in the database, and must leave existing tables alone."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        import pytest  # type: ignore
+
+        pytest.skip("sqlite-vec unavailable")
+
+    db = Path(tmp_path) / "store.db"
+
+    # Initialize the store at dimension 768.
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
+    beam.init_beam(db)
+    conn = beam._get_connection(db)
+
+    # Simulate a database written before vec_working existed: only vec_episodes
+    # (at the real dimension, 768) remains.
+    conn.execute("DROP TABLE IF EXISTS vec_working")
+    conn.commit()
+    assert beam._existing_vec_dim(conn) == 768
+
+    # Reopen configured for a DIFFERENT dimension (the misconfiguration).
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+    beam.init_beam(db)
+
+    # The guard must NOT have created vec_working at the wrong dimension.
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'vec_working'"
+    ).fetchone()
+    assert row is None or "[384]" not in row[0]
+
+    # The existing data table is left untouched at its real dimension.
+    ep = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'vec_episodes'"
+    ).fetchone()
+    assert ep is not None and "[768]" in ep[0]
+
+
+def test_init_beam_creates_vec_tables_when_dim_matches(tmp_path, monkeypatch):
+    """When the configured dimension matches (or the DB is fresh), the vec0 tables
+    are created normally -- the guard must not be a false positive."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        import pytest  # type: ignore
+
+        pytest.skip("sqlite-vec unavailable")
+
+    db = Path(tmp_path) / "match.db"
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
+    beam.init_beam(db)
+    conn = beam._get_connection(db)
+
+    working = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'vec_working'"
+    ).fetchone()
+    assert working is not None and "[768]" in working[0]


### PR DESCRIPTION
## What

Guards sqlite-vec (`vec0`) table creation in `init_beam()` against an embedding-dimension mismatch. Fixes #334.

## Why

A `vec0` table's dimension is fixed at creation time. `init_beam()` created `vec_episodes` / `vec_working` / `vec_facts` at the process's configured `EMBEDDING_DIM` with **no check against the dimension already stored in the database**. Opening an existing store under a different configured dim silently creates wrong-dimension tables — after which every real-vector insert fails, recall reads an empty/incompatible index, and the open-time backfill logs one skip per row.

It's easiest to hit when a process opens the store **without the writer's environment** (a CLI/diagnostic invocation that didn't inherit `MNEMOSYNE_EMBEDDING_DIM` / model), or on the **3.8.0 upgrade**, where `vec_working` is created for the first time against an existing higher-dimension store. Full detail in #334.

## Change

- New helper `_existing_vec_dim(conn)` — reads the declared dimension from any existing `vec0` table's DDL via `sqlite_master` (no extension required, safe to call before the tables are (re)created). The stored data, not the env-derived `EMBEDDING_DIM`, is the source of truth.
- In `init_beam()` — if an established dim exists and differs from `EMBEDDING_DIM`: set `vec_dim_mismatch`, skip creating the vec tables, skip the backfill, leave existing tables untouched, and log **one** actionable error pointing at `mnemosyne reindex`.
- **Fail-soft (skip + log), not raise**: `mnemosyne reindex` opens the DB to repair it, so a hard error would make a mismatched store unrepairable. Recall falls back to the float-JSON voice meanwhile.

## Behavior / cost

- Fresh DBs and matching configurations: **unchanged**.
- Mismatch: no wrong-dim table created; a single clear error instead of per-row insert noise.
- Cost: one `sqlite_master` read at open. No recall/write hot-path impact.

## Tests

`tests/test_vec_dim_guard.py`:
- `_existing_vec_dim` returns the declared dim, and `None` on a fresh DB;
- `init_beam()` skips vec creation on a dim mismatch and leaves the existing table intact;
- `init_beam()` still creates the tables when the dim matches (guards against a false positive).

All four pass, and the existing `tests/test_reindex_vectors.py` still passes.

Opened as **draft** for maintainer review.
