### PR TITLE
fix(recovery): resolve default DB/backup paths from MNEMOSYNE_DATA_DIR / HERMES_HOME

### DIFF
--- a/mnemosyne/dr/recovery.py
+++ b/mnemosyne/dr/recovery.py
@@ -6,6 +6,7 @@ Comprehensive backup, restore, and integrity verification for Mnemosyne.
 
 import gzip
 import io
+import os
 import json
 import hashlib
 import shutil
@@ -16,9 +17,28 @@ from typing import Dict, List, Optional
 
 
 def get_default_paths():
-    """Get default Mnemosyne paths"""
-    data_dir = Path.home() / ".mnemosyne" / "data"
-    backup_dir = Path.home() / ".mnemosyne" / "backups"
+    """Get default Mnemosyne paths.
+
+    These MUST resolve to the same location the live store uses (see
+    ``mnemosyne.core.beam``), or backup/restore -- and ``mnemosyne reindex``'s
+    auto-backup -- operate on a different database than the one in use. The
+    precedence mirrors beam:
+
+    * data dir: ``MNEMOSYNE_DATA_DIR`` if set, else
+      ``$HERMES_HOME/mnemosyne/data`` (``HERMES_HOME`` defaults to ``~/.hermes``).
+    * backups: ``MNEMOSYNE_BACKUP_DIR`` if set, else a ``backups`` dir alongside
+      the data dir.
+
+    Previously this hardcoded ``~/.mnemosyne/data``, which disagreed with the
+    store whenever ``MNEMOSYNE_DATA_DIR`` or ``HERMES_HOME`` was set, so
+    operations failed with "Database not found".
+    """
+    if os.environ.get("MNEMOSYNE_DATA_DIR"):
+        data_dir = Path(os.environ["MNEMOSYNE_DATA_DIR"])
+    else:
+        root = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        data_dir = root / "mnemosyne" / "data"
+    backup_dir = Path(os.environ.get("MNEMOSYNE_BACKUP_DIR", data_dir.parent / "backups"))
     db_path = data_dir / "mnemosyne.db"
     return data_dir, backup_dir, db_path
 

--- a/tests/test_recovery_paths.py
+++ b/tests/test_recovery_paths.py
@@ -1,0 +1,49 @@
+"""Tests for recovery.get_default_paths() honoring the same path configuration
+as the live store (mnemosyne.core.beam).
+
+The disaster-recovery helpers (backup/restore, and `mnemosyne reindex`'s
+auto-backup) must resolve the database to the same location the store actually
+uses. Previously they hardcoded ``~/.mnemosyne/data`` and ignored
+MNEMOSYNE_DATA_DIR / HERMES_HOME, so they operated on (or failed to find) the
+wrong database.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from mnemosyne.dr import recovery
+
+
+def test_get_default_paths_honors_data_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.delenv("MNEMOSYNE_BACKUP_DIR", raising=False)
+    data_dir, backup_dir, db_path = recovery.get_default_paths()
+    assert data_dir == tmp_path / "data"
+    assert db_path == tmp_path / "data" / "mnemosyne.db"
+    # backups land alongside the data dir, not under ~/.mnemosyne
+    assert backup_dir == tmp_path / "backups"
+
+
+def test_get_default_paths_honors_hermes_home(monkeypatch, tmp_path):
+    monkeypatch.delenv("MNEMOSYNE_DATA_DIR", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_BACKUP_DIR", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    data_dir, backup_dir, db_path = recovery.get_default_paths()
+    assert data_dir == tmp_path / "home" / "mnemosyne" / "data"
+    assert db_path == data_dir / "mnemosyne.db"
+    assert backup_dir == tmp_path / "home" / "mnemosyne" / "backups"
+
+
+def test_get_default_paths_backup_dir_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("MNEMOSYNE_BACKUP_DIR", str(tmp_path / "custom_backups"))
+    _, backup_dir, _ = recovery.get_default_paths()
+    assert backup_dir == tmp_path / "custom_backups"
+
+
+def test_get_default_paths_data_dir_takes_precedence_over_hermes_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "explicit"))
+    data_dir, _, db_path = recovery.get_default_paths()
+    assert data_dir == tmp_path / "explicit"
+    assert db_path == tmp_path / "explicit" / "mnemosyne.db"


### PR DESCRIPTION
## What

Make the disaster-recovery helpers resolve the database/backup paths from the same configuration the live store uses. Fixes the secondary issue noted in #334.

## Why

`recovery.get_default_paths()` hardcoded `~/.mnemosyne/data` and ignored both `MNEMOSYNE_DATA_DIR` and `HERMES_HOME`. The live store (`mnemosyne.core.beam`) resolves the database to `$MNEMOSYNE_DATA_DIR`, else `$HERMES_HOME/mnemosyne/data` (with `HERMES_HOME` defaulting to `~/.hermes`).

So whenever `MNEMOSYNE_DATA_DIR` / `HERMES_HOME` is set, backup/restore — and `mnemosyne reindex`'s auto-backup — operated on a *different* path than the store actually uses. Concretely, `mnemosyne reindex` aborts with:

```
Error: Backup failed (use --no-backup to skip): Database not found: <home>/.mnemosyne/data/mnemosyne.db
```

even though the real database is at the configured `MNEMOSYNE_DATA_DIR`.

## Change

`get_default_paths()` now mirrors beam's precedence:

- **data dir**: `MNEMOSYNE_DATA_DIR` if set, else `$HERMES_HOME/mnemosyne/data` (`HERMES_HOME` defaults to `~/.hermes`);
- **backups**: `MNEMOSYNE_BACKUP_DIR` if set, else a `backups/` dir alongside the data dir (previously `~/.mnemosyne/backups`, disconnected from the data tree).

All `get_default_paths()` callers (`create_backup`, `restore_backup`, `list_backups`, integrity checks) inherit the corrected resolution.

## Note for review

This also moves the default **backup** location to sit next to the data dir (instead of `~/.mnemosyne/backups`), so backups live in the same tree as the data they protect and follow `HERMES_HOME`/`MNEMOSYNE_DATA_DIR`. `MNEMOSYNE_BACKUP_DIR` is available if a separate location is preferred. Happy to drop that part and only fix the db-path resolution if you'd rather keep the backup default unchanged.

## Tests

`tests/test_recovery_paths.py`: `MNEMOSYNE_DATA_DIR` and `HERMES_HOME` are honored, `MNEMOSYNE_DATA_DIR` takes precedence, and `MNEMOSYNE_BACKUP_DIR` overrides the backup dir. All pass.

Opened as draft for review.
