### PR TITLE
fix(recall): admit inflected Cyrillic forms past the lexical relevance gate

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1694,6 +1694,13 @@ def _lexical_relevance(query_tokens: List[str], content: str, query_lower: str =
                 or "\uac00" <= ch <= "\ud7af"
             }
             score = len(query_cjk & content_cjk) / len(query_cjk)
+        elif _has_cyrillic(query_lower):
+            # Cyrillic inflected forms (тёмная/тёмную, резервная/резервное)
+            # defeat exact token matching. _cyrillic_score uses trigram
+            # Jaccard, which handles inflection correctly. The scoring
+            # pipeline already uses _cyrillic_like_search for candidate
+            # generation; this keeps the relevance gate consistent.
+            score = _cyrillic_score(query_lower, content_lower)
 
     return min(score, 1.0)
 

--- a/tests/test_cyrillic_fts.py
+++ b/tests/test_cyrillic_fts.py
@@ -38,6 +38,8 @@ from mnemosyne.core.beam import (
     _cyrillic_like_search,
     _fts_search,
     _fts_search_working,
+    _lexical_relevance,
+    _recall_tokens,
 )
 
 
@@ -350,3 +352,61 @@ class TestFtsSearchRoutesCyrillic:
         finally:
             conn.close()
         assert any(r["id"] == "m1" for r in rows)
+
+
+class TestLexicalRelevanceCyrillicGate:
+    """Verify the relevance gate admits inflected Cyrillic forms.
+
+    Before this fix, `_lexical_relevance` returned 0.0 for short inflected
+    Cyrillic queries (тёмная vs тёмную) because exact token matching
+    cannot span Russian case endings. The scoring pipeline generated the
+    candidate via `_cyrillic_like_search` (LIKE + trigram Jaccard) but
+    then dropped it at the relevance gate, so the recall returned 0
+    results for the very queries Cyrillic users actually type.
+    """
+
+    def test_inflected_query_passes_gate(self):
+        # Nominative "тёмная тема" vs accusative "тёмную тему":
+        # exact match returns 0.0; Cyrillic fallback returns trigram
+        # Jaccard, which should be > the 0.15 threshold for a 2-token
+        # query.
+        q = "тёмная тема"
+        content = "Пользователь предпочитает тёмную тему интерфейса"
+        rel = _lexical_relevance(_recall_tokens(q), content, q)
+        cyr_score = _cyrillic_score(q, content)
+        assert rel > 0.0, f"gate returned 0.0 for inflected Cyrillic (cyr_score={cyr_score})"
+        assert rel == pytest.approx(cyr_score), "fallback should mirror _cyrillic_score"
+
+    def test_exact_form_still_full_score(self):
+        # When the query and content use the same surface form, the
+        # exact-token path should still return 1.0 and not get diluted
+        # by the Cyrillic fallback.
+        q = "тёмную тему"
+        content = "Пользователь предпочитает тёмную тему интерфейса"
+        rel = _lexical_relevance(_recall_tokens(q), content, q)
+        assert rel == pytest.approx(1.0)
+
+    def test_english_query_unaffected(self):
+        # Non-Cyrillic queries must not engage the Cyrillic fallback.
+        q = "dark mode"
+        content = "User prefers dark mode interfaces"
+        rel = _lexical_relevance(_recall_tokens(q), content, q)
+        assert rel == pytest.approx(1.0)
+
+    def test_latin_query_against_cyrillic_content_returns_zero(self):
+        # Latin query vs Cyrillic content: no token overlap, no Cyrillic
+        # in query, so neither path fires. The fallback would be wrong
+        # if it engaged here.
+        q = "dark mode"
+        content = "Пользователь предпочитает тёмную тему"
+        rel = _lexical_relevance(_recall_tokens(q), content, q)
+        assert rel == 0.0
+
+    def test_second_decline_inflection_passes_gate(self):
+        # "резервная копия" vs "Резервное копирование": the second
+        # word's inflection (копия -> копирование) also defeats exact
+        # matching. The Cyrillic fallback should still admit this.
+        q = "резервная копия"
+        content = "Резервное копирование Яндекс Диска включено по расписанию"
+        rel = _lexical_relevance(_recall_tokens(q), content, q)
+        assert rel > 0.0, f"gate returned 0.0 for inflected Cyrillic (rel={rel})"


### PR DESCRIPTION
Fixes #341.

## Problem

The lexical relevance gate in `_lexical_relevance` returned 0.0 for short inflected Cyrillic queries (тёмная vs тёмную, резервная vs резервное) because exact token matching cannot span Russian case endings.

The scoring pipeline already generated the candidate via `_cyrillic_like_search` (LIKE + trigram Jaccard), but the gate then dropped the candidate, so `recall()` returned 0 results for the very queries Cyrillic users actually type.

## Fix

Add a Cyrillic fallback inside `_lexical_relevance`, mirroring the existing CJK fallback that already lives at the bottom of the function. When the query contains Cyrillic and the exact-token path returns 0, use `_cyrillic_score` (trigram Jaccard) so the relevance gate stays consistent with `_cyrillic_like_search`.

The change is contained: one `elif` branch inside the existing fallback block. All 5 call sites of `_lexical_relevance` benefit (working memory gate, episodic memory gate, and the MEMORIA relevance path).

## Reproduction before the fix

```python
recall("тёмная тема")   # → 0 results (missed)
recall("тёмную тему")   # → 1 result
```

## After

```python
recall("тёмная тема")   # → 1 result, _cyrillic_score = 0.333, passes 0.15 threshold
recall("тёмную тему")   # → 1 result, exact match, score = 1.0
```

## Tests

Added a new `TestLexicalRelevanceCyrillicGate` class in `tests/test_cyrillic_fts.py`:

- inflected query passes the gate
- exact form still returns full score (no dilution)
- English query unaffected
- Latin query against Cyrillic content returns zero (no false positives)
- second-declension inflection (резервная копия vs Резервное копирование) passes

All 32 tests in `test_cyrillic_fts.py` pass, plus 99 recall precision regression tests.

## Credit

Diagnosis and suggested fix path from @rvboris in #341. I picked this up because the issue was filed without a follow-up PR after the offer, and the fix is contained enough to ship fast. rvboris is credited here for the root cause analysis and the suggested gate shape.