### PR TITLE
Add query/document embedding prompt prefix env vars

### DIFF
--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -68,6 +68,28 @@ _DEFAULT_MODEL = os.environ.get("MNEMOSYNE_EMBEDDING_MODEL", "BAAI/bge-small-en-
 _embedding_model = None
 _API_CALL_COUNT = 0
 
+# (1) Prefix support — read at call time so env changes and test fixtures take effect
+# without a module reload. The _PREFIXES_LOGGED guard suppresses log spam.
+_PREFIXES_LOGGED = False
+
+
+def _get_prefix(kind: str) -> str:
+    """Model prompt prefixes (e.g. E5 'query: '/'passage: ', EmbeddingGemma retrieval
+    prompts). Applied VERBATIM — no trimming, no separator magic — because trailing
+    whitespace is part of the trained prompt for several models."""
+    var = ("MNEMOSYNE_EMBEDDING_QUERY_PREFIX" if kind == "query"
+           else "MNEMOSYNE_EMBEDDING_DOC_PREFIX")
+    prefix = os.environ.get(var, "")
+    global _PREFIXES_LOGGED
+    if prefix and not _PREFIXES_LOGGED:
+        import logging
+        logging.getLogger(__name__).info(
+            "embedding prefixes active: query=%r doc=%r",
+            os.environ.get("MNEMOSYNE_EMBEDDING_QUERY_PREFIX", ""),
+            os.environ.get("MNEMOSYNE_EMBEDDING_DOC_PREFIX", ""))
+        _PREFIXES_LOGGED = True
+    return prefix
+
 
 def _is_disabled() -> bool:
     """True when dense retrieval has been opted out via env var.
@@ -274,44 +296,47 @@ def available_api() -> bool:
     return bool(_OPENAI_API_KEY)
 
 
-@lru_cache(maxsize=512)
+# (2) embed_query: apply query prefix verbatim, then delegate to a cached inner
+#     function keyed on the PREFIXED text. Keying on prefixed text (rather than raw)
+#     prevents stale vectors if the prefix env var changes within a process.
 def embed_query(text: str) -> Optional[np.ndarray]:
     """Encode a single query text into a dense vector."""
     if not text:
         return None
+    return _embed_query_cached(_get_prefix("query") + text)
 
+
+@lru_cache(maxsize=512)
+def _embed_query_cached(prefixed: str) -> Optional[np.ndarray]:
     if _is_api_model(_DEFAULT_MODEL):
-        result = _embed_api([text])
+        result = _embed_api([prefixed])
         return result[0] if result is not None else None
 
     model = _get_model()
     if model is None or model == "api":
         return None
-    vectors = list(model.embed([text]))
+    vectors = list(model.embed([prefixed]))
     if not vectors:
         return None
     return vectors[0].astype(np.float32)
 
 
+# (3) embed: apply DOC prefix to every text. Removed the single-text delegation to
+#     embed_query — that path stamped the query prefix onto stored documents.
 def embed(texts: List[str]) -> Optional[np.ndarray]:
-    """Encode texts into dense vectors."""
+    """Encode texts (documents) into dense vectors."""
     if not texts:
         return None
+    doc_prefix = _get_prefix("doc")
+    prefixed = [doc_prefix + t for t in texts]
 
     if _is_api_model(_DEFAULT_MODEL):
-        return _embed_api(texts)
-
-    # Use cached single-query path for common case of 1 text
-    if len(texts) == 1:
-        v = embed_query(texts[0])
-        if v is None:
-            return None
-        return np.stack([v])
+        return _embed_api(prefixed)
 
     model = _get_model()
     if model is None or model == "api":
         return None
-    vectors = list(model.embed(texts))
+    vectors = list(model.embed(prefixed))
     return np.stack(vectors).astype(np.float32)
 
 

--- a/tests/test_embedding_prefixes.py
+++ b/tests/test_embedding_prefixes.py
@@ -1,0 +1,93 @@
+"""Prefix env vars are applied verbatim, byte-exact, on the correct call paths.
+Uses a stub HTTP server so the raw request bytes are asserted (trailing spaces!).
+
+Covers BOTH client branches: the API path (stub HTTP server asserts raw wire
+bytes) and the fastembed path (fake model object records what reaches .embed())."""
+import importlib, json, threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import pytest
+
+QUERY_PREFIX = "task: search result | query: "   # trailing space is load-bearing
+DOC_PREFIX = "title: none | text: "
+
+RECORDED = []
+
+class StubHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers["Content-Length"]))
+        RECORDED.append(json.loads(body))
+        n = len(json.loads(body)["input"])
+        resp = json.dumps({"object": "list", "model": "stub",
+                           "data": [{"object": "embedding", "index": i, "embedding": [0.1] * 768}
+                                    for i in range(n)],
+                           "usage": {"prompt_tokens": 1, "total_tokens": 1}}).encode()
+        self.send_response(200); self.send_header("Content-Length", str(len(resp)))
+        self.send_header("Content-Type", "application/json"); self.end_headers()
+        self.wfile.write(resp)
+    def log_message(self, *a): pass
+
+@pytest.fixture
+def embeddings_mod(monkeypatch):
+    server = HTTPServer(("127.0.0.1", 0), StubHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    url = f"http://127.0.0.1:{server.server_port}/v1"
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_API_URL", url)
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_MODEL", "embeddinggemma-300m-q4")
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_DIM", "768")
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_QUERY_PREFIX", QUERY_PREFIX)
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_DOC_PREFIX", DOC_PREFIX)
+    RECORDED.clear()
+    from mnemosyne.core import embeddings
+    # Reload ONLY because upstream reads the API URL/model at module import time.
+    # The PREFIXES are read at call time by the patch, so no reload is ever
+    # needed for prefix changes (see test_unset_prefixes_unchanged).
+    importlib.reload(embeddings)
+    yield embeddings
+    server.shutdown()
+
+def test_query_prefix_byte_exact(embeddings_mod):
+    # No cache manipulation: the cache is keyed on the PREFIXED text, so prefix
+    # changes can never serve stale entries (see patch note in Step 4).
+    assert embeddings_mod.embed_query("hvor bor brukeren") is not None
+    assert RECORDED[-1]["input"] == ["task: search result | query: hvor bor brukeren"]
+
+def test_doc_prefix_on_batch(embeddings_mod):
+    assert embeddings_mod.embed(["fact one", "fact two"]) is not None
+    assert RECORDED[-1]["input"] == ["title: none | text: fact one",
+                                     "title: none | text: fact two"]
+
+def test_single_doc_gets_doc_prefix_not_query(embeddings_mod):
+    # Regression: embed([one]) used to delegate to embed_query (query prefix on a document)
+    assert embeddings_mod.embed(["only fact"]) is not None
+    assert RECORDED[-1]["input"] == ["title: none | text: only fact"]
+
+def test_unset_prefixes_unchanged(embeddings_mod, monkeypatch):
+    # No reload needed: prefixes are read at call time (this test proves it), and
+    # the prefixed-text cache key means "plain" cannot collide with earlier entries.
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_QUERY_PREFIX")
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_DOC_PREFIX")
+    assert embeddings_mod.embed_query("plain") is not None
+    assert RECORDED[-1]["input"] == ["plain"]
+
+def test_fastembed_path_applies_prefixes(monkeypatch):
+    # The fastembed (local ONNX) branch must apply the same prefixes: only the
+    # model object is doubled; the branch selection logic runs for real.
+    import numpy as np
+    from mnemosyne.core import embeddings as emb
+    class FakeFastembedModel:
+        def __init__(self): self.received = []
+        def embed(self, texts):
+            self.received.append(list(texts))
+            return [np.ones(768, dtype=np.float32) for _ in texts]
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_API_URL", raising=False)   # force non-API path
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDINGS_VIA_API", raising=False)
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_QUERY_PREFIX", QUERY_PREFIX)
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_DOC_PREFIX", DOC_PREFIX)
+    fake = FakeFastembedModel()
+    monkeypatch.setattr(emb, "TextEmbedding", object())      # fastembed "available"
+    monkeypatch.setattr(emb, "_embedding_model", fake)       # already-"loaded" model
+    emb._embed_query_cached.cache_clear()                    # isolate from API-path tests
+    assert emb.embed(["local fact"]) is not None
+    assert fake.received[-1] == [DOC_PREFIX + "local fact"]
+    assert emb.embed_query("local query") is not None
+    assert fake.received[-1] == [QUERY_PREFIX + "local query"]


### PR DESCRIPTION
## Why
Several recommended models require asymmetric prompt prefixes (multilingual-E5: `query: `/`passage: `; EmbeddingGemma: `task: search result | query: ` / `title: none | text: `). The client currently sends raw text on both paths, so these models run off-label. Also, `embed([single_text])` delegates to `embed_query()`, which would stamp a query prefix onto a stored document once prefixes exist.

## What
- `MNEMOSYNE_EMBEDDING_QUERY_PREFIX` / `MNEMOSYNE_EMBEDDING_DOC_PREFIX` (default empty = no behavior change), applied verbatim (trailing whitespace preserved) in `embed_query()` / `embed()` for both the API and fastembed paths.
- Removed the single-text delegation in `embed()`.
- Byte-exact tests against a stub HTTP server, including the single-document regression.

Note: tests cover both branches — byte-exact wire assertions for the API path and a fake-model test proving the prefixes reach the fastembed path's .embed() call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)