### PR TITLE
fix(hermes): restore mnemosyne-hermes CLI entry point

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -26,12 +26,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 from datetime import datetime, timedelta
 
-# Mnemosyne core is installed via pip (mnemosyne-memory>=3.1 dependency).
-# No path hacks needed — standard imports work.
-from mnemosyne.core.episodic_graph import GraphEdge
-from mnemosyne.core.beam import WORKING_MEMORY_TTL_HOURS
+# Mnemosyne core is installed via pip (mnemosyne-memory>=3.1 dependency),
+# but keep imports lazy so installer/status CLI commands still work in broken
+# or partially-installed environments.
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +52,16 @@ _provider_lock = threading.Lock()
 def _get_beam_class():
     from mnemosyne.core.beam import BeamMemory
     return BeamMemory
+
+
+def _get_working_memory_ttl_hours() -> int:
+    from mnemosyne.core.beam import WORKING_MEMORY_TTL_HOURS
+    return WORKING_MEMORY_TTL_HOURS
+
+
+def _get_graph_edge_class():
+    from mnemosyne.core.episodic_graph import GraphEdge
+    return GraphEdge
 
 
 def _get_triple_module():
@@ -1206,7 +1215,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 # spinning up a full sleep pass just to find nothing
                 # eligible (common with longer TTLs after a prior
                 # auto-sleep already consolidated everything).
-                cutoff = (datetime.now() - timedelta(hours=WORKING_MEMORY_TTL_HOURS // 2)).isoformat()
+                cutoff = (datetime.now() - timedelta(hours=_get_working_memory_ttl_hours() // 2)).isoformat()
                 eligible = self._beam._count_unconsolidated_before(cutoff)
                 if eligible == 0:
                     return
@@ -2233,6 +2242,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             })
         if self._beam.episodic_graph is None:
             return json.dumps({"error": "Episodic graph not available"})
+        GraphEdge = _get_graph_edge_class()
         edge = GraphEdge(
             source=source_id,
             target=target_id,

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -1,181 +1,348 @@
-"""
-Hermes plugin discovery path installation.
+"""Installer CLI for the Mnemosyne Hermes memory provider."""
 
-Lifecycle:
-1. ``install_plugin`` — symlink or wrapper-mode plugin in the default home,
-   plus per-profile links for every opted-in Hermes profile.
-2. ``uninstall_plugin`` — remove the plugin link and all per-profile links.
-3. ``install_status`` — ``mnemosyne-hermes status`` checks both the default
-   home and every opted-in profile.
-"""
 from __future__ import annotations
 
+import argparse
+import importlib
 import os
 import re
 import shutil
-import site
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
+
 
 PLUGIN_NAME = "mnemosyne"
 
 
+@dataclass(frozen=True)
+class PluginState:
+    """Detailed installation state for the Hermes plugin directory."""
+
+    status: str
+    installed: bool
+    target: Path
+    message: str
+    link_target: Path | None = None
+    mode: str = "missing"
+    wrapper_python: Path | None = None
+    wrapper_site_packages: Path | None = None
+    wrapper_import_ok: bool | None = None
+    wrapper_import_error: str | None = None
+
+
 def hermes_home() -> Path:
-    """Return the effective Hermes home directory."""
-    home = os.environ.get("HERMES_HOME", "").strip()
-    if home:
-        return Path(home).expanduser().resolve()
-    return Path.home() / ".hermes"
+    """Return the Hermes home directory used for user-installed plugins."""
+    return Path(os.environ.get("HERMES_HOME") or "~/.hermes").expanduser()
+
+
+def _resolve_package_dir() -> Path:
+    """Return the installed mnemosyne_hermes package directory.
+
+    Avoid importing the package here: console-script loading first imports the
+    package ``__init__`` before this module, and install/status commands should
+    remain useful even when the Mnemosyne core dependency is unavailable or
+    broken.
+    """
+    return Path(__file__).resolve().parent
 
 
 def plugin_target_dir(hermes_home_path: str | Path | None = None) -> Path:
-    """Return the path where the Mnemosyne plugin should be installed."""
+    """Return the Hermes memory plugin destination for Mnemosyne.
+
+    Directory name matches the provider name used in
+    ``memory.provider: mnemosyne`` config. Hermes discovers memory
+    providers by scanning ``$HERMES_HOME/plugins/<name>/`` for
+    directories whose ``__init__.py`` contains ``register_memory_provider``
+    or ``MemoryProvider``.
+    """
     base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
     return base / "plugins" / PLUGIN_NAME
 
 
-def _resolve_package_dir() -> Path:
-    """Return the directory containing this package (the mnemosyne_hermes source)."""
-    # __file__ is .../mnemosyne_hermes/install.py -> parent is the package dir
-    return Path(__file__).parent.resolve()
+def _provider_init_is_valid(init_file: Path) -> bool:
+    """Return whether an __init__.py looks like a Mnemosyne Hermes provider."""
+    try:
+        source = init_file.read_text(errors="replace")
+        return "register_memory_provider" in source or "MnemosyneMemoryProvider" in source
+    except Exception:
+        return False
+
+
+def _extract_wrapper_metadata(init_file: Path) -> tuple[Path | None, Path | None]:
+    """Return (python, site-packages) metadata from a generated wrapper shim."""
+    try:
+        source = init_file.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return None, None
+
+    def _match(name: str) -> Path | None:
+        match = re.search(rf"^{name}\s*=\s*(['\"])(.*?)\1", source, flags=re.MULTILINE)
+        if not match:
+            return None
+        value = match.group(2).strip()
+        return Path(value).expanduser() if value else None
+
+    return _match("_PYTHON"), _match("_SITE")
 
 
 def _site_packages_for_python(python: Path) -> Path:
-    """Get the site-packages path from a specific Python interpreter."""
+    """Ask an interpreter for its purelib/site-packages path."""
     result = subprocess.run(
-        [str(python), "-c", "import site; print(site.getsitepackages()[0])"],
+        [str(python), "-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])"],
         capture_output=True,
         text=True,
-        check=True,
+        timeout=10,
     )
-    return Path(result.stdout.strip())
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"Could not resolve site-packages for {python}: {stderr}")
+    site = Path(result.stdout.strip()).expanduser()
+    if not site:
+        raise RuntimeError(f"Could not resolve site-packages for {python}")
+    return site
 
 
-def _check_wrapper_import(site_packages: Path, python: Path) -> tuple[bool, str]:
-    """Check that mnemosyne_hermes is importable from the given Python environment."""
+def _check_wrapper_import(site_packages: Path, python: Path | None = None) -> tuple[bool, str | None]:
+    """Return whether mnemosyne_hermes imports from the wrapper target."""
+    if not site_packages.exists():
+        return False, f"site-packages target missing: {site_packages}"
+    if python is not None and not python.is_file():
+        return False, f"wrapper Python missing: {python}"
+    runner = python or Path(sys.executable)
+    code = (
+        "import sys; "
+        f"sys.path.insert(0, {str(site_packages)!r}); "
+        "import mnemosyne_hermes; "
+        "print(getattr(mnemosyne_hermes, '__version__', 'unknown'))"
+    )
     result = subprocess.run(
-        [
-            str(python), "-c",
-            f"import sys; sys.path.insert(0, {str(site_packages)!r}); ",
-            "from mnemosyne_hermes import __version__; print(__version__)",
-        ],
+        [str(runner), "-c", code],
         capture_output=True,
         text=True,
+        timeout=10,
     )
     if result.returncode == 0:
-        return True, result.stdout.strip()
-    return False, result.stderr.strip()
+        return True, None
+    return False, (result.stderr.strip() or result.stdout.strip() or "import failed")[:500]
 
 
 def _copy_plugin_yaml(target: Path) -> None:
-    """Copy plugin.yaml alongside the wrapper plugin."""
-    plugin_yaml = _resolve_package_dir() / "plugin.yaml"
-    if plugin_yaml.is_file():
-        import shutil
-        shutil.copy2(plugin_yaml, target / "plugin.yaml")
+    source_yaml = _resolve_package_dir() / "plugin.yaml"
+    if source_yaml.is_file():
+        shutil.copy2(source_yaml, target / "plugin.yaml")
 
 
-def _prepare_plugin_target(base: Path, target: Path, *, force: bool = False) -> None:
-    """Ensure the plugin target directory is ready for installation.
-
-    Creates parent directories and handles existing symlinks/directories.
-    """
-    if not target.is_symlink() and not target.exists():
-        target.parent.mkdir(parents=True, exist_ok=True)
-        return
-
-    if not force:
-        raise FileExistsError(
-            f"Plugin target {target} already exists. Use --force to replace."
-        )
+def plugin_state(*, hermes_home_path: str | Path | None = None) -> PluginState:
+    """Return detailed state for Hermes' Mnemosyne plugin discovery path."""
+    target = plugin_target_dir(hermes_home_path)
 
     if target.is_symlink():
-        target.unlink()
-    elif target.is_dir():
-        shutil.rmtree(target)
-    else:
-        target.unlink()
-
-    target.parent.mkdir(parents=True, exist_ok=True)
-
-
-def _write_wrapper_plugin(target: Path, *, python: Path, site_packages: Path) -> None:
-    """Create a persistent Hermes plugin shim that imports from a selected env."""
-    target.mkdir(parents=True, exist_ok=False)
-    init_source = f"""\"\"\"Persistent Mnemosyne Hermes plugin wrapper.
-
-Generated by ``mnemosyne-hermes install --mode wrapper``. The wrapper keeps the
-Hermes discovery directory stable while importing the real ``mnemosyne_hermes``
-package from the selected Python environment.
-\"\"\"
-from __future__ import annotations
-
-import sys as _sys
-
-# Metadata used by ``mnemosyne-hermes status``.
-_PYTHON = {str(python)!r}
-_SITE = {str(site_packages)!r}
-
-if _SITE not in _sys.path:
-    _sys.path.insert(0, _SITE)
-
-# Hermes discovery marker: register_memory_provider / MnemosyneMemoryProvider
-from mnemosyne_hermes import *  # noqa: F401,F403,E402
-"""
-    (target / "__init__.py").write_text(init_source, encoding="utf-8")
-    _copy_plugin_yaml(target)
-
-
-def install_plugin(
-    *,
-    hermes_home_path: str | Path | None = None,
-    force: bool = False,
-    mode: str = "symlink",
-    python: str | Path | None = None,
-) -> Path:
-    """Install the Mnemosyne provider into Hermes' user plugin directory.
-
-    ``mode='symlink'`` keeps the historical behavior. ``mode='wrapper'``
-    creates a real persistent plugin directory containing a tiny shim that adds
-    the selected interpreter's site-packages path to ``sys.path`` and imports
-    ``mnemosyne_hermes`` from there.
-
-    After installing the primary plugin, every opted-in profile under
-    ``<hermes_home>/profiles/*`` that selects ``memory.provider: mnemosyne``
-    also gets a per-profile symlink.
-    """
-    if mode not in {"symlink", "wrapper"}:
-        raise ValueError("mode must be 'symlink' or 'wrapper'")
-
-    source = _resolve_package_dir()
-    if not source.is_dir():
-        raise FileNotFoundError(f"mnemosyne_hermes package not found at {source}")
-
-    base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
-    target = plugin_target_dir(hermes_home_path)
-    _prepare_plugin_target(base, target, force=force)
-
-    if mode == "symlink":
-        os.symlink(str(source), str(target))
-    else:
-        wrapper_python = Path(python).expanduser() if python else Path(sys.executable)
-        if not wrapper_python.is_file():
-            raise FileNotFoundError(f"Python interpreter not found: {wrapper_python}")
-        site_packages = _site_packages_for_python(wrapper_python)
-        import_ok, import_error = _check_wrapper_import(site_packages, wrapper_python)
-        if not import_ok:
-            raise RuntimeError(
-                "Selected Python environment cannot import mnemosyne_hermes: "
-                f"{import_error}"
+        raw_link = os.readlink(str(target))
+        link_target = Path(raw_link)
+        if not link_target.is_absolute():
+            link_target = target.parent / link_target
+        link_target = link_target.expanduser()
+        if not link_target.exists():
+            return PluginState(
+                status="broken_symlink",
+                installed=False,
+                target=target,
+                link_target=link_target,
+                mode="symlink",
+                message=(
+                    "Plugin symlink exists but target is missing "
+                    "(likely after a Hermes venv rebuild, Docker image update, "
+                    "or package reinstall)."
+                ),
             )
-        _write_wrapper_plugin(target, python=wrapper_python, site_packages=site_packages)
 
-    # Link any named profiles that opt into Mnemosyne (no-op without profiles).
-    _link_all_profiles(source, hermes_home_path=hermes_home_path, force=force)
+    if not target.exists():
+        return PluginState(
+            status="missing",
+            installed=False,
+            target=target,
+            message=f"No plugin directory or symlink at {target}.",
+        )
 
-    return target
+    init_file = target / "__init__.py"
+    if not init_file.is_file():
+        return PluginState(
+            status="missing_init",
+            installed=False,
+            target=target,
+            mode="symlink" if target.is_symlink() else "directory",
+            message=f"Plugin path exists but has no __init__.py: {target}",
+        )
+
+    if not _provider_init_is_valid(init_file):
+        return PluginState(
+            status="invalid_provider",
+            installed=False,
+            target=target,
+            mode="symlink" if target.is_symlink() else "directory",
+            message=(
+                "Plugin path exists but does not look like a Mnemosyne provider "
+                "(__init__.py lacks provider markers)."
+            ),
+        )
+
+    link_target = None
+    mode = "wrapper"
+    wrapper_python = None
+    wrapper_site = None
+    wrapper_import_ok = None
+    wrapper_import_error = None
+
+    if target.is_symlink():
+        mode = "symlink"
+        raw_link = os.readlink(str(target))
+        link_target = Path(raw_link)
+        if not link_target.is_absolute():
+            link_target = target.parent / link_target
+        link_target = link_target.expanduser()
+    else:
+        wrapper_python, wrapper_site = _extract_wrapper_metadata(init_file)
+        if wrapper_site is None:
+            mode = "directory"
+        else:
+            wrapper_import_ok, wrapper_import_error = _check_wrapper_import(
+                wrapper_site,
+                wrapper_python,
+            )
+            if not wrapper_import_ok:
+                return PluginState(
+                    status="stale_wrapper",
+                    installed=False,
+                    target=target,
+                    mode="wrapper",
+                    wrapper_python=wrapper_python,
+                    wrapper_site_packages=wrapper_site,
+                    wrapper_import_ok=wrapper_import_ok,
+                    wrapper_import_error=wrapper_import_error,
+                    message="Wrapper plugin exists but its target package cannot be imported.",
+                )
+
+    return PluginState(
+        status="installed",
+        installed=True,
+        target=target,
+        link_target=link_target,
+        mode=mode,
+        wrapper_python=wrapper_python,
+        wrapper_site_packages=wrapper_site,
+        wrapper_import_ok=wrapper_import_ok,
+        wrapper_import_error=wrapper_import_error,
+        message="Plugin is installed and discoverable.",
+    )
+
+def _find_hermes_python() -> Optional[Path]:
+    """Try to find Hermes' python executable for dep validation.
+
+    Returns None when we can't find it (user runs manually).
+    """
+    hermes_home_path = hermes_home()
+
+    # 1. Resolve the `hermes` launcher on PATH back to its venv Python.
+    #    This is the most reliable probe: a pip/pipx-installed Hermes puts its
+    #    console script next to the interpreter that runs it, so the Python is
+    #    always a sibling of the resolved binary. Covers the common
+    #    /usr/local/lib/hermes-agent/venv layout that the hardcoded roots below
+    #    miss entirely (the silent-no-op that left provider deps out of Hermes'
+    #    actual venv and produced "loaded but no provider instance found").
+    hermes_bin = shutil.which("hermes")
+    if hermes_bin:
+        # NOTE: resolve the *launcher* symlink (hermes -> venv/bin/hermes) to
+        # find the venv bin dir, but do NOT resolve the python symlink itself.
+        # A venv's bin/python is a symlink to the base interpreter; running the
+        # venv path activates the venv site-packages, running the resolved base
+        # path does NOT. Returning the resolved base interpreter would silently
+        # drop the provider deps again.
+        bin_dir = Path(hermes_bin).resolve().parent
+        for py_name in ("python", "python3"):
+            candidate = bin_dir / py_name
+            if candidate.is_file():
+                return candidate
+
+    # 2. Check known hermes-agent checkout / install roots with a venv.
+    for root in [
+        hermes_home_path / "hermes-agent",
+        Path.home() / "hermes-agent",
+        Path("/opt/hermes/hermes-agent"),
+        Path("/usr/local/lib/hermes-agent"),
+        Path("/usr/lib/hermes-agent"),
+    ]:
+        for venv_name in ("venv", ".venv"):
+            candidate = root / venv_name / "bin" / "python"
+            if candidate.is_file():
+                return candidate.resolve()
+
+    # 3. Check if we're running inside Hermes' venv ourselves
+    if sys.prefix != sys.base_prefix:
+        venv_python = Path(sys.prefix) / "bin" / "python"
+        if venv_python.is_file():
+            return venv_python.resolve()
+
+    # 4. Check VIRTUAL_ENV env var (uv-managed or explicit)
+    ve = os.environ.get("VIRTUAL_ENV")
+    if ve:
+        candidate = Path(ve) / "bin" / "python"
+        if candidate.is_file():
+            return candidate.resolve()
+
+    return None
+
+
+def _bootstrap_hermes_venv(hermes_python: Path) -> bool:
+    """Install mnemosyne-hermes into Hermes' Python venv."""
+    from . import __version__
+    pkg_name = f"mnemosyne-hermes[all]=={__version__}"
+    cmd = [str(hermes_python), "-m", "pip", "install", "--upgrade", pkg_name]
+    print(f"  Installing {pkg_name} into {hermes_python.parent.parent.name}...")
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        if result.returncode != 0:
+            stderr = result.stderr.strip()[:500]
+            print(f"  ⚠ Bootstrap failed: {stderr}", file=sys.stderr)
+            return False
+        print(f"  ✓ mnemosyne-hermes installed into Hermes' venv")
+        return True
+    except Exception as exc:
+        print(f"  ⚠ Bootstrap failed: {exc}", file=sys.stderr)
+        return False
+
+
+def check_mnemosyne_core() -> bool:
+    """Verify mnemosyne-memory core library is installed."""
+    try:
+        importlib.import_module("mnemosyne.core.beam")
+        import mnemosyne
+        print(f"  mnemosyne-memory {mnemosyne.__version__} installed")
+        return True
+    except ImportError:
+        return False
+
+
+def check_mnemosyne_core_for_hermes_python(hermes_python: Path) -> Optional[str]:
+    """Check if Hermes' Python can import mnemosyne core.
+
+    Returns the version string if importable, None otherwise.
+    """
+    try:
+        result = subprocess.run(
+            [str(hermes_python), "-c",
+             "import mnemosyne; print(mnemosyne.__version__); "
+             "import sqlite_vec"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip().split("\n")[0]
+        return None
+    except Exception:
+        return None
 
 
 def _config_selects_mnemosyne(text: str) -> bool:
@@ -350,3 +517,498 @@ def _unlink_all_profiles(*, hermes_home_path: str | Path | None = None) -> None:
                 print(f"  Removed profile link: {target}")
         except OSError:
             continue
+
+
+def _prepare_plugin_target(base: Path, target: Path, *, force: bool) -> None:
+    """Migrate legacy plugin names and remove an existing target when forced."""
+    old_plugin_dir = base / "plugins" / "hermes-mnemosyne"
+    if old_plugin_dir.is_symlink() or old_plugin_dir.exists():
+        if old_plugin_dir.is_symlink() or os.path.islink(str(old_plugin_dir)):
+            old_plugin_dir.unlink()
+        else:
+            shutil.rmtree(old_plugin_dir)
+        print(f"  Removed old plugin directory: {old_plugin_dir}")
+
+    config_path = base / "config.yaml"
+    if config_path.is_file():
+        try:
+            config_text = config_path.read_text(encoding="utf-8")
+            if "provider: hermes-mnemosyne" in config_text:
+                new_text = config_text.replace("provider: hermes-mnemosyne", "provider: mnemosyne")
+                config_path.write_text(new_text, encoding="utf-8")
+                print("  Updated config: memory.provider hermes-mnemosyne -> mnemosyne")
+        except Exception:
+            pass
+
+    if target.is_symlink() or target.exists():
+        if not force:
+            raise FileExistsError(
+                f"{target} already exists. Re-run with --force to replace it."
+            )
+        if target.is_symlink():
+            target.unlink()
+        elif target.is_dir():
+            shutil.rmtree(target)
+        else:
+            target.unlink()
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _write_wrapper_plugin(target: Path, *, python: Path, site_packages: Path) -> None:
+    """Create a persistent Hermes plugin shim that imports from a selected env."""
+    target.mkdir(parents=True, exist_ok=False)
+    init_source = f"""\"\"\"Persistent Mnemosyne Hermes plugin wrapper.
+
+Generated by ``mnemosyne-hermes install --mode wrapper``. The wrapper keeps the
+Hermes discovery directory stable while importing the real ``mnemosyne_hermes``
+package from the selected Python environment.
+\"\"\"
+from __future__ import annotations
+
+import sys as _sys
+
+# Metadata used by ``mnemosyne-hermes status``.
+_PYTHON = {str(python)!r}
+_SITE = {str(site_packages)!r}
+
+if _SITE not in _sys.path:
+    _sys.path.insert(0, _SITE)
+
+# Hermes discovery marker: register_memory_provider / MnemosyneMemoryProvider
+from mnemosyne_hermes import *  # noqa: F401,F403,E402
+"""
+    (target / "__init__.py").write_text(init_source, encoding="utf-8")
+    _copy_plugin_yaml(target)
+
+
+def install_plugin(
+    *,
+    hermes_home_path: str | Path | None = None,
+    force: bool = False,
+    mode: str = "symlink",
+    python: str | Path | None = None,
+) -> Path:
+    """Install the Mnemosyne provider into Hermes' user plugin directory.
+
+    ``mode='symlink'`` keeps the historical behavior. ``mode='wrapper'``
+    creates a real persistent plugin directory containing a tiny shim that adds
+    the selected interpreter's site-packages path to ``sys.path`` and imports
+    ``mnemosyne_hermes`` from there.
+    """
+    if mode not in {"symlink", "wrapper"}:
+        raise ValueError("mode must be 'symlink' or 'wrapper'")
+
+    source = _resolve_package_dir()
+    if not source.is_dir():
+        raise FileNotFoundError(f"mnemosyne_hermes package not found at {source}")
+
+    base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
+    target = plugin_target_dir(hermes_home_path)
+    _prepare_plugin_target(base, target, force=force)
+
+    if mode == "symlink":
+        os.symlink(str(source), str(target))
+        _link_all_profiles(source, hermes_home_path=hermes_home_path, force=force)
+        return target
+
+    wrapper_python = Path(python).expanduser() if python else Path(sys.executable)
+    if not wrapper_python.is_file():
+        raise FileNotFoundError(f"Python interpreter not found: {wrapper_python}")
+    site_packages = _site_packages_for_python(wrapper_python)
+    import_ok, import_error = _check_wrapper_import(site_packages, wrapper_python)
+    if not import_ok:
+        raise RuntimeError(
+            "Selected Python environment cannot import mnemosyne_hermes: "
+            f"{import_error}"
+        )
+    _write_wrapper_plugin(target, python=wrapper_python, site_packages=site_packages)
+    _link_all_profiles(source, hermes_home_path=hermes_home_path, force=force)
+    return target
+
+def uninstall_plugin(*, hermes_home_path: str | Path | None = None) -> Path:
+    """Remove the Mnemosyne provider symlink from Hermes' user plugin directory."""
+    _unlink_all_profiles(hermes_home_path=hermes_home_path)
+    target = plugin_target_dir(hermes_home_path)
+    if target.is_symlink():
+        target.unlink()
+    elif target.exists():
+        shutil.rmtree(target)
+    return target
+
+
+def cleanup_plugin(
+    *,
+    hermes_home_path: str | Path | None = None,
+    dry_run: bool = False,
+) -> list[str]:
+    """Remove all traces of mnemosyne from Hermes' plugin directory.
+
+    Safe to run -- never touches the database or memory files.
+
+    Returns a list of actions taken (or would be taken with dry_run=True).
+    """
+    base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
+    actions: list[str] = []
+
+    # 1. Current plugin symlink/dir
+    target = plugin_target_dir(hermes_home_path)
+    if target.is_symlink() or target.exists():
+        if dry_run:
+            actions.append(f"Would remove: {target}")
+        else:
+            if target.is_symlink():
+                target.unlink()
+            else:
+                shutil.rmtree(target)
+            actions.append(f"Removed: {target}")
+
+    # 2. Old hermes-mnemosyne directory (deploy script era)
+    old_dir = base / "plugins" / "hermes-mnemosyne"
+    if old_dir.is_symlink() or old_dir.exists():
+        if dry_run:
+            actions.append(f"Would remove: {old_dir}")
+        else:
+            if old_dir.is_symlink() or os.path.islink(str(old_dir)):
+                old_dir.unlink()
+            else:
+                shutil.rmtree(old_dir)
+            actions.append(f"Removed: {old_dir}")
+
+    # 3. Reset config if it points to mnemosyne
+    config_path = base / "config.yaml"
+    if config_path.is_file():
+        try:
+            config_text = config_path.read_text(encoding="utf-8")
+            if "memory.provider: mnemosyne" in config_text or "memory:\n  provider: mnemosyne" in config_text:
+                if dry_run:
+                    actions.append("Would reset config: memory.provider from 'mnemosyne' to unset")
+                else:
+                    # Simple line-based replacement to remove the provider setting
+                    import re as _re
+                    new_text = _re.sub(
+                        r"^memory:\n\s+provider: mnemosyne",
+                        "memory:\n  # provider: mnemosyne (unset by cleanup)",
+                        config_text,
+                        flags=_re.MULTILINE,
+                    )
+                    # Also handle inline form
+                    new_text = new_text.replace("memory.provider: mnemosyne", "# memory.provider: mnemosyne (unset by cleanup)")
+                    if new_text != config_text:
+                        config_path.write_text(new_text, encoding="utf-8")
+                        actions.append("Reset config: memory.provider from 'mnemosyne' to unset")
+        except Exception:
+            pass
+
+    return actions
+
+
+def _do_upgrade(*, force: bool = True, hermes_home_path: str | Path | None = None) -> bool:
+    """Run pipx upgrade mnemosyne-hermes then install --force."""
+    import subprocess as _sp
+
+    print("  Upgrading mnemosyne-hermes via pipx...")
+    try:
+        result = _sp.run(
+            ["pipx", "upgrade", "mnemosyne-hermes"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()[:300]
+            if "not installed" in stderr:
+                print("  ⚠ mnemosyne-hermes not installed via pipx. Install it first:")
+                print("     pipx install mnemosyne-hermes")
+                return False
+            print(f"  ⚠ pipx upgrade failed: {stderr}")
+            # Continue anyway -- maybe the user installed via pip directly
+            print("  Continuing with re-install...")
+        else:
+            out = result.stdout.strip()[:200]
+            if out:
+                print(f"  {out}")
+    except FileNotFoundError:
+        print("  ⚠ pipx not found. Install it: pip install pipx")
+        return False
+
+    # Now re-install the plugin symlink
+    print("  Re-installing plugin symlink...")
+    try:
+        target = install_plugin(hermes_home_path=hermes_home_path, force=force)
+        print(f"  Installed. Symlink at {target}")
+        print(f"    -> {os.readlink(str(target))}")
+        return True
+    except Exception as exc:
+        print(f"  ⚠ Re-install failed: {exc}")
+        return False
+
+
+def is_installed(*, hermes_home_path: str | Path | None = None) -> bool:
+    """Return whether the Mnemosyne provider is installed for Hermes discovery."""
+    return plugin_state(hermes_home_path=hermes_home_path).installed
+
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mnemosyne-hermes",
+        description="Install the Mnemosyne memory provider for Hermes Agent.",
+    )
+    parser.add_argument(
+        "--hermes-home",
+        help="Hermes home directory. Defaults to HERMES_HOME or ~/.hermes.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    install = subparsers.add_parser(
+        "install",
+        help="Install Mnemosyne into Hermes' memory provider plugin directory.",
+    )
+    install.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing Mnemosyne plugin directory.",
+    )
+    install.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes.",
+    )
+    install.add_argument(
+        "--no-bootstrap",
+        action="store_true",
+        help="Skip auto-installing mnemosyne-hermes into Hermes' venv.",
+    )
+    install.add_argument(
+        "--mode",
+        choices=("symlink", "wrapper"),
+        default="symlink",
+        help="Install mode: symlink (default) or persistent wrapper shim.",
+    )
+    install.add_argument(
+        "--python",
+        dest="python",
+        help="Python interpreter whose site-packages the wrapper should import from.",
+    )
+    subparsers.add_parser(
+        "uninstall",
+        help="Remove Mnemosyne from Hermes' memory provider plugin directory.",
+    )
+    subparsers.add_parser(
+        "status",
+        help="Show whether Mnemosyne is installed for Hermes memory discovery.",
+    )
+    cleanup = subparsers.add_parser(
+        "cleanup",
+        help="Remove all traces of Mnemosyne from Hermes plugin directory (safe, never touches database).",
+    )
+    cleanup.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be cleaned without removing anything.",
+    )
+    upgrade = subparsers.add_parser(
+        "upgrade",
+        help="Upgrade mnemosyne-hermes via pipx and re-install the plugin symlink.",
+    )
+    upgrade.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes.",
+    )
+    return parser
+
+
+def run_install(
+    *,
+    force: bool = False,
+    hermes_home_path: str | Path | None = None,
+    no_bootstrap: bool = False,
+    mode: str = "symlink",
+    python: str | Path | None = None,
+) -> int:
+    """Core install logic — check deps, bootstrap Hermes venv if needed, create symlink.
+
+    Returns 0 on success, 1 on failure.
+    Can be called from the CLI ``install`` subcommand or programmatically
+    (e.g., from ``upgrade.py`` after upgrading the pip package).
+    """
+    # Check core library first (installer's own Python)
+    core_ok = check_mnemosyne_core()
+    if not core_ok:
+        print(
+            "  mnemosyne-memory NOT found in this Python. Install it first:\n"
+            "    pip install mnemosyne-hermes[all]",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Symlink installs need Hermes' own Python to contain the package. Wrapper
+    # installs validate the explicitly selected interpreter in install_plugin().
+    hermes_python = _find_hermes_python() if mode == "symlink" else None
+    if hermes_python and hermes_python.resolve() != Path(sys.executable).resolve():
+        hermes_core = check_mnemosyne_core_for_hermes_python(hermes_python)
+        if hermes_core is None:
+            print(f"\n  ⚠ Hermes' Python at {hermes_python} can't import mnemosyne core.")
+            print(f"     mnemosyne-hermes is installed in YOUR Python ({sys.executable}),")
+            print(f"     but Hermes runs from a different venv.\n")
+            if not no_bootstrap:
+                print("  → Attempting auto-bootstrap...")
+                if _bootstrap_hermes_venv(hermes_python):
+                    print("     ✓ Hermes venv now has mnemosyne-hermes installed.\n")
+                else:
+                    print("\n  Install it manually:\n"
+                          f"    uv pip install --python {hermes_python} -U 'mnemosyne-hermes[all]'\n"
+                          "  Then re-run: mnemosyne-hermes install")
+                    return 1
+            else:
+                print("  → Skipping auto-bootstrap (--no-bootstrap).\n"
+                      "    Install manually:\n"
+                      f"      uv pip install --python {hermes_python} -U 'mnemosyne-hermes[all]'\n"
+                      "    Then re-run: mnemosyne-hermes install")
+                return 1
+        else:
+            print(f"  Hermes' Python: mnemosyne-memory {hermes_core} OK")
+
+    target = install_plugin(
+        hermes_home_path=hermes_home_path,
+        force=force,
+        mode=mode,
+        python=python,
+    )
+    if mode == "wrapper":
+        state = plugin_state(hermes_home_path=hermes_home_path)
+        print(f"Installed. Wrapper directory at {target}")
+        if state.wrapper_python:
+            print(f"  Python: {state.wrapper_python}")
+        if state.wrapper_site_packages:
+            print(f"  Site-packages: {state.wrapper_site_packages}")
+    else:
+        print(f"Installed. Symlink at {target}")
+        print(f"  -> {os.readlink(str(target))}")
+    print("Done. Next steps:")
+    print("  hermes config set memory.provider mnemosyne")
+    print("  hermes memory status")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the mnemosyne-hermes installer CLI."""
+    parser = _parser()
+    args = parser.parse_args(argv)
+    command = args.command or "install"
+
+    try:
+        if command == "install":
+            # Dry-run: just show what would happen
+            hermes_python = _find_hermes_python()
+            target = plugin_target_dir(args.hermes_home)
+            if getattr(args, "dry_run", False):
+                print(f"  Plugin target dir: {target}")
+                print(f"  Hermes Python: {hermes_python or 'not found'}")
+                print(f"  Currently installed: {'yes' if is_installed(hermes_home_path=args.hermes_home) else 'no'}")
+                print(f"  Install mode: {getattr(args, 'mode', 'symlink')}")
+                if getattr(args, "mode", "symlink") == "wrapper":
+                    wrapper_python = Path(getattr(args, "python", None) or sys.executable).expanduser()
+                    print(f"  Wrapper Python: {wrapper_python}")
+                    if wrapper_python.is_file():
+                        print(f"  Wrapper site-packages: {_site_packages_for_python(wrapper_python)}")
+                print(f"  Will force: {bool(getattr(args, 'force', False))}")
+                if hermes_python:
+                    print(f"  Will bootstrap: {not getattr(args, 'no_bootstrap', False)}")
+                return 0
+
+            return run_install(
+                force=getattr(args, "force", False),
+                hermes_home_path=args.hermes_home,
+                no_bootstrap=getattr(args, "no_bootstrap", False),
+                mode=getattr(args, "mode", "symlink"),
+                python=getattr(args, "python", None),
+            )
+
+        if command == "uninstall":
+            target = uninstall_plugin(hermes_home_path=args.hermes_home)
+            print(f"Removed. Symlink at {target} deleted.")
+            return 0
+
+        if command == "status":
+            state = plugin_state(hermes_home_path=args.hermes_home)
+            target = state.target
+            installed = state.installed
+            hermes_python = _find_hermes_python()
+            print(f"Status for mnemosyne-hermes plugin")
+            print(f"  Plugin path: {target}")
+            print(f"  State: {state.status}")
+            print(f"  Mode: {state.mode}")
+            if installed:
+                if state.mode == "symlink" and state.link_target is not None:
+                    print(f"  Target: {state.link_target}")
+                elif state.mode == "wrapper":
+                    print(f"  Wrapper Python: {state.wrapper_python}")
+                    print(f"  Wrapper site-packages: {state.wrapper_site_packages}")
+                    print(f"  Wrapper import: {'OK' if state.wrapper_import_ok else 'not checked'}")
+                else:
+                    print(f"  Type: directory (not symlink)")
+                print(f"  Plugin:    installed ✓")
+            elif state.status == "broken_symlink":
+                print(f"  Plugin:    broken symlink (target missing) ✗")
+                print(f"  Broken target: {state.link_target}")
+                print(f"  → Run: mnemosyne-hermes install --force")
+            elif state.status == "stale_wrapper":
+                print(f"  Plugin:    stale wrapper target ✗")
+                print(f"  Wrapper Python: {state.wrapper_python}")
+                print(f"  Wrapper site-packages: {state.wrapper_site_packages}")
+                print(f"  Import error: {state.wrapper_import_error}")
+                print(f"  → Re-run: mnemosyne-hermes install --mode wrapper --force --python <venv>/bin/python")
+            else:
+                print(f"  NOT installed: {state.message}")
+                if state.link_target is not None:
+                    print(f"  Broken target: {state.link_target}")
+            print(f"  Core library: {'OK' if check_mnemosyne_core() else 'MISSING'}")
+            print(f"  This Python: {sys.executable} ({sys.version.split()[0]})")
+            if hermes_python:
+                try:
+                    import subprocess as _sp
+                    _r = _sp.run([str(hermes_python), "--version"], capture_output=True, text=True, timeout=5)
+                    _ver = _r.stdout.strip() or _r.stderr.strip()
+                    print(f"  Hermes' Python: {hermes_python} ({_ver})")
+                    if state.mode == "symlink" and hermes_python.resolve() != Path(sys.executable).resolve():
+                        print(f"  ⚠ Python version MISMATCH! Install and Hermes use different Python versions.")
+                        print(f"  → Run: {_ver.split()[1]}" if " " in _ver else "")
+                except Exception:
+                    print(f"  Hermes' Python: {hermes_python} (unable to check version)")
+            else:
+                print(f"  Hermes' Python: not found")
+            if installed and state.mode == "symlink" and hermes_python and hermes_python.resolve() != Path(sys.executable).resolve():
+                print(f"  → Hermes Python vs install Python mismatch means the symlink exists but Hermes")
+                print(f"     may not be able to import mnemosyne core. Run with --dry-run to diagnose.")
+            return 0 if installed else 1
+
+        if command == "cleanup":
+            dry_run = getattr(args, "dry_run", False)
+            mode = " (dry-run)" if dry_run else ""
+            print(f"Cleaning up mnemosyne-hermes plugin{mode}...")
+            actions = cleanup_plugin(
+                hermes_home_path=args.hermes_home,
+                dry_run=dry_run,
+            )
+            if not actions:
+                print("  Nothing to clean up.")
+            for a in actions:
+                print(f"  {a}")
+            return 0
+
+        if command == "upgrade":
+            from mnemosyne_hermes.upgrade import upgrade_command
+            return upgrade_command(args)
+
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/hermes/tests/test_install_cli_entrypoint.py
+++ b/integrations/hermes/tests/test_install_cli_entrypoint.py
@@ -1,0 +1,60 @@
+"""Regression tests for the mnemosyne-hermes console entry point."""
+
+from __future__ import annotations
+
+import importlib.abc
+import importlib.metadata
+import subprocess
+import sys
+
+import mnemosyne_hermes
+from mnemosyne_hermes import install
+
+
+class _BlockMnemosyneCore(importlib.abc.MetaPathFinder):
+    """Simulate an environment where mnemosyne.core is unavailable."""
+
+    def find_spec(self, fullname, path=None, target=None):  # noqa: D401
+        if fullname == "mnemosyne.core" or fullname.startswith("mnemosyne.core."):
+            raise ModuleNotFoundError("No module named 'mnemosyne.core'")
+        return None
+
+
+def test_main_help_exits_successfully(capsys):
+    try:
+        install.main(["--help"])
+    except SystemExit as exc:
+        assert exc.code == 0
+    out = capsys.readouterr().out
+    assert "mnemosyne-hermes" in out
+    assert "install" in out
+    assert "status" in out
+
+
+def test_package_version_matches_distribution_metadata():
+    assert mnemosyne_hermes.__version__ == importlib.metadata.version("mnemosyne-hermes")
+
+
+def test_package_and_install_module_import_without_mnemosyne_core():
+    code = r'''
+import importlib.abc
+import sys
+class BlockMnemosyneCore(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "mnemosyne.core" or fullname.startswith("mnemosyne.core."):
+            raise ModuleNotFoundError("No module named 'mnemosyne.core'")
+        return None
+sys.meta_path.insert(0, BlockMnemosyneCore())
+import mnemosyne_hermes
+from mnemosyne_hermes import install
+assert callable(install.main)
+print("ok")
+'''
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"


### PR DESCRIPTION
## Summary

- restore the `mnemosyne-hermes` console entry point by bringing back the installer CLI surface (`main`, status/uninstall helpers, plugin-state diagnostics)
- keep `mnemosyne_hermes` core imports lazy so installer/status/help commands can import even when `mnemosyne.core` is unavailable or partially broken
- add regression coverage for `mnemosyne-hermes --help` and importing the install module without `mnemosyne.core`

Fixes #388.

## Tests

- `uv run --no-sync --with pytest --with-editable . pytest tests/test_install_cli_entrypoint.py tests/test_install_status.py tests/test_install_hermes.py -q`
- `uv build --wheel`
- installed the built wheel into a clean venv with `pip install --no-deps` and verified `mnemosyne-hermes --help` exits successfully
