### PR TITLE
feat: make remote LLM timeout configurable via MNEMOSYNE_LLM_TIMEOUT

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,6 +135,7 @@ Use a remote model instead of the local MiniCPM5-1B GGUF:
 | `MNEMOSYNE_LLM_BASE_URL` | *(none)* | OpenAI-compatible API base URL (e.g. `http://localhost:8080/v1`) |
 | `MNEMOSYNE_LLM_API_KEY` | *(none)* | API key for authenticated endpoints |
 | `MNEMOSYNE_LLM_MODEL` | *(none)* | Model identifier sent in requests |
+| `MNEMOSYNE_LLM_TIMEOUT` | `60` | HTTP timeout in seconds for remote LLM calls. Increase for slow proxies or models with long generation times (e.g. `300` for reasoning models routed through local proxies). |
 
 When `MNEMOSYNE_LLM_BASE_URL` is set, Mnemosyne uses the remote endpoint for consolidation. Falls back to local ctransformers if the remote is unreachable, then to AAAK encoding.
 

--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -36,6 +36,7 @@ if _env_repo and _env_file:
 LLM_BASE_URL = os.environ.get("MNEMOSYNE_LLM_BASE_URL", "").rstrip("/")
 LLM_API_KEY = os.environ.get("MNEMOSYNE_LLM_API_KEY", "")
 LLM_REMOTE_MODEL = os.environ.get("MNEMOSYNE_LLM_MODEL", "")
+LLM_TIMEOUT = float(os.environ.get("MNEMOSYNE_LLM_TIMEOUT", "60"))
 
 # Retryable errors only: 404/400 (model-not-found), 5xx, connection. Not 401/403/429.
 LLM_FALLBACK_MODELS = [
@@ -461,7 +462,7 @@ def _call_remote_llm_with_model(
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
-    timeout: float = 60.0,
+    timeout: float = LLM_TIMEOUT,
 ) -> "tuple[Optional[str], Optional[int], Optional[Exception]]":
     """Call an OpenAI-compatible endpoint with a specific model name.
 


### PR DESCRIPTION
### Problem

`_call_remote_llm_with_model()` in `mnemosyne/core/local_llm.py` hardcodes a 60-second HTTP timeout:

```python
def _call_remote_llm_with_model(
    prompt: str,
    model: str,
    temperature: float = 0.3,
    *,
    base_url: Optional[str] = None,
    api_key: Optional[str] = None,
    timeout: float = 60.0,  # ← hardcoded, no env var
) -> ...
```

This timeout covers both consolidation (`summarize_memories`) and fact extraction (`extract_facts`), the two LLM-dependent codepaths in the sleep cycle.

For deployments routing to frontier models, 60 seconds isn't enough. Measured latencies with claude-sonnet-4.6:

| Scenario | Observed latency |
|---|---|
| Typical 10-turn consolidation batch | 30-50s |
| Large backlog after extended gap | 60-120s |
| Proxy under load / reasoning model | up to 180s |

When the timeout fires, `_call_remote_llm_with_model` returns `(None, None, TimeoutError)`. The caller falls through to local GGUF inference (not installed in most containerised setups), then to `None`. The sleep cycle produces no episodic memories. Nothing gets logged because `_maybe_auto_sleep` wraps everything in `except Exception: pass`.

The failure is silent and persistent. Consolidation looks broken with no diagnostic signal beyond episodic count staying at zero.

### Fix

Two lines. Read the timeout from `MNEMOSYNE_LLM_TIMEOUT` env var with a 60s default:

```python
# Module level (alongside other LLM_* constants):
LLM_TIMEOUT = float(os.environ.get("MNEMOSYNE_LLM_TIMEOUT", "60"))

# Function signature:
def _call_remote_llm_with_model(
    ...
    timeout: float = LLM_TIMEOUT,  # was: 60.0
) -> ...
```

### Affected code paths

| Caller | Context |
|---|---|
| `_call_remote_llm()` → `summarize_memories()` | Sleep/consolidation cycle |
| `_call_remote_llm()` → `extract_facts()` | Structured fact extraction via `remember(..., extract=True)` |

Both callers delegate to `_call_remote_llm_with_model` without passing `timeout`, so they inherit the new configurable default.

### Design alignment

- **Zero-config:** Default unchanged at 60s. No configuration required for existing users.
- **Local-first:** No cloud dependency introduced. Env var follows the established `MNEMOSYNE_LLM_*` naming convention.
- **Minimal:** Two lines of code, one line of docs.

### Regression risk

None. Default value is unchanged at 60s. Existing deployments without the env var behave identically. The env var is read once at module load, consistent with all other `MNEMOSYNE_LLM_*` constants.

Closes #375