### PR TITLE
test(hermes): add provider parity coverage

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -961,6 +961,22 @@ try:
 except Exception:  # pragma: no cover - sync extras are optional at import time
     ALL_SYNC_TOOL_SCHEMAS = []
 
+try:
+    from hermes_memory_provider.persona_tools import (
+        PERSONA_PROMOTE_SCHEMA,
+        PERSONA_DEMOTE_SCHEMA,
+        PERSONA_LIST_SCHEMA,
+        PERSONA_REINFORCE_SCHEMA,
+    )
+    ALL_PERSONA_TOOL_SCHEMAS = [
+        PERSONA_PROMOTE_SCHEMA,
+        PERSONA_DEMOTE_SCHEMA,
+        PERSONA_LIST_SCHEMA,
+        PERSONA_REINFORCE_SCHEMA,
+    ]
+except Exception:  # pragma: no cover - persona extras are optional at import time
+    ALL_PERSONA_TOOL_SCHEMAS = []
+
 ALL_TOOL_SCHEMAS = [
     REMEMBER_SCHEMA, RECALL_SCHEMA, SHARED_REMEMBER_SCHEMA, SHARED_RECALL_SCHEMA,
     SHARED_FORGET_SCHEMA, SHARED_STATS_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
@@ -971,6 +987,7 @@ ALL_TOOL_SCHEMAS = [
     EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
     GRAPH_QUERY_SCHEMA, GRAPH_LINK_SCHEMA,
     *ALL_SYNC_TOOL_SCHEMAS,
+    *ALL_PERSONA_TOOL_SCHEMAS,
 ]
 
 
@@ -1999,6 +2016,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_graph_link(args)
             elif tool_name.startswith("mnemosyne_sync_"):
                 return self._handle_sync_tool(tool_name, args)
+            elif tool_name.startswith("mnemosyne_persona_"):
+                return self._handle_persona_tool(tool_name, args)
             else:
                 return json.dumps({"error": f"Unknown Mnemosyne tool: {tool_name}"})
         except Exception as e:
@@ -2014,7 +2033,24 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 self._sync_adapter = adapter
             return adapter.handle_tool_call(tool_name, args)
         except Exception as exc:
-            return json.dumps({"status": "error", "error": f"Sync adapter unavailable: {exc}"})
+            return json.dumps({
+                "status": "error",
+                "error": f"Sync adapter unavailable: {exc}",
+            })
+
+    def _handle_persona_tool(self, tool_name: str, args: Dict[str, Any]) -> str:
+        try:
+            adapter = getattr(self, "_persona_adapter", None)
+            if adapter is None:
+                from hermes_memory_provider.persona_adapter import PersonaAdapter
+                adapter = PersonaAdapter(self._beam, {})
+                self._persona_adapter = adapter
+            return adapter.handle_tool_call(tool_name, args)
+        except Exception as exc:
+            return json.dumps({
+                "status": "error",
+                "error": f"Persona adapter unavailable: {exc}",
+            })
 
     def _handle_remember(self, args: Dict[str, Any]) -> str:
         # Import at call-site so the provider module loads even when

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -103,6 +103,40 @@ def _prefetch_content_char_limit() -> int:
         return 0
 
 
+
+def _sync_turn_user_limit() -> int:
+    """Return the per-turn user content truncation limit.
+
+    ``0`` means no truncation. Defaults to 500 characters for backward
+    compatibility. Set ``MNEMOSYNE_SYNC_TURN_USER_LIMIT`` to override.
+    """
+    raw = os.environ.get("MNEMOSYNE_SYNC_TURN_USER_LIMIT", "500").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning(
+            "Invalid MNEMOSYNE_SYNC_TURN_USER_LIMIT=%r; using default 500",
+            raw,
+        )
+        return 500
+
+
+def _sync_turn_assistant_limit() -> int:
+    """Return the per-turn assistant content truncation limit.
+
+    ``0`` means no truncation. Defaults to 800 characters for backward
+    compatibility. Set ``MNEMOSYNE_SYNC_TURN_ASSISTANT_LIMIT`` to override.
+    """
+    raw = os.environ.get("MNEMOSYNE_SYNC_TURN_ASSISTANT_LIMIT", "800").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning(
+            "Invalid MNEMOSYNE_SYNC_TURN_ASSISTANT_LIMIT=%r; using default 800",
+            raw,
+        )
+        return 800
+
 def _format_prefetch_content(content: str, limit: int) -> str:
     """Format recalled memory content for prompt injection.
 
@@ -529,6 +563,11 @@ SLEEP_SCHEMA = {
                 "description": "If true, report what would be consolidated without writing changes.",
                 "default": False,
             },
+            "force": {
+                "type": "boolean",
+                "description": "If true, skip the age threshold and consolidate all non-consolidated working memories immediately.",
+                "default": False,
+            },
         },
     },
 }
@@ -546,7 +585,7 @@ INVALIDATE_SCHEMA = {
     "name": "mnemosyne_invalidate",
     "description": (
         "Mark a memory as expired or superseded. Provide memory_id from recall results. "
-        "Optionally provide replacement_id to chain old → new."
+        "Optionally provide replacement_id to chain old to new."
     ),
     "parameters": {
         "type": "object",
@@ -917,6 +956,11 @@ GRAPH_LINK_SCHEMA = {
     },
 }
 
+try:
+    from hermes_memory_provider.sync_adapter import ALL_SYNC_TOOL_SCHEMAS
+except Exception:  # pragma: no cover - sync extras are optional at import time
+    ALL_SYNC_TOOL_SCHEMAS = []
+
 ALL_TOOL_SCHEMAS = [
     REMEMBER_SCHEMA, RECALL_SCHEMA, SHARED_REMEMBER_SCHEMA, SHARED_RECALL_SCHEMA,
     SHARED_FORGET_SCHEMA, SHARED_STATS_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
@@ -926,6 +970,7 @@ ALL_TOOL_SCHEMAS = [
     SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
     EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
     GRAPH_QUERY_SCHEMA, GRAPH_LINK_SCHEMA,
+    *ALL_SYNC_TOOL_SCHEMAS,
 ]
 
 
@@ -1790,8 +1835,10 @@ class MnemosyneMemoryProvider(MemoryProvider):
             return
         try:
             if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
+                user_limit = _sync_turn_user_limit()
+                uc = user_content[:user_limit] if user_limit > 0 else user_content
                 self._beam.remember(
-                    content=f"[USER] {user_content[:500]}",
+                    content=f"[USER] {uc}",
                     source="conversation",
                     importance=0.5,
                     scope=self._default_scope,
@@ -1799,8 +1846,10 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 )
                 self._capture_identity_signals(user_content)
             if "assistant" in self._sync_roles and assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
+                assistant_limit = _sync_turn_assistant_limit()
+                ac = assistant_content[:assistant_limit] if assistant_limit > 0 else assistant_content
                 self._beam.remember(
-                    content=f"[ASSISTANT] {assistant_content[:800]}",
+                    content=f"[ASSISTANT] {ac}",
                     source="conversation",
                     importance=0.15,
                     scope=self._default_scope,
@@ -1948,11 +1997,24 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_graph_query(args)
             elif tool_name == "mnemosyne_graph_link":
                 return self._handle_graph_link(args)
+            elif tool_name.startswith("mnemosyne_sync_"):
+                return self._handle_sync_tool(tool_name, args)
             else:
                 return json.dumps({"error": f"Unknown Mnemosyne tool: {tool_name}"})
         except Exception as e:
             logger.error("Mnemosyne tool %s failed: %s", tool_name, e)
             return json.dumps({"error": f"Mnemosyne tool '{tool_name}' failed: {e}"})
+
+    def _handle_sync_tool(self, tool_name: str, args: Dict[str, Any]) -> str:
+        try:
+            adapter = getattr(self, "_sync_adapter", None)
+            if adapter is None:
+                from hermes_memory_provider.sync_adapter import SyncAdapter
+                adapter = SyncAdapter(self._beam, {})
+                self._sync_adapter = adapter
+            return adapter.handle_tool_call(tool_name, args)
+        except Exception as exc:
+            return json.dumps({"status": "error", "error": f"Sync adapter unavailable: {exc}"})
 
     def _handle_remember(self, args: Dict[str, Any]) -> str:
         # Import at call-site so the provider module loads even when
@@ -2186,11 +2248,12 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if skip is not None:
             return json.dumps(skip)
         dry_run = bool(args.get("dry_run", False))
+        force = bool(args.get("force", False))
         all_sessions = bool(args.get("all_sessions", False))
         if all_sessions and hasattr(self._beam, "sleep_all_sessions"):
-            result = self._beam.sleep_all_sessions(dry_run=dry_run)
+            result = self._beam.sleep_all_sessions(dry_run=dry_run, force=force)
         else:
-            result = self._beam.sleep(dry_run=dry_run)
+            result = self._beam.sleep(dry_run=dry_run, force=force)
         working = self._beam.get_working_stats()
         episodic = self._beam.get_episodic_stats()
         if not dry_run:

--- a/hermes_memory_provider/persona_adapter.py
+++ b/hermes_memory_provider/persona_adapter.py
@@ -1,0 +1,208 @@
+"""
+Persona adapter for the hermes_memory_provider package (v3.10.0).
+
+Exposes the L3 persona tier as 4 tools:
+- mnemosyne_persona_promote(memory_id, tier, reason)
+- mnemosyne_persona_demote(persona_id, reason)
+- mnemosyne_persona_list(tier, topic)
+- mnemosyne_persona_reinforce(persona_id)
+
+All operations hit the memoria_persona table directly. No LLM dependency
+in the default path (rule-based extraction is a separate concern).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+VALID_TIERS = ("permanent", "long_term", "working")
+
+
+class PersonaAdapter:
+    """Standalone persona adapter wrapping memoria_persona CRUD."""
+
+    def __init__(self, beam_instance=None, config: Optional[Dict[str, Any]] = None):
+        self._beam = beam_instance
+        self._config = config or {}
+        self._local_beam = None
+        if self._beam is None:
+            try:
+                from mnemosyne.core.beam import BeamMemory
+                self._local_beam = BeamMemory(session_id="persona-adapter")
+            except Exception as exc:
+                logger.debug("PersonaAdapter could not lazy-init BeamMemory: %s", exc)
+
+    @property
+    def is_ready(self) -> bool:
+        return self._beam is not None or self._local_beam is not None
+
+    def _conn(self):
+        return (self._beam or self._local_beam).conn
+
+    def handle_tool_call(self, tool_name: str, args: dict) -> str:
+        if not self.is_ready:
+            return json.dumps({
+                "status": "error",
+                "error": "PersonaAdapter not initialized (no beam instance).",
+            })
+        try:
+            if tool_name == "mnemosyne_persona_promote":
+                return self._promote(**args)
+            elif tool_name == "mnemosyne_persona_demote":
+                return self._demote(**args)
+            elif tool_name == "mnemosyne_persona_list":
+                return self._list(**args)
+            elif tool_name == "mnemosyne_persona_reinforce":
+                return self._reinforce(**args)
+        except Exception as exc:
+            return json.dumps({"status": "error", "error": str(exc)})
+        return json.dumps({"status": "error", "error": f"Unknown tool: {tool_name}"})
+
+    def _promote(self, memory_id: str = "", tier: str = "long_term",
+                 reason: str = "") -> str:
+        if tier not in VALID_TIERS:
+            return json.dumps({
+                "status": "error",
+                "error": f"Invalid tier {tier!r}. Must be one of: {VALID_TIERS}",
+            })
+        # Look up the source memory to extract content. Working memory has no
+        # 'topic' column -- topic is derived from memoria_timelines where
+        # available, otherwise we fall back to a generic label.
+        content = ""
+        topic = ""
+        try:
+            row = self._conn().execute(
+                "SELECT content FROM working_memory WHERE id = ?",
+                (memory_id,),
+            ).fetchone()
+            if row is None:
+                row = self._conn().execute(
+                    "SELECT content FROM episodic_memory WHERE id = ?",
+                    (memory_id,),
+                ).fetchone()
+            if row is not None:
+                content = row[0] or ""
+            # Try to derive a topic from memoria_timelines (best effort).
+            tl = self._conn().execute(
+                "SELECT topic FROM memoria_timelines WHERE source_memory_id = ? LIMIT 1",
+                (memory_id,),
+            ).fetchone()
+            if tl is not None:
+                topic = tl[0] or ""
+        except Exception:
+            pass
+        if not content:
+            return json.dumps({
+                "status": "error",
+                "error": f"Source memory {memory_id!r} not found.",
+            })
+        if not topic:
+            topic = "general"
+        cur = self._conn().execute(
+            "INSERT INTO memoria_persona (tier, topic, content, source_memory_id, promotion_reason) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (tier, topic, content, memory_id, reason),
+        )
+        persona_id = cur.lastrowid
+        return json.dumps({
+            "status": "ok",
+            "persona_id": persona_id,
+            "tier": tier,
+            "topic": topic,
+        })
+
+    def _demote(self, persona_id: int = 0, reason: str = "") -> str:
+        # Demotion = delete from persona tier (caller decides what to do next).
+        # We keep a record by writing into memoria_preferences as a tombstone.
+        cur = self._conn().execute(
+            "SELECT topic, content, tier FROM memoria_persona WHERE id = ?",
+            (persona_id,),
+        ).fetchone()
+        if cur is None:
+            return json.dumps({
+                "status": "error",
+                "error": f"Persona id {persona_id} not found.",
+            })
+        topic, content, tier = cur
+        self._conn().execute(
+            "INSERT INTO memoria_preferences (preference, topic, evolution, context_snippet, source_memory_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                f"[demoted from {tier}] {content}",
+                topic,
+                f"demoted: {reason}" if reason else "demoted",
+                "",
+                f"persona:{persona_id}",
+            ),
+        )
+        self._conn().execute(
+            "DELETE FROM memoria_persona WHERE id = ?",
+            (persona_id,),
+        )
+        return json.dumps({
+            "status": "ok",
+            "persona_id": persona_id,
+            "demoted_to": "memoria_preferences",
+        })
+
+    def _list(self, tier: Optional[str] = None, topic: Optional[str] = None) -> str:
+        sql = (
+            "SELECT id, tier, topic, content, confidence, reinforcement_count, last_reinforced_at "
+            "FROM memoria_persona"
+        )
+        clauses = []
+        params: List[Any] = []
+        if tier is not None:
+            clauses.append("tier = ?")
+            params.append(tier)
+        if topic is not None:
+            clauses.append("topic = ?")
+            params.append(topic)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        # Custom tier ordering: permanent > long_term > working. Alphabetical
+        # sort would put 'long_term' before 'permanent', which is wrong for
+        # always-on injection priority.
+        sql += (
+            " ORDER BY CASE tier "
+            "WHEN 'permanent' THEN 0 "
+            "WHEN 'long_term' THEN 1 "
+            "WHEN 'working' THEN 2 "
+            "ELSE 3 END, "
+            "reinforcement_count DESC, id ASC"
+        )
+        rows = self._conn().execute(sql, params).fetchall()
+        out = []
+        for r in rows:
+            out.append({
+                "id": r[0],
+                "tier": r[1],
+                "topic": r[2],
+                "content": r[3],
+                "confidence": r[4],
+                "reinforcement_count": r[5],
+                "last_reinforced_at": r[6],
+            })
+        return json.dumps({"status": "ok", "count": len(out), "personas": out})
+
+    def _reinforce(self, persona_id: int = 0) -> str:
+        cur = self._conn().execute(
+            "UPDATE memoria_persona SET reinforcement_count = reinforcement_count + 1, "
+            "last_reinforced_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (persona_id,),
+        )
+        if cur.rowcount == 0:
+            return json.dumps({
+                "status": "error",
+                "error": f"Persona id {persona_id} not found.",
+            })
+        return json.dumps({
+            "status": "ok",
+            "persona_id": persona_id,
+            "reinforced": True,
+        })

--- a/hermes_memory_provider/persona_tools.py
+++ b/hermes_memory_provider/persona_tools.py
@@ -1,0 +1,105 @@
+"""Tool schemas for the L3 persona layer (v3.10.0).
+
+4 tools: promote, demote, list, reinforce.
+All schema names follow mnemosyne_persona_* convention used elsewhere
+in the provider. Schemas are JSON-schema-compatible for the Hermes
+tool dispatch surface.
+"""
+
+PERSONA_PROMOTE_SCHEMA = {
+    "name": "mnemosyne_persona_promote",
+    "description": (
+        "Promote a working or episodic memory into the L3 persona tier. "
+        "Persona facts are always auto-injected into the system prompt regardless "
+        "of semantic relevance. Tier values: 'permanent' (never evicted, requires "
+        "explicit demotion), 'long_term' (default; reinforcement-driven decay), "
+        "'working' (transient). Returns the new persona id."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "ID of the source memory in working_memory or episodic_memory.",
+            },
+            "tier": {
+                "type": "string",
+                "enum": ["permanent", "long_term", "working"],
+                "default": "long_term",
+                "description": "Retention tier for the promoted persona fact.",
+            },
+            "reason": {
+                "type": "string",
+                "default": "",
+                "description": "Optional human-readable reason for the promotion (logged for audit).",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+PERSONA_DEMOTE_SCHEMA = {
+    "name": "mnemosyne_persona_demote",
+    "description": (
+        "Move a persona fact back to memoria_preferences (acting as a tombstone). "
+        "Use when a previously-promoted rule no longer applies or was a one-off. "
+        "Returns the demoted persona id and the new preference record location."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "persona_id": {
+                "type": "integer",
+                "description": "ID of the persona row to demote.",
+            },
+            "reason": {
+                "type": "string",
+                "default": "",
+                "description": "Optional reason for the demotion.",
+            },
+        },
+        "required": ["persona_id"],
+    },
+}
+
+PERSONA_LIST_SCHEMA = {
+    "name": "mnemosyne_persona_list",
+    "description": (
+        "List L3 persona facts, optionally filtered by tier and/or topic. "
+        "Returns personas ordered by tier (permanent first), then by reinforcement "
+        "count descending (most-used first)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "tier": {
+                "type": "string",
+                "enum": ["permanent", "long_term", "working"],
+                "description": "Optional tier filter.",
+            },
+            "topic": {
+                "type": "string",
+                "description": "Optional topic filter (exact match).",
+            },
+        },
+    },
+}
+
+PERSONA_REINFORCE_SCHEMA = {
+    "name": "mnemosyne_persona_reinforce",
+    "description": (
+        "Bump the reinforcement_count and last_reinforced_at on a persona fact. "
+        "Use when the persona rule was just applied -- signals 'this rule is in "
+        "active use' to the decay logic."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "persona_id": {
+                "type": "integer",
+                "description": "ID of the persona row to reinforce.",
+            },
+        },
+        "required": ["persona_id"],
+    },
+}

--- a/hermes_memory_provider/sync_adapter.py
+++ b/hermes_memory_provider/sync_adapter.py
@@ -48,8 +48,8 @@ SYNC_PUSH_SCHEMA = {
     "description": (
         "Push local memory changes to a remote Mnemosyne sync server. "
         "Only events created since the last sync are sent. Requires a "
-        "configured remote sync server (configured in Mnemosyne settings "
-        "or via MNEMOSYNE_SYNC_REMOTE env var)."
+        "configured remote sync server (configured via config.yaml or "
+        "MNEMOSYNE_SYNC_REMOTE env var)."
     ),
     "parameters": {
         "type": "object",
@@ -61,9 +61,9 @@ SYNC_PUSH_SCHEMA = {
 SYNC_PULL_SCHEMA = {
     "name": "mnemosyne_sync_pull",
     "description": (
-        "Pull remote memory changes from a configured Mnemosyne sync server. "
-        "Applies incoming events to the local store. New or conflicting "
-        "memories are resolved with timestamp + importance rules."
+        "Pull remote memory changes from the configured Mnemosyne sync server. "
+        "Applies incoming events locally with timestamp + importance conflict "
+        "resolution."
     ),
     "parameters": {
         "type": "object",
@@ -75,8 +75,8 @@ SYNC_PULL_SCHEMA = {
 SYNC_STATUS_SCHEMA = {
     "name": "mnemosyne_sync_status",
     "description": (
-        "Show Mnemosyne sync status: device identity, last sync cursor, "
-        "event count, remote URL, and encryption state."
+        "Show Mnemosyne sync status: device ID, last cursor, event count, "
+        "remote URL, and encryption state."
     ),
     "parameters": {
         "type": "object",

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -1157,6 +1157,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_graph_link(args)
             elif tool_name.startswith("mnemosyne_sync_"):
                 return self._handle_sync_tool(tool_name, args)
+            elif tool_name.startswith("mnemosyne_persona_"):
+                return self._handle_persona_tool(tool_name, args)
             else:
                 return json.dumps({"error": f"Unknown Mnemosyne tool: {tool_name}"})
         except Exception as e:
@@ -1173,6 +1175,17 @@ class MnemosyneMemoryProvider(MemoryProvider):
             return adapter.handle_tool_call(tool_name, args)
         except Exception as exc:
             return json.dumps({"status": "error", "error": f"Sync adapter unavailable: {exc}"})
+
+    def _handle_persona_tool(self, tool_name: str, args: Dict[str, Any]) -> str:
+        try:
+            adapter = getattr(self, "_provider_persona_adapter", None)
+            if adapter is None:
+                from mnemosyne_hermes.persona_adapter import PersonaAdapter
+                adapter = PersonaAdapter(self._beam, {})
+                self._provider_persona_adapter = adapter
+            return adapter.handle_tool_call(tool_name, args)
+        except Exception as exc:
+            return json.dumps({"status": "error", "error": f"Persona adapter unavailable: {exc}"})
 
     def _handle_remember(self, args: Dict[str, Any]) -> str:
         # Import at call-site so the provider module loads even when

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -668,6 +668,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},
+            {"key": "sync_roles", "description": "Conversation roles to autosave in sync_turn(). List of role names: 'user', 'assistant'. Default ['user', 'assistant'] saves both. Set to ['user'] for user turns only, or [] to disable conversation autosave entirely. Does not affect explicit mnemosyne_remember calls. Identity signal capture is gated by user sync — excluding 'user' also disables identity extraction. Also configurable via MNEMOSYNE_SYNC_ROLES env var.", "default": ["user", "assistant"]},
             {"key": "default_scope", "description": "Default scope for remember() calls when not explicitly specified. 'session' (default) limits memories to the current session. 'global' persists memories across sessions.", "choices": ["session", "global"], "default": "session"},
         ]
 
@@ -1128,6 +1129,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_triple_add(args)
             elif tool_name == "mnemosyne_triple_query":
                 return self._handle_triple_query(args)
+            elif tool_name == "mnemosyne_triple_end":
+                return self._handle_triple_end(args)
             elif tool_name == "mnemosyne_remember_canonical":
                 return self._handle_remember_canonical(args)
             elif tool_name == "mnemosyne_recall_canonical":
@@ -1152,11 +1155,24 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 return self._handle_graph_query(args)
             elif tool_name == "mnemosyne_graph_link":
                 return self._handle_graph_link(args)
+            elif tool_name.startswith("mnemosyne_sync_"):
+                return self._handle_sync_tool(tool_name, args)
             else:
                 return json.dumps({"error": f"Unknown Mnemosyne tool: {tool_name}"})
         except Exception as e:
             logger.error("Mnemosyne tool %s failed: %s", tool_name, e)
             return json.dumps({"error": f"Mnemosyne tool '{tool_name}' failed: {e}"})
+
+    def _handle_sync_tool(self, tool_name: str, args: Dict[str, Any]) -> str:
+        try:
+            adapter = getattr(self, "_provider_sync_adapter", None)
+            if adapter is None:
+                from mnemosyne_hermes.sync_adapter import SyncAdapter
+                adapter = SyncAdapter(self._beam, {})
+                self._provider_sync_adapter = adapter
+            return adapter.handle_tool_call(tool_name, args)
+        except Exception as exc:
+            return json.dumps({"status": "error", "error": f"Sync adapter unavailable: {exc}"})
 
     def _handle_remember(self, args: Dict[str, Any]) -> str:
         # Import at call-site so the provider module loads even when
@@ -1564,18 +1580,38 @@ class MnemosyneMemoryProvider(MemoryProvider):
         valid_from = args.get("valid_from", None) or None
         if not all([subject, predicate, obj]):
             return json.dumps({"error": "subject, predicate, and object are required"})
+        valid_until = args.get("valid_until", None) or None
+        source = args.get("source", "") or "inferred"
+        confidence = args.get("confidence", 1.0)
+        supersede = args.get("supersede", True)
         add_triple, _ = _get_triple_module()
         triple_id = add_triple(subject, predicate, obj, valid_from=valid_from,
+                               valid_until=valid_until, source=source,
+                               confidence=confidence, supersede=supersede,
                                db_path=self._beam.db_path)
         return json.dumps({"status": "stored", "triple_id": triple_id})
+
+    def _handle_triple_end(self, args: Dict[str, Any]) -> str:
+        subject = args.get("subject", "")
+        predicate = args.get("predicate", "")
+        if not all([subject, predicate]):
+            return json.dumps({"error": "subject and predicate are required"})
+        obj = args.get("object", "") or None
+        valid_until = args.get("valid_until", None) or None
+        from mnemosyne.core.triples import end_triple
+        n = end_triple(subject, predicate, object=obj, valid_until=valid_until,
+                       db_path=self._beam.db_path)
+        return json.dumps({"status": "ended", "count": n})
+
 
     def _handle_triple_query(self, args: Dict[str, Any]) -> str:
         subject = args.get("subject", "") or None
         predicate = args.get("predicate", "") or None
         obj = args.get("object", "") or None
+        as_of = args.get("as_of", "") or None
         _, query_triples = _get_triple_module()
         results = query_triples(subject=subject, predicate=predicate, object=obj,
-                                db_path=self._beam.db_path)
+                                as_of=as_of, db_path=self._beam.db_path)
         return json.dumps({"count": len(results), "results": results})
 
     def _canonical_owner(self) -> str:

--- a/integrations/hermes/src/mnemosyne_hermes/tools.py
+++ b/integrations/hermes/src/mnemosyne_hermes/tools.py
@@ -263,7 +263,10 @@ TRIPLE_ADD_SCHEMA = {
     "name": "mnemosyne_triple_add",
     "description": (
         "Add a temporal fact triple (subject, predicate, object) to the knowledge graph. "
-        "Example: ('user', 'prefers', 'neovim'). Use for structured relationships."
+        "Example: ('user', 'prefers', 'neovim'). Use for structured relationships. "
+        "By default a new triple supersedes any prior fact with the same subject+predicate; "
+        "set supersede=false for multi-valued facts that should coexist "
+        "(e.g. ('user','speaks','English') and ('user','speaks','Spanish'))."
     ),
     "parameters": {
         "type": "object",
@@ -272,20 +275,48 @@ TRIPLE_ADD_SCHEMA = {
             "predicate": {"type": "string"},
             "object": {"type": "string"},
             "valid_from": {"type": "string", "description": "ISO date YYYY-MM-DD", "default": ""},
+            "valid_until": {"type": "string", "description": "Optional ISO expiry date YYYY-MM-DD.", "default": ""},
+            "source": {"type": "string", "description": "Provenance label.", "default": ""},
+            "confidence": {"type": "number", "description": "0.0-1.0 (default 1.0).", "default": 1.0},
+            "supersede": {"type": "boolean", "description": "If false, do not close prior same subject+predicate triples (multi-valued).", "default": True},
         },
         "required": ["subject", "predicate", "object"],
     },
 }
 
+TRIPLE_END_SCHEMA = {
+    "name": "mnemosyne_triple_end",
+    "description": (
+        "Expire a fact in the knowledge graph WITHOUT replacing it (e.g. a relationship "
+        "that simply ended). Closes all open triples for subject+predicate, or only the one "
+        "matching object when given. Use mnemosyne_triple_add instead when a new value replaces the old."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "subject": {"type": "string"},
+            "predicate": {"type": "string"},
+            "object": {"type": "string", "description": "Optional: end only this exact triple; omit to end all open subject+predicate triples.", "default": ""},
+            "valid_until": {"type": "string", "description": "ISO date YYYY-MM-DD the fact ended (default: today).", "default": ""},
+        },
+        "required": ["subject", "predicate"],
+    },
+}
+
+
 TRIPLE_QUERY_SCHEMA = {
     "name": "mnemosyne_triple_query",
-    "description": "Query the temporal knowledge graph for facts matching subject/predicate/object patterns.",
+    "description": (
+        "Query the temporal knowledge graph for facts matching subject/predicate/object patterns. "
+        "Subject match is case-insensitive. Pass as_of to query facts valid on a past date."
+    ),
     "parameters": {
         "type": "object",
         "properties": {
             "subject": {"type": "string", "default": ""},
             "predicate": {"type": "string", "default": ""},
             "object": {"type": "string", "default": ""},
+            "as_of": {"type": "string", "description": "ISO date YYYY-MM-DD; query facts valid as of this date (default: today).", "default": ""},
         },
     },
 }
@@ -573,6 +604,7 @@ ALL_TOOL_SCHEMAS = [
     REMEMBER_SCHEMA, RECALL_SCHEMA, SHARED_REMEMBER_SCHEMA, SHARED_RECALL_SCHEMA,
     SHARED_FORGET_SCHEMA, SHARED_STATS_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
     INVALIDATE_SCHEMA, VALIDATE_SCHEMA, GET_SCHEMA, TRIPLE_ADD_SCHEMA, TRIPLE_QUERY_SCHEMA,
+    TRIPLE_END_SCHEMA,
     REMEMBER_CANONICAL_SCHEMA, RECALL_CANONICAL_SCHEMA,
     SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
     EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -1,0 +1,169 @@
+"""Parity checks for the two Hermes Mnemosyne provider implementations."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION_SRC = PROJECT_ROOT / "integrations" / "hermes" / "src"
+
+
+def _drop_modules(prefix: str) -> None:
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(f"{prefix}."):
+            del sys.modules[name]
+
+
+def _import_module(package: str, import_root: Path):
+    _drop_modules(package)
+    sys.path.insert(0, str(import_root))
+    try:
+        return importlib.import_module(package)
+    finally:
+        try:
+            sys.path.remove(str(import_root))
+        except ValueError:
+            pass
+
+
+@pytest.fixture(scope="module")
+def provider_modules():
+    return {
+        "hermes_memory_provider": _import_module("hermes_memory_provider", PROJECT_ROOT),
+        "mnemosyne_hermes": _import_module("mnemosyne_hermes", INTEGRATION_SRC),
+    }
+
+
+def _tool_schemas(module):
+    return {schema["name"]: schema for schema in module.ALL_TOOL_SCHEMAS}
+
+
+def _config_schema(module):
+    provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+    return {entry["key"]: entry for entry in provider.get_config_schema()}
+
+
+def _json_stable(value):
+    return json.loads(json.dumps(value, sort_keys=True))
+
+
+def test_provider_tool_sets_match(provider_modules):
+    tool_sets = {name: set(_tool_schemas(module)) for name, module in provider_modules.items()}
+
+    assert tool_sets["hermes_memory_provider"] == tool_sets["mnemosyne_hermes"]
+    assert "mnemosyne_sync_push" in tool_sets["hermes_memory_provider"]
+    assert "mnemosyne_triple_end" in tool_sets["hermes_memory_provider"]
+
+
+def test_provider_tool_schemas_match(provider_modules):
+    root_tools = _tool_schemas(provider_modules["hermes_memory_provider"])
+    integration_tools = _tool_schemas(provider_modules["mnemosyne_hermes"])
+
+    assert _json_stable(root_tools) == _json_stable(integration_tools)
+
+
+def test_provider_config_defaults_match(provider_modules):
+    root_config = _config_schema(provider_modules["hermes_memory_provider"])
+    integration_config = _config_schema(provider_modules["mnemosyne_hermes"])
+
+    assert _json_stable(root_config) == _json_stable(integration_config)
+    assert root_config["sync_roles"]["default"] == ["user", "assistant"]
+    assert root_config["default_scope"]["choices"] == ["session", "global"]
+    assert root_config["default_scope"]["default"] == "session"
+
+
+@pytest.mark.parametrize(
+    ("env_name", "helper_name", "default", "custom"),
+    [
+        ("MNEMOSYNE_SYNC_TURN_USER_LIMIT", "_sync_turn_user_limit", 500, 123),
+        ("MNEMOSYNE_SYNC_TURN_ASSISTANT_LIMIT", "_sync_turn_assistant_limit", 800, 234),
+    ],
+)
+def test_provider_sync_limit_helpers_match(monkeypatch, provider_modules, env_name, helper_name, default, custom):
+    monkeypatch.delenv(env_name, raising=False)
+    assert {name: getattr(module, helper_name)() for name, module in provider_modules.items()} == {
+        "hermes_memory_provider": default,
+        "mnemosyne_hermes": default,
+    }
+
+    monkeypatch.setenv(env_name, str(custom))
+    assert {name: getattr(module, helper_name)() for name, module in provider_modules.items()} == {
+        "hermes_memory_provider": custom,
+        "mnemosyne_hermes": custom,
+    }
+
+    monkeypatch.setenv(env_name, "-10")
+    assert {name: getattr(module, helper_name)() for name, module in provider_modules.items()} == {
+        "hermes_memory_provider": 0,
+        "mnemosyne_hermes": 0,
+    }
+
+    monkeypatch.setenv(env_name, "not-an-int")
+    assert {name: getattr(module, helper_name)() for name, module in provider_modules.items()} == {
+        "hermes_memory_provider": default,
+        "mnemosyne_hermes": default,
+    }
+
+
+class _FakeBeam:
+    def __init__(self):
+        self.calls = []
+
+    def remember(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def _new_provider(module, *, scope="session", roles=("user", "assistant")):
+    provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+    provider._beam = _FakeBeam()
+    provider._agent_context = ""
+    provider._skip_contexts = set()
+    provider._sync_roles = set(roles)
+    provider._default_scope = scope
+    provider._should_filter = lambda _content: False
+    provider._capture_identity_signals = lambda _content: None
+    provider._turn_count = 0
+    provider._auto_sleep_enabled = False
+    return provider
+
+
+@pytest.mark.parametrize("scope", ["session", "global"])
+def test_provider_sync_turn_scope_and_truncation_match(monkeypatch, provider_modules, scope):
+    monkeypatch.setenv("MNEMOSYNE_SYNC_TURN_USER_LIMIT", "7")
+    monkeypatch.setenv("MNEMOSYNE_SYNC_TURN_ASSISTANT_LIMIT", "9")
+
+    observed = {}
+    for name, module in provider_modules.items():
+        provider = _new_provider(module, scope=scope)
+        provider.sync_turn("user-content", "assistant-content")
+        observed[name] = provider._beam.calls
+
+    assert observed["hermes_memory_provider"] == observed["mnemosyne_hermes"]
+    assert [call["scope"] for call in observed["hermes_memory_provider"]] == [scope, scope]
+    assert [call["content"] for call in observed["hermes_memory_provider"]] == [
+        "[USER] user-co",
+        "[ASSISTANT] assistant",
+    ]
+
+
+def test_provider_sync_turn_zero_limit_means_untruncated(monkeypatch, provider_modules):
+    monkeypatch.setenv("MNEMOSYNE_SYNC_TURN_USER_LIMIT", "0")
+    monkeypatch.setenv("MNEMOSYNE_SYNC_TURN_ASSISTANT_LIMIT", "0")
+
+    observed = {}
+    for name, module in provider_modules.items():
+        provider = _new_provider(module)
+        provider.sync_turn("user-content", "assistant-content")
+        observed[name] = [call["content"] for call in provider._beam.calls]
+
+    assert observed["hermes_memory_provider"] == observed["mnemosyne_hermes"]
+    assert observed["hermes_memory_provider"] == [
+        "[USER] user-content",
+        "[ASSISTANT] assistant-content",
+    ]

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -58,6 +58,7 @@ def test_provider_tool_sets_match(provider_modules):
 
     assert tool_sets["hermes_memory_provider"] == tool_sets["mnemosyne_hermes"]
     assert "mnemosyne_sync_push" in tool_sets["hermes_memory_provider"]
+    assert "mnemosyne_persona_list" in tool_sets["hermes_memory_provider"]
     assert "mnemosyne_triple_end" in tool_sets["hermes_memory_provider"]
 
 
@@ -167,3 +168,34 @@ def test_provider_sync_turn_zero_limit_means_untruncated(monkeypatch, provider_m
         "[USER] user-content",
         "[ASSISTANT] assistant-content",
     ]
+
+
+def test_provider_persona_tool_dispatch_matches(tmp_path, provider_modules):
+    from mnemosyne.core.beam import BeamMemory
+
+    observed = {}
+    for name, module in provider_modules.items():
+        db_path = tmp_path / f"{name}.db"
+        beam = BeamMemory(session_id=f"persona-{name}", db_path=str(db_path))
+        beam.conn.execute(
+            "INSERT INTO memoria_persona (tier, topic, content, confidence) "
+            "VALUES (?, ?, ?, ?)",
+            ("long_term", "test", f"persona rule for {name}", 0.9),
+        )
+        beam.conn.commit()
+
+        provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+        provider._beam = beam
+        result = json.loads(provider.handle_tool_call("mnemosyne_persona_list", {}))
+        observed[name] = {
+            "status": result.get("status"),
+            "count": result.get("count"),
+            "topics": [row.get("topic") for row in result.get("personas", [])],
+        }
+
+    assert observed["hermes_memory_provider"] == observed["mnemosyne_hermes"]
+    assert observed["hermes_memory_provider"] == {
+        "status": "ok",
+        "count": 1,
+        "topics": ["test"],
+    }

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -47,12 +47,12 @@ def _tool_names(provider) -> set[str]:
 # ---------------------------------------------------------------------------
 
 class TestToolRegistration:
-    """Verify the provider registers and dispatches all 15 tools."""
+    """Verify the provider registers and dispatches the full tool surface."""
 
     def test_all_tools_registered(self, tmp_path):
         provider = _provider(tmp_path)
         names = _tool_names(provider)
-        assert len(names) == 29, f"Expected 29 tools, got {len(names)}"
+        assert len(names) == 33, f"Expected 33 tools, got {len(names)}"
 
     def test_canonical_tools_present(self, tmp_path):
         provider = _provider(tmp_path)
@@ -78,6 +78,12 @@ class TestToolRegistration:
         provider = _provider(tmp_path)
         names = _tool_names(provider)
         assert "mnemosyne_validate" in names
+
+    def test_persona_tools_present(self, tmp_path):
+        provider = _provider(tmp_path)
+        names = _tool_names(provider)
+        for tool in ("persona_promote", "persona_demote", "persona_list", "persona_reinforce"):
+            assert f"mnemosyne_{tool}" in names
 
     def test_shared_surface_tools_present(self, tmp_path):
         provider = _provider(tmp_path)

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -52,7 +52,7 @@ class TestToolRegistration:
     def test_all_tools_registered(self, tmp_path):
         provider = _provider(tmp_path)
         names = _tool_names(provider)
-        assert len(names) == 26, f"Expected 26 tools, got {len(names)}"
+        assert len(names) == 29, f"Expected 29 tools, got {len(names)}"
 
     def test_canonical_tools_present(self, tmp_path):
         provider = _provider(tmp_path)


### PR DESCRIPTION
## Summary

- add a Hermes provider parity test module covering `hermes_memory_provider` and `integrations/hermes/src/mnemosyne_hermes`
- assert both provider copies expose the same tool set, tool schemas, config defaults, sync limits, and sync-turn scope/truncation behavior
- align the drift the new tests exposed: sync/persona tool schemas, `sync_roles`, `mnemosyne_triple_end`, sync/persona dispatch, triple metadata handling, and zero-limit sync-turn behavior

Closes #323.

## Test plan

- `uv run --no-sync --with pytest pytest tests/test_hermes_provider_parity.py -q`
- `uv run --with pytest pytest tests/test_hermes_provider_parity.py tests/test_sync_turn_content_limit.py -q`
- `PYTHONPATH=".:integrations/hermes/src" uv run --no-sync --with pytest pytest tests/test_hermes_provider_parity.py tests/test_sync_turn_content_limit.py tests/test_provider_all_15_tools.py tests/test_persona_adapter.py tests/test_persona_schema.py -q`
