### PR TITLE
fix(hermes): restore L3 persona prompt parity

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -42,6 +42,7 @@ from mnemosyne.batch_tool import (
     validate_batch_operations,
 )
 from mnemosyne.hermes_config import read_hermes_config_key
+from mnemosyne.integrations.hermes_persona_prompt import HermesPersonaPromptMixin
 
 logger = logging.getLogger(__name__)
 
@@ -1239,7 +1240,7 @@ def _parse_env_optional_int(key: str, default: Optional[int]) -> Optional[int]:
     return _coerce_optional_int(os.environ.get(key), default)
 
 
-class MnemosyneMemoryProvider(MemoryProvider):
+class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
     """Mnemosyne native memory — local SQLite with vector + FTS5 hybrid search."""
 
     # How long on_session_end will wait for sleep/consolidation to finish before
@@ -1865,10 +1866,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 "answer directly. Use session_search only when the injected Mnemosyne "
                 "context is missing, stale, or insufficient."
             )
-            persona_block = self._persona_block()
-            if persona_block:
-                base += "\n\n# L3 Persona (Active Behavioral Rules)\n" + persona_block
-            return base
+            return self._with_persona_block(base)
         # C27: when init failed (as opposed to a deliberate skip-context),
         # surface the failure in the system prompt so the agent -- and through
         # it the user -- can see that memory is unavailable rather than
@@ -3441,47 +3439,6 @@ class MnemosyneMemoryProvider(MemoryProvider):
     # contract). Tests may shorten this to keep the suite fast. Override via
     # MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT.
     SHUTDOWN_DRAIN_TIMEOUT_SECONDS = _parse_env_float("MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT", 2)
-
-    # L3 persona file injection. Default OFF -- opt in via
-    # MNEMOSYNE_PERSONA_ENABLED=true. When OFF, no file IO happens.
-    PERSONA_ENABLED = _parse_env_bool("MNEMOSYNE_PERSONA_ENABLED", False)
-    PERSONA_FILE = Path(
-        os.environ.get(
-            "MNEMOSYNE_PERSONA_FILE",
-            str(Path.home() / ".hermes" / "memory" / "persona.md"),
-        )
-    )
-    PERSONA_TOKEN_CAP = int(os.environ.get("MNEMOSYNE_PERSONA_TOKEN_CAP", "1500"))
-    _persona_cache: Dict[str, Any] = {"mtime": None, "content": None}
-
-    def _persona_block(self) -> str:
-        """Read persona.md if feature enabled and file exists. Cached by mtime."""
-        if not self.PERSONA_ENABLED:
-            return ""
-        try:
-            if not self.PERSONA_FILE.exists():
-                self._persona_cache = {"mtime": None, "content": None}
-                return ""
-            mtime = self.PERSONA_FILE.stat().st_mtime
-            if (
-                self._persona_cache.get("mtime") == mtime
-                and self._persona_cache.get("content") is not None
-            ):
-                return self._persona_cache["content"]
-            raw = self.PERSONA_FILE.read_text()
-            words = raw.split()
-            max_words = int(self.PERSONA_TOKEN_CAP * 0.75)
-            if len(words) > max_words:
-                truncated = " ".join(words[:max_words])
-                last_section = truncated.rfind("\n## ")
-                if last_section > 0:
-                    truncated = truncated[:last_section]
-                raw = truncated + "\n... (truncated, see persona file for full content)"
-            self._persona_cache = {"mtime": mtime, "content": raw}
-            return raw
-        except Exception as exc:
-            logger.debug("persona_block read failed: %s", exc)
-            return ""
 
     def shutdown(self) -> None:
         # If session_end's daemon thread is still consolidating when shutdown

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1853,7 +1853,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             # (matches the auto-capture for identity-significant feelings
             # added in that PR), and keep C27's three-branch structure
             # (working / init-failed-visible / skip-context-silent).
-            return (
+            base = (
                 "# Mnemosyne Memory\n"
                 "Active (native local memory). Use mnemosyne_remember to store ANY "
                 "durable fact, preference, identity, or insight. Use mnemosyne_recall to search. "
@@ -1865,6 +1865,10 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 "answer directly. Use session_search only when the injected Mnemosyne "
                 "context is missing, stale, or insufficient."
             )
+            persona_block = self._persona_block()
+            if persona_block:
+                base += "\n\n# L3 Persona (Active Behavioral Rules)\n" + persona_block
+            return base
         # C27: when init failed (as opposed to a deliberate skip-context),
         # surface the failure in the system prompt so the agent -- and through
         # it the user -- can see that memory is unavailable rather than
@@ -3437,6 +3441,47 @@ class MnemosyneMemoryProvider(MemoryProvider):
     # contract). Tests may shorten this to keep the suite fast. Override via
     # MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT.
     SHUTDOWN_DRAIN_TIMEOUT_SECONDS = _parse_env_float("MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT", 2)
+
+    # L3 persona file injection. Default OFF -- opt in via
+    # MNEMOSYNE_PERSONA_ENABLED=true. When OFF, no file IO happens.
+    PERSONA_ENABLED = _parse_env_bool("MNEMOSYNE_PERSONA_ENABLED", False)
+    PERSONA_FILE = Path(
+        os.environ.get(
+            "MNEMOSYNE_PERSONA_FILE",
+            str(Path.home() / ".hermes" / "memory" / "persona.md"),
+        )
+    )
+    PERSONA_TOKEN_CAP = int(os.environ.get("MNEMOSYNE_PERSONA_TOKEN_CAP", "1500"))
+    _persona_cache: Dict[str, Any] = {"mtime": None, "content": None}
+
+    def _persona_block(self) -> str:
+        """Read persona.md if feature enabled and file exists. Cached by mtime."""
+        if not self.PERSONA_ENABLED:
+            return ""
+        try:
+            if not self.PERSONA_FILE.exists():
+                self._persona_cache = {"mtime": None, "content": None}
+                return ""
+            mtime = self.PERSONA_FILE.stat().st_mtime
+            if (
+                self._persona_cache.get("mtime") == mtime
+                and self._persona_cache.get("content") is not None
+            ):
+                return self._persona_cache["content"]
+            raw = self.PERSONA_FILE.read_text()
+            words = raw.split()
+            max_words = int(self.PERSONA_TOKEN_CAP * 0.75)
+            if len(words) > max_words:
+                truncated = " ".join(words[:max_words])
+                last_section = truncated.rfind("\n## ")
+                if last_section > 0:
+                    truncated = truncated[:last_section]
+                raw = truncated + "\n... (truncated, see persona file for full content)"
+            self._persona_cache = {"mtime": mtime, "content": raw}
+            return raw
+        except Exception as exc:
+            logger.debug("persona_block read failed: %s", exc)
+            return ""
 
     def shutdown(self) -> None:
         # If session_end's daemon thread is still consolidating when shutdown

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -27,19 +27,79 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 from datetime import datetime, timedelta
 
-from .tools import ALL_TOOL_SCHEMAS
-from mnemosyne.batch_tool import (
-    BatchValidationError,
-    apply_beam_batch,
-    batch_validation_error_payload,
-    dry_run_batch,
-    validate_batch_operations,
-)
-from mnemosyne.hermes_config import read_hermes_config_key
-
 # Mnemosyne core is installed via pip (mnemosyne-memory>=3.11.1 dependency),
 # but keep imports lazy so installer/status CLI commands still work in broken
 # or partially-installed environments.
+try:
+    from .tools import ALL_TOOL_SCHEMAS
+except Exception as _tool_schema_import_exc:  # pragma: no cover - broken install diagnostic path
+    logging.getLogger(__name__).warning(
+        "Mnemosyne Hermes tool schemas unavailable (%s); no tools will be exposed until the install is repaired.",
+        _tool_schema_import_exc,
+    )
+    ALL_TOOL_SCHEMAS = []
+
+try:
+    from mnemosyne.batch_tool import (
+        BatchValidationError,
+        apply_beam_batch,
+        batch_validation_error_payload,
+        dry_run_batch,
+        validate_batch_operations,
+    )
+except Exception as _batch_tool_import_exc:  # pragma: no cover - broken install diagnostic path
+    logging.getLogger(__name__).warning(
+        "mnemosyne_batch helpers unavailable (%s); batch tool calls will return an error until mnemosyne-memory is upgraded.",
+        _batch_tool_import_exc,
+    )
+
+    class BatchValidationError(ValueError):
+        """Fallback validation error used when mnemosyne.batch_tool is unavailable."""
+
+    def validate_batch_operations(_operations):
+        raise BatchValidationError("mnemosyne_batch is unavailable; upgrade mnemosyne-memory")
+
+    def batch_validation_error_payload(exc: Exception) -> Dict[str, Any]:
+        return {"status": "error", "error": str(exc)}
+
+    def dry_run_batch(_operations):
+        return {"status": "error", "error": "mnemosyne_batch is unavailable; upgrade mnemosyne-memory"}
+
+    def apply_beam_batch(*_args, **_kwargs):
+        return {"status": "error", "error": "mnemosyne_batch is unavailable; upgrade mnemosyne-memory"}
+
+try:
+    from mnemosyne.hermes_config import read_hermes_config_key
+except Exception as _hermes_config_import_exc:  # pragma: no cover - broken install diagnostic path
+    logging.getLogger(__name__).warning(
+        "Hermes config helper unavailable (%s); memory.mnemosyne config keys will use defaults until mnemosyne-memory is upgraded.",
+        _hermes_config_import_exc,
+    )
+
+    def read_hermes_config_key(_hermes_home: Optional[str], _key: str) -> Any:
+        return None
+
+try:
+    from mnemosyne.integrations.hermes_persona_prompt import HermesPersonaPromptMixin
+except Exception as _persona_import_exc:  # pragma: no cover - graceful import for installer/status diagnostics
+    logging.getLogger(__name__).warning(
+        "L3 persona prompt mixin unavailable (%s); persona injection disabled. "
+        "Upgrade mnemosyne-memory to restore it.",
+        _persona_import_exc,
+    )
+
+    class HermesPersonaPromptMixin:
+        """Fallback used only when mnemosyne core is missing or too old."""
+
+        PERSONA_ENABLED = False
+        PERSONA_FILE = Path.home() / ".hermes" / "memory" / "persona.md"
+        PERSONA_TOKEN_CAP = 1500
+
+        def _persona_block(self) -> str:
+            return ""
+
+        def _with_persona_block(self, base: str) -> str:
+            return base
 
 __version__ = "0.3.1"
 
@@ -417,7 +477,7 @@ def _parse_env_optional_int(key: str, default: Optional[int]) -> Optional[int]:
     return _coerce_optional_int(os.environ.get(key), default)
 
 
-class MnemosyneMemoryProvider(MemoryProvider):
+class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
     """Mnemosyne native memory — local SQLite with vector + FTS5 hybrid search."""
 
     _VALID_SYNC_ROLES: frozenset = frozenset({"user", "assistant"})
@@ -1045,14 +1105,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
                 "answer directly. Use session_search only when the injected Mnemosyne "
                 "context is missing, stale, or insufficient."
             )
-            # L3 persona injection (v3.10.0): always-on behavioral rules.
-            # Feature-gated by MNEMOSYNE_PERSONA_ENABLED -- default OFF to
-            # preserve opt-in upgrade story. Reads persona.md atomically,
-            # caches by mtime to avoid re-reads on every prompt build.
-            persona_block = self._persona_block()
-            if persona_block:
-                base += "\n\n# L3 Persona (Active Behavioral Rules)\n" + persona_block
-            return base
+            return self._with_persona_block(base)
         # C27: when init failed (as opposed to a deliberate skip-context),
         # surface the failure in the system prompt so the agent -- and through
         # it the user -- can see that memory is unavailable rather than
@@ -2434,47 +2487,6 @@ class MnemosyneMemoryProvider(MemoryProvider):
     # contract). Tests may shorten this to keep the suite fast. Override via
     # MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT.
     SHUTDOWN_DRAIN_TIMEOUT_SECONDS = _parse_env_float("MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT", 2)
-
-    # L3 persona file injection (v3.10.0). Default OFF -- opt-in via
-    # MNEMOSYNE_PERSONA_ENABLED=true. When OFF, no file IO happens.
-    PERSONA_ENABLED = _parse_env_bool("MNEMOSYNE_PERSONA_ENABLED", False)
-    PERSONA_FILE = Path(
-        os.environ.get(
-            "MNEMOSYNE_PERSONA_FILE",
-            str(Path.home() / ".hermes" / "memory" / "persona.md"),
-        )
-    )
-    PERSONA_TOKEN_CAP = int(os.environ.get("MNEMOSYNE_PERSONA_TOKEN_CAP", "1500"))
-    _persona_cache: Dict[str, Any] = {"mtime": None, "content": None}
-
-    def _persona_block(self) -> str:
-        """Read persona.md if feature enabled and file exists. Cached by mtime."""
-        if not self.PERSONA_ENABLED:
-            return ""
-        try:
-            if not self.PERSONA_FILE.exists():
-                # Clear cache when file vanishes
-                self._persona_cache = {"mtime": None, "content": None}
-                return ""
-            mtime = self.PERSONA_FILE.stat().st_mtime
-            if self._persona_cache.get("mtime") == mtime and self._persona_cache.get("content") is not None:
-                return self._persona_cache["content"]
-            raw = self.PERSONA_FILE.read_text()
-            # Rough token cap (~1 token / 0.75 words).
-            words = raw.split()
-            max_words = int(self.PERSONA_TOKEN_CAP * 0.75)
-            if len(words) > max_words:
-                # Truncate at section boundary if possible
-                truncated = " ".join(words[:max_words])
-                last_section = truncated.rfind("\n## ")
-                if last_section > 0:
-                    truncated = truncated[:last_section]
-                raw = truncated + "\n... (truncated, see persona file for full content)"
-            self._persona_cache = {"mtime": mtime, "content": raw}
-            return raw
-        except Exception as exc:
-            logger.debug("persona_block read failed: %s", exc)
-            return ""
 
     def shutdown(self) -> None:
         # If session_end's daemon thread is still consolidating when shutdown

--- a/mnemosyne/integrations/hermes_persona_prompt.py
+++ b/mnemosyne/integrations/hermes_persona_prompt.py
@@ -1,0 +1,96 @@
+"""Shared Hermes persona prompt helpers.
+
+Both Hermes provider surfaces (the root plugin package and the packaged
+``mnemosyne_hermes`` integration) use this module so persona prompt injection
+stays behaviorally identical.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+PERSONA_ENABLED_ENV = "MNEMOSYNE_PERSONA_ENABLED"
+PERSONA_FILE_ENV = "MNEMOSYNE_PERSONA_FILE"
+PERSONA_TOKEN_CAP_ENV = "MNEMOSYNE_PERSONA_TOKEN_CAP"
+PERSONA_PROMPT_HEADER = "# L3 Persona (Active Behavioral Rules)"
+DEFAULT_PERSONA_TOKEN_CAP = 1500
+DEFAULT_PERSONA_FILE = Path.home() / ".hermes" / "memory" / "persona.md"
+
+
+def _parse_env_bool(key: str, default: bool) -> bool:
+    value = os.environ.get(key)
+    if value is None:
+        return default
+    raw = value.strip().lower()
+    if raw in ("1", "true", "yes", "on"):
+        return True
+    if raw in ("0", "false", "no", "off"):
+        return False
+    return default
+
+
+def _parse_env_int(key: str, default: int) -> int:
+    value = os.environ.get(key)
+    if value is None:
+        return default
+    try:
+        return int(value.strip())
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %s", key, value, default)
+        return default
+
+
+def _persona_file_from_env() -> Path:
+    return Path(os.environ.get(PERSONA_FILE_ENV, str(DEFAULT_PERSONA_FILE)))
+
+
+class HermesPersonaPromptMixin:
+    """Mixin providing opt-in persona prompt injection for Hermes providers."""
+
+    # L3 persona file injection. Default OFF -- opt in via
+    # MNEMOSYNE_PERSONA_ENABLED=true. When OFF, no file IO happens.
+    PERSONA_ENABLED = _parse_env_bool(PERSONA_ENABLED_ENV, False)
+    PERSONA_FILE = _persona_file_from_env()
+    PERSONA_TOKEN_CAP = _parse_env_int(PERSONA_TOKEN_CAP_ENV, DEFAULT_PERSONA_TOKEN_CAP)
+    _persona_cache: Dict[str, Any] = {"mtime": None, "content": None}
+
+    def _persona_block(self) -> str:
+        """Read persona.md if feature enabled and file exists. Cached by mtime."""
+        if not self.PERSONA_ENABLED:
+            return ""
+        try:
+            persona_file = Path(self.PERSONA_FILE)
+            if not persona_file.exists():
+                self._persona_cache = {"mtime": None, "content": None}
+                return ""
+            mtime = persona_file.stat().st_mtime
+            if (
+                self._persona_cache.get("mtime") == mtime
+                and self._persona_cache.get("content") is not None
+            ):
+                return self._persona_cache["content"]
+            raw = persona_file.read_text()
+            words = raw.split()
+            max_words = max(0, int(self.PERSONA_TOKEN_CAP * 0.75))
+            if len(words) > max_words:
+                truncated = " ".join(words[:max_words])
+                last_section = truncated.rfind("\n## ")
+                if last_section > 0:
+                    truncated = truncated[:last_section]
+                raw = truncated + "\n... (truncated, see persona file for full content)"
+            self._persona_cache = {"mtime": mtime, "content": raw}
+            return raw
+        except Exception as exc:
+            logger.debug("persona_block read failed: %s", exc)
+            return ""
+
+    def _with_persona_block(self, base: str) -> str:
+        persona_block = self._persona_block()
+        if persona_block:
+            return f"{base}\n\n{PERSONA_PROMPT_HEADER}\n{persona_block}"
+        return base

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -673,18 +673,100 @@ def test_provider_persona_prompt_injection_matches(tmp_path, provider_modules):
 
 
 def test_provider_persona_prompt_silent_when_disabled_or_missing(tmp_path, provider_modules):
+    persona_file = tmp_path / "persona.md"
+    persona_file.write_text("# Persona\n\n- should stay hidden when disabled\n")
     missing_file = tmp_path / "missing-persona.md"
 
     for module in provider_modules.values():
         provider = _prompt_provider(module)
         provider.PERSONA_ENABLED = False
-        provider.PERSONA_FILE = missing_file
-        assert "# L3 Persona" not in provider.system_prompt_block()
+        provider.PERSONA_FILE = persona_file
+        block = provider.system_prompt_block()
+        assert "# L3 Persona" not in block
+        assert "should stay hidden when disabled" not in block
 
         provider = _prompt_provider(module)
         provider.PERSONA_ENABLED = True
         provider.PERSONA_FILE = missing_file
         assert "# L3 Persona" not in provider.system_prompt_block()
+
+
+def test_provider_persona_negative_token_cap_does_not_slice_from_end(tmp_path, provider_modules):
+    persona_file = tmp_path / "persona.md"
+    persona_file.write_text("# Persona\n\n## privacy\n- secret tail should not leak\n")
+
+    for module in provider_modules.values():
+        provider = _prompt_provider(module)
+        provider.PERSONA_ENABLED = True
+        provider.PERSONA_FILE = persona_file
+        provider.PERSONA_TOKEN_CAP = -10
+        block = provider.system_prompt_block()
+        assert "secret tail should not leak" not in block
+        assert "truncated" in block
+
+
+@pytest.mark.parametrize("bad_token_cap", ["", "not-an-int"])
+def test_provider_persona_token_cap_invalid_env_falls_back(monkeypatch, bad_token_cap):
+    monkeypatch.setenv("MNEMOSYNE_PERSONA_TOKEN_CAP", bad_token_cap)
+
+    modules = {
+        "hermes_memory_provider": _import_module("hermes_memory_provider", PROJECT_ROOT),
+        "mnemosyne_hermes": _import_module("mnemosyne_hermes", INTEGRATION_SRC),
+    }
+
+    assert {name: module.MnemosyneMemoryProvider.PERSONA_TOKEN_CAP for name, module in modules.items()} == {
+        "hermes_memory_provider": 1500,
+        "mnemosyne_hermes": 1500,
+    }
+
+
+def test_packaged_provider_import_survives_missing_core_helpers():
+    """Installer/status diagnostics must import even with a broken core install."""
+
+    import importlib.abc
+
+    blocked = {
+        "mnemosyne.batch_tool",
+        "mnemosyne.hermes_config",
+        "mnemosyne.integrations.hermes_persona_prompt",
+    }
+
+    class _BlockCoreHelperImports(importlib.abc.MetaPathFinder):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname in blocked:
+                raise ModuleNotFoundError(f"blocked test import: {fullname}")
+            return None
+
+    finder = _BlockCoreHelperImports()
+    saved = {name: module for name, module in sys.modules.items() if name in blocked}
+    for name in blocked:
+        sys.modules.pop(name, None)
+    _drop_modules("mnemosyne_hermes")
+    sys.path.insert(0, str(INTEGRATION_SRC))
+    sys.meta_path.insert(0, finder)
+    try:
+        module = importlib.import_module("mnemosyne_hermes")
+    finally:
+        sys.meta_path.remove(finder)
+        try:
+            sys.path.remove(str(INTEGRATION_SRC))
+        except ValueError:
+            pass
+        for name in blocked:
+            sys.modules.pop(name, None)
+        sys.modules.update(saved)
+
+    try:
+        assert module.read_hermes_config_key(None, "tools") is None
+        with pytest.raises(module.BatchValidationError):
+            module.validate_batch_operations([])
+        provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+        assert provider._with_persona_block("base") == "base"
+    finally:
+        _drop_modules("mnemosyne_hermes")
+        _import_module("mnemosyne_hermes", INTEGRATION_SRC)
+
+
 def _save_mnemosyne_modules():
     return {
         name: module for name, module in sys.modules.items()

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -640,8 +640,51 @@ def test_sync_adapter_pull_tolerates_null_next_cursor(sync_modules):
         "next_cursor": "",
     }
 
+def _prompt_provider(module):
+    provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+    provider._beam = object()
+    provider._init_error = None
+    if hasattr(provider, "_persona_cache"):
+        provider._persona_cache = {"mtime": None, "content": None}
+    return provider
 
 
+def test_provider_persona_prompt_injection_matches(tmp_path, provider_modules):
+    persona_file = tmp_path / "persona.md"
+    persona_file.write_text(
+        "# Persona\n\n"
+        "## privacy\n"
+        "- expected persona/privacy rule [importance: 0.90]\n"
+    )
+
+    observed = {}
+    for name, module in provider_modules.items():
+        provider = _prompt_provider(module)
+        # Class-level env defaults are read at import time; set the attrs
+        # directly so both already-imported provider surfaces see this file.
+        provider.PERSONA_ENABLED = True
+        provider.PERSONA_FILE = persona_file
+        observed[name] = provider.system_prompt_block()
+
+    for block in observed.values():
+        assert "# Mnemosyne Memory" in block
+        assert "# L3 Persona (Active Behavioral Rules)" in block
+        assert "expected persona/privacy rule" in block
+
+
+def test_provider_persona_prompt_silent_when_disabled_or_missing(tmp_path, provider_modules):
+    missing_file = tmp_path / "missing-persona.md"
+
+    for module in provider_modules.values():
+        provider = _prompt_provider(module)
+        provider.PERSONA_ENABLED = False
+        provider.PERSONA_FILE = missing_file
+        assert "# L3 Persona" not in provider.system_prompt_block()
+
+        provider = _prompt_provider(module)
+        provider.PERSONA_ENABLED = True
+        provider.PERSONA_FILE = missing_file
+        assert "# L3 Persona" not in provider.system_prompt_block()
 def _save_mnemosyne_modules():
     return {
         name: module for name, module in sys.modules.items()


### PR DESCRIPTION
## Summary

- restores L3 persona prompt injection in the root `hermes_memory_provider` surface
- keeps the behavior opt-in via `MNEMOSYNE_PERSONA_ENABLED=true`
- adds provider parity coverage for `system_prompt_block()` persona injection

## Why

`mnemosyne_hermes` already appended the `# L3 Persona (Active Behavioral Rules)` block when an enabled, non-empty persona file was present. The root `hermes_memory_provider` package had the persona tools/schemas, but missed the prompt injection path. Some real installs still load that root provider package, so L3 appeared configured but never reached the system prompt.

## Tests

- `PYTHONPATH=".:integrations/hermes/src" uv run --no-sync --with pytest --with pyyaml pytest tests/test_hermes_provider_parity.py tests/test_persona_injection.py tests/test_provider_all_15_tools.py -q`
- `python3 -m py_compile hermes_memory_provider/__init__.py tests/test_hermes_provider_parity.py`
- manual provider smoke: both `hermes_memory_provider` and `mnemosyne_hermes` include Mnemosyne header, L3 header, and persona file content


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hermes-related prompts can now automatically include optional persona text from a markdown file, with header injection and token/size-based truncation.
* **Bug Fixes**
  * More robust handling when persona prompting is disabled, the persona file is missing, or configuration values are invalid—prompt composition now safely falls back without failing.
* **Tests**
  * Added parity and regression coverage to ensure persona prompt behavior matches across provider implementations, including edge cases like negative/invalid token-cap values and resilient imports in reduced environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->