### PR TITLE
fix: forward veracity through module-level remember

### DIFF
--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -924,12 +924,14 @@ def remember(content: str, source: str = "conversation",
              scope: str = "session", valid_until: str = None,
              extract_entities: bool = False,
              extract: bool = False, bank: str = None,
-             trust_tier: str = None) -> str:
+             trust_tier: str = None,
+             veracity: str = "unknown") -> str:
     """Store a memory using the global instance"""
     return _get_default(bank).remember(content, source, importance, metadata,
                                        scope=scope, valid_until=valid_until,
                                        extract_entities=extract_entities,
-                                       extract=extract, trust_tier=trust_tier)
+                                       extract=extract, trust_tier=trust_tier,
+                                       veracity=veracity)
 
 
 def recall(query: str, top_k: int = 5, *,

--- a/tests/test_memory_banks.py
+++ b/tests/test_memory_banks.py
@@ -177,6 +177,35 @@ class TestBankManager:
             delete_bank("mod_test", data_dir)
             assert not bank_exists("mod_test", data_dir)
 
+    def test_module_level_remember_forwards_veracity(self):
+        """Module-level remember() should preserve veracity like Mnemosyne.remember()."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir)
+            old_data_dir = os.environ.get("MNEMOSYNE_DATA_DIR")
+            os.environ["MNEMOSYNE_DATA_DIR"] = str(data_dir)
+            try:
+                set_bank("default")
+                memory_id = remember(
+                    "module-level veracity passthrough",
+                    source="test",
+                    veracity="tool",
+                )
+
+                mem = Mnemosyne()
+                row = mem.beam.conn.execute(
+                    "SELECT veracity FROM working_memory WHERE id = ?",
+                    (memory_id,),
+                ).fetchone()
+
+                assert row is not None
+                assert row[0] == "tool"
+            finally:
+                set_bank("default")
+                if old_data_dir is None:
+                    os.environ.pop("MNEMOSYNE_DATA_DIR", None)
+                else:
+                    os.environ["MNEMOSYNE_DATA_DIR"] = old_data_dir
+
 
 # ============================================================================
 # Mnemosyne bank integration tests


### PR DESCRIPTION
## Summary

Follow-up to #398: keep the module-level `mnemosyne.core.memory.remember(...)` convenience function in parity with `Mnemosyne.remember(...)` by accepting `veracity` and forwarding it to the default instance.

## Why

#398 fixed MCP `mnemosyne_remember` by widening the `Mnemosyne.remember()` wrapper. The module-level convenience API still dropped the same field, so callers using `mnemosyne.core.memory.remember(..., veracity="tool")` could not persist provenance.

## Test

```bash
PYTHONPATH=. uv run --no-sync --with pytest pytest \
  tests/test_memory_banks.py::TestBankManager::test_module_level_remember_forwards_veracity \
  tests/test_memory_banks.py::TestBankManager::test_module_level_functions -q

PYTHONPATH=. uv run --no-sync --with pytest pytest \
  tests/test_memory_banks.py tests/test_mcp_server.py -q

python3 -m py_compile mnemosyne/core/memory.py tests/test_memory_banks.py
git diff --check
```

Local result: `53 passed, 1 skipped` for the adjacent bank + MCP suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory entries can now include a veracity value when saved through the module-level memory helper.
  * The provided veracity setting is now preserved end-to-end when storing new memories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->