### PR TITLE
fix(embeddings): respect HERMES_HOME for fastembed cache default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Respect `HERMES_HOME` for the fastembed cache default.** The default ONNX
+  model cache path now resolves to `<HERMES_HOME>/cache/fastembed` (falling back
+  to `~/.hermes/cache/fastembed` when `HERMES_HOME` is unset), instead of always
+  writing to `~/.hermes`. Keeps the cache co-located with the rest of Hermes'
+  state for users on a relocated layout (e.g. `~/.config/hermes`). No-op for
+  default installs; matches the `HERMES_HOME` handling already used elsewhere in
+  the package. `MNEMOSYNE_FASTEMBED_CACHE_DIR` still overrides.
+
 ## [3.10.1] — 2026-06-22
 
 ### Security

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -41,11 +41,20 @@ def _is_fastembed_available() -> bool:
 # Use _is_fastembed_available() in new code — it re-evaluates on each call.
 _FASTEMBED_AVAILABLE = _is_fastembed_available()
 # Allow CI / scripted environments to redirect the fastembed cache to a
-# stable path that can be restored by actions/cache. Defaults to the
-# user-local ~/.hermes/cache/fastembed directory.
+# stable path that can be restored by actions/cache. Defaults to
+# <HERMES_HOME>/cache/fastembed, falling back to ~/.hermes/cache/fastembed
+# when HERMES_HOME is unset. Respecting HERMES_HOME keeps the cache co-located
+# with the rest of Hermes' state (config, db, logs) instead of leaking a
+# separate ~/.hermes directory when a user relocates HERMES_HOME (e.g. to
+# ~/.config/hermes). Matches the HERMES_HOME handling already used elsewhere
+# in the package (see mcp_tools.py).
 _FASTEMBED_CACHE_DIR = os.environ.get(
     "MNEMOSYNE_FASTEMBED_CACHE_DIR",
-    os.path.join(os.path.expanduser("~/.hermes"), "cache", "fastembed"),
+    os.path.join(
+        os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")),
+        "cache",
+        "fastembed",
+    ),
 )
 
 # --- OpenAI-compatible API ---


### PR DESCRIPTION
The `MNEMOSYNE_FASTEMBED_CACHE_DIR` override (added in `fix/ci-embedding-model-cache`) lets CI redirect the fastembed model cache, but its **default** still hardcodes `~/.hermes` and ignores `HERMES_HOME`.

## Problem

Users who relocate `HERMES_HOME` — e.g. to `~/.config/hermes` for XDG cleanliness — end up with a stray `~/.hermes/cache/fastembed` directory holding ~64MB of BGE model weights, separate from the rest of their Hermes state (config, db, logs, mnemosyne data), all of which correctly live under `$HERMES_HOME`.

Because the cache path is passed as an explicit `cache_dir=` argument to `TextEmbedding()`, no fastembed env var can redirect it — the explicit arg wins. So the default itself has to honor `HERMES_HOME`.

## Fix

Default the cache to `<HERMES_HOME>/cache/fastembed`, falling back to `~/.hermes/cache/fastembed` when `HERMES_HOME` is unset.

```python
_FASTEMBED_CACHE_DIR = os.environ.get(
    "MNEMOSYNE_FASTEMBED_CACHE_DIR",
    os.path.join(
        os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")),
        "cache",
        "fastembed",
    ),
)
```

This matches the `HERMES_HOME` handling already used elsewhere in the package (`mcp_tools.py`), and is a no-op for anyone on the default layout (HERMES_HOME unset → identical `~/.hermes` path). The explicit `MNEMOSYNE_FASTEMBED_CACHE_DIR` override still takes precedence.

## Testing

- `ast.parse` clean.
- Verified locally on a relocated `HERMES_HOME=~/.config/hermes`: `_FASTEMBED_CACHE_DIR` resolves to `~/.config/hermes/cache/fastembed`, the model loads from there, and `embed()` returns a `(1, 384)` vector. No `~/.hermes` directory is recreated.