### PR TITLE
fix(hermes): sync package __version__ with 0.3.1 release

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -30,7 +30,7 @@ from datetime import datetime, timedelta
 # but keep imports lazy so installer/status CLI commands still work in broken
 # or partially-installed environments.
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/hermes/tests/test_install_cli_entrypoint.py
+++ b/integrations/hermes/tests/test_install_cli_entrypoint.py
@@ -32,7 +32,11 @@ def test_main_help_exits_successfully(capsys):
 
 
 def test_package_version_matches_distribution_metadata():
-    assert mnemosyne_hermes.__version__ == importlib.metadata.version("mnemosyne-hermes")
+    dist_version = importlib.metadata.version("mnemosyne-hermes")
+
+    assert mnemosyne_hermes.__version__ == dist_version, (
+        "mnemosyne_hermes.__version__ must stay in sync with package metadata"
+    )
 
 
 def test_package_and_install_module_import_without_mnemosyne_core():


### PR DESCRIPTION
## Summary
- sync mnemosyne_hermes.__version__ with the 0.3.1 package metadata
- tighten the version drift regression assertion against importlib.metadata

## Test plan
- uv run --extra test pytest tests -q
- uv build --out-dir /opt/data/tmp/mnemosyne-hermes-version-031-dist
- install built wheel in a clean uv venv and assert importlib.metadata.version("mnemosyne-hermes") == mnemosyne_hermes.__version__ == "0.3.1"