### PR TITLE
fix: propagate force in sleep_all_sessions

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -8009,7 +8009,7 @@ class BeamMemory:
                     author_id=self.author_id,
                     author_type=self.author_type,
                 )
-                result = beam.sleep(dry_run=dry_run)
+                result = beam.sleep(dry_run=dry_run, force=force)
                 result = dict(result)
                 result["session_id"] = session_id
                 result["eligible"] = row["eligible"] if hasattr(row, "keys") else row[1]

--- a/tests/test_beam_e3_additive_sleep.py
+++ b/tests/test_beam_e3_additive_sleep.py
@@ -571,6 +571,29 @@ class TestE3AdditiveSleep:
         conn.close()
         assert marker is None
 
+    def test_sleep_all_sessions_force_consolidates_fresh_rows(self, temp_db, monkeypatch):
+        monkeypatch.setattr(
+            "mnemosyne.core.local_llm.llm_available", lambda: False
+        )
+        beam = BeamMemory(session_id="maintenance", db_path=temp_db)
+        _seed_old_wm(temp_db, "s1", n=1, ts_offset_hours=0)
+
+        result = beam.sleep_all_sessions(dry_run=False, force=True)
+
+        assert result["sessions_consolidated"] == 1
+        assert result["items_consolidated"] == 1
+        conn = sqlite3.connect(str(temp_db))
+        summary_of = conn.execute(
+            "SELECT summary_of FROM episodic_memory WHERE source = 'sleep_consolidation'"
+        ).fetchone()[0]
+        final = conn.execute(
+            "SELECT consolidated_at, consolidation_claimed_at FROM working_memory WHERE id = 'e3-s1-0'"
+        ).fetchone()
+        conn.close()
+        assert summary_of == "e3-s1-0"
+        assert final[0] is not None
+        assert final[1] is None
+
     def test_manual_reclaim_then_sleep_all_sessions_consolidates_orphan(self, temp_db, monkeypatch):
         monkeypatch.setattr(
             "mnemosyne.core.local_llm.llm_available", lambda: False


### PR DESCRIPTION
## Summary

Fixes `BeamMemory.sleep_all_sessions(force=True)` so the `force` flag is passed into each per-session `sleep()` call.

Without this, `sleep_all_sessions(force=True)` selected fresh/non-age-eligible sessions in the outer query, but each delegated session still ran `sleep(force=False)`. The result was a misleading no-op for rows that should have been consolidated by a forced maintenance pass.

## What changed

- Pass `force=force` from `sleep_all_sessions()` to per-session `sleep()`.
- Add a regression test that seeds a fresh working-memory row and verifies `sleep_all_sessions(force=True)` consolidates it immediately.

Related to #318, but this PR includes the concrete fix plus regression coverage.

## Verification

- RED: the new regression failed before the fix with `assert 0 == 1` for `sessions_consolidated`.
- `python -m pytest tests/test_beam_e3_additive_sleep.py::TestE3AdditiveSleep::test_sleep_all_sessions_force_consolidates_fresh_rows tests/test_beam_e3_additive_sleep.py::TestE3AdditiveSleep::test_manual_reclaim_then_sleep_all_sessions_consolidates_orphan -q -o 'addopts='` -> `2 passed`
- `python -m pytest tests/test_beam_e3_additive_sleep.py -q -o 'addopts='` -> `22 passed`
- `python -m py_compile mnemosyne/core/beam.py` -> passed
- `git diff --check` -> passed

Full-suite note: with `PYTHONPATH=integrations/hermes/src`, the full suite reached `1681 passed` and one unrelated existing failure in `tests/test_llm_conflict_detector.py::test_beam_integration_with_llm_conflict`, where conflict candidates were empty before this PR's changed path is involved.
