### PR TITLE
fix: register host LLM backend before skip-context early return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Host LLM backend registration in skip-context sessions.**
+  `register_hermes_host_llm()` was called at the end of
+  `MnemosyneMemoryProvider.initialize()`, after the skip-context early
+  return. Cron, subagent, and background sessions never reached it, so
+  `mnemosyne_sleep` silently fell back to AAAK. Registration now fires
+  before the skip-context check; `shutdown()` only unregisters when the
+  session is not in a skip context. Also fixes the CLI standalone-loading
+  fallback import path for both `cli.py` copies (#368, supersedes #361).
+
 - **Respect `HERMES_HOME` for the fastembed cache default.** The default ONNX
   model cache path now resolves to `<HERMES_HOME>/cache/fastembed` (falling back
   to `~/.hermes/cache/fastembed` when `HERMES_HOME` is unset), instead of always
@@ -48,6 +57,16 @@ If you cannot upgrade right away, restrict network access to the sync
 endpoint (firewall, reverse proxy with mTLS, or localhost bind with SSH
 tunnel). The vulnerability is not exploitable against an unreachable
 endpoint.
+=======
+- **Host LLM backend registration in skip-context sessions.**
+  `register_hermes_host_llm()` was called at the end of
+  `MnemosyneMemoryProvider.initialize()`, after the skip-context early
+  return. Cron, subagent, and background sessions never reached it, so
+  `mnemosyne_sleep` silently fell back to AAAK. Registration now fires
+  before the skip-context check; `shutdown()` only unregisters when the
+  session is not in a skip context. Also fixes the CLI standalone-loading
+  fallback import path for both `cli.py` copies (#368, supersedes #361).
+>>>>>>> 35627ea (docs: add CHANGELOG entry for host LLM skip-context fix + fix _discover_plugins doc reference)
 
 ## [3.10.0] — 2026-06-18
 

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1535,6 +1535,20 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # Apply provider-specific config from kwargs (Hermes-passed) or config.yaml fallback
         self._apply_provider_config(kwargs)
 
+        # Register the Hermes auxiliary LLM backend BEFORE the skip-context
+        # early return. The backend is process-global and needed by
+        # mnemosyne_sleep / extract_facts regardless of whether this session
+        # gets memory injection. Without this, cron-context sessions that
+        # still call mnemosyne_sleep as a tool silently fall back to AAAK
+        # because register_hermes_host_llm() was after the early return.
+        # Idempotent: set_host_llm_backend() just overwrites the global.
+        try:
+            from hermes_memory_provider.hermes_llm_adapter import register_hermes_host_llm
+            if register_hermes_host_llm():
+                logger.info("Mnemosyne registered Hermes auxiliary LLM backend for memory operations")
+        except Exception as exc:
+            logger.debug("Mnemosyne could not register Hermes auxiliary LLM backend: %s", exc)
+
         if self._agent_context in self._skip_contexts:
             logger.debug("Mnemosyne skipped: non-primary context=%s", self._agent_context)
             # C13: a skip-context re-init must DEACTIVATE the instance if
@@ -1602,18 +1616,6 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if self._beam is not None:
             self._activate_in_module()
             self._init_audit_log()
-
-        # Register the Hermes auxiliary LLM backend so Mnemosyne can route
-        # consolidation and fact extraction through Hermes' authenticated
-        # provider (e.g., openai-codex via OAuth) when the user opts in via
-        # MNEMOSYNE_HOST_LLM_ENABLED=true. Registration alone does not
-        # change Mnemosyne behavior; failure here must not break the provider.
-        try:
-            from hermes_memory_provider.hermes_llm_adapter import register_hermes_host_llm
-            if register_hermes_host_llm():
-                logger.info("Mnemosyne registered Hermes auxiliary LLM backend for memory operations")
-        except Exception as exc:
-            logger.debug("Mnemosyne could not register Hermes auxiliary LLM backend: %s", exc)
 
     def system_prompt_block(self) -> str:
         if self._beam:
@@ -2900,11 +2902,15 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # Symmetric with initialize(): clear the Hermes host LLM backend so a
         # process that later uses Mnemosyne outside Hermes does not retain a
         # stale reference into agent.auxiliary_client.
-        try:
-            from hermes_memory_provider.hermes_llm_adapter import unregister_hermes_host_llm
-            unregister_hermes_host_llm()
-        except Exception as exc:
-            logger.debug("Mnemosyne could not unregister Hermes auxiliary LLM backend: %s", exc)
+        # BUT: skip-context sessions (cron, subagent, etc.) did not own the
+        # backend — it was registered by a primary session. Skip unregister
+        # so we don't kill the backend for the whole process.
+        if self._agent_context not in self._skip_contexts:
+            try:
+                from hermes_memory_provider.hermes_llm_adapter import unregister_hermes_host_llm
+                unregister_hermes_host_llm()
+            except Exception as exc:
+                logger.debug("Mnemosyne could not unregister Hermes auxiliary LLM backend: %s", exc)
         self._beam = None
 
         # C13: decrement this instance's contribution to the module-level

--- a/hermes_memory_provider/cli.py
+++ b/hermes_memory_provider/cli.py
@@ -69,9 +69,17 @@ def mnemosyne_command(args):
         print("Usage: hermes mnemosyne {stats|sleep|version|inspect|clear|export|import}")
         return 1
 
-    # Register Hermes host LLM backend so sleep uses Hermes' provider
+    # Register Hermes host LLM backend so sleep uses Hermes' provider.
+    # Use a try/except fallback chain: the relative import works when loaded
+    # as part of the hermes_memory_provider package; the absolute import is
+    # needed when this module is loaded standalone (e.g. Hermes user-plugin
+    # discovery via importlib.util.spec_from_file_location, which does not
+    # set up the parent package — breaking relative imports silently).
     try:
-        from .hermes_llm_adapter import register_hermes_host_llm
+        try:
+            from .hermes_llm_adapter import register_hermes_host_llm
+        except ImportError:
+            from hermes_memory_provider.hermes_llm_adapter import register_hermes_host_llm
         register_hermes_host_llm()
     except Exception:
         pass

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -775,6 +775,20 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # Apply provider-specific config from kwargs (Hermes-passed) or config.yaml fallback
         self._apply_provider_config(kwargs)
 
+        # Register the Hermes auxiliary LLM backend BEFORE the skip-context
+        # early return. The backend is process-global and needed by
+        # mnemosyne_sleep / extract_facts regardless of whether this session
+        # gets memory injection. Without this, cron-context sessions that
+        # still call mnemosyne_sleep as a tool silently fall back to AAAK
+        # because register_hermes_host_llm() was after the early return.
+        # Idempotent: set_host_llm_backend() just overwrites the global.
+        try:
+            from .hermes_llm_adapter import register_hermes_host_llm
+            if register_hermes_host_llm():
+                logger.info("Mnemosyne registered Hermes auxiliary LLM backend for memory operations")
+        except Exception as exc:
+            logger.debug("Mnemosyne could not register Hermes auxiliary LLM backend: %s", exc)
+
         if self._agent_context in self._skip_contexts:
             logger.debug("Mnemosyne skipped: non-primary context=%s", self._agent_context)
             # C13: a skip-context re-init must DEACTIVATE the instance if
@@ -850,18 +864,6 @@ class MnemosyneMemoryProvider(MemoryProvider):
         if self._beam is not None:
             self._activate_in_module()
             self._init_audit_log()
-
-        # Register the Hermes auxiliary LLM backend so Mnemosyne can route
-        # consolidation and fact extraction through Hermes' authenticated
-        # provider (e.g., openai-codex via OAuth) when the user opts in via
-        # MNEMOSYNE_HOST_LLM_ENABLED=true. Registration alone does not
-        # change Mnemosyne behavior; failure here must not break the provider.
-        try:
-            from .hermes_llm_adapter import register_hermes_host_llm
-            if register_hermes_host_llm():
-                logger.info("Mnemosyne registered Hermes auxiliary LLM backend for memory operations")
-        except Exception as exc:
-            logger.debug("Mnemosyne could not register Hermes auxiliary LLM backend: %s", exc)
 
     def system_prompt_block(self) -> str:
         if self._beam:
@@ -2042,11 +2044,15 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # Symmetric with initialize(): clear the Hermes host LLM backend so a
         # process that later uses Mnemosyne outside Hermes does not retain a
         # stale reference into agent.auxiliary_client.
-        try:
-            from .hermes_llm_adapter import unregister_hermes_host_llm
-            unregister_hermes_host_llm()
-        except Exception as exc:
-            logger.debug("Mnemosyne could not unregister Hermes auxiliary LLM backend: %s", exc)
+        # BUT: skip-context sessions (cron, subagent, etc.) did not own the
+        # backend — it was registered by a primary session. Skip unregister
+        # so we don't kill the backend for the whole process.
+        if self._agent_context not in self._skip_contexts:
+            try:
+                from .hermes_llm_adapter import unregister_hermes_host_llm
+                unregister_hermes_host_llm()
+            except Exception as exc:
+                logger.debug("Mnemosyne could not unregister Hermes auxiliary LLM backend: %s", exc)
         self._beam = None
 
         # C13: decrement this instance's contribution to the module-level

--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -65,9 +65,17 @@ def mnemosyne_command(args):
         print("Usage: hermes mnemosyne {stats|sleep|version|inspect|clear|export|import}")
         return 1
 
-    # Register Hermes host LLM backend so sleep uses Hermes' provider
+    # Register Hermes host LLM backend so sleep uses Hermes' provider.
+    # Use a try/except fallback chain: the relative import works when loaded
+    # as part of the mnemosyne_hermes package; the absolute import is needed
+    # when this module is loaded standalone (e.g. Hermes user-plugin
+    # discovery via importlib.util.spec_from_file_location, which does not
+    # set up the parent package — breaking relative imports silently).
     try:
-        from .hermes_llm_adapter import register_hermes_host_llm
+        try:
+            from .hermes_llm_adapter import register_hermes_host_llm
+        except ImportError:
+            from mnemosyne_hermes.hermes_llm_adapter import register_hermes_host_llm
         register_hermes_host_llm()
     except Exception:
         pass

--- a/tests/test_cli_host_llm_standalone_loading.py
+++ b/tests/test_cli_host_llm_standalone_loading.py
@@ -1,0 +1,115 @@
+"""Regression test: CLI host LLM backend registration under standalone module loading.
+
+When Hermes' plugin discovery loads cli.py via
+``importlib.util.spec_from_file_location()`` (without registering the
+parent package), relative imports like ``from .hermes_llm_adapter import ...``
+fail silently. The try/except in ``mnemosyne_command()`` swallows the
+ImportError, so ``register_hermes_host_llm()`` never runs and
+``MNEMOSYNE_HOST_LLM_ENABLED`` is silently ignored.
+
+This test loads both CLI copies the same way ``discover_plugins``
+(in `mnemosyne/core/plugins.py`) does and verifies the registration path is reached.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mnemosyne.core import llm_backends
+from mnemosyne.core.llm_backends import get_host_llm_backend
+
+
+# ---------------------------------------------------------------------------
+# Fake `agent` package — same pattern as test_hermes_llm_adapter.py
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fake_agent_module(monkeypatch):
+    agent_pkg = types.ModuleType("agent")
+    aux_client = types.ModuleType("agent.auxiliary_client")
+    agent_pkg.auxiliary_client = aux_client
+    monkeypatch.setitem(sys.modules, "agent", agent_pkg)
+    monkeypatch.setitem(sys.modules, "agent.auxiliary_client", aux_client)
+    yield aux_client
+    # cleanup
+    llm_backends.set_host_llm_backend(None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CLI_COPIES = [
+    REPO_ROOT / "integrations" / "hermes" / "src" / "mnemosyne_hermes" / "cli.py",
+    REPO_ROOT / "hermes_memory_provider" / "cli.py",
+]
+
+
+def _load_cli_standalone(cli_path: Path, module_name: str):
+    """Load a cli.py as a standalone module via spec_from_file_location,
+    exactly like Hermes' discover_plugins() (mnemosyne/core/plugins.py) does.
+
+    The parent package is NOT registered in sys.modules, so relative
+    imports (``from .hermes_llm_adapter import ...``) will fail.
+    """
+    spec = importlib.util.spec_from_file_location(module_name, str(cli_path))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clear_backend():
+    """Ensure each test starts with no backend registered."""
+    llm_backends.set_host_llm_backend(None)
+    yield
+    llm_backends.set_host_llm_backend(None)
+
+
+@pytest.mark.parametrize("cli_path", CLI_COPIES, ids=[str(p.relative_to(REPO_ROOT)) for p in CLI_COPIES])
+def test_register_host_llm_reached_under_standalone_loading(fake_agent_module, cli_path):
+    """Loading cli.py via spec_from_file_location must still reach
+    register_hermes_host_llm() — the fallback import chain must succeed
+    even though the relative import fails.
+    """
+    fake_agent_module.call_llm = MagicMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+
+    mod_name = f"_test_standalone_{cli_path.stem}_{hash(str(cli_path)) & 0xFFFFFFFF:x}"
+    mod = _load_cli_standalone(cli_path, mod_name)
+
+    # Verify mnemosyne_command exists and is callable
+    assert hasattr(mod, "mnemosyne_command"), f"{cli_path} does not define mnemosyne_command"
+
+    # Call mnemosyne_command with args that pass the early-return guard
+    # (mnemosyne_cmd must be set) but exercise a lightweight subcommand.
+    # "version" only needs to import mnemosyne.__version__ — no DB access.
+    # The registration happens before subcommand dispatch, so any valid cmd
+    # triggers it. We capture stdout to suppress the version output.
+    import argparse, io, contextlib
+    args = argparse.Namespace(mnemosyne_cmd="version")
+    with contextlib.redirect_stdout(io.StringIO()):
+        mod.mnemosyne_command(args)
+
+    # The backend should be registered — if the import fallback failed
+    # silently, this assertion fails.
+    backend = get_host_llm_backend()
+    assert backend is not None, (
+        f"register_hermes_host_llm() was not reached when loading {cli_path} "
+        f"via spec_from_file_location — the relative import likely failed "
+        f"silently and the fallback import was not attempted."
+    )
+    assert backend.name == "hermes"

--- a/tests/test_hermes_memory_provider.py
+++ b/tests/test_hermes_memory_provider.py
@@ -101,12 +101,17 @@ def test_initialize_does_not_fail_when_register_returns_false(monkeypatch):
 
 
 def test_initialize_skips_for_non_primary_context(monkeypatch):
-    """REGRESSION: subagent/cron/flush contexts still skip initialization entirely."""
+    """REGRESSION: subagent/cron/flush contexts still skip beam initialization.
+
+    The host LLM backend IS registered (it's process-global and needed by
+    mnemosyne_sleep even in skip-context sessions), but the beam must not
+    be initialized (no memory injection for non-primary contexts).
+    """
     provider = MnemosyneMemoryProvider()
     with patch("hermes_memory_provider.hermes_llm_adapter.register_hermes_host_llm") as mock_reg:
         provider.initialize(session_id="x", agent_context="cron")
-    mock_reg.assert_not_called()
-    assert provider._beam is None
+    mock_reg.assert_called_once()  # Backend registered even in skip context
+    assert provider._beam is None   # But no beam initialized
 
 
 # ---------------------------------------------------------------------------
@@ -114,7 +119,11 @@ def test_initialize_skips_for_non_primary_context(monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_shutdown_clears_host_backend(monkeypatch):
-    """After shutdown(), the host LLM backend must be unregistered."""
+    """After shutdown(), the host LLM backend must be unregistered.
+
+    This test uses the default (primary) agent context, so shutdown()
+    should unregister the backend.
+    """
     from hermes_memory_provider import hermes_llm_adapter
 
     provider = MnemosyneMemoryProvider()
@@ -124,6 +133,24 @@ def test_shutdown_clears_host_backend(monkeypatch):
 
     provider.shutdown()
     assert get_host_llm_backend() is None
+    assert provider._beam is None
+
+
+def test_shutdown_skip_context_preserves_host_backend(monkeypatch):
+    """Skip-context sessions must NOT unregister the host LLM backend on shutdown.
+
+    The backend is process-global and owned by the primary session.
+    A cron/subagent shutdown must not kill it for the whole process.
+    """
+    from hermes_memory_provider import hermes_llm_adapter
+
+    provider = MnemosyneMemoryProvider()
+    provider._agent_context = "cron"  # Simulate skip context
+    hermes_llm_adapter.register_hermes_host_llm()
+    assert get_host_llm_backend() is not None
+
+    provider.shutdown()
+    assert get_host_llm_backend() is not None  # Backend survives
     assert provider._beam is None
 
 


### PR DESCRIPTION
Closes #368. Direct cherry-pick from @tml89's PR since GitHub merge tree was stale. All tests pass (66/66).