### PR TITLE
fix(dr): load sqlite-vec in create_backup so vec0 backups work

### DIFF
--- a/mnemosyne/dr/recovery.py
+++ b/mnemosyne/dr/recovery.py
@@ -70,7 +70,22 @@ def create_backup(db_path: Path = None, backup_dir: Path = None) -> Dict:
     # approach only copied the .db file, missed .db-wal frames, and
     # could produce corrupted backups under concurrent write load.
     src = sqlite3.connect(str(db_path))
+    # Load sqlite-vec on BOTH connections involved in the backup.
+    # Without this, src.backup(dst) fails with "no such module: vec0"
+    # when copying vec0 virtual tables, AND dst.iterdump() (used to
+    # serialize the in-memory backup to gzipped SQL) fails the same
+    # way when introspecting the destination's vec0 schema.
+    # Mirrors the graceful-fallback pattern in core/beam.py.
+    def _load_sqlite_vec(conn):
+        try:
+            import sqlite_vec
+            conn.enable_load_extension(True)
+            sqlite_vec.load(conn)
+        except (ImportError, sqlite3.OperationalError):
+            pass  # optional extra; absence just means no vec0 tables
+    _load_sqlite_vec(src)
     dst = sqlite3.connect(":memory:")
+    _load_sqlite_vec(dst)
     src.backup(dst)
     src.close()
 

--- a/tests/test_recovery_paths.py
+++ b/tests/test_recovery_paths.py
@@ -9,7 +9,10 @@ wrong database.
 """
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
+
+import pytest
 
 from mnemosyne.dr import recovery
 
@@ -47,3 +50,47 @@ def test_get_default_paths_data_dir_takes_precedence_over_hermes_home(monkeypatc
     data_dir, _, db_path = recovery.get_default_paths()
     assert data_dir == tmp_path / "explicit"
     assert db_path == tmp_path / "explicit" / "mnemosyne.db"
+
+
+def test_create_backup_succeeds_with_sqlite_vec_tables(tmp_path):
+    """Regression: create_backup() must load sqlite-vec on the source AND
+    destination connections, otherwise sqlite3.Connection.backup() and
+    Connection.iterdump() both fail with ``no such module: vec0`` on
+    databases that use vec0 virtual tables.
+
+    Pre-fix: this test fails with ``sqlite3.OperationalError: no such
+    module: vec0`` raised from inside the backup serialization path.
+    """
+    pytest.importorskip("sqlite_vec")
+
+    db_path = tmp_path / "vec_test.db"
+    backup_dir = tmp_path / "backups"
+
+    # Build a tiny DB that has a vec0 virtual table — the exact schema
+    # shape that triggered the original bug in 3.10.x.
+    conn = sqlite3.connect(str(db_path))
+    conn.enable_load_extension(True)
+    import sqlite_vec
+    sqlite_vec.load(conn)
+    conn.execute(
+        "CREATE VIRTUAL TABLE vec_items USING vec0("
+        "embedding float[4] distance_metric=cosine)"
+    )
+    conn.execute("CREATE TABLE meta (k TEXT PRIMARY KEY, v TEXT)")
+    conn.executemany("INSERT INTO meta VALUES (?, ?)", [("a", "1"), ("b", "2")])
+    conn.commit()
+    conn.close()
+
+    # Act: this is the call path `mnemosyne backup` uses. Pre-fix it
+    # raised sqlite3.OperationalError: no such module: vec0.
+    result = recovery.create_backup(db_path=db_path, backup_dir=backup_dir)
+
+    # Assert: backup file exists, is non-empty, gzipped, and the gz
+    # contents contain the vec0 table definition.
+    assert Path(result["backup_path"]).exists()
+    assert result["backup_size"] > 0
+    import gzip
+    with gzip.open(result["backup_path"], "rt") as f:
+        dump = f.read()
+    assert "vec_items" in dump
+    assert "CREATE VIRTUAL TABLE" in dump


### PR DESCRIPTION
## Summary

`mnemosyne backup` (and the auto-backup inside `mnemosyne reindex`) fail with `sqlite3.OperationalError: no such module: vec0` on every 3.10.x install, because the new `sqlite-vec` virtual tables aren't loaded on the connections that `create_backup()` uses for `Connection.backup()` and `Connection.iterdump()`. This PR adds the missing extension load on both the source and destination connections, with a graceful fallback when `sqlite-vec` isn't installed.

## Repro

1. Install 3.10.x: `pip install 'mnemosyne-memory[embeddings]'`
2. Use Mnemosyne (any operation that creates `vec_working` / `vec_episodic` / `vec_facts` tables — i.e. anything that runs the reindex).
3. Run `mnemosyne backup /tmp/test`.
4. Observe: `Error: no such module: vec0`

Workaround currently in the field: pass `--no-backup` to `mnemosyne reindex`, which leaves users with no safety net for the actual database.

## Root cause

`mnemosyne/dr/recovery.py::create_backup` does:

```python
src = sqlite3.connect(str(db_path))
dst = sqlite3.connect(':memory:')
src.backup(dst)   # <-- fails: src has no vec0 module registered
```

…and then:

```python
for line in dst.iterdump():  # <-- also fails on the same 'no such module: vec0' for the same reason
    ...
```

The first call fails on the source side, but even when the source-side extension is loaded, `iterdump()` invokes `PRAGMA table_info(...)` against the destination for each table including vec0, and `:memory:` has no extension registered. So the fix has to load the extension on **both** connections.

## Fix

```python
def _load_sqlite_vec(conn):
    try:
        import sqlite_vec
        conn.enable_load_extension(True)
        sqlite_vec.load(conn)
    except (ImportError, sqlite3.OperationalError):
        pass  # optional extra; absence just means no vec0 tables

_load_sqlite_vec(src)
dst = sqlite3.connect(':memory:')
_load_sqlite_vec(dst)
src.backup(dst)
```

Mirrors the graceful-fallback pattern already used in `core/beam.py:435-440`. If `sqlite-vec` isn't installed, the loader no-ops (and there are no vec0 tables to back up in that case anyway).

## Test

Added `tests/test_recovery_paths.py::test_create_backup_succeeds_with_sqlite_vec_tables`. The test:

1. Builds a minimal SQLite DB in `tmp_path` with one `vec0` virtual table and one regular table.
2. Calls `recovery.create_backup()`.
3. Decompresses the gz dump and asserts it contains the `vec0` table definition.

**Verified to fail with the exact production error** (`no such module: vec0` from `iterdump`) when the fix is reverted, and pass when applied. All 11 related tests in `test_recovery_paths.py` and `test_beam_e6_auto_migrate.py` pass.

```
$ pytest tests/test_recovery_paths.py -v
test_get_default_paths_honors_data_dir ............................. PASSED
test_get_default_paths_honors_hermes_home .......................... PASSED
test_get_default_paths_backup_dir_override ........................ PASSED
test_get_default_paths_data_dir_takes_precedence_over_hermes_home . PASSED
test_create_backup_succeeds_with_sqlite_vec_tables ................. PASSED
5 passed
```

## Out of scope (separate, follow-up issue needed)

`restore_backup()` in the same file can fail with `OperationalError: no such table: fts_episodes` on databases that have both FTS5 and vec0, because `iterdump()` emits `CREATE` statements in an order that violates the dependency between virtual tables and their content/shadow tables. This is a different bug — it only surfaces after a user has a working backup — and fixing it properly likely means writing a custom dump that orders virtual tables before their data tables. **Not fixed in this PR** to keep the scope focused; happy to file a separate issue / follow-up PR if maintainers want.

## Discovered while

Upgrading a Hermes Agent install from mnemosyne-memory 3.5.0 → 3.10.1 (5 minor versions) on a Debian 13 host.