### PR TITLE
[docs][Hermes Integration] Use Hermes venv

### DIFF
--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -28,8 +28,8 @@ pip install mnemosyne-hermes
 **Debian / Trixie users:** newer Debian releases block bare pip installs. Use a venv:
 
 ```bash
-python3 -m venv ~/.hermes-venv
-source ~/.hermes-venv/bin/activate
+python3 -m venv ~/.hermes/hermes-agent/venv
+source ~/.hermes/hermes-agent/venv/bin/activate
 pip install mnemosyne-hermes
 ```
 


### PR DESCRIPTION
## Description

This documentation uses a different venv in step 1 vs step 2. I've updated it to use the Hermes venv in both.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [ ] Existing tests still pass (`pytest tests/ -v`)
- [ ] New tests added for any new functionality
- [x] Manual verification (describe what you tested)

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py`
- [ ] `CHANGELOG.md` updated with a brief entry
- [ ] README updated if user-facing behavior changed
- [ ] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency
