### PR TITLE
fix(sync): correct try/except/else structure in push_changes

### DIFF
--- a/mnemosyne/core/sync.py
+++ b/mnemosyne/core/sync.py
@@ -1004,29 +1004,29 @@ class SyncEngine:
                                     memory_id=ev.memory_id,
                                 )
                                 stats["accepted"] += 1
+                            else:
+                                # Fallback: direct DeltaSync
+                                delta_item: Dict[str, Any] = {"id": ev.memory_id}
+                                for key in ("content", "importance", "source", "memory_type", "veracity"):
+                                    if payload_dict and key in payload_dict:
+                                        delta_item[key] = payload_dict[key]
+                                if self._delta_sync is not None:
+                                    apply_stats = self._delta_sync.apply_delta(
+                                        peer_id=ev.device_id,
+                                        delta=[delta_item],
+                                        table="working_memory",
+                                    )
+                                    if apply_stats.get("inserted") or apply_stats.get("updated"):
+                                        stats["accepted"] += 1
+                                    else:
+                                        stats["details"].append(
+                                            f"event {ev.event_id}: no rows affected"
+                                        )
+                                else:
+                                    stats["accepted"] += 1
                         except KeyboardInterrupt:
                             stats["interrupted"] = True
                             break
-                        else:
-                            # Fallback: direct DeltaSync
-                            delta_item: Dict[str, Any] = {"id": ev.memory_id}
-                            for key in ("content", "importance", "source", "memory_type", "veracity"):
-                                if payload_dict and key in payload_dict:
-                                    delta_item[key] = payload_dict[key]
-                            if self._delta_sync is not None:
-                                apply_stats = self._delta_sync.apply_delta(
-                                    peer_id=ev.device_id,
-                                    delta=[delta_item],
-                                    table="working_memory",
-                                )
-                                if apply_stats.get("inserted") or apply_stats.get("updated"):
-                                    stats["accepted"] += 1
-                                else:
-                                    stats["details"].append(
-                                        f"event {ev.event_id}: no rows affected"
-                                    )
-                            else:
-                                stats["accepted"] += 1
                     else:
                         # No content — just log the event
                         stats["accepted"] += 1


### PR DESCRIPTION
## Summary

Commit `12b85b8` ("fix(sync): progress indicator + graceful Ctrl+C handling") introduced a control-flow bug in `push_changes()`.

The DeltaSync fallback `else:` ended up attached to the outer `try/except KeyboardInterrupt` instead of the inner `if self._beam.remember` branch. This caused every successful `remember()` call to also execute the fallback path.

Result: double-counted `accepted` stats and duplicate memory writes via DeltaSync on every CREATE.

## Affected tests

- `test_push_routes_through_remember_pipeline`
- `test_push_deduplicates_by_hash`

Both expect `accepted == 1`, but were getting `accepted == 2`.

## Fix

Re-attach the `else:` to the correct `if/else` inside the `try` block, so the DeltaSync fallback only runs when `remember()` is not available.

KeyboardInterrupt handling is preserved.

## Notes

- This bug lives on `main` (introduced by `12b85b8`).
- The fix is already included in PR #340.
- Recommend cherry-picking this onto `main` so CI goes green again.

(cherry picked from the fix included in PR #340)