### PR TITLE
fix: forward veracity through Mnemosyne.remember (unbreaks MCP remember)

### DIFF
--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -304,6 +304,7 @@ class Mnemosyne:
                  valid_until: str = None, scope: str = "session",
                  extract_entities: bool = False,
                  extract: bool = False,
+                 veracity: str = "unknown",
                  trust_tier: str = None) -> str:
         """
         Store a memory directly to SQLite.
@@ -352,6 +353,7 @@ class Mnemosyne:
             importance=importance, metadata=metadata,
             valid_until=valid_until, scope=scope,
             extract_entities=extract_entities, extract=extract,
+            veracity=veracity,
             trust_tier=trust_tier,
         )
         timestamp = datetime.now().isoformat()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 
 # Test tool schemas
 from mnemosyne.mcp_tools import (
-    TOOLS, get_tool_definitions, handle_tool_call,
+    TOOLS, get_tool_definitions, handle_tool_call, _create_instance,
 )
 
 
@@ -137,6 +137,35 @@ class TestToolHandlers:
         assert result["memory_id"] == "test-memory-id-123"
         assert result["bank"] == "default"
         mock_mnemosyne.remember.assert_called_once()
+
+    def test_handle_remember_forwards_veracity(self, tmp_path, monkeypatch):
+        """Regression: MCP remember must forward veracity to Mnemosyne.remember.
+
+        #386 wired veracity into _handle_remember() but Mnemosyne.remember()
+        never got the parameter, so every real MCP remember raised
+        `TypeError: remember() got an unexpected keyword argument 'veracity'`.
+        The mocked handler tests above miss it because a MagicMock swallows any
+        kwarg -- this test drives a real instance so the signature is exercised.
+        """
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        result = handle_tool_call("mnemosyne_remember", {
+            "content": "veracity plumbing regression",
+            "source": "test",
+            "scope": "global",
+            "veracity": "tool",
+        })
+        assert result["status"] == "stored"
+
+        # veracity must persist to the beam working_memory row, not be dropped.
+        mem = _create_instance(bank="default")
+        row = mem.beam.conn.execute(
+            "SELECT veracity FROM working_memory WHERE id = ?",
+            (result["memory_id"],),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "tool"
 
     def test_handle_remember_uses_mcp_bank_env_default(self, mock_mnemosyne, monkeypatch):
         """MCP server bank default applies when tool call omits bank."""


### PR DESCRIPTION
## Problem

Every MCP `mnemosyne_remember` call currently raises:

```
TypeError: remember() got an unexpected keyword argument 'veracity'
```

#386 wired `veracity` into `_handle_remember()` and passes it to `mem.remember(...)`. That commit's message assumed the call lands on the beam's `remember()` ("the beam's remember() already has the parameter"), but `mem` is a `Mnemosyne` instance, so the call actually goes through the `Mnemosyne.remember()` compatibility wrapper in `core/memory.py` — which was never given a `veracity` parameter. So the argument dies at the wrapper and no MCP remember can succeed. This ships in 3.11.1 and is still present on `main`.

## Fix

Widen the wrapper to accept `veracity` and forward it to `self.beam.remember(...)` (which already accepts and clamps it). Two lines.

## Test

Added `test_handle_remember_forwards_veracity`, which drives a **real** `Mnemosyne` instance through `handle_tool_call("mnemosyne_remember", …)` against a temp `MNEMOSYNE_DATA_DIR` and asserts the row persists with `veracity='tool'`.

The existing handler tests mock `Mnemosyne`, so a `MagicMock` swallows the bad kwarg and the signature mismatch goes undetected — this is why the regression slipped through. Verified the new test fails with the exact `TypeError` when the `memory.py` change is reverted, and passes with it. Full `tests/test_mcp_server.py` is green (26 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)