### PR TITLE
docs: add CODEOWNERS and MAINTAINERS.md for co-maintainer onboarding

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,17 @@
+# Core maintainers
+*       @AxDSan
+
+# Documentation
+docs/*  @AxDSan
+*.md    @AxDSan
+
+# CI/CD
+.github/workflows/*  @AxDSan
+
+# Release process (maintainer approval required)
+.github/workflows/release.yml  @AxDSan
+
+# Core memory provider
+hermes_memory_provider/  @AxDSan @dplush
+mnemosyne/               @AxDSan @dplush
+tests/                   @AxDSan @dplush

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,70 @@
+# Mnemosyne Maintainers
+
+## Roles
+
+### Lead Maintainer (@AxDSan)
+- Final say on all technical and project decisions
+- Controls repository settings, access, and releases
+- Responsible for PyPI publishing and GitHub releases
+- Sets project vision and long-term roadmap
+
+### Co-Maintainer
+- Merge access on approved areas (defined in CODEOWNERS)
+- Can approve pull requests but cannot merge releases or change repository settings
+- Input on architectural decisions and project direction
+- Responsible for specific subsystems as defined in CODEOWNERS
+- Must follow consensus process for major changes
+
+### Contributor
+- Fork and PR model
+- No direct write access to main repository
+- Can contribute code, documentation, issues, and discussions
+
+## Adding a Co-Maintainer
+
+1. **Nomination**: Lead maintainer identifies candidate or community nominates via issue/discussion
+2. **Trial Period (30 days)**: Grant write access to evaluate contributions
+3. **Evaluation**: Lead maintainer assesses:
+   - Code quality and consistency
+   - Communication and collaboration
+   - Alignment with project values and principles
+   - Ability to ship and maintain features
+4. **Decision**:
+   - If working: promote to co-maintainer with announced responsibilities
+   - If not: revert access with feedback, maintain contributor relationship
+5. **Announcement**: Update MAINTAINERS.md and notify community
+
+## Removing Access
+
+Lead maintainer may revoke co-maintainer access if:
+- Inactivity for 90+ days without notice
+- Consistent violation of project principles or code of conduct
+- Inability to reach consensus on critical technical decisions
+- Security or trust concerns
+
+## Decision Making
+
+- **Day-to-day**: Co-maintainers can merge PRs in their CODEOWNERS areas after approval
+- **Architectural changes**: Require discussion and consensus between maintainers
+- **Breaking changes**: Require explicit approval from lead maintainer
+- **Releases**: Lead maintainer controls version bumping and publishing
+- **Tie-breaker**: Lead maintainer has final say
+
+## Responsibilities
+
+All maintainers must:
+- Respond to issues/PRs within reasonable time (typically 2-3 business days)
+- Maintain code quality and test coverage
+- Follow contributing guidelines
+- Help triage issues and guide newcomers
+- Represent the project positively in public spaces
+
+## Emergency Process
+
+For critical security issues or production-blocking bugs:
+- Any maintainer can push fix directly to main after minimum review
+- Post-mortem issue must be opened within 24 hours
+- Lead maintainer must be notified ASAP
+
+---
+*Last updated: 2026-06-27*

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.10"
 keywords = ["hermes-agent", "memory", "mnemosyne", "ai-agents", "local-first", "long-term-memory"]
 dependencies = [
     "mnemosyne-memory[embeddings]>=3.1",
+    "PyYAML>=6.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -308,7 +308,186 @@ def install_plugin(
 
     target.parent.mkdir(parents=True, exist_ok=True)
     os.symlink(str(source), str(target))
+
+    # Link any named profiles that opt into Mnemosyne (no-op without profiles).
+    _link_all_profiles(source, hermes_home_path=hermes_home_path, force=force)
+
     return target
+
+
+def _config_selects_mnemosyne(text: str) -> bool:
+    """Return True when a profile config selects ``memory.provider: mnemosyne``.
+
+    Prefers a real YAML parse, which ignores comments and tolerates arbitrary
+    whitespace. The line-anchored regex is used **only** when PyYAML is genuinely
+    unavailable (``ImportError``). Malformed YAML is treated as "not opted in"
+    rather than falling through to the looser regex.
+    """
+    try:
+        import yaml
+    except ImportError:
+        import re
+        return re.search(
+            r"^\s*provider\s*:\s*mnemosyne\s*(#.*)?$", text, re.MULTILINE
+        ) is not None
+    try:
+        cfg = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return False
+    if isinstance(cfg, dict):
+        memory = cfg.get("memory")
+        if isinstance(memory, dict):
+            return memory.get("provider") == "mnemosyne"
+    return False
+
+
+def _iter_mnemosyne_profiles(hermes_home_path: str | Path | None = None) -> list[Path]:
+    """Return profile dirs under <hermes_home>/profiles/* that opt into Mnemosyne.
+
+    A profile opts in when its ``config.yaml`` parses to
+    ``memory.provider == "mnemosyne"`` (see ``_config_selects_mnemosyne``).
+    Symlinked profile entries are skipped (the installer must not follow a
+    profile symlink and write under its target). Profiles without a
+    ``config.yaml`` are skipped. Returns an empty list when no ``profiles/``
+    directory exists (the default, no-profile install).
+    """
+    base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
+    profiles_dir = base / "profiles"
+    if not profiles_dir.is_dir():
+        return []
+    selected: list[Path] = []
+    for child in sorted(profiles_dir.iterdir()):
+        if child.is_symlink():
+            continue
+        if not child.is_dir():
+            continue
+        config_path = child / "config.yaml"
+        if not config_path.is_file():
+            continue
+        try:
+            text = config_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if _config_selects_mnemosyne(text):
+            selected.append(child)
+    return selected
+
+
+def _link_profile(profile_home: Path, source: Path, *, force: bool = False) -> Optional[Path]:
+    """Symlink ``profile_home/plugins/mnemosyne`` to source. Idempotent.
+
+    A link already pointing at ``source`` is left untouched. A stale or broken
+    link is replaced only when ``force`` is set; otherwise it is left in place
+    and reported. Returns the link path on success, else None.
+    """
+    target = profile_home / "plugins" / PLUGIN_NAME
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if target.is_symlink() or target.exists():
+        try:
+            already = target.resolve() == source.resolve()
+        except OSError:
+            already = False
+        if already:
+            print(f"  Profile {profile_home.name}: already linked")
+            return target
+        if not force:
+            print(f"  Profile {profile_home.name}: exists, skipped (use --force to replace)")
+            return None
+        if target.is_symlink():
+            print(f"  Profile {profile_home.name}: replacing existing link -> {target.readlink()}")
+            target.unlink()
+        elif target.is_dir():
+            print(f"  Profile {profile_home.name}: replacing existing directory {target}")
+            shutil.rmtree(target)
+        else:
+            print(f"  Profile {profile_home.name}: replacing existing file {target}")
+            target.unlink()
+
+    try:
+        os.symlink(str(source), str(target))
+    except OSError as e:
+        print(f"  Profile {profile_home.name}: failed to link: {e}")
+        return None
+    print(f"  Profile {profile_home.name}: linked {target}")
+    return target
+
+
+def _link_all_profiles(
+    source: Path,
+    *,
+    hermes_home_path: str | Path | None = None,
+    force: bool = False,
+) -> list[Path]:
+    """Link Mnemosyne into every opted-in profile. No-op without profiles.
+
+    A failure on one profile is reported and does not abort the remaining
+    profiles.
+    """
+    linked: list[Path] = []
+    for profile_home in _iter_mnemosyne_profiles(hermes_home_path):
+        try:
+            result = _link_profile(profile_home, source, force=force)
+        except OSError as e:
+            print(f"  Profile {profile_home.name}: failed: {e}")
+            continue
+        if result is not None:
+            linked.append(result)
+    return linked
+
+
+def _verify_links(*, hermes_home_path: str | Path | None = None) -> bool:
+    """Print PASS/FAIL for each home that should have a resolvable plugin link.
+
+    Checks the default home plus every opted-in profile. Returns True only
+    when every checked link resolves to the provider source.
+    """
+    source = _resolve_package_dir()
+    base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
+    homes: list[Path] = [base]
+    homes.extend(_iter_mnemosyne_profiles(hermes_home_path))
+
+    all_ok = True
+    print("Verifying plugin links...")
+    for home in homes:
+        target = home / "plugins" / PLUGIN_NAME
+        ok = target.is_symlink() or target.exists()
+        if ok:
+            try:
+                ok = target.resolve() == source.resolve()
+            except OSError:
+                ok = False
+        all_ok = all_ok and ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {home.name or home}: {target}")
+    return all_ok
+
+
+def _unlink_all_profiles(*, hermes_home_path: str | Path | None = None) -> None:
+    """Remove the per-profile plugin links created by ``_link_all_profiles``.
+
+    Scans every profile directory by *link*, not by config opt-in: a profile's
+    ``plugins/mnemosyne`` is removed when it is a symlink resolving to the
+    provider source, regardless of what (or whether) the profile's
+    ``config.yaml`` currently selects. This still never touches a real directory
+    or a link pointing elsewhere. Symlinked profile entries are skipped.
+    """
+    base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
+    profiles_dir = base / "profiles"
+    if not profiles_dir.is_dir():
+        return
+    source = _resolve_package_dir()
+    for child in sorted(profiles_dir.iterdir()):
+        if child.is_symlink():
+            continue
+        target = child / "plugins" / PLUGIN_NAME
+        if not target.is_symlink():
+            continue
+        try:
+            if target.resolve() == source.resolve():
+                target.unlink()
+                print(f"  Removed profile link: {target}")
+        except OSError:
+            continue
 
 
 def uninstall_plugin(*, hermes_home_path: str | Path | None = None) -> Path:
@@ -318,6 +497,10 @@ def uninstall_plugin(*, hermes_home_path: str | Path | None = None) -> Path:
         target.unlink()
     elif target.exists():
         shutil.rmtree(target)
+
+    # Remove any per-profile links created at install time
+    _unlink_all_profiles(hermes_home_path=hermes_home_path)
+
     return target
 
 
@@ -599,11 +782,14 @@ def main(argv: list[str] | None = None) -> int:
                     print(f"  Will bootstrap: {not getattr(args, 'no_bootstrap', False)}")
                 return 0
 
-            return run_install(
+            rc = run_install(
                 force=getattr(args, "force", False),
                 hermes_home_path=args.hermes_home,
                 no_bootstrap=getattr(args, "no_bootstrap", False),
             )
+            if rc == 0:
+                _verify_links(hermes_home_path=args.hermes_home)
+            return rc
 
         if command == "uninstall":
             target = uninstall_plugin(hermes_home_path=args.hermes_home)

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -1,0 +1,248 @@
+"""Tests for the profile-aware Mnemosyne Hermes installer."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from mnemosyne_hermes import install as install_mod
+from mnemosyne_hermes.install import install_plugin
+
+
+def _skip_on_windows() -> None:
+    if sys.platform.startswith("win32"):
+        pytest.skip("POSIX symlink test")
+
+
+def _source() -> "object":
+    return install_mod._resolve_package_dir()
+
+
+def _make_profile(hermes_home, name, provider):
+    profile = hermes_home / "profiles" / name
+    profile.mkdir(parents=True)
+    (profile / "config.yaml").write_text(
+        f"memory:\n  provider: {provider}\n", encoding="utf-8"
+    )
+    return profile
+
+
+def test_default_install_links_single_home(tmp_path):
+    _skip_on_windows()
+
+    target = install_plugin(hermes_home_path=tmp_path)
+
+    assert target == tmp_path / "plugins" / "mnemosyne"
+    assert target.is_symlink()
+    assert target.resolve() == _source().resolve()
+    assert install_mod._iter_mnemosyne_profiles(tmp_path) == []
+
+
+def test_only_opted_in_profile_gets_link(tmp_path):
+    _skip_on_windows()
+    profile_a = _make_profile(tmp_path, "alice", "mnemosyne")
+    profile_b = _make_profile(tmp_path, "bob", "honcho")
+
+    install_plugin(hermes_home_path=tmp_path)
+
+    link_a = profile_a / "plugins" / "mnemosyne"
+    assert link_a.is_symlink() and link_a.resolve() == _source().resolve()
+    assert not (profile_b / "plugins" / "mnemosyne").exists()
+
+
+def test_rerun_is_idempotent(tmp_path):
+    _skip_on_windows()
+    profile_a = _make_profile(tmp_path, "alice", "mnemosyne")
+
+    install_plugin(hermes_home_path=tmp_path)
+    link_a = profile_a / "plugins" / "mnemosyne"
+    first = link_a.readlink()
+
+    # Second profile pass leaves the existing good link untouched.
+    install_mod._link_all_profiles(_source(), hermes_home_path=tmp_path)
+    assert link_a.is_symlink()
+    assert link_a.readlink() == first
+    assert link_a.resolve() == _source().resolve()
+
+
+def test_missing_profiles_dir_is_noop(tmp_path):
+    _skip_on_windows()
+
+    assert install_mod._iter_mnemosyne_profiles(tmp_path) == []
+    target = install_plugin(hermes_home_path=tmp_path)  # must not raise
+    assert target.is_symlink()
+
+
+def test_profile_without_config_is_skipped(tmp_path):
+    _skip_on_windows()
+    (tmp_path / "profiles" / "stray").mkdir(parents=True)  # no config.yaml
+
+    assert install_mod._iter_mnemosyne_profiles(tmp_path) == []
+
+
+def test_uninstall_removes_profile_links(tmp_path):
+    _skip_on_windows()
+    profile_a = _make_profile(tmp_path, "alice", "mnemosyne")
+
+    install_plugin(hermes_home_path=tmp_path)
+    link_a = profile_a / "plugins" / "mnemosyne"
+    assert link_a.is_symlink()
+
+    install_mod.uninstall_plugin(hermes_home_path=tmp_path)
+
+    assert not link_a.is_symlink() and not link_a.exists()
+
+
+def test_link_profile_returns_none_on_symlink_error(tmp_path, monkeypatch):
+    _skip_on_windows()
+    profile_a = _make_profile(tmp_path, "alice", "mnemosyne")
+    _make_profile(tmp_path, "bob", "mnemosyne")
+    source = _source()
+
+    attempts = []
+
+    def boom(src, dst):
+        attempts.append(dst)
+        raise OSError("symlink denied")
+
+    monkeypatch.setattr(install_mod.os, "symlink", boom)
+
+    assert install_mod._link_profile(profile_a, source) is None
+    # A failing profile must not abort the batch; both profiles are attempted.
+    assert install_mod._link_all_profiles(source, hermes_home_path=tmp_path) == []
+    assert len(attempts) == 3  # 1 single call + 2 in the batch
+
+
+def test_force_overwrite_logs_old_target(tmp_path, capsys):
+    _skip_on_windows()
+    profile_a = _make_profile(tmp_path, "alice", "mnemosyne")
+    other = tmp_path / "other_pkg"
+    other.mkdir()
+    target = profile_a / "plugins" / "mnemosyne"
+    target.parent.mkdir(parents=True)
+    os.symlink(str(other), str(target))
+
+    result = install_mod._link_profile(profile_a, _source(), force=True)
+
+    out = capsys.readouterr().out
+    assert result is not None
+    assert str(other) in out
+    assert result.resolve() == _source().resolve()
+
+
+def test_profile_with_commented_provider_is_skipped(tmp_path):
+    _skip_on_windows()
+    profile = tmp_path / "profiles" / "carol"
+    profile.mkdir(parents=True)
+    (profile / "config.yaml").write_text(
+        "# memory:\n#   provider: mnemosyne\n", encoding="utf-8"
+    )
+
+    assert install_mod._iter_mnemosyne_profiles(tmp_path) == []
+
+
+def test_profile_with_extra_whitespace_in_provider_is_detected(tmp_path):
+    _skip_on_windows()
+    profile = tmp_path / "profiles" / "dave"
+    profile.mkdir(parents=True)
+    (profile / "config.yaml").write_text(
+        "memory:\n  provider:   mnemosyne\n", encoding="utf-8"
+    )
+
+    assert profile in install_mod._iter_mnemosyne_profiles(tmp_path)
+
+
+def test_symlinked_profile_dir_is_skipped(tmp_path):
+    _skip_on_windows()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    (outside / "config.yaml").write_text(
+        "memory:\n  provider: mnemosyne\n", encoding="utf-8"
+    )
+    profiles_dir = tmp_path / "profiles"
+    profiles_dir.mkdir(parents=True)
+    os.symlink(str(outside), str(profiles_dir / "evil-link"))
+
+    assert install_mod._iter_mnemosyne_profiles(tmp_path) == []
+
+
+def test_uninstall_keeps_foreign_profile_link(tmp_path):
+    _skip_on_windows()
+    profile_a = _make_profile(tmp_path, "alice", "mnemosyne")
+    foreign = tmp_path / "other_provider"
+    foreign.mkdir()
+    link = profile_a / "plugins" / "mnemosyne"
+    link.parent.mkdir(parents=True)
+    os.symlink(str(foreign), str(link))
+
+    install_mod.uninstall_plugin(hermes_home_path=tmp_path)
+
+    assert link.is_symlink()
+    assert link.resolve() == foreign.resolve()
+
+
+def test_uninstall_removes_orphaned_link_after_config_change(tmp_path):
+    _skip_on_windows()
+    profile_a = _make_profile(tmp_path, "alice", "mnemosyne")
+
+    install_plugin(hermes_home_path=tmp_path)
+    link = profile_a / "plugins" / "mnemosyne"
+    assert link.is_symlink() and link.resolve() == _source().resolve()
+
+    (profile_a / "config.yaml").write_text(
+        "memory:\n  provider: honcho\n", encoding="utf-8"
+    )
+
+    install_mod.uninstall_plugin(hermes_home_path=tmp_path)
+
+    assert not link.is_symlink() and not link.exists()
+
+
+def test_uninstall_removes_home_link_too(tmp_path):
+    _skip_on_windows()
+    install_plugin(hermes_home_path=tmp_path)
+    home_link = tmp_path / "plugins" / "mnemosyne"
+    assert home_link.is_symlink()
+
+    install_mod.uninstall_plugin(hermes_home_path=tmp_path)
+
+    assert not home_link.is_symlink() and not home_link.exists()
+
+
+def test_link_all_profiles_continues_on_mkdir_error(tmp_path, monkeypatch):
+    _skip_on_windows()
+    _make_profile(tmp_path, "alice", "mnemosyne")
+    _make_profile(tmp_path, "bob", "mnemosyne")
+
+    from pathlib import Path
+
+    calls = []
+    real_mkdir = Path.mkdir
+
+    def boom(self, *args, **kwargs):
+        if self.name == "plugins":
+            calls.append(self)
+            raise PermissionError("denied")
+        return real_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", boom)
+
+    result = install_mod._link_all_profiles(_source(), hermes_home_path=tmp_path)
+
+    assert result == []
+    assert len(calls) == 2  # both profiles attempted despite the first failing
+
+
+def test_malformed_yaml_config_is_treated_as_not_opted_in(tmp_path):
+    _skip_on_windows()
+    profile = tmp_path / "profiles" / "broken"
+    profile.mkdir(parents=True)
+    # Raw text contains `provider: mnemosyne` (the regex fallback would match),
+    # but the YAML path must return False on YAMLError without reaching it.
+    (profile / "config.yaml").write_text(
+        "memory:\n  provider: mnemosyne\n  bad: [unclosed\n", encoding="utf-8"
+    )
+
+    assert install_mod._iter_mnemosyne_profiles(tmp_path) == []

--- a/mnemosyne/install.py
+++ b/mnemosyne/install.py
@@ -78,6 +78,28 @@ def _remove_link(link_path: Path) -> None:
         shutil.rmtree(link_path)
 
 
+def _make_link(target: Path, source: Path) -> tuple[bool, str]:
+    """Create a symlink (POSIX) or junction (Windows) from target to source.
+
+    Returns (ok, message). The caller must remove any existing path at
+    ``target`` first.
+    """
+    if _is_windows():
+        import subprocess
+        result = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(target), str(source)],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            return False, f"Failed to create junction: {result.stderr.strip()}"
+        return True, f"Junction: {target} -> {source}"
+    try:
+        target.symlink_to(source, target_is_directory=True)
+    except OSError as e:
+        return False, f"Failed to create symlink: {e}"
+    return True, f"Symlinked: {target} -> {source}"
+
+
 def _ensure_link() -> bool:
     """Create the plugin link from ~/.hermes/plugins/mnemosyne -> hermes_memory_provider.
 
@@ -125,20 +147,182 @@ def _ensure_link() -> bool:
         _remove_link(target)
         print(f"🔄 Removed existing {target}")
 
-    if _is_windows():
-        import subprocess
-        result = subprocess.run(
-            ["cmd", "/c", "mklink", "/J", str(target), str(source)],
-            capture_output=True, text=True,
-        )
-        if result.returncode != 0:
-            print(f"❌ Failed to create junction: {result.stderr.strip()}")
-            return False
-        print(f"✅ Junction: {target} -> {source}")
-    else:
-        target.symlink_to(source, target_is_directory=True)
-        print(f"✅ Symlinked: {target} -> {source}")
+    ok, msg = _make_link(target, source)
+    if not ok:
+        print(f"❌ {msg}")
+        return False
+    print(f"✅ {msg}")
     return True
+
+
+def _config_selects_mnemosyne(text: str) -> bool:
+    """Return True when a profile config selects ``memory.provider: mnemosyne``.
+
+    Prefers a real YAML parse, which ignores comments and tolerates arbitrary
+    whitespace. The line-anchored regex is used **only** when PyYAML is genuinely
+    unavailable (``ImportError``), so the core package keeps working without a
+    hard YAML dependency. Malformed YAML is treated as "not opted in" rather than
+    falling through to the looser regex.
+    """
+    try:
+        import yaml
+    except ImportError:
+        import re
+        return re.search(
+            r"^\s*provider\s*:\s*mnemosyne\s*(#.*)?$", text, re.MULTILINE
+        ) is not None
+    try:
+        cfg = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return False
+    if isinstance(cfg, dict):
+        memory = cfg.get("memory")
+        if isinstance(memory, dict):
+            return memory.get("provider") == "mnemosyne"
+    return False
+
+
+def _iter_mnemosyne_profiles() -> list[Path]:
+    """Return profile dirs under <hermes_home>/profiles/* that opt into Mnemosyne.
+
+    A profile opts in when its ``config.yaml`` parses to
+    ``memory.provider == "mnemosyne"`` (see ``_config_selects_mnemosyne``).
+    Symlinked profile entries are skipped (the installer must not follow a
+    profile symlink and write under its target). Profiles without a
+    ``config.yaml`` are skipped. Returns an empty list when no ``profiles/``
+    directory exists (the default, no-profile install).
+    """
+    hermes_home = _get_hermes_home()
+    if not hermes_home:
+        return []
+    profiles_dir = hermes_home / "profiles"
+    if not profiles_dir.is_dir():
+        return []
+    selected: list[Path] = []
+    for child in sorted(profiles_dir.iterdir()):
+        if child.is_symlink():
+            continue
+        if not child.is_dir():
+            continue
+        config_path = child / "config.yaml"
+        if not config_path.is_file():
+            continue
+        try:
+            text = config_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if _config_selects_mnemosyne(text):
+            selected.append(child)
+    return selected
+
+
+def _link_profile(profile_home: Path, source: Path, *, force: bool = False) -> bool:
+    """Link ``profile_home/plugins/mnemosyne`` to source. Idempotent.
+
+    A link already pointing at ``source`` is left untouched. A stale or broken
+    symlink is replaced. A real (non-symlink) path is left in place and reported
+    unless ``force`` is set — the installer never silently deletes user data.
+    Returns True on success.
+    """
+    plugins_dir = profile_home / "plugins"
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+    target = plugins_dir / "mnemosyne"
+
+    if target.is_symlink():
+        try:
+            if target.resolve() == source.resolve():
+                print(f"✅ Profile {profile_home.name}: already linked")
+                return True
+        except OSError:
+            pass
+        _remove_link(target)  # stale/broken symlink — safe to replace
+    elif target.exists():
+        if not force:
+            print(f"⏭️  Profile {profile_home.name}: {target} exists (not a link), skipped")
+            return False
+        _remove_link(target)
+
+    ok, msg = _make_link(target, source)
+    print(f"{'✅' if ok else '❌'} Profile {profile_home.name}: {msg}")
+    return ok
+
+
+def _link_all_profiles() -> None:
+    """Link Mnemosyne into every opted-in profile. No-op without profiles.
+
+    A failure on one profile is reported and does not abort the remaining
+    profiles.
+    """
+    profiles = _iter_mnemosyne_profiles()
+    if not profiles:
+        return
+    source = _get_mnemosyne_root() / "hermes_memory_provider"
+    print()
+    print(f"🔗 Linking {len(profiles)} profile(s)...")
+    for profile_home in profiles:
+        try:
+            _link_profile(profile_home, source)
+        except OSError as e:
+            print(f"❌ Profile {profile_home.name}: {e}")
+
+
+def _unlink_all_profiles() -> None:
+    """Remove the per-profile plugin links created by ``_link_all_profiles``.
+
+    Scans every profile directory by *link*, not by config opt-in: a profile's
+    ``plugins/mnemosyne`` is removed when it is a symlink resolving to the
+    provider source, regardless of what (or whether) the profile's
+    ``config.yaml`` currently selects. This still never touches a real directory
+    or a link pointing elsewhere. Symlinked profile entries are skipped.
+    """
+    hermes_home = _get_hermes_home()
+    if not hermes_home:
+        return
+    profiles_dir = hermes_home / "profiles"
+    if not profiles_dir.is_dir():
+        return
+    source = _get_mnemosyne_root() / "hermes_memory_provider"
+    for child in sorted(profiles_dir.iterdir()):
+        if child.is_symlink():
+            continue
+        target = child / "plugins" / "mnemosyne"
+        if not target.is_symlink():
+            continue
+        try:
+            if target.resolve() == source.resolve():
+                _remove_link(target)
+                print(f"Removed profile link: {target}")
+        except OSError:
+            continue
+
+
+def _verify_links() -> bool:
+    """Print PASS/FAIL for each home that should have a resolvable plugin link.
+
+    Checks the default home plus every opted-in profile. Returns True only
+    when every checked link resolves to the provider source.
+    """
+    source = _get_mnemosyne_root() / "hermes_memory_provider"
+    hermes_home = _get_hermes_home()
+    homes: list[Path] = []
+    if hermes_home:
+        homes.append(hermes_home)
+    homes.extend(_iter_mnemosyne_profiles())
+
+    all_ok = True
+    print()
+    print("🔍 Verifying plugin links...")
+    for home in homes:
+        target = home / "plugins" / "mnemosyne"
+        ok = target.is_symlink() or target.exists()
+        if ok:
+            try:
+                ok = target.resolve() == source.resolve()
+            except OSError:
+                ok = False
+        all_ok = all_ok and ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {home.name or home}: {target}")
+    return all_ok
 
 
 def _configure_hermes() -> bool:
@@ -217,19 +401,23 @@ def install():
     print("=" * 40)
     print()
 
-    # Step 1: Link (symlink on POSIX, junction on Windows)
+    # Step 1: Link default home (symlink on POSIX, junction on Windows)
     if not _ensure_link():
         print()
         print("❌ Install failed at symlink step.")
         sys.exit(1)
 
-    # Step 2: Configure
+    # Step 1b: Link any named profiles that opt into Mnemosyne
+    _link_all_profiles()
+
+    # Step 2: Configure (default home only — profile configs stay the user's)
     _configure_hermes()
 
     # Step 3: Verify
     print()
     print("🔍 Verifying...")
     _verify()
+    _verify_links()
 
     print()
     print("✅ Mnemosyne is ready!")
@@ -260,6 +448,9 @@ def uninstall():
         print(f"Removed {target}")
     else:
         print("ℹ️  Mnemosyne plugin not found in Hermes.")
+
+    # Remove any per-profile links created at install time
+    _unlink_all_profiles()
 
     # Reset config
     config_path = hermes_home / "config.yaml"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,233 @@
+"""Tests for the profile-aware Mnemosyne installer (mnemosyne/install.py)."""
+
+import os
+import sys
+
+import pytest
+
+from mnemosyne import install
+
+
+@pytest.fixture
+def fake_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME and the repo root under tmp_path.
+
+    Yields (hermes_home, source) where source is the provider directory the
+    installer links to.
+    """
+    if sys.platform.startswith("win32"):
+        pytest.skip("POSIX symlink test")
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+
+    repo_root = tmp_path / "repo"
+    source = repo_root / "hermes_memory_provider"
+    source.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(install, "_get_mnemosyne_root", lambda: repo_root)
+    # Keep config writes out of these assertions; they are tested elsewhere.
+    monkeypatch.setattr(install, "_configure_hermes", lambda: True)
+    monkeypatch.setattr(install, "_verify", lambda: True)
+    yield hermes_home, source
+
+
+def _make_profile(hermes_home, name, provider):
+    profile = hermes_home / "profiles" / name
+    profile.mkdir(parents=True)
+    (profile / "config.yaml").write_text(
+        f"memory:\n  provider: {provider}\n", encoding="utf-8"
+    )
+    return profile
+
+
+def test_default_install_links_single_home(fake_env):
+    hermes_home, source = fake_env
+
+    assert install._ensure_link() is True
+    install._link_all_profiles()  # no profiles/ dir -> no-op
+
+    link = hermes_home / "plugins" / "mnemosyne"
+    assert link.is_symlink()
+    assert link.resolve() == source.resolve()
+    assert install._iter_mnemosyne_profiles() == []
+
+
+def test_only_opted_in_profile_gets_link(fake_env):
+    hermes_home, source = fake_env
+    profile_a = _make_profile(hermes_home, "alice", "mnemosyne")
+    profile_b = _make_profile(hermes_home, "bob", "honcho")
+
+    install._ensure_link()
+    install._link_all_profiles()
+
+    link_a = profile_a / "plugins" / "mnemosyne"
+    assert link_a.is_symlink() and link_a.resolve() == source.resolve()
+    assert not (profile_b / "plugins" / "mnemosyne").exists()
+
+
+def test_rerun_is_idempotent(fake_env):
+    hermes_home, source = fake_env
+    profile_a = _make_profile(hermes_home, "alice", "mnemosyne")
+
+    install._ensure_link()
+    install._link_all_profiles()
+    link_a = profile_a / "plugins" / "mnemosyne"
+    first = link_a.readlink()
+
+    install._link_all_profiles()  # second pass leaves the good link alone
+    assert link_a.is_symlink()
+    assert link_a.readlink() == first
+    assert link_a.resolve() == source.resolve()
+
+
+def test_missing_profiles_dir_is_noop(fake_env):
+    hermes_home, _ = fake_env
+
+    assert install._iter_mnemosyne_profiles() == []
+    install._link_all_profiles()  # must not raise
+
+    assert install._ensure_link() is True
+    assert (hermes_home / "plugins" / "mnemosyne").is_symlink()
+
+
+def test_profile_without_config_is_skipped(fake_env):
+    hermes_home, _ = fake_env
+    (hermes_home / "profiles" / "stray").mkdir(parents=True)  # no config.yaml
+
+    assert install._iter_mnemosyne_profiles() == []
+
+
+def test_uninstall_removes_profile_links(fake_env):
+    hermes_home, source = fake_env
+    profile_a = _make_profile(hermes_home, "alice", "mnemosyne")
+
+    install._ensure_link()
+    install._link_all_profiles()
+    link_a = profile_a / "plugins" / "mnemosyne"
+    assert link_a.is_symlink()
+
+    install.uninstall()
+
+    assert not link_a.exists() and not link_a.is_symlink()
+    assert not (hermes_home / "plugins" / "mnemosyne").exists()
+
+
+def test_legacy_link_profile_skips_real_dir(fake_env, capsys):
+    hermes_home, source = fake_env
+    profile_a = _make_profile(hermes_home, "alice", "mnemosyne")
+
+    # A real directory (not a symlink) sitting at the target must be preserved.
+    target = profile_a / "plugins" / "mnemosyne"
+    target.mkdir(parents=True)
+    sentinel = target / "user_data.txt"
+    sentinel.write_text("keep me", encoding="utf-8")
+
+    result = install._link_profile(profile_a, source)
+
+    assert result is False
+    assert target.is_dir() and not target.is_symlink()
+    assert sentinel.read_text(encoding="utf-8") == "keep me"
+    assert "skipped" in capsys.readouterr().out
+
+
+def test_profile_with_commented_provider_is_skipped(fake_env):
+    hermes_home, _ = fake_env
+    profile = hermes_home / "profiles" / "carol"
+    profile.mkdir(parents=True)
+    (profile / "config.yaml").write_text(
+        "# memory:\n#   provider: mnemosyne\n", encoding="utf-8"
+    )
+
+    assert install._iter_mnemosyne_profiles() == []
+
+
+def test_profile_with_extra_whitespace_in_provider_is_detected(fake_env):
+    hermes_home, _ = fake_env
+    profile = hermes_home / "profiles" / "dave"
+    profile.mkdir(parents=True)
+    (profile / "config.yaml").write_text(
+        "memory:\n  provider:   mnemosyne\n", encoding="utf-8"
+    )
+
+    assert profile in install._iter_mnemosyne_profiles()
+
+
+def test_symlinked_profile_dir_is_skipped(fake_env):
+    hermes_home, _ = fake_env
+    outside = hermes_home.parent / "elsewhere"
+    outside.mkdir()
+    (outside / "config.yaml").write_text(
+        "memory:\n  provider: mnemosyne\n", encoding="utf-8"
+    )
+    profiles_dir = hermes_home / "profiles"
+    profiles_dir.mkdir(parents=True)
+    evil = profiles_dir / "evil-link"
+    os.symlink(str(outside), str(evil))
+
+    assert evil not in install._iter_mnemosyne_profiles()
+    assert install._iter_mnemosyne_profiles() == []
+
+
+def test_uninstall_keeps_foreign_profile_link(fake_env):
+    hermes_home, source = fake_env
+    profile_a = _make_profile(hermes_home, "alice", "mnemosyne")
+    # A link pointing at a DIFFERENT source must survive uninstall.
+    foreign = hermes_home.parent / "other_provider"
+    foreign.mkdir()
+    link = profile_a / "plugins" / "mnemosyne"
+    link.parent.mkdir(parents=True)
+    os.symlink(str(foreign), str(link))
+
+    install.uninstall()
+
+    assert link.is_symlink()
+    assert link.resolve() == foreign.resolve()
+
+
+def test_uninstall_removes_orphaned_link_after_config_change(fake_env):
+    hermes_home, source = fake_env
+    profile_a = _make_profile(hermes_home, "alice", "mnemosyne")
+
+    install._ensure_link()
+    install._link_all_profiles()
+    link = profile_a / "plugins" / "mnemosyne"
+    assert link.is_symlink() and link.resolve() == source.resolve()
+
+    # User switches the profile to another provider after install.
+    (profile_a / "config.yaml").write_text(
+        "memory:\n  provider: honcho\n", encoding="utf-8"
+    )
+
+    install.uninstall()
+
+    # Scan-by-link finds the orphan even though the config no longer opts in.
+    assert not link.is_symlink() and not link.exists()
+
+
+def test_malformed_yaml_config_is_treated_as_not_opted_in(fake_env):
+    hermes_home, _ = fake_env
+    profile = hermes_home / "profiles" / "broken"
+    profile.mkdir(parents=True)
+    # Raw text contains `provider: mnemosyne` (the regex fallback would match),
+    # but the YAML path must return False on YAMLError without reaching it.
+    (profile / "config.yaml").write_text(
+        "memory:\n  provider: mnemosyne\n  bad: [unclosed\n", encoding="utf-8"
+    )
+
+    assert install._iter_mnemosyne_profiles() == []
+
+
+def test_legacy_link_profile_force_replaces_real_dir(fake_env):
+    hermes_home, source = fake_env
+    profile_a = _make_profile(hermes_home, "alice", "mnemosyne")
+    target = profile_a / "plugins" / "mnemosyne"
+    target.mkdir(parents=True)
+    (target / "stale.txt").write_text("old", encoding="utf-8")
+
+    result = install._link_profile(profile_a, source, force=True)
+
+    assert result is True
+    assert target.is_symlink()
+    assert target.resolve() == source.resolve()


### PR DESCRIPTION
Adds CODEOWNERS to define ownership areas (including co-maintainer @dplush) and MAINTAINERS.md to document the governance model, roles, and process for adding/removing maintainers.