### PR TITLE
feat(hermes): add sync_turn diagnostics

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -20,6 +20,7 @@ import os
 import re
 import sys
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
@@ -1198,6 +1199,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
     # it's not re-parsed on every _maybe_auto_sleep call.
     _AUTO_SLEEP_TIMEOUT_SECONDS = _parse_env_float("MNEMOSYNE_AUTO_SLEEP_TIMEOUT", 5)
 
+    _SYNC_TURN_SLOW_THRESHOLD_SECONDS = _parse_env_float("MNEMOSYNE_SYNC_TURN_SLOW_THRESHOLD", 5)
+
     _VALID_SYNC_ROLES: frozenset = frozenset({"user", "assistant"})
 
     def __init__(self):
@@ -1223,6 +1226,22 @@ class MnemosyneMemoryProvider(MemoryProvider):
         self._platform = "cli"
         self._agent_context = "primary"
         self._turn_count = 0
+        self._sync_turn_lock = threading.Lock()
+        self._sync_turn_telemetry: Dict[str, Any] = {
+            "pending_queue_length": 0,
+            "max_queue_length": 0,
+            "completed": 0,
+            "failed": 0,
+            # Reserved for a future bounded async queue; v1 keeps sync_turn
+            # inline but exposes stable diagnostic keys.
+            "merged": 0,
+            "dropped": 0,
+            "slow_sync_count": 0,
+            "last_duration_ms": None,
+            "max_duration_ms": 0.0,
+            "last_error": None,
+            "in_flight": 0,
+        }
         self._auto_sleep_threshold = 50
         self._auto_sleep_enabled = os.environ.get("MNEMOSYNE_AUTO_SLEEP_ENABLED", "").strip().lower() in ("1", "true", "yes", "on")
         # Reflection/sleep guardrails.  "reflection" maps to Mnemosyne's
@@ -2083,10 +2102,55 @@ class MnemosyneMemoryProvider(MemoryProvider):
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         pass
 
+    def _ensure_sync_turn_telemetry(self) -> None:
+        """Initialize sync_turn telemetry for tests that construct via __new__."""
+        if not hasattr(self, "_sync_turn_lock"):
+            self._sync_turn_lock = threading.Lock()
+        if not hasattr(self, "_sync_turn_telemetry"):
+            self._sync_turn_telemetry = {
+                "pending_queue_length": 0,
+                "max_queue_length": 0,
+                "completed": 0,
+                "failed": 0,
+                # Reserved for a future bounded async queue; v1 keeps sync_turn
+                # inline but exposes stable diagnostic keys.
+                "merged": 0,
+                "dropped": 0,
+                "slow_sync_count": 0,
+                "last_duration_ms": None,
+                "max_duration_ms": 0.0,
+                "last_error": None,
+                "in_flight": 0,
+            }
+
+    def _sync_turn_diagnostics(self) -> Dict[str, Any]:
+        """Return a PII-safe snapshot of sync_turn telemetry."""
+        self._ensure_sync_turn_telemetry()
+        with self._sync_turn_lock:
+            return dict(self._sync_turn_telemetry)
+
+    @staticmethod
+    def _sanitize_sync_turn_error(exc: BaseException) -> str:
+        """Bound error detail without including user/assistant content."""
+        return f"{type(exc).__name__}: <redacted>"
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Persist the turn to Mnemosyne episodic memory."""
         if not self._beam or self._agent_context in self._skip_contexts:
             return
+        started = time.perf_counter()
+        self._ensure_sync_turn_telemetry()
+        with self._sync_turn_lock:
+            self._sync_turn_telemetry["in_flight"] += 1
+            in_flight = int(self._sync_turn_telemetry["in_flight"])
+            # v1 does not introduce a separate async queue yet. Expose the
+            # current in-flight sync work through the queue-shaped diagnostic
+            # fields so operators can see backlog pressure without raw content.
+            self._sync_turn_telemetry["pending_queue_length"] = in_flight
+            self._sync_turn_telemetry["max_queue_length"] = max(
+                int(self._sync_turn_telemetry.get("max_queue_length") or 0),
+                in_flight,
+            )
         try:
             if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
                 user_limit = _sync_turn_user_limit()
@@ -2112,8 +2176,36 @@ class MnemosyneMemoryProvider(MemoryProvider):
             self._turn_count += 1
             if self._auto_sleep_enabled and self._turn_count % 10 == 0:
                 self._maybe_auto_sleep()
+            with self._sync_turn_lock:
+                self._sync_turn_telemetry["completed"] += 1
+                self._sync_turn_telemetry["last_error"] = None
         except Exception as e:
-            logger.debug("Mnemosyne sync_turn failed: %s", e)
+            with self._sync_turn_lock:
+                self._sync_turn_telemetry["failed"] += 1
+                self._sync_turn_telemetry["last_error"] = self._sanitize_sync_turn_error(e)
+            logger.debug("Mnemosyne sync_turn failed: %s", self._sanitize_sync_turn_error(e))
+        finally:
+            duration_ms = (time.perf_counter() - started) * 1000.0
+            slow = duration_ms >= (self._SYNC_TURN_SLOW_THRESHOLD_SECONDS * 1000.0)
+            with self._sync_turn_lock:
+                self._sync_turn_telemetry["in_flight"] = max(0, self._sync_turn_telemetry["in_flight"] - 1)
+                self._sync_turn_telemetry["pending_queue_length"] = int(self._sync_turn_telemetry["in_flight"])
+                self._sync_turn_telemetry["last_duration_ms"] = duration_ms
+                self._sync_turn_telemetry["max_duration_ms"] = max(
+                    float(self._sync_turn_telemetry.get("max_duration_ms") or 0.0),
+                    duration_ms,
+                )
+                if slow:
+                    self._sync_turn_telemetry["slow_sync_count"] += 1
+                snapshot = dict(self._sync_turn_telemetry)
+            if slow:
+                logger.warning(
+                    "Mnemosyne sync_turn slow: duration_ms=%.1f completed=%s failed=%s pending_queue_length=%s",
+                    duration_ms,
+                    snapshot["completed"],
+                    snapshot["failed"],
+                    snapshot["pending_queue_length"],
+                )
 
     # Identity-significant expressions the user may voice about themselves or
     # their relationship to their work. When a match is found, the memory is
@@ -3101,6 +3193,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
         repair_requested = bool(args.get("repair_vec_working", False))
         dry_run = bool(args.get("dry_run", False))
         result = run_diagnostics(repair_vec_working=repair_requested, dry_run=dry_run)
+        if self._beam is not None:
+            result["sync_turn"] = self._sync_turn_diagnostics()
 
         # run_diagnostics() reports Mnemosyne's legacy/default DB path. When
         # Hermes profile isolation is enabled, the active provider may use a

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -22,6 +22,7 @@ import os
 import re
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 from datetime import datetime, timedelta
@@ -424,6 +425,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
     # it's not re-parsed on every _maybe_auto_sleep call.
     _AUTO_SLEEP_TIMEOUT_SECONDS = _parse_env_float("MNEMOSYNE_AUTO_SLEEP_TIMEOUT", 5)
 
+    _SYNC_TURN_SLOW_THRESHOLD_SECONDS = _parse_env_float("MNEMOSYNE_SYNC_TURN_SLOW_THRESHOLD", 5)
+
     def __init__(self):
         self._beam: Optional[Any] = None
         self._surface_beam: Optional[Any] = None
@@ -447,6 +450,22 @@ class MnemosyneMemoryProvider(MemoryProvider):
         self._platform = "cli"
         self._agent_context = "primary"
         self._turn_count = 0
+        self._sync_turn_lock = threading.Lock()
+        self._sync_turn_telemetry: Dict[str, Any] = {
+            "pending_queue_length": 0,
+            "max_queue_length": 0,
+            "completed": 0,
+            "failed": 0,
+            # Reserved for a future bounded async queue; v1 keeps sync_turn
+            # inline but exposes stable diagnostic keys.
+            "merged": 0,
+            "dropped": 0,
+            "slow_sync_count": 0,
+            "last_duration_ms": None,
+            "max_duration_ms": 0.0,
+            "last_error": None,
+            "in_flight": 0,
+        }
         self._auto_sleep_threshold = 50
         self._auto_sleep_enabled = os.environ.get("MNEMOSYNE_AUTO_SLEEP_ENABLED", "").strip().lower() in ("1", "true", "yes", "on")
         # Reflection/sleep guardrails. "Reflection" maps to Mnemosyne's
@@ -1141,10 +1160,55 @@ class MnemosyneMemoryProvider(MemoryProvider):
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         pass
 
+    def _ensure_sync_turn_telemetry(self) -> None:
+        """Initialize sync_turn telemetry for tests that construct via __new__."""
+        if not hasattr(self, "_sync_turn_lock"):
+            self._sync_turn_lock = threading.Lock()
+        if not hasattr(self, "_sync_turn_telemetry"):
+            self._sync_turn_telemetry = {
+                "pending_queue_length": 0,
+                "max_queue_length": 0,
+                "completed": 0,
+                "failed": 0,
+                # Reserved for a future bounded async queue; v1 keeps sync_turn
+                # inline but exposes stable diagnostic keys.
+                "merged": 0,
+                "dropped": 0,
+                "slow_sync_count": 0,
+                "last_duration_ms": None,
+                "max_duration_ms": 0.0,
+                "last_error": None,
+                "in_flight": 0,
+            }
+
+    def _sync_turn_diagnostics(self) -> Dict[str, Any]:
+        """Return a PII-safe snapshot of sync_turn telemetry."""
+        self._ensure_sync_turn_telemetry()
+        with self._sync_turn_lock:
+            return dict(self._sync_turn_telemetry)
+
+    @staticmethod
+    def _sanitize_sync_turn_error(exc: BaseException) -> str:
+        """Bound error detail without including user/assistant content."""
+        return f"{type(exc).__name__}: <redacted>"
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Persist the turn to Mnemosyne episodic memory."""
         if not self._beam or self._agent_context in self._skip_contexts:
             return
+        started = time.perf_counter()
+        self._ensure_sync_turn_telemetry()
+        with self._sync_turn_lock:
+            self._sync_turn_telemetry["in_flight"] += 1
+            in_flight = int(self._sync_turn_telemetry["in_flight"])
+            # v1 does not introduce a separate async queue yet. Expose the
+            # current in-flight sync work through the queue-shaped diagnostic
+            # fields so operators can see backlog pressure without raw content.
+            self._sync_turn_telemetry["pending_queue_length"] = in_flight
+            self._sync_turn_telemetry["max_queue_length"] = max(
+                int(self._sync_turn_telemetry.get("max_queue_length") or 0),
+                in_flight,
+            )
         try:
             if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
                 user_limit = _sync_turn_user_limit()
@@ -1171,8 +1235,36 @@ class MnemosyneMemoryProvider(MemoryProvider):
             self._turn_count += 1
             if self._auto_sleep_enabled and self._turn_count % 10 == 0:
                 self._maybe_auto_sleep()
+            with self._sync_turn_lock:
+                self._sync_turn_telemetry["completed"] += 1
+                self._sync_turn_telemetry["last_error"] = None
         except Exception as e:
-            logger.debug("Mnemosyne sync_turn failed: %s", e)
+            with self._sync_turn_lock:
+                self._sync_turn_telemetry["failed"] += 1
+                self._sync_turn_telemetry["last_error"] = self._sanitize_sync_turn_error(e)
+            logger.debug("Mnemosyne sync_turn failed: %s", self._sanitize_sync_turn_error(e))
+        finally:
+            duration_ms = (time.perf_counter() - started) * 1000.0
+            slow = duration_ms >= (self._SYNC_TURN_SLOW_THRESHOLD_SECONDS * 1000.0)
+            with self._sync_turn_lock:
+                self._sync_turn_telemetry["in_flight"] = max(0, self._sync_turn_telemetry["in_flight"] - 1)
+                self._sync_turn_telemetry["pending_queue_length"] = int(self._sync_turn_telemetry["in_flight"])
+                self._sync_turn_telemetry["last_duration_ms"] = duration_ms
+                self._sync_turn_telemetry["max_duration_ms"] = max(
+                    float(self._sync_turn_telemetry.get("max_duration_ms") or 0.0),
+                    duration_ms,
+                )
+                if slow:
+                    self._sync_turn_telemetry["slow_sync_count"] += 1
+                snapshot = dict(self._sync_turn_telemetry)
+            if slow:
+                logger.warning(
+                    "Mnemosyne sync_turn slow: duration_ms=%.1f completed=%s failed=%s pending_queue_length=%s",
+                    duration_ms,
+                    snapshot["completed"],
+                    snapshot["failed"],
+                    snapshot["pending_queue_length"],
+                )
 
     # Identity-significant expressions the user may voice about themselves or
     # their relationship to their work. When a match is found, the memory is
@@ -2056,6 +2148,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
     def _handle_diagnose(self, args: Dict[str, Any]) -> str:
         from mnemosyne.diagnose import run_diagnostics
         result = run_diagnostics()
+        if self._beam is not None:
+            result["sync_turn"] = self._sync_turn_diagnostics()
 
         # run_diagnostics() reports Mnemosyne's legacy/default DB path. When
         # Hermes profile isolation is enabled, the active provider may use a

--- a/tests/test_sync_turn_diagnostics.py
+++ b/tests/test_sync_turn_diagnostics.py
@@ -1,0 +1,98 @@
+"""Tests for sync_turn telemetry and diagnostics."""
+
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_REQUIRED_SYNC_TURN_KEYS = {
+    "pending_queue_length",
+    "max_queue_length",
+    "completed",
+    "failed",
+    "merged",
+    "dropped",
+    "slow_sync_count",
+    "last_error",
+}
+
+
+@pytest.fixture
+def provider():
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    p = MnemosyneMemoryProvider()
+    p._agent_context = "test"
+    p._skip_contexts = set()
+    p._auto_sleep_enabled = False
+    p._default_scope = "session"
+    p._beam = MagicMock()
+    p._beam.db_path = None
+    return p
+
+
+def test_sync_turn_increments_completed_and_records_duration(provider):
+    provider.sync_turn("remember this user preference", "ack")
+
+    diag = provider._sync_turn_diagnostics()
+    assert diag["completed"] == 1
+    assert diag["failed"] == 0
+    assert diag["in_flight"] == 0
+    assert diag["pending_queue_length"] == 0
+    assert diag["max_queue_length"] >= 1
+    assert diag["last_duration_ms"] is not None
+    assert diag["max_duration_ms"] >= diag["last_duration_ms"]
+    assert _REQUIRED_SYNC_TURN_KEYS.issubset(diag)
+
+
+def test_diagnose_exposes_sync_turn_section(provider, monkeypatch):
+    import mnemosyne.diagnose
+
+    monkeypatch.setattr(
+        mnemosyne.diagnose,
+        "run_diagnostics",
+        lambda **kwargs: {"checks_total": 0, "entries": [], "key_findings": []},
+    )
+    provider.sync_turn("remember this user preference", "ack")
+
+    result = json.loads(provider._handle_diagnose({}))
+
+    assert "sync_turn" in result
+    assert result["sync_turn"]["completed"] == 1
+    assert _REQUIRED_SYNC_TURN_KEYS.issubset(result["sync_turn"])
+
+
+def test_slow_sync_turn_warns_without_content(provider, monkeypatch, caplog):
+    import hermes_memory_provider
+
+    secret_user = "secret user content should not appear"
+    secret_assistant = "secret assistant content should not appear"
+    times = iter([100.0, 100.250])
+    monkeypatch.setattr(hermes_memory_provider.time, "perf_counter", lambda: next(times))
+    provider._SYNC_TURN_SLOW_THRESHOLD_SECONDS = 0.001
+
+    with caplog.at_level(logging.WARNING):
+        provider.sync_turn(secret_user, secret_assistant)
+
+    diag = provider._sync_turn_diagnostics()
+    warning_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert diag["slow_sync_count"] == 1
+    assert "Mnemosyne sync_turn slow" in warning_text
+    assert secret_user not in warning_text
+    assert secret_assistant not in warning_text
+
+
+def test_sync_turn_failure_is_recorded_and_sanitized(provider):
+    secret = "private user message should not leak"
+    provider._beam.remember.side_effect = RuntimeError(secret)
+
+    provider.sync_turn("remember this user preference", "ack")
+
+    diag = provider._sync_turn_diagnostics()
+    assert diag["completed"] == 0
+    assert diag["failed"] == 1
+    assert diag["last_error"] == "RuntimeError: <redacted>"
+    assert secret not in diag["last_error"]
+    assert diag["in_flight"] == 0


### PR DESCRIPTION
## Summary

Adds a narrow v1 telemetry surface for Hermes provider `sync_turn()` so slow or failing memory sync work is visible instead of silently disappearing into the off-thread path.

This keeps the current inline sync behavior and does **not** introduce a new async worker or DB/schema changes.

## Changes

- Track PII-safe `sync_turn` counters on both Hermes provider surfaces:
  - `pending_queue_length`
  - `max_queue_length`
  - `completed`
  - `failed`
  - `merged`
  - `dropped`
  - `slow_sync_count`
  - `last_error`
  - plus duration/in-flight gauges
- Emit a warning when `sync_turn()` exceeds `MNEMOSYNE_SYNC_TURN_SLOW_THRESHOLD` (default 5s).
- Sanitize sync errors before storing/logging them.
- Expose the telemetry under `mnemosyne_diagnose` as `sync_turn`.
- Add focused tests for normal sync, diagnose output, slow warning privacy, and failure sanitization.

## Notes

`merged` and `dropped` are stable diagnostic placeholders for a future bounded async queue. In this v1, backlog pressure is represented by the in-flight sync work via `pending_queue_length` / `max_queue_length`.

## Verification

- `uv run --no-sync --with pytest pytest tests/test_sync_roles.py tests/test_provider_all_15_tools.py tests/test_sync_turn_diagnostics.py -q`
- `python3 -m py_compile hermes_memory_provider/__init__.py integrations/hermes/src/mnemosyne_hermes/__init__.py tests/test_sync_turn_diagnostics.py`
- Independent Claude/Opus review: no blockers

Closes #328
