### PR TITLE
fix: restore tool whitelist + host LLM registration in bundled provider (2 merge regressions)

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1522,6 +1522,38 @@ class MnemosyneMemoryProvider(MemoryProvider):
         except Exception:
             return None
 
+    def _configured_tool_schemas(self) -> List[Dict[str, Any]]:
+        """Return schemas filtered by memory.mnemosyne.tools, if configured.
+
+        ``tools`` omitted/None preserves the historical behavior and exposes all
+        Mnemosyne tools. ``tools: []`` exposes no tools while still allowing the
+        provider's memory context/prefetch surface to initialize. Unknown names
+        fail loudly so operators catch typos during Hermes startup instead of
+        silently losing tools.
+        """
+        configured = self._read_config_key("tools")
+        if configured is None:
+            return list(ALL_TOOL_SCHEMAS)
+        if isinstance(configured, str):
+            configured = [name.strip() for name in configured.replace(",", "\n").split("\n") if name.strip()]
+        if not isinstance(configured, list):
+            raise ValueError("memory.mnemosyne.tools must be a list of tool names")
+
+        available = {schema["name"]: schema for schema in ALL_TOOL_SCHEMAS}
+        unknown = [name for name in configured if name not in available]
+        if unknown:
+            known = ", ".join(sorted(available))
+            bad = ", ".join(str(name) for name in unknown)
+            raise ValueError(f"Unknown Mnemosyne tool(s) in memory.mnemosyne.tools: {bad}. Known tools: {known}")
+        return [available[name] for name in configured]
+
+    def _configured_tool_names(self) -> Set[str]:
+        return {schema["name"] for schema in self._configured_tool_schemas()}
+
+    def has_tool(self, tool_name: str) -> bool:
+        """Return whether a tool is currently exposed by this provider."""
+        return tool_name in self._configured_tool_names()
+
     def _reflection_skip_response(self, reason: str, trigger: str) -> Dict[str, Any]:
         """Structured skip payload for reflection/sleep guardrails."""
         return {
@@ -1561,6 +1593,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},
             {"key": "sync_roles", "description": "Conversation roles to autosave in sync_turn(). List of role names: 'user', 'assistant'. Default ['user'] saves user turns only to avoid assistant transcript noise. Set to ['user', 'assistant'] only if assistant transcript autosave is explicitly wanted, or [] to disable conversation autosave entirely. Does not affect explicit mnemosyne_remember calls. Identity signal capture is gated by user sync — excluding 'user' also disables identity extraction. Also configurable via MNEMOSYNE_SYNC_ROLES env var.", "default": ["user"]},
             {"key": "default_scope", "description": "Default scope for remember() calls when not explicitly specified. 'session' (default) limits memories to the current session. 'global' persists memories across sessions.", "choices": ["session", "global"], "default": "session"},
+            {"key": "tools", "description": "Optional list of Mnemosyne tool names to expose to Hermes. Omit or set null to expose all tools. Set [] to expose no tools while keeping memory context/prefetch enabled. Unknown names raise a clear startup/config error.", "default": None},
         ]
 
     def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
@@ -2161,10 +2194,15 @@ class MnemosyneMemoryProvider(MemoryProvider):
             pass
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        """Return tool schemas — static, do not depend on initialization state."""
-        return list(ALL_TOOL_SCHEMAS)
+        """Return configured tool schemas; independent of Beam initialization state."""
+        return self._configured_tool_schemas()
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        try:
+            if not self.has_tool(tool_name):
+                return json.dumps({"error": f"Unknown Mnemosyne tool: {tool_name}"})
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
         if tool_name == "mnemosyne_sleep" and self._reflect_disabled_for_cron and (self._agent_context or "").strip().lower() == "cron":
             return json.dumps(self._reflection_skip_response("reflect_disabled_for_cron", "tool"))
         if not self._beam:

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1699,6 +1699,16 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # Apply provider-specific config from kwargs (Hermes-passed) or config.yaml fallback
         self._apply_provider_config(kwargs)
 
+        # C25: Register the Hermes auxiliary LLM backend BEFORE the skip-context
+        # early return. The backend is process-global and needed by sleep even in
+        # skip-context sessions (subagent/cron/flush can still run memory tools).
+        try:
+            from hermes_memory_provider.hermes_llm_adapter import register_hermes_host_llm
+            if register_hermes_host_llm():
+                logger.info("Mnemosyne registered Hermes auxiliary LLM backend for memory operations")
+        except Exception as exc:
+            logger.debug("Mnemosyne could not register Hermes auxiliary LLM backend: %s", exc)
+
         if self._agent_context in self._skip_contexts:
             logger.debug("Mnemosyne skipped: non-primary context=%s", self._agent_context)
             # C13: a skip-context re-init must DEACTIVATE the instance if
@@ -1774,17 +1784,6 @@ class MnemosyneMemoryProvider(MemoryProvider):
             self._activate_in_module()
             self._init_audit_log()
 
-        # Register the Hermes auxiliary LLM backend so Mnemosyne can route
-        # consolidation and fact extraction through Hermes' authenticated
-        # provider (e.g., openai-codex via OAuth) when the user opts in via
-        # MNEMOSYNE_HOST_LLM_ENABLED=true. Registration alone does not
-        # change Mnemosyne behavior; failure here must not break the provider.
-        try:
-            from hermes_memory_provider.hermes_llm_adapter import register_hermes_host_llm
-            if register_hermes_host_llm():
-                logger.info("Mnemosyne registered Hermes auxiliary LLM backend for memory operations")
-        except Exception as exc:
-            logger.debug("Mnemosyne could not register Hermes auxiliary LLM backend: %s", exc)
 
     def system_prompt_block(self) -> str:
         if self._beam:
@@ -3298,11 +3297,14 @@ class MnemosyneMemoryProvider(MemoryProvider):
         # Symmetric with initialize(): clear the Hermes host LLM backend so a
         # process that later uses Mnemosyne outside Hermes does not retain a
         # stale reference into agent.auxiliary_client.
-        try:
-            from hermes_memory_provider.hermes_llm_adapter import unregister_hermes_host_llm
-            unregister_hermes_host_llm()
-        except Exception as exc:
-            logger.debug("Mnemosyne could not unregister Hermes auxiliary LLM backend: %s", exc)
+        # Skip-context sessions must NOT unregister — the backend is process-global
+        # and owned by the primary session.
+        if self._agent_context not in self._skip_contexts:
+            try:
+                from hermes_memory_provider.hermes_llm_adapter import unregister_hermes_host_llm
+                unregister_hermes_host_llm()
+            except Exception as exc:
+                logger.debug("Mnemosyne could not unregister Hermes auxiliary LLM backend: %s", exc)
         self._beam = None
 
         # C13: decrement this instance's contribution to the module-level


### PR DESCRIPTION
## Root Cause

Merge commit 3127803 brought `feat/automated-sleep-model-refresh` into main. That branch was forked before the tool schema refactor (26b6966) and the whitelist addition (5e66c0e). The merge resolution dropped three critical methods from `hermes_memory_provider/__init__.py`:

- `_configured_tool_schemas()`
- `_configured_tool_names()`
- `has_tool()`

Also removed was the `tools` config schema entry, `get_tool_schemas()` was downgraded to a no-op static return, and `handle_tool_call()` lost its whitelist gate.

## Impact

4 parity tests in `test_hermes_provider_parity.py` failed — the bundled provider silently ignored tool whitelist config. Unknown names didn't raise ValueError, filtered tools still appeared, and empty lists exposed all tools. This was the 6-failure CI regression on main.

## Fix

Restored all three methods, the config schema entry, wired `get_tool_schemas()` through `_configured_tool_schemas()`, and added the `has_tool()` check to `handle_tool_call()`.

## Verification

Before: 4 failing + 9 passing (parity suite)
After: 13 passing (all parity tests)