### PR TITLE
feat(recall): add explain trace mode (#322 v1)

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -455,6 +455,11 @@ RECALL_SCHEMA = {
                 "type": "number",
                 "description": "Importance score weight in hybrid scoring. Omit (or pass null) to use MNEMOSYNE_IMPORTANCE_WEIGHT env var or built-in default 0.2.",
             },
+            "explain": {
+                "type": "boolean",
+                "description": "If true, return a structured per-query recall explain trace. Default false.",
+                "default": False,
+            },
         },
         "required": ["query"],
     },
@@ -2007,6 +2012,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
         temporal_weight = float(args.get("temporal_weight", 0.0))
         query_time = args.get("query_time") or None
         temporal_halflife_hours = float(args.get("temporal_halflife", 24))
+        explain = bool(args.get("explain", False))
         if not query:
             return json.dumps({"error": "query is required"})
 
@@ -2020,12 +2026,20 @@ class MnemosyneMemoryProvider(MemoryProvider):
             "temporal_weight": temporal_weight,
             "query_time": query_time,
             "temporal_halflife": temporal_halflife_hours,
+            "explain": explain,
         }
         for weight_key in ("vec_weight", "fts_weight", "importance_weight"):
             if weight_key in args:
                 recall_kwargs[weight_key] = args[weight_key]
 
-        results = self._beam.recall(query, **recall_kwargs)
+        recall_payload = self._beam.recall(query, **recall_kwargs)
+        explain_payload = None
+        if explain:
+            explain_payload = recall_payload.get("explain", {})
+            results = recall_payload.get("results", [])
+        else:
+            results = recall_payload
+
         # Tag private results with their bank so callers can distinguish from
         # shared-surface entries when surface read is enabled.
         for r in results:
@@ -2049,16 +2063,21 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     combined = list(results) + list(surface_results)
                     combined.sort(key=lambda x: x.get("score") or 0.0, reverse=True)
                     results = combined[:top_k]
+                    if explain_payload is not None:
+                        explain_payload.setdefault("provider", {})["shared_surface_untraced"] = len(surface_results)
                 except Exception as exc:
                     logger.warning("Mnemosyne shared surface recall failed: %s", exc)
 
-        return json.dumps({
+        response = {
             "query": query,
             "count": len(results),
             "temporal_weight": temporal_weight,
             "shared_surface_read": self._shared_surface_read,
             "results": results,
-        })
+        }
+        if explain_payload is not None:
+            response["explain"] = explain_payload
+        return json.dumps(response)
 
     @staticmethod
     def _surface_hash(content: str) -> str:

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -1217,6 +1217,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
         temporal_weight = float(args.get("temporal_weight", 0.0))
         query_time = args.get("query_time") or None
         temporal_halflife_hours = float(args.get("temporal_halflife", 24))
+        explain = bool(args.get("explain", False))
         if not query:
             return json.dumps({"error": "query is required"})
 
@@ -1230,12 +1231,20 @@ class MnemosyneMemoryProvider(MemoryProvider):
             "temporal_weight": temporal_weight,
             "query_time": query_time,
             "temporal_halflife": temporal_halflife_hours,
+            "explain": explain,
         }
         for weight_key in ("vec_weight", "fts_weight", "importance_weight"):
             if weight_key in args:
                 recall_kwargs[weight_key] = args[weight_key]
 
-        results = self._beam.recall(query, **recall_kwargs)
+        recall_payload = self._beam.recall(query, **recall_kwargs)
+        explain_payload = None
+        if explain:
+            explain_payload = recall_payload.get("explain", {})
+            results = recall_payload.get("results", [])
+        else:
+            results = recall_payload
+
         # Tag private results with their bank so callers can distinguish from
         # shared-surface entries when surface read is enabled.
         for r in results:
@@ -1259,16 +1268,21 @@ class MnemosyneMemoryProvider(MemoryProvider):
                     combined = list(results) + list(surface_results)
                     combined.sort(key=lambda x: x.get("score") or 0.0, reverse=True)
                     results = combined[:top_k]
+                    if explain_payload is not None:
+                        explain_payload.setdefault("provider", {})["shared_surface_untraced"] = len(surface_results)
                 except Exception as exc:
                     logger.warning("Mnemosyne shared surface recall failed: %s", exc)
 
-        return json.dumps({
+        response = {
             "query": query,
             "count": len(results),
             "temporal_weight": temporal_weight,
             "shared_surface_read": self._shared_surface_read,
             "results": results,
-        })
+        }
+        if explain_payload is not None:
+            response["explain"] = explain_payload
+        return json.dumps(response)
 
     @staticmethod
     def _surface_hash(content: str) -> str:

--- a/integrations/hermes/src/mnemosyne_hermes/tools.py
+++ b/integrations/hermes/src/mnemosyne_hermes/tools.py
@@ -89,6 +89,11 @@ RECALL_SCHEMA = {
                 "type": "number",
                 "description": "Importance score weight in hybrid scoring. Omit (or pass null) to use MNEMOSYNE_IMPORTANCE_WEIGHT env var or built-in default 0.2.",
             },
+            "explain": {
+                "type": "boolean",
+                "description": "If true, return a structured per-query recall explain trace. Default false.",
+                "default": False,
+            },
         },
         "required": ["query"],
     },

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -85,12 +85,38 @@ def cmd_store(args):
 def cmd_recall(args):
     """Search memories."""
     if not args:
-        _usage("Usage: mnemosyne recall <query> [top_k]")
-    query = args[0]
-    top_k = _parse_int(args[1], "top_k") if len(args) > 1 else 5
+        _usage("Usage: mnemosyne recall <query> [top_k] [--explain] [--json]")
+
+    explain = False
+    json_output = False
+    positionals = []
+    for arg in args:
+        if arg == "--explain":
+            explain = True
+        elif arg == "--json":
+            json_output = True
+        else:
+            positionals.append(arg)
+
+    if not positionals:
+        _usage("Usage: mnemosyne recall <query> [top_k] [--explain] [--json]")
+    query = positionals[0]
+    top_k = _parse_int(positionals[1], "top_k") if len(positionals) > 1 else 5
 
     mem = _get_memory()
-    results = mem.recall(query, top_k=top_k)
+    payload = mem.recall(query, top_k=top_k, explain=explain)
+    if explain:
+        results = payload.get("results", [])
+    else:
+        results = payload
+
+    if json_output:
+        if explain:
+            print(json.dumps(payload, ensure_ascii=False, default=str))
+        else:
+            print(json.dumps({"query": query, "top_k": top_k, "results": results}, ensure_ascii=False, default=str))
+        return
+
     print(f"\nResults for: {query}\n")
     for r in results:
         content = r.get("content", "")

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -5134,7 +5134,8 @@ class BeamMemory:
                temporal_halflife: Optional[float] = None,
                vec_weight: float = None,
                fts_weight: float = None,
-               importance_weight: float = None) -> List[Dict]:
+               importance_weight: float = None,
+               explain: bool = False) -> List[Dict]:
         """
         Hybrid recall across working_memory + episodic_memory.
         Uses sqlite-vec + FTS5 for episodic, FTS5 for working.
@@ -5193,7 +5194,7 @@ class BeamMemory:
         # contract as the linear path. /review found that omitting
         # them under flag=ON was a data-isolation regression (P1).
         if os.environ.get("MNEMOSYNE_POLYPHONIC_RECALL", "0") == "1":
-            return self._recall_polyphonic(
+            poly_results = self._recall_polyphonic(
                 query, top_k,
                 from_date=from_date, to_date=to_date,
                 source=source, topic=topic,
@@ -5201,6 +5202,18 @@ class BeamMemory:
                 channel_id=channel_id,
                 veracity=veracity, memory_type=memory_type,
             )
+            if explain:
+                return {
+                    "query": query,
+                    "top_k": top_k,
+                    "engine": "polyphonic",
+                    "results": poly_results,
+                    "explain": {
+                        "unsupported": True,
+                        "reason": "polyphonic recall explain is not implemented in v1; inspect per-result voice_scores instead.",
+                    },
+                }
+            return poly_results
 
         results = []
         query_lower = query.lower()
@@ -5208,6 +5221,26 @@ class BeamMemory:
 
         # ---- Configurable hybrid scoring setup (Phase 4) ----
         vw, fw, iw = _normalize_weights(vec_weight, fts_weight, importance_weight)
+        _explain_trace = None
+        if explain:
+            from mnemosyne.core.recall_diagnostics import RecallExplainTrace
+            _explain_trace = RecallExplainTrace(
+                query=query,
+                top_k=top_k,
+                engine="linear",
+                filters={
+                    "from_date": from_date,
+                    "to_date": to_date,
+                    "source": source,
+                    "topic": topic,
+                    "author_id": author_id,
+                    "author_type": author_type,
+                    "channel_id": channel_id,
+                    "veracity": veracity,
+                    "memory_type": memory_type,
+                },
+                weights={"vec": vw, "fts": fw, "importance": iw, "temporal": temporal_weight},
+            )
 
         # Query embeddings are used by several recall subpaths. Compute the
         # vector at most once per recall() call, then reuse it for working
@@ -5263,6 +5296,7 @@ class BeamMemory:
             wm_fts = _fts_search_working(self.conn, query, k=max(top_k * 3, 50))
         except Exception:
             wm_fts = []
+        _wm_fts_raw_count = len(wm_fts)
 
         wm_ids = {r["id"] for r in wm_fts}
         wm_ranks = {r["id"]: r["rank"] for r in wm_fts}
@@ -5370,6 +5404,8 @@ class BeamMemory:
             # scoring loop above. record_fallback_used was already
             # called when wm_ids was empty.
 
+        _wm_after_filter_count = len(rows)
+
         # Precompute min_rank/rng for wm_ranks normalization
         if wm_ranks:
             min_rank = min(wm_ranks.values())
@@ -5465,6 +5501,15 @@ class BeamMemory:
             # fallback scanned candidate rows, even if the stricter relevance
             # gate abstained from returning them.
             _wm_fallback_kept = len(rows)
+
+        if _explain_trace is not None:
+            _explain_trace.add_stage(
+                "wm_fallback" if _wm_fallback_used else "wm_primary",
+                raw_count=_wm_fts_raw_count + len(wm_vec_sims),
+                after_filter_count=_wm_after_filter_count,
+                kept_count=_wm_fts_kept + _wm_vec_kept + _wm_fallback_kept,
+                fallback_used=_wm_fallback_used,
+            )
 
         # ---- Entity-aware recall ----
         entity_memory_ids = _find_memories_by_entity(self, query)
@@ -5737,6 +5782,7 @@ class BeamMemory:
 
         fts_results = {}
         fts_rows = _fts_search(self.conn, query, k=max(top_k * 3, 20))
+        _em_fts_raw_count = len(fts_rows)
         if fts_rows:
             min_rank = min(r["rank"] for r in fts_rows)
             max_rank = max(r["rank"] for r in fts_rows)
@@ -5812,7 +5858,10 @@ class BeamMemory:
                 WHERE rowid IN ({placeholders})
                   AND {em_where}
             """, (*tuple(episodic_rowids), *em_params))
-        for row in cursor.fetchall():
+            _em_candidate_rows = cursor.fetchall()
+        else:
+            _em_candidate_rows = []
+        for row in _em_candidate_rows:
             rid = row["rowid"]
             sim = vec_results.get(rid, 0.0)
             fts = fts_results.get(rid, 0.0)
@@ -5921,6 +5970,15 @@ class BeamMemory:
                 "superseded_by": row["superseded_by"] if "superseded_by" in row.keys() else None
             })
 
+        if _explain_trace is not None and episodic_rowids:
+            _explain_trace.add_stage(
+                "em_primary",
+                raw_count=_em_fts_raw_count + len(vec_results),
+                after_filter_count=len(_em_candidate_rows),
+                kept_count=_em_fts_kept + _em_vec_kept,
+                fallback_used=False,
+            )
+
         # Fallback: if no episodic matches from vec/FTS, scan recent episodic entries
         if not episodic_rowids:
             _em_fallback_used = True
@@ -6024,6 +6082,15 @@ class BeamMemory:
                         "valid_until": row["valid_until"] if "valid_until" in row.keys() else None,
                         "superseded_by": row["superseded_by"] if "superseded_by" in row.keys() else None
                     })
+
+            if _explain_trace is not None:
+                _explain_trace.add_stage(
+                    "em_fallback",
+                    raw_count=len(_em_fallback_rows),
+                    after_filter_count=len(_em_fallback_rows),
+                    kept_count=_em_fallback_kept,
+                    fallback_used=True,
+                )
 
         # --- Tiered degradation weighting: apply tier multiplier to episodic scores ---
         weight_map = {1: TIER1_WEIGHT, 2: TIER2_WEIGHT, 3: TIER3_WEIGHT}
@@ -6176,6 +6243,7 @@ class BeamMemory:
                 covered.update(set(_recall_tokens(picked.get("content", "").lower())) & q_word_set)
             results = selected + pool
 
+        _ranked_results_for_explain = list(results) if _explain_trace is not None else None
         final_results = results[:top_k]
 
         # --- Recall tracking: increment counts + set last_recalled ---
@@ -6268,6 +6336,20 @@ class BeamMemory:
                 final_results = final_results[:top_k]
             except Exception:
                 logger.debug("fact recall integration failed (non-fatal)", exc_info=True)
+
+        if _explain_trace is not None:
+            _explain_trace.set_embedding(
+                available=embeddings_available,
+                computed=query_embedding_computed,
+            )
+            _explain_trace.add_ranked_candidates(_ranked_results_for_explain or [], final_results)
+            return {
+                "query": query,
+                "top_k": top_k,
+                "engine": "linear",
+                "results": final_results,
+                "explain": _explain_trace.to_dict(),
+            }
 
         return final_results
 

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -396,7 +396,8 @@ class Mnemosyne:
                temporal_halflife: Optional[float] = None,
                vec_weight: float = None,
                fts_weight: float = None,
-               importance_weight: float = None) -> List[Dict]:
+               importance_weight: float = None,
+               explain: bool = False) -> List[Dict]:
         """
         Search memories with hybrid relevance scoring.
         Uses BEAM episodic + working memory retrieval (sqlite-vec + FTS5).
@@ -415,7 +416,8 @@ class Mnemosyne:
                                 temporal_halflife=temporal_halflife,
                                 vec_weight=vec_weight,
                                 fts_weight=fts_weight,
-                                importance_weight=importance_weight)
+                                importance_weight=importance_weight,
+                                explain=explain)
 
     def _emit_wrapper(self, event_type: str, memory_id: str, **kwargs) -> None:
         """Emit a streaming event through the Mnemosyne wrapper layer."""
@@ -934,6 +936,7 @@ def recall(query: str, top_k: int = 5, *,
            vec_weight: float = None,
            fts_weight: float = None,
            importance_weight: float = None,
+           explain: bool = False,
            bank: str = None) -> List[Dict]:
     """Search memories using the global instance with temporal filtering and scoring"""
     return _get_default(bank).recall(query, top_k,
@@ -944,7 +947,8 @@ def recall(query: str, top_k: int = 5, *,
                                      temporal_halflife=temporal_halflife,
                                      vec_weight=vec_weight,
                                      fts_weight=fts_weight,
-                                     importance_weight=importance_weight)
+                                     importance_weight=importance_weight,
+                                     explain=explain)
 
 
 def get_context(limit: int = 10, bank: str = None) -> List[Dict]:

--- a/mnemosyne/core/recall_diagnostics.py
+++ b/mnemosyne/core/recall_diagnostics.py
@@ -34,7 +34,7 @@ import logging
 import threading
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Any, Dict, List, Optional
 
 
 logger = logging.getLogger(__name__)
@@ -45,6 +45,89 @@ logger = logging.getLogger(__name__)
 # to know what fraction of their recall traffic actually comes from
 # the FTS/vec primary path vs. the substring/recency fallback.
 RECALL_TIERS = ("wm_fts", "wm_vec", "wm_fallback", "em_fts", "em_vec", "em_fallback")
+
+
+class RecallExplainTrace:
+    """Per-query recall explanation recorder.
+
+    This is intentionally opt-in and local to one recall() call. It is not
+    connected to the process-global counters above, so explain=False keeps the
+    existing hot path free of per-candidate allocations.
+    """
+
+    def __init__(self, *, query: str, top_k: int, engine: str, filters: Dict[str, Any], weights: Dict[str, Any]) -> None:
+        self.query = query
+        self.top_k = top_k
+        self.engine = engine
+        self.filters = {k: v for k, v in filters.items() if v is not None}
+        self.weights = weights
+        self.embedding = {"available": False, "computed": False}
+        self.stages: List[Dict[str, Any]] = []
+        self.candidates: List[Dict[str, Any]] = []
+        self.truncated_count = 0
+
+    def set_embedding(self, *, available: bool, computed: bool) -> None:
+        self.embedding = {"available": bool(available), "computed": bool(computed)}
+
+    def add_stage(self, name: str, *, raw_count: int, after_filter_count: int, kept_count: int, fallback_used: bool = False) -> None:
+        self.stages.append({
+            "name": name,
+            "raw_count": int(raw_count),
+            "after_filter_count": int(after_filter_count),
+            "kept_count": int(kept_count),
+            "fallback_used": bool(fallback_used),
+        })
+
+    @staticmethod
+    def _source_path(result: Dict[str, Any]) -> str:
+        tier = result.get("tier") or "unknown"
+        if tier == "working":
+            if result.get("fts_score", 0.0) > 0:
+                return "wm_fts"
+            if result.get("dense_score", 0.0) > 0:
+                return "wm_vec"
+            return "wm_fallback"
+        if tier == "episodic":
+            if result.get("fts_score", 0.0) > 0:
+                return "em_fts"
+            if result.get("dense_score", 0.0) > 0:
+                return "em_vec"
+            return "em_fallback"
+        return str(tier)
+
+    def add_ranked_candidates(self, ranked_results: List[Dict[str, Any]], final_results: List[Dict[str, Any]], *, preview_chars: int = 120, max_candidates: int = 50) -> None:
+        final_ids = {r.get("id") for r in final_results}
+        self.truncated_count = max(0, len(ranked_results) - len(final_results))
+        for rank, result in enumerate(ranked_results[:max_candidates], start=1):
+            kept = result.get("id") in final_ids
+            content = str(result.get("content") or "")
+            self.candidates.append({
+                "id": result.get("id") if kept else None,
+                "tier": result.get("tier"),
+                "source_path": self._source_path(result),
+                "rank": rank,
+                "kept": kept,
+                "drop_reason": None if kept else "top_k_truncated",
+                "scores": {
+                    "keyword": result.get("keyword_score", 0.0),
+                    "fts": result.get("fts_score", 0.0),
+                    "dense": result.get("dense_score", 0.0),
+                    "importance": result.get("importance", 0.0),
+                    "recency_decay": result.get("recency_decay", 0.0),
+                    "final": result.get("score", 0.0),
+                },
+                "content_preview": content[:preview_chars] if kept else None,
+            })
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "filters": self.filters,
+            "weights": self.weights,
+            "embedding": self.embedding,
+            "stages": self.stages,
+            "candidates": self.candidates,
+            "truncation": {"top_k": self.top_k, "dropped_count": self.truncated_count},
+        }
 
 
 @dataclass

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -37,7 +37,10 @@ from mnemosyne.core.beam import BeamMemory
 try:
     from mnemosyne_hermes.tools import ALL_TOOL_SCHEMAS
 except ImportError:
-    ALL_TOOL_SCHEMAS = []
+    try:
+        from hermes_memory_provider import ALL_TOOL_SCHEMAS
+    except ImportError:
+        ALL_TOOL_SCHEMAS = []
 
 # ---------------------------------------------------------------------------
 # Tool Definitions
@@ -230,9 +233,10 @@ def _handle_recall(arguments: Dict[str, Any]) -> Dict[str, Any]:
     vec_weight = arguments.get("vec_weight")
     fts_weight = arguments.get("fts_weight")
     importance_weight = arguments.get("importance_weight")
+    explain = bool(arguments.get("explain", False))
 
     mem = _create_instance(author_id=arguments.get("author_id"), author_type=arguments.get("author_type"), channel_id=arguments.get("channel_id"), bank=bank)
-    results = mem.recall(
+    recall_payload = mem.recall(
         query=query,
         top_k=top_k,
         temporal_weight=temporal_weight,
@@ -241,7 +245,14 @@ def _handle_recall(arguments: Dict[str, Any]) -> Dict[str, Any]:
         vec_weight=vec_weight,
         fts_weight=fts_weight,
         importance_weight=importance_weight,
+        explain=explain,
     )
+    if explain:
+        results = recall_payload.get("results", [])
+        explain_payload = recall_payload.get("explain", {})
+    else:
+        results = recall_payload
+        explain_payload = None
 
     serializable = []
     for r in results:
@@ -252,12 +263,15 @@ def _handle_recall(arguments: Dict[str, Any]) -> Dict[str, Any]:
                     item[key] = item[key].isoformat()
         serializable.append(item)
 
-    return {
+    response = {
         "status": "ok",
         "count": len(serializable),
         "results": serializable,
         "bank": bank
     }
+    if explain_payload is not None:
+        response.update({"query": query, "top_k": top_k, "explain": explain_payload})
+    return response
 
 
 def _handle_shared_remember(arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_cli_usage_errors.py
+++ b/tests/test_cli_usage_errors.py
@@ -1,5 +1,6 @@
 """CLI usage error regression tests."""
 
+import json
 import os
 import subprocess
 import sys
@@ -55,3 +56,17 @@ def test_help_exits_successfully(tmp_path):
     assert result.returncode == 0
     assert "Usage: mnemosyne <command> [args]" in result.stdout
     assert "Traceback" not in result.stderr
+
+
+def test_recall_explain_json_outputs_parseable_payload(tmp_path):
+    store = run_cli(["store", "Alice prefers Vim", "cli", "0.8"], tmp_path)
+    assert store.returncode == 0, store.stderr
+
+    result = run_cli(["recall", "Alice", "--explain", "--json"], tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["query"] == "Alice"
+    assert payload["top_k"] == 5
+    assert isinstance(payload["results"], list)
+    assert "explain" in payload

--- a/tests/test_hermes_memory_provider.py
+++ b/tests/test_hermes_memory_provider.py
@@ -16,6 +16,54 @@ from hermes_memory_provider import MnemosyneMemoryProvider
 from mnemosyne.core.llm_backends import get_host_llm_backend
 
 
+class _RecallBeam:
+    def __init__(self):
+        self.kwargs = None
+
+    def recall(self, query, **kwargs):
+        self.kwargs = kwargs
+        if kwargs.get("explain"):
+            return {
+                "query": query,
+                "top_k": kwargs.get("top_k"),
+                "results": [{"id": "m1", "content": "Alice", "score": 1.0}],
+                "explain": {"stages": [], "candidates": []},
+            }
+        return [{"id": "m1", "content": "Alice", "score": 1.0}]
+
+
+def _provider_with_recall_beam():
+    provider = MnemosyneMemoryProvider()
+    provider._beam = _RecallBeam()
+    provider._shared_surface_read = False
+    return provider
+
+
+def test_recall_schema_exposes_explain_flag():
+    schema = next(s for s in MnemosyneMemoryProvider().get_tool_schemas() if s["name"] == "mnemosyne_recall")
+    assert schema["parameters"]["properties"]["explain"]["type"] == "boolean"
+
+
+def test_handle_recall_explain_forwards_and_unwraps_payload():
+    provider = _provider_with_recall_beam()
+
+    payload = json.loads(provider._handle_recall({"query": "Alice", "explain": True}))
+
+    assert provider._beam.kwargs["explain"] is True
+    assert payload["results"][0]["bank"] == "private"
+    assert "explain" in payload
+
+
+def test_handle_recall_normal_shape_unchanged():
+    provider = _provider_with_recall_beam()
+
+    payload = json.loads(provider._handle_recall({"query": "Alice"}))
+
+    assert provider._beam.kwargs["explain"] is False
+    assert "explain" not in payload
+    assert payload["results"][0]["bank"] == "private"
+
+
 # ---------------------------------------------------------------------------
 # initialize() registration
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -87,6 +87,7 @@ class TestToolSchemas:
         assert "limit" in schema["properties"]
         # bank is not in the schema - handled via MCP server env var MNEMOSYNE_MCP_BANK
         assert "temporal_weight" in schema["properties"]
+        assert schema["properties"]["explain"]["type"] == "boolean"
 
     def test_destructive_tools_exist(self):
         """Destructive tools are now exposed (Phase 7+)."""
@@ -200,6 +201,29 @@ class TestToolHandlers:
         assert result["count"] == 1
         assert len(result["results"]) == 1
         mock_mnemosyne.recall.assert_called_once()
+        assert mock_mnemosyne.recall.call_args.kwargs["explain"] is False
+
+    def test_handle_recall_explain_unwraps_payload(self, mock_mnemosyne):
+        mock_mnemosyne.recall.return_value = {
+            "query": "test query",
+            "top_k": 5,
+            "results": [{"id": "mem1", "content": "Test content", "score": 0.95}],
+            "explain": {"stages": [], "candidates": []},
+        }
+        with patch("mnemosyne.mcp_tools._create_instance", return_value=mock_mnemosyne):
+            result = handle_tool_call("mnemosyne_recall", {
+                "query": "test query",
+                "top_k": 5,
+                "explain": True,
+                "bank": "default",
+            })
+
+        assert result["status"] == "ok"
+        assert result["query"] == "test query"
+        assert result["top_k"] == 5
+        assert result["count"] == 1
+        assert "explain" in result
+        assert mock_mnemosyne.recall.call_args.kwargs["explain"] is True
 
     def test_handle_recall_forwards_scoring_weights(self, mock_mnemosyne):
         """Schema-advertised recall weights should be forwarded to Mnemosyne.recall()."""

--- a/tests/test_recall_explain.py
+++ b/tests/test_recall_explain.py
@@ -1,0 +1,95 @@
+"""Regression tests for opt-in recall explain traces (#322)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+def test_recall_default_return_shape_unchanged(temp_db):
+    beam = BeamMemory(session_id="s1", db_path=temp_db)
+    beam.remember("Alice prefers Vim editor", source="pref", importance=0.7)
+
+    results = beam.recall("Alice Vim", top_k=5)
+
+    assert isinstance(results, list)
+    assert results
+    assert all(isinstance(row, dict) for row in results)
+
+
+def test_recall_explain_returns_structured_payload(temp_db):
+    beam = BeamMemory(session_id="s1", db_path=temp_db)
+    beam.remember("Alice prefers Vim editor", source="pref", importance=0.7)
+
+    payload = beam.recall("Alice Vim", top_k=5, explain=True)
+
+    assert payload["query"] == "Alice Vim"
+    assert payload["top_k"] == 5
+    assert payload["engine"] == "linear"
+    assert isinstance(payload["results"], list)
+    explain = payload["explain"]
+    assert set(explain) >= {"filters", "weights", "embedding", "stages", "candidates", "truncation"}
+    json.dumps(payload)
+
+
+def test_explain_contains_stage_counts_and_topk_truncation(temp_db):
+    beam = BeamMemory(session_id="s1", db_path=temp_db)
+    for i in range(4):
+        beam.remember(f"Alice project note {i}", source="note", importance=0.5)
+
+    payload = beam.recall("Alice project", top_k=1, explain=True)
+    explain = payload["explain"]
+
+    assert explain["stages"]
+    assert explain["truncation"]["top_k"] == 1
+    assert explain["truncation"]["dropped_count"] >= 1
+    assert any(c["drop_reason"] == "top_k_truncated" for c in explain["candidates"])
+
+
+def test_explain_candidate_has_source_path_and_scores(temp_db):
+    beam = BeamMemory(session_id="s1", db_path=temp_db)
+    beam.remember("Alice keeps architecture notes", source="note", importance=0.6)
+
+    payload = beam.recall("Alice architecture", top_k=5, explain=True)
+    candidates = payload["explain"]["candidates"]
+
+    assert candidates
+    candidate = candidates[0]
+    assert candidate["source_path"] in {"wm_fts", "wm_vec", "wm_fallback", "em_fts", "em_vec", "em_fallback", "memoria", "memoria_source"}
+    assert set(candidate["scores"]) >= {"keyword", "fts", "dense", "importance", "recency_decay", "final"}
+
+
+def test_explain_does_not_leak_cross_session_filtered_rows(temp_db):
+    foreign = BeamMemory(session_id="foreign", db_path=temp_db)
+    foreign.remember("SECRET foreign Alice content", source="note", importance=0.9)
+    local = BeamMemory(session_id="local", db_path=temp_db)
+    local.remember("Alice local visible content", source="note", importance=0.5)
+
+    payload = local.recall("Alice", top_k=5, explain=True)
+    serialized_explain = json.dumps(payload["explain"])
+
+    assert "SECRET foreign" not in serialized_explain
+
+
+def test_explain_has_no_raw_sql_or_embedding_values(temp_db):
+    beam = BeamMemory(session_id="s1", db_path=temp_db)
+    beam.remember("Alice prefers Vim editor", source="pref", importance=0.7)
+
+    payload = beam.recall("Alice Vim", top_k=5, explain=True)
+    serialized_explain = json.dumps(payload["explain"])
+
+    assert "SELECT " not in serialized_explain.upper()
+    assert " MATCH " not in serialized_explain.upper()
+    assert "embedding" in payload["explain"]
+    assert "values" not in payload["explain"]["embedding"]


### PR DESCRIPTION
Opt-in explain trace for recall.

- `BeamMemory.recall(..., explain=True)` returns structured payload with query/top_k/results/explain
- `RecallExplainTrace` in `recall_diagnostics.py` (zero overhead when explain=False)
- CLI: `mnemosyne recall "q" --explain --json`
- Hermes/MCP: optional `explain` boolean on schema + handler
- Tests: `test_recall_explain.py` + regression in CLI/MCP/Hermes provider

Scope strictly v1: no pretty output, no global trace, no embedding/SQL leakage, no cross-session ID/content leaks, top-k truncation visible.

Closes #322