### PR TITLE
fix(hermes): tell agent to read Mnemosyne context before retrieval

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1560,7 +1560,12 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 "Active (native local memory). Use mnemosyne_remember to store ANY "
                 "durable fact, preference, identity, or insight. Use mnemosyne_recall to search. "
                 "Use mnemosyne_shared_* tools for manual shared surface CRUD. "
-                "The legacy memory tool is deprecated for durable storage — Mnemosyne is primary."
+                "The legacy memory tool is deprecated for durable storage — Mnemosyne is primary.\n"
+                "\n"
+                "When a `## Mnemosyne Context` block is injected into the current turn, "
+                "read it before calling retrieval tools. If it answers the user's question, "
+                "answer directly. Use session_search only when the injected Mnemosyne "
+                "context is missing, stale, or insufficient."
             )
         # C27: when init failed (as opposed to a deliberate skip-context),
         # surface the failure in the system prompt so the agent -- and through

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -881,7 +881,12 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 "mnemosyne_validate/invalidate/update/forget for provenance, corrections, stale facts, and cleanup; "
                 "mnemosyne_scratchpad_* for temporary working notes; "
                 "mnemosyne_shared_* only for compact cross-agent stable metadata, never raw conversation.\n"
-                "Prefer compact, declarative, non-imperative memories. Do not save one-off task progress."
+                "Prefer compact, declarative, non-imperative memories. Do not save one-off task progress.\n"
+                "\n"
+                "When a `## Mnemosyne Context` block is injected into the current turn, "
+                "read it before calling retrieval tools. If it answers the user's question, "
+                "answer directly. Use session_search only when the injected Mnemosyne "
+                "context is missing, stale, or insufficient."
             )
         # C27: when init failed (as opposed to a deliberate skip-context),
         # surface the failure in the system prompt so the agent -- and through

--- a/integrations/hermes/tests/test_system_prompt.py
+++ b/integrations/hermes/tests/test_system_prompt.py
@@ -20,3 +20,23 @@ def test_system_prompt_routes_to_structured_mnemosyne_surfaces():
     assert "mnemosyne_scratchpad_*" in block
     assert "mnemosyne_shared_*" in block
     assert "Do not save one-off task progress" in block
+
+
+def test_system_prompt_tells_agent_to_read_mnemosyne_context_first():
+    """Pin the rule added in #321.
+
+    The Mnemosyne context block is injected into the turn and the agent
+    should answer from it before reaching for session_search. Without
+    this standing rule, the agent defaults to retrieval tools out of
+    habit and wastes a turn.
+    """
+    provider = MnemosyneMemoryProvider()
+    provider._beam = object()
+
+    block = provider.system_prompt_block()
+
+    assert "## Mnemosyne Context" in block
+    assert "read it before calling retrieval tools" in block
+    assert "answer directly" in block
+    assert "session_search" in block
+    assert "missing, stale, or insufficient" in block

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -298,3 +298,16 @@ class TestUnavailableGuard:
         provider = MnemosyneMemoryProvider()
         provider._beam = None
         assert provider.system_prompt_block() == ""
+
+    def test_system_prompt_tells_agent_to_read_mnemosyne_context_first(self):
+        """Pin the rule added in #321 on the legacy provider path."""
+        provider = MnemosyneMemoryProvider()
+        provider._beam = object()
+
+        block = provider.system_prompt_block()
+
+        assert "## Mnemosyne Context" in block
+        assert "read it before calling retrieval tools" in block
+        assert "answer directly" in block
+        assert "session_search" in block
+        assert "missing, stale, or insufficient" in block


### PR DESCRIPTION
Fixes #321.

## Problem

The Mnemosyne context block is injected into the turn and is often sufficient to answer the user's question. The agent defaults to retrieval tools out of habit, fires `session_search()`, and only then acknowledges the answer was already in the injected block. Wasted turn, wasted tokens.

## Fix

Add a short standing rule to `MnemosyneMemoryProvider.system_prompt_block()` on both provider paths:

```
When a ## Mnemosyne Context block is injected into the current turn,
read it before calling retrieval tools. If it answers the user's
question, answer directly. Use session_search only when the injected
Mnemosyne context is missing, stale, or insufficient.
```

Wording per dplush's suggested shape in #321. Short enough to keep in the standing prompt without inflating per-turn tokens, and leaves the `prefetch()` output as raw context (no Hermes-specific tags emitted from Mnemosyne).

## Files changed

- `integrations/hermes/src/mnemosyne_hermes/__init__.py` — new provider path
- `hermes_memory_provider/__init__.py` — legacy provider path
- `integrations/hermes/tests/test_system_prompt.py` — pin the rule on the new path
- `tests/test_provider_all_15_tools.py` — pin the rule on the legacy path

The init-failed and skip-context branches are unchanged. The rule only applies when the provider is active.

## Tests

Two new tests pin the rule on each provider path. All 33 tests across `test_system_prompt.py` and `test_provider_all_15_tools.py` pass.

## Credit

Diagnosis and suggested wording from @dplush in #321. I picked this up because I committed to shipping it in the original issue thread and the dplush-shaped fix is small and contained. dplush is credited here for the implementation shape.