### PR TITLE
feat(hermes): add atomic mnemosyne_batch tool

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -41,6 +41,7 @@ from mnemosyne.batch_tool import (
     dry_run_batch,
     validate_batch_operations,
 )
+from mnemosyne.hermes_config import read_hermes_config_key
 
 logger = logging.getLogger(__name__)
 
@@ -922,6 +923,7 @@ BATCH_SCHEMA = {
         "properties": {
             "operations": {
                 "type": "array",
+                "maxItems": 50,
                 "description": "Ordered mutation operations to apply atomically.",
                 "items": {
                     "type": "object",
@@ -943,6 +945,10 @@ BATCH_SCHEMA = {
                 },
             },
             "dry_run": {"type": "boolean", "default": False},
+            "bank": {"type": "string"},
+            "author_id": {"type": "string"},
+            "author_type": {"type": "string"},
+            "channel_id": {"type": "string"},
         },
         "required": ["operations"],
     },
@@ -1576,67 +1582,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
     def _read_config_key(self, key: str) -> Any:
         """Read a single key from memory.mnemosyne in config.yaml."""
-        try:
-            import os
-            config_path = os.path.join(self._hermes_home, "config.yaml") if self._hermes_home else ""
-            if not config_path or not os.path.exists(config_path):
-                return None
-            try:
-                import yaml
-            except ImportError:
-                return self._read_config_key_without_yaml(config_path, key)
-            with open(config_path, "r") as f:
-                config = yaml.safe_load(f) or {}
-            return config.get("memory", {}).get("mnemosyne", {}).get(key)
-        except Exception:
-            return None
-
-    def _read_config_key_without_yaml(self, config_path: str, key: str) -> Any:
-        """Tiny fallback for memory.mnemosyne.<key> when PyYAML is unavailable."""
-        lines = Path(config_path).read_text().splitlines()
-        in_memory = False
-        in_mnemosyne = False
-        memory_indent = mnemosyne_indent = -1
-        for i, line in enumerate(lines):
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#"):
-                continue
-            indent = len(line) - len(line.lstrip())
-            if stripped == "memory:":
-                in_memory = True
-                in_mnemosyne = False
-                memory_indent = indent
-                continue
-            if in_memory and indent <= memory_indent:
-                in_memory = False
-                in_mnemosyne = False
-            if in_memory and stripped == "mnemosyne:" and indent > memory_indent:
-                in_mnemosyne = True
-                mnemosyne_indent = indent
-                continue
-            if in_mnemosyne and indent <= mnemosyne_indent:
-                in_mnemosyne = False
-            if not in_mnemosyne or indent <= mnemosyne_indent or not stripped.startswith(f"{key}:"):
-                continue
-            value = stripped.split(":", 1)[1].strip()
-            if value == "[]":
-                return []
-            if value:
-                return value.strip('"\'')
-            items = []
-            for child in lines[i + 1:]:
-                child_stripped = child.strip()
-                if not child_stripped:
-                    continue
-                child_indent = len(child) - len(child.lstrip())
-                if child_indent <= indent:
-                    break
-                if child_stripped.startswith("-"):
-                    items.append(child_stripped[1:].strip().strip('"\''))
-                    continue
-                break
-            return items if items else None
-        return None
+        return read_hermes_config_key(getattr(self, "_hermes_home", None), key)
 
     def _configured_tool_schemas(self) -> List[Dict[str, Any]]:
         """Return schemas filtered by memory.mnemosyne.tools, if configured.
@@ -2572,7 +2518,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             remember_source_default="user",
             remember_source_tool="mnemosyne_batch",
             audit_event=self._audit_event,
-            extract_defaults_global=True,
+            extract_defaults_global=False,
         ))
 
     def _handle_recall(self, args: Dict[str, Any]) -> str:

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -34,6 +34,13 @@ if str(_mnemosyne_root) not in sys.path:
 
 from mnemosyne.core.episodic_graph import GraphEdge
 from mnemosyne.core.beam import WORKING_MEMORY_TTL_HOURS
+from mnemosyne.batch_tool import (
+    BatchValidationError,
+    apply_beam_batch,
+    batch_validation_error_payload,
+    dry_run_batch,
+    validate_batch_operations,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -902,6 +909,45 @@ FORGET_SCHEMA = {
     },
 }
 
+BATCH_SCHEMA = {
+    "name": "mnemosyne_batch",
+    "description": (
+        "Apply multiple Mnemosyne memory mutations atomically in one tool call. "
+        "Supported v1 actions: remember, update, forget, invalidate. "
+        "All operations are validated before mutation; on failure the whole batch rolls back. "
+        "Destructive actions require exact memory IDs. Recall/search/canonical/persona/shared-surface operations are not included in v1."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "operations": {
+                "type": "array",
+                "description": "Ordered mutation operations to apply atomically.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "action": {"type": "string", "enum": ["remember", "update", "forget", "invalidate"]},
+                        "content": {"type": "string"},
+                        "memory_id": {"type": "string"},
+                        "importance": {"type": "number"},
+                        "source": {"type": "string"},
+                        "scope": {"type": "string"},
+                        "valid_until": {"type": "string"},
+                        "metadata": {"type": "object"},
+                        "extract_entities": {"type": "boolean"},
+                        "extract": {"type": "boolean"},
+                        "veracity": {"type": "string"},
+                        "replacement_id": {"type": "string"},
+                    },
+                    "required": ["action"],
+                },
+            },
+            "dry_run": {"type": "boolean", "default": False},
+        },
+        "required": ["operations"],
+    },
+}
+
 IMPORT_SCHEMA = {
     "name": "mnemosyne_import",
     "description": "Import Mnemosyne memories from a JSON file or another memory provider (Hindsight, Mem0). Idempotent by default.",
@@ -1120,7 +1166,7 @@ ALL_TOOL_SCHEMAS = [
     TRIPLE_END_SCHEMA,
     REMEMBER_CANONICAL_SCHEMA, RECALL_CANONICAL_SCHEMA, MODEL_CARD_SCHEMA,
     MODEL_REFRESH_SCHEMA, SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
-    EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
+    EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, BATCH_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
     RECALL_DIAGNOSTICS_SCHEMA, TASK_PROGRESS_SCHEMA,
     GRAPH_QUERY_SCHEMA, GRAPH_LINK_SCHEMA,
     *ALL_SYNC_TOOL_SCHEMAS,
@@ -1531,15 +1577,66 @@ class MnemosyneMemoryProvider(MemoryProvider):
     def _read_config_key(self, key: str) -> Any:
         """Read a single key from memory.mnemosyne in config.yaml."""
         try:
-            import yaml, os
+            import os
             config_path = os.path.join(self._hermes_home, "config.yaml") if self._hermes_home else ""
             if not config_path or not os.path.exists(config_path):
                 return None
+            try:
+                import yaml
+            except ImportError:
+                return self._read_config_key_without_yaml(config_path, key)
             with open(config_path, "r") as f:
                 config = yaml.safe_load(f) or {}
             return config.get("memory", {}).get("mnemosyne", {}).get(key)
         except Exception:
             return None
+
+    def _read_config_key_without_yaml(self, config_path: str, key: str) -> Any:
+        """Tiny fallback for memory.mnemosyne.<key> when PyYAML is unavailable."""
+        lines = Path(config_path).read_text().splitlines()
+        in_memory = False
+        in_mnemosyne = False
+        memory_indent = mnemosyne_indent = -1
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            indent = len(line) - len(line.lstrip())
+            if stripped == "memory:":
+                in_memory = True
+                in_mnemosyne = False
+                memory_indent = indent
+                continue
+            if in_memory and indent <= memory_indent:
+                in_memory = False
+                in_mnemosyne = False
+            if in_memory and stripped == "mnemosyne:" and indent > memory_indent:
+                in_mnemosyne = True
+                mnemosyne_indent = indent
+                continue
+            if in_mnemosyne and indent <= mnemosyne_indent:
+                in_mnemosyne = False
+            if not in_mnemosyne or indent <= mnemosyne_indent or not stripped.startswith(f"{key}:"):
+                continue
+            value = stripped.split(":", 1)[1].strip()
+            if value == "[]":
+                return []
+            if value:
+                return value.strip('"\'')
+            items = []
+            for child in lines[i + 1:]:
+                child_stripped = child.strip()
+                if not child_stripped:
+                    continue
+                child_indent = len(child) - len(child.lstrip())
+                if child_indent <= indent:
+                    break
+                if child_stripped.startswith("-"):
+                    items.append(child_stripped[1:].strip().strip('"\''))
+                    continue
+                break
+            return items if items else None
+        return None
 
     def _configured_tool_schemas(self) -> List[Dict[str, Any]]:
         """Return schemas filtered by memory.mnemosyne.tools, if configured.
@@ -2314,6 +2411,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
         try:
             if tool_name == "mnemosyne_remember":
                 return self._handle_remember(args)
+            elif tool_name == "mnemosyne_batch":
+                return self._handle_batch(args)
             elif tool_name == "mnemosyne_recall":
                 return self._handle_recall(args)
             elif tool_name == "mnemosyne_shared_remember":
@@ -2456,6 +2555,25 @@ class MnemosyneMemoryProvider(MemoryProvider):
             "metadata": metadata,
             "veracity": veracity,
         })
+
+    def _handle_batch(self, args: Dict[str, Any]) -> str:
+        try:
+            normalized = validate_batch_operations(args.get("operations"))
+        except BatchValidationError as exc:
+            return json.dumps(batch_validation_error_payload(exc))
+
+        if bool(args.get("dry_run", False)):
+            return json.dumps(dry_run_batch(normalized))
+
+        return json.dumps(apply_beam_batch(
+            self._beam,
+            normalized,
+            default_scope=self._default_scope,
+            remember_source_default="user",
+            remember_source_tool="mnemosyne_batch",
+            audit_event=self._audit_event,
+            extract_defaults_global=True,
+        ))
 
     def _handle_recall(self, args: Dict[str, Any]) -> str:
         query = args.get("query", "")

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -3,4 +3,4 @@ version: 0.3.1
 description: "Native local memory for Hermes - SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, and temporal triples. Zero cloud. Zero latency. Pipx-installable via `pipx install mnemosyne-hermes`."
 author: Abdias J
 pip_dependencies:
-  - mnemosyne-memory>=3.1
+  - mnemosyne-memory>=3.11.1

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "Abdias J", email = "abdi.moya@gmail.com"}]
 requires-python = ">=3.10"
 keywords = ["hermes-agent", "memory", "mnemosyne", "ai-agents", "local-first", "long-term-memory"]
 dependencies = [
-    "mnemosyne-memory[embeddings]>=3.1",
+    "mnemosyne-memory[embeddings]>=3.11.1",
     "PyYAML>=6.0",
 ]
 classifiers = [
@@ -27,11 +27,11 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-llm = ["mnemosyne-memory[llm]>=3.1"]
-mcp = ["mnemosyne-memory[mcp]>=3.1"]
+llm = ["mnemosyne-memory[llm]>=3.11.1"]
+mcp = ["mnemosyne-memory[mcp]>=3.11.1"]
 test = ["pytest>=7.0"]
 dev = ["mnemosyne-hermes[test]", "build", "twine"]
-all = ["mnemosyne-memory[all]>=3.1"]
+all = ["mnemosyne-memory[all]>=3.11.1"]
 
 [project.entry-points."hermes_agent.plugins"]
 mnemosyne = "mnemosyne_hermes:register"

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -27,7 +27,17 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 from datetime import datetime, timedelta
 
-# Mnemosyne core is installed via pip (mnemosyne-memory>=3.1 dependency),
+from .tools import ALL_TOOL_SCHEMAS
+from mnemosyne.batch_tool import (
+    BatchValidationError,
+    apply_beam_batch,
+    batch_validation_error_payload,
+    dry_run_batch,
+    validate_batch_operations,
+)
+from mnemosyne.hermes_config import read_hermes_config_key
+
+# Mnemosyne core is installed via pip (mnemosyne-memory>=3.11.1 dependency),
 # but keep imports lazy so installer/status CLI commands still work in broken
 # or partially-installed environments.
 
@@ -346,17 +356,6 @@ def _sync_turn_assistant_limit() -> int:
             raw,
         )
         return 800
-
-
-# ---------------------------------------------------------------------------
-from .tools import ALL_TOOL_SCHEMAS
-from mnemosyne.batch_tool import (
-    BatchValidationError,
-    apply_beam_batch,
-    batch_validation_error_payload,
-    dry_run_batch,
-    validate_batch_operations,
-)
 
 
 # ---------------------------------------------------------------------------
@@ -744,67 +743,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
     def _read_config_key(self, key: str) -> Any:
         """Read a single key from memory.mnemosyne in config.yaml."""
-        try:
-            import os
-            config_path = os.path.join(self._hermes_home, "config.yaml") if self._hermes_home else ""
-            if not config_path or not os.path.exists(config_path):
-                return None
-            try:
-                import yaml
-            except ImportError:
-                return self._read_config_key_without_yaml(config_path, key)
-            with open(config_path, "r") as f:
-                config = yaml.safe_load(f) or {}
-            return config.get("memory", {}).get("mnemosyne", {}).get(key)
-        except Exception:
-            return None
-
-    def _read_config_key_without_yaml(self, config_path: str, key: str) -> Any:
-        """Tiny fallback for memory.mnemosyne.<key> when PyYAML is unavailable."""
-        lines = Path(config_path).read_text().splitlines()
-        in_memory = False
-        in_mnemosyne = False
-        memory_indent = mnemosyne_indent = -1
-        for i, line in enumerate(lines):
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#"):
-                continue
-            indent = len(line) - len(line.lstrip())
-            if stripped == "memory:":
-                in_memory = True
-                in_mnemosyne = False
-                memory_indent = indent
-                continue
-            if in_memory and indent <= memory_indent:
-                in_memory = False
-                in_mnemosyne = False
-            if in_memory and stripped == "mnemosyne:" and indent > memory_indent:
-                in_mnemosyne = True
-                mnemosyne_indent = indent
-                continue
-            if in_mnemosyne and indent <= mnemosyne_indent:
-                in_mnemosyne = False
-            if not in_mnemosyne or indent <= mnemosyne_indent or not stripped.startswith(f"{key}:"):
-                continue
-            value = stripped.split(":", 1)[1].strip()
-            if value == "[]":
-                return []
-            if value:
-                return value.strip('"\'')
-            items = []
-            for child in lines[i + 1:]:
-                child_stripped = child.strip()
-                if not child_stripped:
-                    continue
-                child_indent = len(child) - len(child.lstrip())
-                if child_indent <= indent:
-                    break
-                if child_stripped.startswith("-"):
-                    items.append(child_stripped[1:].strip().strip('"\''))
-                    continue
-                break
-            return items if items else None
-        return None
+        return read_hermes_config_key(getattr(self, "_hermes_home", None), key)
 
 
     def _configured_tool_schemas(self) -> List[Dict[str, Any]]:
@@ -1519,13 +1458,10 @@ class MnemosyneMemoryProvider(MemoryProvider):
         source = args.get("source", "user")
         extract = bool(args.get("extract", False))
         extract_entities = bool(args.get("extract_entities", False))
-        # When extract=true and scope is not explicitly passed by the caller,
-        # auto-default to global. Facts extracted via LLM are identity-significant
-        # and should survive session boundaries. When extract=false, fall back
-        # to the configured default_scope (user-configurable via default_scope
-        # in config.yaml). If the caller explicitly passed scope, respect that
-        # choice.
-        scope = args.get("scope", "global" if extract else self._default_scope)
+        # Use the configured default scope unless the caller explicitly passes
+        # a scope. This matches the root Hermes provider and keeps
+        # mnemosyne_remember / mnemosyne_batch scope behavior in parity.
+        scope = args.get("scope", self._default_scope)
         valid_until = args.get("valid_until", None) or None
         metadata = args.get("metadata") or None
         # Trust-boundary clamp — see VERACITY_ALLOWED in
@@ -1576,7 +1512,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             remember_source_default="user",
             remember_source_tool="mnemosyne_batch",
             audit_event=self._audit_event,
-            extract_defaults_global=True,
+            extract_defaults_global=False,
         ))
 
     def _handle_recall(self, args: Dict[str, Any]) -> str:

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -350,6 +350,13 @@ def _sync_turn_assistant_limit() -> int:
 
 # ---------------------------------------------------------------------------
 from .tools import ALL_TOOL_SCHEMAS
+from mnemosyne.batch_tool import (
+    BatchValidationError,
+    apply_beam_batch,
+    batch_validation_error_payload,
+    dry_run_batch,
+    validate_batch_operations,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -738,15 +745,66 @@ class MnemosyneMemoryProvider(MemoryProvider):
     def _read_config_key(self, key: str) -> Any:
         """Read a single key from memory.mnemosyne in config.yaml."""
         try:
-            import yaml, os
+            import os
             config_path = os.path.join(self._hermes_home, "config.yaml") if self._hermes_home else ""
             if not config_path or not os.path.exists(config_path):
                 return None
+            try:
+                import yaml
+            except ImportError:
+                return self._read_config_key_without_yaml(config_path, key)
             with open(config_path, "r") as f:
                 config = yaml.safe_load(f) or {}
             return config.get("memory", {}).get("mnemosyne", {}).get(key)
         except Exception:
             return None
+
+    def _read_config_key_without_yaml(self, config_path: str, key: str) -> Any:
+        """Tiny fallback for memory.mnemosyne.<key> when PyYAML is unavailable."""
+        lines = Path(config_path).read_text().splitlines()
+        in_memory = False
+        in_mnemosyne = False
+        memory_indent = mnemosyne_indent = -1
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            indent = len(line) - len(line.lstrip())
+            if stripped == "memory:":
+                in_memory = True
+                in_mnemosyne = False
+                memory_indent = indent
+                continue
+            if in_memory and indent <= memory_indent:
+                in_memory = False
+                in_mnemosyne = False
+            if in_memory and stripped == "mnemosyne:" and indent > memory_indent:
+                in_mnemosyne = True
+                mnemosyne_indent = indent
+                continue
+            if in_mnemosyne and indent <= mnemosyne_indent:
+                in_mnemosyne = False
+            if not in_mnemosyne or indent <= mnemosyne_indent or not stripped.startswith(f"{key}:"):
+                continue
+            value = stripped.split(":", 1)[1].strip()
+            if value == "[]":
+                return []
+            if value:
+                return value.strip('"\'')
+            items = []
+            for child in lines[i + 1:]:
+                child_stripped = child.strip()
+                if not child_stripped:
+                    continue
+                child_indent = len(child) - len(child.lstrip())
+                if child_indent <= indent:
+                    break
+                if child_stripped.startswith("-"):
+                    items.append(child_stripped[1:].strip().strip('"\''))
+                    continue
+                break
+            return items if items else None
+        return None
 
 
     def _configured_tool_schemas(self) -> List[Dict[str, Any]]:
@@ -1357,6 +1415,8 @@ class MnemosyneMemoryProvider(MemoryProvider):
         try:
             if tool_name == "mnemosyne_remember":
                 return self._handle_remember(args)
+            elif tool_name == "mnemosyne_batch":
+                return self._handle_batch(args)
             elif tool_name == "mnemosyne_recall":
                 return self._handle_recall(args)
             elif tool_name == "mnemosyne_shared_remember":
@@ -1499,6 +1559,25 @@ class MnemosyneMemoryProvider(MemoryProvider):
             "metadata": metadata,
             "veracity": veracity,
         })
+
+    def _handle_batch(self, args: Dict[str, Any]) -> str:
+        try:
+            normalized = validate_batch_operations(args.get("operations"))
+        except BatchValidationError as exc:
+            return json.dumps(batch_validation_error_payload(exc))
+
+        if bool(args.get("dry_run", False)):
+            return json.dumps(dry_run_batch(normalized))
+
+        return json.dumps(apply_beam_batch(
+            self._beam,
+            normalized,
+            default_scope=self._default_scope,
+            remember_source_default="user",
+            remember_source_tool="mnemosyne_batch",
+            audit_event=self._audit_event,
+            extract_defaults_global=True,
+        ))
 
     def _handle_recall(self, args: Dict[str, Any]) -> str:
         query = args.get("query", "")

--- a/integrations/hermes/src/mnemosyne_hermes/tools.py
+++ b/integrations/hermes/src/mnemosyne_hermes/tools.py
@@ -477,6 +477,45 @@ FORGET_SCHEMA = {
     },
 }
 
+BATCH_SCHEMA = {
+    "name": "mnemosyne_batch",
+    "description": (
+        "Apply multiple Mnemosyne memory mutations atomically in one tool call. "
+        "Supported v1 actions: remember, update, forget, invalidate. "
+        "All operations are validated before mutation; on failure the whole batch rolls back. "
+        "Destructive actions require exact memory IDs. Recall/search/canonical/persona/shared-surface operations are not included in v1."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "operations": {
+                "type": "array",
+                "description": "Ordered mutation operations to apply atomically.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "action": {"type": "string", "enum": ["remember", "update", "forget", "invalidate"]},
+                        "content": {"type": "string"},
+                        "memory_id": {"type": "string"},
+                        "importance": {"type": "number"},
+                        "source": {"type": "string"},
+                        "scope": {"type": "string"},
+                        "valid_until": {"type": "string"},
+                        "metadata": {"type": "object"},
+                        "extract_entities": {"type": "boolean"},
+                        "extract": {"type": "boolean"},
+                        "veracity": {"type": "string"},
+                        "replacement_id": {"type": "string"},
+                    },
+                    "required": ["action"],
+                },
+            },
+            "dry_run": {"type": "boolean", "default": False},
+        },
+        "required": ["operations"],
+    },
+}
+
 IMPORT_SCHEMA = {
     "name": "mnemosyne_import",
     "description": "Import Mnemosyne memories from a JSON file or another memory provider (Hindsight, Mem0). Idempotent by default.",
@@ -717,7 +756,7 @@ ALL_TOOL_SCHEMAS = [
     TRIPLE_END_SCHEMA,
     REMEMBER_CANONICAL_SCHEMA, RECALL_CANONICAL_SCHEMA, MODEL_CARD_SCHEMA,
     MODEL_REFRESH_SCHEMA, SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
-    EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
+    EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, BATCH_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
     RECALL_DIAGNOSTICS_SCHEMA,
     TASK_PROGRESS_SCHEMA,
     GRAPH_QUERY_SCHEMA, GRAPH_LINK_SCHEMA,

--- a/integrations/hermes/src/mnemosyne_hermes/tools.py
+++ b/integrations/hermes/src/mnemosyne_hermes/tools.py
@@ -490,6 +490,7 @@ BATCH_SCHEMA = {
         "properties": {
             "operations": {
                 "type": "array",
+                "maxItems": 50,
                 "description": "Ordered mutation operations to apply atomically.",
                 "items": {
                     "type": "object",
@@ -511,6 +512,10 @@ BATCH_SCHEMA = {
                 },
             },
             "dry_run": {"type": "boolean", "default": False},
+            "bank": {"type": "string"},
+            "author_id": {"type": "string"},
+            "author_type": {"type": "string"},
+            "channel_id": {"type": "string"},
         },
         "required": ["operations"],
     },

--- a/mnemosyne/batch_tool.py
+++ b/mnemosyne/batch_tool.py
@@ -1,0 +1,199 @@
+"""Shared v1 implementation for the narrow mnemosyne_batch mutation tool."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from mnemosyne.core.beam import _deferred_commits
+from mnemosyne.core.veracity_consolidation import clamp_veracity
+
+
+_ALLOWED_BATCH_ACTIONS = {"remember", "update", "forget", "invalidate"}
+_FUZZY_BATCH_FIELDS = {"old_text", "query", "content_match"}
+_BATCH_MAX_OPS = 50
+
+
+@dataclass(frozen=True)
+class BatchValidationError(ValueError):
+    message: str
+    failed_index: int | None = None
+    action: str | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class BatchOperationError(RuntimeError):
+    pass
+
+
+def validate_batch_operations(operations: Any) -> list[dict[str, Any]]:
+    if not isinstance(operations, list) or not operations:
+        raise BatchValidationError("operations must be a non-empty list")
+    if len(operations) > _BATCH_MAX_OPS:
+        raise BatchValidationError(f"operations must contain at most {_BATCH_MAX_OPS} items")
+
+    normalized: list[dict[str, Any]] = []
+    for index, op in enumerate(operations):
+        if not isinstance(op, dict):
+            raise BatchValidationError("operation must be an object", index)
+        action = op.get("action")
+        if not isinstance(action, str) or not action:
+            raise BatchValidationError("action is required", index)
+        if action not in _ALLOWED_BATCH_ACTIONS:
+            raise BatchValidationError(f"unknown action: {action}", index, action)
+        fuzzy = sorted(_FUZZY_BATCH_FIELDS.intersection(op))
+        if fuzzy:
+            raise BatchValidationError(
+                f"fuzzy fields are not supported in mnemosyne_batch v1: {', '.join(fuzzy)}",
+                index,
+                action,
+            )
+
+        if action == "remember":
+            content = op.get("content")
+            if not isinstance(content, str) or not content.strip():
+                raise BatchValidationError("content is required", index, action)
+        elif action == "update":
+            if not _non_empty_string(op.get("memory_id")):
+                raise BatchValidationError("memory_id is required", index, action)
+            if op.get("content") is None and op.get("importance") is None:
+                raise BatchValidationError("content or importance is required", index, action)
+        elif action in {"forget", "invalidate"}:
+            if not _non_empty_string(op.get("memory_id")):
+                raise BatchValidationError("memory_id is required", index, action)
+
+        normalized.append({"index": index, "action": action, "payload": dict(op)})
+    return normalized
+
+
+def dry_run_batch(normalized: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "status": "dry_run",
+        "operations_count": len(normalized),
+        "results": [_dry_run_result(op) for op in normalized],
+    }
+
+
+def batch_validation_error_payload(exc: BatchValidationError) -> dict[str, Any]:
+    payload: dict[str, Any] = {"status": "error", "error": str(exc)}
+    if exc.failed_index is not None:
+        payload["failed_index"] = exc.failed_index
+    if exc.action:
+        payload["action"] = exc.action
+    return payload
+
+
+def apply_beam_batch(
+    beam: Any,
+    normalized: list[dict[str, Any]],
+    *,
+    default_scope: str = "session",
+    remember_source_default: str = "user",
+    remember_source_tool: str = "mnemosyne_batch",
+    audit_event: Callable[..., Any] | None = None,
+    extract_defaults_global: bool = False,
+) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    audit_events: list[tuple[str, dict[str, Any]]] = []
+    current = {"index": None, "action": None}
+    try:
+        with _deferred_commits(beam.conn):
+            for current in normalized:
+                results.append(_apply_one(
+                    beam,
+                    current,
+                    default_scope=default_scope,
+                    remember_source_default=remember_source_default,
+                    remember_source_tool=remember_source_tool,
+                    audit_events=audit_events,
+                    extract_defaults_global=extract_defaults_global,
+                ))
+    except Exception as exc:
+        return {
+            "status": "error",
+            "failed_index": current.get("index"),
+            "action": current.get("action"),
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    if audit_event:
+        for event_name, event_kwargs in audit_events:
+            audit_event(event_name, **event_kwargs)
+    return {"status": "ok", "operations_count": len(results), "results": results}
+
+
+def _apply_one(
+    beam: Any,
+    op: dict[str, Any],
+    *,
+    default_scope: str,
+    remember_source_default: str,
+    remember_source_tool: str,
+    audit_events: list[tuple[str, dict[str, Any]]],
+    extract_defaults_global: bool,
+) -> dict[str, Any]:
+    index = op["index"]
+    action = op["action"]
+    payload = op["payload"]
+
+    if action == "remember":
+        extract = bool(payload.get("extract", False))
+        scope = payload.get("scope", "global" if extract_defaults_global and extract else default_scope)
+        metadata = payload.get("metadata") or None
+        veracity = clamp_veracity(payload.get("veracity"), context="mnemosyne_batch")
+        content = payload["content"]
+        memory_id = beam.remember(
+            content=content,
+            importance=float(payload.get("importance", 0.5)),
+            source=payload.get("source", remember_source_default),
+            scope=scope,
+            valid_until=payload.get("valid_until") or None,
+            extract_entities=bool(payload.get("extract_entities", False)),
+            extract=extract,
+            metadata=metadata,
+            veracity=veracity,
+        )
+        audit_events.append((
+            "remember",
+            {"memory_id": memory_id, "bank": "private", "scope": scope, "source_tool": remember_source_tool},
+        ))
+        return {"index": index, "action": action, "status": "stored", "memory_id": memory_id, "content_preview": content[:100]}
+
+    memory_id = str(payload["memory_id"]).strip()
+    if action == "update":
+        ok = beam.update_working(memory_id, content=payload.get("content"), importance=payload.get("importance"))
+        if not ok:
+            raise BatchOperationError("memory_not_found")
+        audit_events.append(("update", {"memory_id": memory_id, "bank": "private", "source_tool": remember_source_tool}))
+        return {"index": index, "action": action, "status": "updated", "memory_id": memory_id}
+    if action == "forget":
+        ok = beam.forget_working(memory_id)
+        if not ok:
+            raise BatchOperationError("memory_not_found")
+        audit_events.append(("forget", {"memory_id": memory_id, "bank": "private", "source_tool": remember_source_tool}))
+        return {"index": index, "action": action, "status": "deleted", "memory_id": memory_id}
+
+    ok = beam.invalidate(memory_id, replacement_id=payload.get("replacement_id") or None)
+    if not ok:
+        raise BatchOperationError("memory_not_found")
+    audit_events.append(("invalidate", {"memory_id": memory_id, "bank": "private", "source_tool": remember_source_tool}))
+    return {"index": index, "action": action, "status": "invalidated", "memory_id": memory_id}
+
+
+def _dry_run_result(op: dict[str, Any]) -> dict[str, Any]:
+    action = op["action"]
+    result: dict[str, Any] = {"index": op["index"], "action": action}
+    if action == "remember":
+        result["status"] = "would_store"
+    elif action == "update":
+        result.update({"status": "would_update", "memory_id": op["payload"]["memory_id"]})
+    elif action == "forget":
+        result.update({"status": "would_delete", "memory_id": op["payload"]["memory_id"]})
+    else:
+        result.update({"status": "would_invalidate", "memory_id": op["payload"]["memory_id"]})
+    return result
+
+
+def _non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())

--- a/mnemosyne/batch_tool.py
+++ b/mnemosyne/batch_tool.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Callable
 
 from mnemosyne.core.beam import _deferred_commits
 from mnemosyne.core.veracity_consolidation import clamp_veracity
 
+
+logger = logging.getLogger(__name__)
 
 _ALLOWED_BATCH_ACTIONS = {"remember", "update", "forget", "invalidate"}
 _FUZZY_BATCH_FIELDS = {"old_text", "query", "content_match"}
@@ -51,21 +54,35 @@ def validate_batch_operations(operations: Any) -> list[dict[str, Any]]:
                 action,
             )
 
-        if action == "remember":
-            content = op.get("content")
-            if not isinstance(content, str) or not content.strip():
-                raise BatchValidationError("content is required", index, action)
-        elif action == "update":
-            if not _non_empty_string(op.get("memory_id")):
-                raise BatchValidationError("memory_id is required", index, action)
-            if op.get("content") is None and op.get("importance") is None:
-                raise BatchValidationError("content or importance is required", index, action)
-        elif action in {"forget", "invalidate"}:
-            if not _non_empty_string(op.get("memory_id")):
-                raise BatchValidationError("memory_id is required", index, action)
-
+        _VALIDATORS[action](op, index, action)
         normalized.append({"index": index, "action": action, "payload": dict(op)})
     return normalized
+
+
+def _validate_remember(op: dict[str, Any], index: int, action: str) -> None:
+    content = op.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise BatchValidationError("content is required", index, action)
+
+
+def _validate_update(op: dict[str, Any], index: int, action: str) -> None:
+    if not _non_empty_string(op.get("memory_id")):
+        raise BatchValidationError("memory_id is required", index, action)
+    if op.get("content") is None and op.get("importance") is None:
+        raise BatchValidationError("content or importance is required", index, action)
+
+
+def _validate_by_memory_id(op: dict[str, Any], index: int, action: str) -> None:
+    if not _non_empty_string(op.get("memory_id")):
+        raise BatchValidationError("memory_id is required", index, action)
+
+
+_VALIDATORS: dict[str, Callable[[dict[str, Any], int, str], None]] = {
+    "remember": _validate_remember,
+    "update": _validate_update,
+    "forget": _validate_by_memory_id,
+    "invalidate": _validate_by_memory_id,
+}
 
 
 def dry_run_batch(normalized: list[dict[str, Any]]) -> dict[str, Any]:
@@ -111,6 +128,11 @@ def apply_beam_batch(
                     extract_defaults_global=extract_defaults_global,
                 ))
     except Exception as exc:
+        logger.exception(
+            "mnemosyne_batch failed at index=%s action=%s",
+            current.get("index"),
+            current.get("action"),
+        )
         return {
             "status": "error",
             "failed_index": current.get("index"),
@@ -162,7 +184,12 @@ def _apply_one(
 
     memory_id = str(payload["memory_id"]).strip()
     if action == "update":
-        ok = beam.update_working(memory_id, content=payload.get("content"), importance=payload.get("importance"))
+        importance = payload.get("importance")
+        ok = beam.update_working(
+            memory_id,
+            content=payload.get("content"),
+            importance=float(importance) if importance is not None else None,
+        )
         if not ok:
             raise BatchOperationError("memory_not_found")
         audit_events.append(("update", {"memory_id": memory_id, "bank": "private", "source_tool": remember_source_tool}))

--- a/mnemosyne/hermes_config.py
+++ b/mnemosyne/hermes_config.py
@@ -1,0 +1,86 @@
+"""Shared Hermes Mnemosyne config helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+def read_hermes_config_key(hermes_home: str | None, key: str) -> Any:
+    """Read ``memory.mnemosyne.<key>`` from a Hermes ``config.yaml``.
+
+    PyYAML is used when available; a tiny indentation-based fallback keeps the
+    provider whitelist/default-scope path working in minimal Hermes plugin
+    environments where PyYAML is not installed.
+    """
+    config_path = os.path.join(hermes_home, "config.yaml") if hermes_home else ""
+    if not config_path or not os.path.exists(config_path):
+        return None
+    try:
+        import yaml
+    except ImportError:
+        return read_config_key_without_yaml(config_path, key)
+
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f) or {}
+    except Exception:
+        return None
+    memory = config.get("memory") if isinstance(config, dict) else None
+    memory = memory if isinstance(memory, dict) else {}
+    mnemosyne = memory.get("mnemosyne")
+    mnemosyne = mnemosyne if isinstance(mnemosyne, dict) else {}
+    return mnemosyne.get(key)
+
+
+def read_config_key_without_yaml(config_path: str, key: str) -> Any:
+    """Tiny fallback parser for ``memory.mnemosyne.<key>`` values."""
+    try:
+        lines = Path(config_path).read_text().splitlines()
+    except OSError:
+        return None
+
+    in_memory = False
+    in_mnemosyne = False
+    memory_indent = mnemosyne_indent = -1
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if stripped == "memory:":
+            in_memory = True
+            in_mnemosyne = False
+            memory_indent = indent
+            continue
+        if in_memory and indent <= memory_indent:
+            in_memory = False
+            in_mnemosyne = False
+        if in_memory and stripped == "mnemosyne:" and indent > memory_indent:
+            in_mnemosyne = True
+            mnemosyne_indent = indent
+            continue
+        if in_mnemosyne and indent <= mnemosyne_indent:
+            in_mnemosyne = False
+        if not in_mnemosyne or indent <= mnemosyne_indent or not stripped.startswith(f"{key}:"):
+            continue
+        value = stripped.split(":", 1)[1].strip()
+        if value == "[]":
+            return []
+        if value:
+            return value.strip('"\'')
+        items = []
+        for child in lines[i + 1:]:
+            child_stripped = child.strip()
+            if not child_stripped:
+                continue
+            child_indent = len(child) - len(child.lstrip())
+            if child_indent <= indent:
+                break
+            if child_stripped.startswith("-"):
+                items.append(child_stripped[1:].strip().strip('"\''))
+                continue
+            break
+        return items if items else None
+    return None

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -31,6 +31,13 @@ from mnemosyne.core.memory import Mnemosyne
 from mnemosyne.core.beam import BeamMemory
 
 from mnemosyne.tool_schemas import ALL_TOOL_SCHEMAS
+from mnemosyne.batch_tool import (
+    BatchValidationError,
+    apply_beam_batch,
+    batch_validation_error_payload,
+    dry_run_batch,
+    validate_batch_operations,
+)
 
 # ---------------------------------------------------------------------------
 # Tool Definitions
@@ -210,6 +217,33 @@ def _handle_remember(arguments: Dict[str, Any]) -> Dict[str, Any]:
         "content_preview": content[:100],
         "bank": bank
     }
+
+
+def _handle_batch(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    """Handle mnemosyne_batch tool call."""
+    try:
+        normalized = validate_batch_operations(arguments.get("operations"))
+    except BatchValidationError as exc:
+        return batch_validation_error_payload(exc)
+
+    if bool(arguments.get("dry_run", False)):
+        return dry_run_batch(normalized)
+
+    bank = _resolve_bank(arguments)
+    mem = _create_instance(
+        author_id=arguments.get("author_id"),
+        author_type=arguments.get("author_type"),
+        channel_id=arguments.get("channel_id"),
+        bank=bank,
+    )
+    result = apply_beam_batch(
+        mem.beam,
+        normalized,
+        default_scope=_resolve_default_scope(),
+        remember_source_default="mcp",
+    )
+    result["bank"] = bank
+    return result
 
 
 def _handle_recall(arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -847,6 +881,7 @@ def _handle_graph_link(arguments: Dict[str, Any]) -> Dict[str, Any]:
 
 _TOOL_HANDLERS = {
     "mnemosyne_remember": _handle_remember,
+    "mnemosyne_batch": _handle_batch,
     "mnemosyne_recall": _handle_recall,
     "mnemosyne_shared_remember": _handle_shared_remember,
     "mnemosyne_shared_recall": _handle_shared_recall,

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -185,6 +185,47 @@ def _serialize(obj):
 # Tool Handlers
 # ---------------------------------------------------------------------------
 
+class _WrapperBatchAdapter:
+    """Expose Mnemosyne wrapper mutations through the Beam batch interface."""
+
+    def __init__(self, mem: Mnemosyne):
+        self._mem = mem
+        self.conn = mem.beam.conn
+        self.wrapper_events = []
+
+    def remember(self, **kwargs):
+        return self._call_wrapper("remember", **kwargs)
+
+    def update_working(self, memory_id: str, *, content=None, importance=None):
+        wrapper_ok = self._call_wrapper("update", memory_id, content=content, importance=importance)
+        if wrapper_ok:
+            return True
+        return self._mem.beam.update_working(memory_id, content=content, importance=importance)
+
+    def forget_working(self, memory_id: str):
+        return self._call_wrapper("forget", memory_id)
+
+    def invalidate(self, memory_id: str, *, replacement_id=None):
+        return self._call_wrapper("invalidate", memory_id, replacement_id=replacement_id)
+
+    def replay_wrapper_events(self) -> None:
+        for event_type, memory_id, kwargs in self.wrapper_events:
+            self._mem._emit_wrapper(event_type, memory_id, **kwargs)
+
+    def _call_wrapper(self, method_name: str, *args, **kwargs):
+        original_conn = self._mem.conn
+        original_emit = self._mem._emit_wrapper
+        self._mem.conn = self.conn
+        self._mem._emit_wrapper = lambda event_type, memory_id, **event_kwargs: self.wrapper_events.append(
+            (event_type, memory_id, event_kwargs)
+        )
+        try:
+            return getattr(self._mem, method_name)(*args, **kwargs)
+        finally:
+            self._mem.conn = original_conn
+            self._mem._emit_wrapper = original_emit
+
+
 def _handle_remember(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_remember tool call."""
     content = arguments["content"]
@@ -236,13 +277,20 @@ def _handle_batch(arguments: Dict[str, Any]) -> Dict[str, Any]:
         channel_id=arguments.get("channel_id"),
         bank=bank,
     )
+    audit_events = []
+    adapter = _WrapperBatchAdapter(mem)
     result = apply_beam_batch(
-        mem.beam,
+        adapter,
         normalized,
         default_scope=_resolve_default_scope(),
         remember_source_default="mcp",
+        audit_event=lambda name, **kwargs: audit_events.append({"event": name, **kwargs}),
     )
+    if result.get("status") == "ok":
+        adapter.replay_wrapper_events()
     result["bank"] = bank
+    if audit_events:
+        result["audit_events"] = audit_events
     return result
 
 

--- a/mnemosyne/tool_schemas.py
+++ b/mnemosyne/tool_schemas.py
@@ -440,6 +440,7 @@ BATCH_SCHEMA = {
         "properties": {
             "operations": {
                 "type": "array",
+                "maxItems": 50,
                 "description": "Ordered mutation operations to apply atomically.",
                 "items": {
                     "type": "object",
@@ -461,6 +462,10 @@ BATCH_SCHEMA = {
                 },
             },
             "dry_run": {"type": "boolean", "default": False},
+            "bank": {"type": "string"},
+            "author_id": {"type": "string"},
+            "author_type": {"type": "string"},
+            "channel_id": {"type": "string"},
         },
         "required": ["operations"],
     },

--- a/mnemosyne/tool_schemas.py
+++ b/mnemosyne/tool_schemas.py
@@ -427,6 +427,45 @@ FORGET_SCHEMA = {
     },
 }
 
+BATCH_SCHEMA = {
+    "name": "mnemosyne_batch",
+    "description": (
+        "Apply multiple Mnemosyne memory mutations atomically in one tool call. "
+        "Supported v1 actions: remember, update, forget, invalidate. "
+        "All operations are validated before mutation; on failure the whole batch rolls back. "
+        "Destructive actions require exact memory IDs. Recall/search/canonical/persona/shared-surface operations are not included in v1."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "operations": {
+                "type": "array",
+                "description": "Ordered mutation operations to apply atomically.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "action": {"type": "string", "enum": ["remember", "update", "forget", "invalidate"]},
+                        "content": {"type": "string"},
+                        "memory_id": {"type": "string"},
+                        "importance": {"type": "number"},
+                        "source": {"type": "string"},
+                        "scope": {"type": "string"},
+                        "valid_until": {"type": "string"},
+                        "metadata": {"type": "object"},
+                        "extract_entities": {"type": "boolean"},
+                        "extract": {"type": "boolean"},
+                        "veracity": {"type": "string"},
+                        "replacement_id": {"type": "string"},
+                    },
+                    "required": ["action"],
+                },
+            },
+            "dry_run": {"type": "boolean", "default": False},
+        },
+        "required": ["operations"],
+    },
+}
+
 IMPORT_SCHEMA = {
     "name": "mnemosyne_import",
     "description": "Import Mnemosyne memories from a JSON file or another memory provider (Hindsight, Mem0). Idempotent by default.",
@@ -701,7 +740,7 @@ ALL_TOOL_SCHEMAS: List[Dict[str, Any]] = [
     TRIPLE_ADD_SCHEMA, TRIPLE_QUERY_SCHEMA, TRIPLE_END_SCHEMA,
     REMEMBER_CANONICAL_SCHEMA, RECALL_CANONICAL_SCHEMA,
     SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
-    EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
+    EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, BATCH_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
     GRAPH_QUERY_SCHEMA, GRAPH_LINK_SCHEMA,
     SYNC_PUSH_SCHEMA, SYNC_PULL_SCHEMA, SYNC_STATUS_SCHEMA,
     PERSONA_PROMOTE_SCHEMA, PERSONA_DEMOTE_SCHEMA, PERSONA_LIST_SCHEMA, PERSONA_REINFORCE_SCHEMA,

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -178,6 +178,23 @@ def test_tool_whitelist_unknown_name_fails_loudly(tmp_path, provider_modules):
             provider.get_tool_schemas()
 
 
+def test_config_reader_tolerates_null_and_non_mapping_levels(tmp_path):
+    from mnemosyne.hermes_config import read_hermes_config_key
+
+    cases = [
+        "memory:\n",
+        "memory: []\n",
+        "memory:\n  mnemosyne:\n",
+        "memory:\n  mnemosyne: []\n",
+        "[]\n",
+    ]
+    for index, body in enumerate(cases):
+        hermes_home = tmp_path / f"case-{index}"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(body)
+        assert read_hermes_config_key(str(hermes_home), "tools") is None
+
+
 @pytest.mark.parametrize(
     ("env_name", "helper_name", "default", "custom"),
     [
@@ -230,7 +247,25 @@ def _new_provider(module, *, scope="session", roles=("user", "assistant")):
     provider._capture_identity_signals = lambda _content: None
     provider._turn_count = 0
     provider._auto_sleep_enabled = False
+    provider._audit_event = lambda *args, **kwargs: None
     return provider
+
+
+def test_provider_remember_extract_uses_default_scope(provider_modules):
+    observed = {}
+    for name, module in provider_modules.items():
+        provider = _new_provider(module, scope="session")
+        result = json.loads(provider._handle_remember({
+            "content": f"extract scope {name}",
+            "extract": True,
+        }))
+        observed[name] = {
+            "status": result.get("status"),
+            "scope": provider._beam.calls[0]["scope"],
+        }
+
+    assert observed["hermes_memory_provider"] == observed["mnemosyne_hermes"]
+    assert observed["hermes_memory_provider"] == {"status": "stored", "scope": "session"}
 
 
 @pytest.mark.parametrize("scope", ["session", "global"])
@@ -337,6 +372,7 @@ def test_provider_batch_dispatch_matches(tmp_path, provider_modules):
             beam = BeamMemory(session_id=f"batch-{name}", db_path=str(db_path))
             provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
             provider._beam = beam
+            provider._hermes_home = str(tmp_path)
             provider._default_scope = "session"
             provider._audit_event = lambda *args, **kwargs: None
 

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -142,8 +142,11 @@ def test_tool_whitelist_filters_schemas_before_routing(tmp_path, provider_module
         observed[name] = _schema_names(provider)
         assert provider.has_tool("mnemosyne_remember") is True
         assert provider.has_tool("mnemosyne_forget") is False
+        assert provider.has_tool("mnemosyne_batch") is False
         rejected = json.loads(provider.handle_tool_call("mnemosyne_forget", {"memory_id": "x"}))
         assert rejected == {"error": "Unknown Mnemosyne tool: mnemosyne_forget"}
+        rejected_batch = json.loads(provider.handle_tool_call("mnemosyne_batch", {"operations": []}))
+        assert rejected_batch == {"error": "Unknown Mnemosyne tool: mnemosyne_batch"}
 
     assert observed["hermes_memory_provider"] == allowed
     assert observed["mnemosyne_hermes"] == allowed
@@ -318,4 +321,45 @@ def test_provider_persona_tool_dispatch_matches(tmp_path, provider_modules):
         "status": "ok",
         "count": 1,
         "topics": ["test"],
+    }
+
+
+def test_provider_batch_dispatch_matches(tmp_path, provider_modules):
+    saved_mnemosyne_modules = _save_mnemosyne_modules()
+    _drop_modules("mnemosyne")
+    sys.path.insert(0, str(PROJECT_ROOT))
+    try:
+        from mnemosyne.core.beam import BeamMemory
+
+        observed = {}
+        for name, module in provider_modules.items():
+            db_path = tmp_path / f"{name}-batch.db"
+            beam = BeamMemory(session_id=f"batch-{name}", db_path=str(db_path))
+            provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+            provider._beam = beam
+            provider._default_scope = "session"
+            provider._audit_event = lambda *args, **kwargs: None
+
+            result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+                "operations": [
+                    {"action": "remember", "content": f"batch parity {name}"},
+                ],
+            }))
+            observed[name] = {
+                "status": result.get("status"),
+                "operations_count": result.get("operations_count"),
+                "result_statuses": [row.get("status") for row in result.get("results", [])],
+            }
+    finally:
+        try:
+            sys.path.remove(str(PROJECT_ROOT))
+        except ValueError:
+            pass
+        _restore_mnemosyne_modules(saved_mnemosyne_modules)
+
+    assert observed["hermes_memory_provider"] == observed["mnemosyne_hermes"]
+    assert observed["hermes_memory_provider"] == {
+        "status": "ok",
+        "operations_count": 1,
+        "result_statuses": ["stored"],
     }

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -104,6 +104,9 @@ class TestToolSchemas:
         schema = batch_tool["inputSchema"]
         assert "operations" in schema["required"]
         assert schema["properties"]["operations"]["type"] == "array"
+        assert schema["properties"]["operations"]["maxItems"] == 50
+        for context_field in ("bank", "author_id", "author_type", "channel_id"):
+            assert context_field in schema["properties"]
 
 
 class TestToolHandlers:
@@ -222,6 +225,75 @@ class TestToolHandlers:
 
         assert result["status"] == "ok"
         assert [item["status"] for item in result["results"]] == ["stored", "stored"]
+        assert [event["event"] for event in result["audit_events"]] == ["remember", "remember"]
+        mem = _create_instance(bank="default")
+        legacy_count = mem.conn.execute(
+            "SELECT COUNT(*) FROM memories WHERE content IN (?, ?)",
+            ("mcp batch one", "mcp batch two"),
+        ).fetchone()[0]
+        assert legacy_count == 2
+
+    def test_handle_batch_updates_beam_only_memory(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        mem = _create_instance(bank="default")
+        memory_id = mem.beam.remember("beam only before", importance=0.2)
+
+        result = handle_tool_call("mnemosyne_batch", {
+            "operations": [
+                {"action": "update", "memory_id": memory_id, "content": "beam only after", "importance": "0.9"},
+            ],
+        })
+
+        assert result["status"] == "ok"
+        assert result["results"][0]["status"] == "updated"
+        updated = _create_instance(bank="default").beam.get(memory_id)
+        assert updated["content"] == "beam only after"
+        assert updated["importance"] == 0.9
+
+
+    def test_handle_batch_wrapper_update_forget_invalidate_and_scope(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        stored = handle_tool_call("mnemosyne_batch", {
+            "operations": [
+                {"action": "remember", "content": "mcp update target"},
+                {"action": "remember", "content": "mcp forget target"},
+                {"action": "remember", "content": "mcp invalidate target"},
+                {"action": "remember", "content": "mcp extract target", "extract": True},
+            ],
+        })
+        ids = [row["memory_id"] for row in stored["results"]]
+
+        result = handle_tool_call("mnemosyne_batch", {
+            "operations": [
+                {"action": "update", "memory_id": ids[0], "content": "mcp updated", "importance": "0.7"},
+                {"action": "forget", "memory_id": ids[1]},
+                {"action": "invalidate", "memory_id": ids[2]},
+            ],
+        })
+
+        assert result["status"] == "ok"
+        assert [item["status"] for item in result["results"]] == ["updated", "deleted", "invalidated"]
+        assert [event["event"] for event in result["audit_events"]] == ["update", "forget", "invalidate"]
+        mem = _create_instance(bank="default")
+        updated = mem.beam.get(ids[0])
+        assert updated["content"] == "mcp updated"
+        assert updated["importance"] == 0.7
+        assert mem.beam.get(ids[1]) is None
+        invalidated = mem.beam.conn.execute(
+            "SELECT valid_until FROM working_memory WHERE id = ?",
+            (ids[2],),
+        ).fetchone()
+        assert invalidated[0]
+        extract_scope = mem.beam.conn.execute(
+            "SELECT scope FROM working_memory WHERE id = ?",
+            (ids[3],),
+        ).fetchone()
+        assert extract_scope[0] == "session"
+
 
     def test_handle_batch_failure_rolls_back(self, tmp_path, monkeypatch):
         monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -28,6 +28,7 @@ class TestToolSchemas:
         assert "mnemosyne_remember_canonical" in names
         assert "mnemosyne_recall_canonical" in names
         assert "mnemosyne_remember" in names
+        assert "mnemosyne_batch" in names
         assert "mnemosyne_recall" in names
         assert "mnemosyne_sleep" in names
         assert "mnemosyne_scratchpad_read" in names
@@ -97,6 +98,12 @@ class TestToolSchemas:
         assert "mnemosyne_invalidate" in names
         assert "mnemosyne_export" in names
         assert "mnemosyne_import" in names
+
+    def test_batch_schema_has_operations(self):
+        batch_tool = next(t for t in TOOLS if t["name"] == "mnemosyne_batch")
+        schema = batch_tool["inputSchema"]
+        assert "operations" in schema["required"]
+        assert schema["properties"]["operations"]["type"] == "array"
 
 
 class TestToolHandlers:
@@ -201,6 +208,40 @@ class TestToolHandlers:
         assert result["status"] == "stored"
         assert result["bank"] == "personal"
         assert create_instance.call_args.kwargs["bank"] == "personal"
+
+    def test_handle_batch_multiple_remember(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        result = handle_tool_call("mnemosyne_batch", {
+            "operations": [
+                {"action": "remember", "content": "mcp batch one"},
+                {"action": "remember", "content": "mcp batch two"},
+            ],
+        })
+
+        assert result["status"] == "ok"
+        assert [item["status"] for item in result["results"]] == ["stored", "stored"]
+
+    def test_handle_batch_failure_rolls_back(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        result = handle_tool_call("mnemosyne_batch", {
+            "operations": [
+                {"action": "remember", "content": "mcp rollback"},
+                {"action": "update", "memory_id": "missing", "content": "x"},
+            ],
+        })
+
+        assert result["status"] == "error"
+        assert result["failed_index"] == 1
+        mem = _create_instance(bank="default")
+        row = mem.beam.conn.execute(
+            "SELECT COUNT(*) FROM working_memory WHERE content = ?",
+            ("mcp rollback",),
+        ).fetchone()
+        assert row[0] == 0
 
     def test_handle_recall_uses_mcp_bank_env_default(self, mock_mnemosyne, monkeypatch):
         """MCP recall should use the server default bank when omitted."""

--- a/tests/test_mnemosyne_batch_tool.py
+++ b/tests/test_mnemosyne_batch_tool.py
@@ -1,0 +1,176 @@
+import json
+from pathlib import Path
+
+from hermes_memory_provider import MnemosyneMemoryProvider
+from mnemosyne.core.beam import BeamMemory
+
+
+def _beam(tmp_path):
+    return BeamMemory(session_id="test_provider", db_path=Path(tmp_path) / "test.db")
+
+
+def _provider(tmp_path):
+    provider = MnemosyneMemoryProvider()
+    provider._beam = _beam(tmp_path)
+    provider._session_id = "test_provider"
+    provider._agent_context = "primary"
+    return provider
+
+
+def _count_matching(beam, text):
+    row = beam.conn.execute(
+        "SELECT COUNT(*) FROM working_memory WHERE content = ?",
+        (text,),
+    ).fetchone()
+    return row[0]
+
+
+def test_batch_schema_registered_and_dispatches(tmp_path):
+    provider = _provider(tmp_path)
+    names = {schema["name"] for schema in provider.get_tool_schemas()}
+    assert "mnemosyne_batch" in names
+
+    result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "operations": [{"action": "remember", "content": "batch dispatch"}],
+    }))
+    assert result["status"] == "ok"
+    assert result["results"][0]["status"] == "stored"
+
+
+def test_batch_multiple_remember_returns_ids(tmp_path):
+    provider = _provider(tmp_path)
+    result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "operations": [
+            {"action": "remember", "content": "batch alpha"},
+            {"action": "remember", "content": "batch beta"},
+        ],
+    }))
+
+    assert result["status"] == "ok"
+    ids = [item["memory_id"] for item in result["results"]]
+    assert len(ids) == 2
+    assert all(ids)
+    assert provider._beam.get(ids[0])["content"] == "batch alpha"
+    assert provider._beam.get(ids[1])["content"] == "batch beta"
+
+
+def test_batch_update_and_invalidate(tmp_path):
+    provider = _provider(tmp_path)
+    update_id = provider._beam.remember("batch old", importance=0.3)
+    invalidate_id = provider._beam.remember("batch expires", importance=0.3)
+
+    result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "operations": [
+            {"action": "update", "memory_id": update_id, "content": "batch new"},
+            {"action": "invalidate", "memory_id": invalidate_id},
+        ],
+    }))
+
+    assert result["status"] == "ok"
+    assert [item["status"] for item in result["results"]] == ["updated", "invalidated"]
+    assert provider._beam.get(update_id)["content"] == "batch new"
+    invalidated = provider._beam.conn.execute(
+        "SELECT valid_until FROM working_memory WHERE id = ?",
+        (invalidate_id,),
+    ).fetchone()
+    assert invalidated[0]
+
+
+def test_batch_failure_rolls_back_earlier_remember(tmp_path):
+    provider = _provider(tmp_path)
+    result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "operations": [
+            {"action": "remember", "content": "rollback me"},
+            {"action": "update", "memory_id": "missing", "content": "x"},
+        ],
+    }))
+
+    assert result["status"] == "error"
+    assert result["failed_index"] == 1
+    assert result["action"] == "update"
+    assert _count_matching(provider._beam, "rollback me") == 0
+
+
+def test_batch_failure_rolls_back_earlier_update(tmp_path):
+    provider = _provider(tmp_path)
+    memory_id = provider._beam.remember("before update", importance=0.3)
+
+    result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "operations": [
+            {"action": "update", "memory_id": memory_id, "content": "after update"},
+            {"action": "forget", "memory_id": "missing"},
+        ],
+    }))
+
+    assert result["status"] == "error"
+    assert result["failed_index"] == 1
+    assert result["action"] == "forget"
+    assert provider._beam.get(memory_id)["content"] == "before update"
+
+
+def test_batch_audit_events_emit_only_after_successful_commit(tmp_path):
+    provider = _provider(tmp_path)
+    events = []
+    provider._audit_event = lambda name, **kwargs: events.append((name, kwargs))
+
+    failed = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "operations": [
+            {"action": "remember", "content": "audit rollback"},
+            {"action": "update", "memory_id": "missing", "content": "x"},
+        ],
+    }))
+    assert failed["status"] == "error"
+    assert events == []
+
+    ok = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "operations": [
+            {"action": "remember", "content": "audit commit"},
+        ],
+    }))
+    assert ok["status"] == "ok"
+    assert [event[0] for event in events] == ["remember"]
+
+
+def test_batch_dry_run_writes_nothing(tmp_path):
+    provider = _provider(tmp_path)
+    existing_id = provider._beam.remember("dry existing", importance=0.3)
+    result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "dry_run": True,
+        "operations": [
+            {"action": "remember", "content": "dry new"},
+            {"action": "update", "memory_id": existing_id, "content": "dry changed"},
+        ],
+    }))
+
+    assert result["status"] == "dry_run"
+    assert [item["status"] for item in result["results"]] == ["would_store", "would_update"]
+    assert _count_matching(provider._beam, "dry new") == 0
+    assert provider._beam.get(existing_id)["content"] == "dry existing"
+
+
+def test_batch_unknown_action_rejected_before_mutation(tmp_path):
+    provider = _provider(tmp_path)
+    result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "operations": [
+            {"action": "remember", "content": "should not write"},
+            {"action": "search", "query": "x"},
+        ],
+    }))
+
+    assert result["status"] == "error"
+    assert result["failed_index"] == 1
+    assert _count_matching(provider._beam, "should not write") == 0
+
+
+def test_batch_requires_exact_ids_for_destructive_ops(tmp_path):
+    provider = _provider(tmp_path)
+    for action in ("update", "forget", "invalidate"):
+        op = {"action": action}
+        if action == "update":
+            op["content"] = "x"
+        result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+            "operations": [op],
+        }))
+        assert result["status"] == "error"
+        assert result["failed_index"] == 0
+        assert result["action"] == action

--- a/tests/test_mnemosyne_batch_tool.py
+++ b/tests/test_mnemosyne_batch_tool.py
@@ -61,19 +61,40 @@ def test_batch_update_and_invalidate(tmp_path):
 
     result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
         "operations": [
-            {"action": "update", "memory_id": update_id, "content": "batch new"},
+            {"action": "update", "memory_id": update_id, "content": "batch new", "importance": "0.8"},
             {"action": "invalidate", "memory_id": invalidate_id},
         ],
     }))
 
     assert result["status"] == "ok"
     assert [item["status"] for item in result["results"]] == ["updated", "invalidated"]
-    assert provider._beam.get(update_id)["content"] == "batch new"
+    updated = provider._beam.get(update_id)
+    assert updated["content"] == "batch new"
+    assert updated["importance"] == 0.8
     invalidated = provider._beam.conn.execute(
         "SELECT valid_until FROM working_memory WHERE id = ?",
         (invalidate_id,),
     ).fetchone()
     assert invalidated[0]
+
+
+def test_batch_extract_remember_uses_provider_default_scope(tmp_path):
+    provider = _provider(tmp_path)
+    provider._default_scope = "session"
+
+    result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "operations": [
+            {"action": "remember", "content": "scope parity extract", "extract": True},
+        ],
+    }))
+
+    assert result["status"] == "ok"
+    memory_id = result["results"][0]["memory_id"]
+    row = provider._beam.conn.execute(
+        "SELECT scope FROM working_memory WHERE id = ?",
+        (memory_id,),
+    ).fetchone()
+    assert row[0] == "session"
 
 
 def test_batch_failure_rolls_back_earlier_remember(tmp_path):

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -52,7 +52,7 @@ class TestToolRegistration:
     def test_all_tools_registered(self, tmp_path):
         provider = _provider(tmp_path)
         names = _tool_names(provider)
-        assert len(names) == 37, f"Expected 37 tools, got {len(names)}"
+        assert len(names) == 38, f"Expected 38 tools, got {len(names)}"
 
     def test_canonical_tools_present(self, tmp_path):
         provider = _provider(tmp_path)
@@ -71,7 +71,7 @@ class TestToolRegistration:
         provider = _provider(tmp_path)
         names = _tool_names(provider)
         for tool in ("remember", "recall", "sleep", "stats",
-                     "invalidate", "triple_add", "triple_query"):
+                     "invalidate", "batch", "triple_add", "triple_query"):
             assert f"mnemosyne_{tool}" in names
 
     def test_validate_tool_present(self, tmp_path):

--- a/tests/test_scope_auto_default.py
+++ b/tests/test_scope_auto_default.py
@@ -1,48 +1,36 @@
-"""Tests for auto-default scope=global when extract=true.
+"""Tests for Hermes remember default scope behavior.
 
-Verifies that _handle_remember in the Hermes provider correctly
-infers scope=global when extract=true and no explicit scope is passed.
+The Hermes providers default to the configured default_scope unless callers
+explicitly pass scope. extract=True does not implicitly promote to global.
 """
 from __future__ import annotations
 
 
-# We test the logic directly by simulating _handle_remember's scope logic
+def _scope_for(args, default_scope="session"):
+    return args.get("scope", default_scope)
+
+
 def test_scope_defaults_to_session_when_extract_false():
-    """Without extract=true, default scope must remain 'session'."""
-    # Simulate the new logic from _handle_remember
     args = {"content": "test content", "extract": False}
-    extract = bool(args.get("extract", False))
-    scope = args.get("scope", "global" if extract else "session")
-    assert scope == "session"
+    assert _scope_for(args) == "session"
 
 
-def test_scope_defaults_to_global_when_extract_true():
-    """With extract=true and no explicit scope, must default to 'global'."""
+def test_scope_defaults_to_default_scope_when_extract_true():
     args = {"content": "test content", "extract": True}
-    extract = bool(args.get("extract", False))
-    scope = args.get("scope", "global" if extract else "session")
-    assert scope == "global"
+    assert _scope_for(args, default_scope="session") == "session"
+    assert _scope_for(args, default_scope="global") == "global"
 
 
 def test_explicit_scope_respected_even_with_extract():
-    """Explicitly passed scope must be respected even when extract=true."""
     args = {"content": "test content", "extract": True, "scope": "session"}
-    extract = bool(args.get("extract", False))
-    scope = args.get("scope", "global" if extract else "session")
-    assert scope == "session"
+    assert _scope_for(args, default_scope="global") == "session"
 
 
 def test_explicit_global_scope_respected():
-    """Explicitly passed scope=global must be respected."""
     args = {"content": "test content", "extract": False, "scope": "global"}
-    extract = bool(args.get("extract", False))
-    scope = args.get("scope", "global" if extract else "session")
-    assert scope == "global"
+    assert _scope_for(args) == "global"
 
 
 def test_extract_entities_does_not_affect_scope():
-    """extract_entities=true without extract=true must NOT trigger global scope."""
     args = {"content": "test content", "extract_entities": True, "extract": False}
-    extract = bool(args.get("extract", False))
-    scope = args.get("scope", "global" if extract else "session")
-    assert scope == "session"
+    assert _scope_for(args) == "session"


### PR DESCRIPTION
## Summary

Adds `mnemosyne_batch`, a narrow atomic mutation tool for Hermes and MCP callers.

V1 supports these actions in a single call:

- `remember`
- `update`
- `forget`
- `invalidate`

The implementation validates the full batch before mutation, supports `dry_run`, applies writes inside a deferred-commit transaction, rolls back on failure, and returns compact per-op results.

## Scope

- one new tool: `mnemosyne_batch`
- same schema exposed through MCP and both Hermes provider surfaces
- exact-ID destructive operations only
- no recall/search operations
- no canonical/persona/shared-surface batching in v1

## Notes

- Audit events are emitted only after the batch commit succeeds, so failed batches do not leave phantom audit entries.
- MCP follows the existing MCP mutation surface conventions; Hermes providers additionally emit provider audit events.

## Verification

```bash
PYTHONPATH=. uv run --no-sync --with pytest pytest \
  tests/test_mnemosyne_batch_tool.py \
  tests/test_hermes_provider_parity.py \
  tests/test_provider_all_15_tools.py \
  tests/test_mcp_server.py -q

python3 -m py_compile \
  mnemosyne/batch_tool.py \
  mnemosyne/tool_schemas.py \
  mnemosyne/mcp_tools.py \
  hermes_memory_provider/__init__.py \
  integrations/hermes/src/mnemosyne_hermes/tools.py \
  integrations/hermes/src/mnemosyne_hermes/__init__.py \
  tests/test_mnemosyne_batch_tool.py \
  tests/test_hermes_provider_parity.py \
  tests/test_mcp_server.py \
  tests/test_provider_all_15_tools.py

git diff --check
```

Local result: `84 passed, 1 skipped, 1 warning` for the focused provider/MCP/parity suite.

Reviewer-Claude: pass-with-followups, no blockers.

Closes #359


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `mnemosyne_batch` tool for atomic, multi-operation memory mutations with per-operation outcomes.
  * Supports `dry_run` to preview results without writing across provider, Hermes, and MCP surfaces.
* **Bug Fixes**
  * Ensures batches validate before mutation and reliably roll back on failure.
  * Adjusted scope resolution so `extract=true` defaults to the configured default scope (not auto-global).
  * Improved Hermes `config.yaml` key lookup and parsing resilience when YAML loading isn’t available.
* **Chores / Maintenance**
  * Raised minimum `mnemosyne-memory` dependency requirements to `>=3.11.1`.
  * Expanded tests for batch schema, routing, rollback, auditing, and parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->