### PR TITLE
fix: validate bank names before path operations

### DIFF
--- a/mnemosyne/core/banks.py
+++ b/mnemosyne/core/banks.py
@@ -96,6 +96,7 @@ class BankManager:
         Raises:
             ValueError: If trying to delete 'default' without force=True.
         """
+        self._validate_name(name)
         if name == "default" and not force:
             raise ValueError("Cannot delete 'default' bank without force=True")
         bank_dir = self.banks_dir / name
@@ -116,6 +117,7 @@ class BankManager:
 
     def bank_exists(self, name: str) -> bool:
         """Check if a bank exists."""
+        self._validate_name(name)
         if name == "default":
             return True
         return (self.banks_dir / name).is_dir()
@@ -127,8 +129,9 @@ class BankManager:
         The 'default' bank uses the legacy path (data_dir/mnemosyne.db).
         All other banks use banks_dir/<name>/mnemosyne.db.
         """
-        if name == "default" or not name:
+        if name == "default":
             return self.data_dir / "mnemosyne.db"
+        self._validate_name(name)
         return self.banks_dir / name / "mnemosyne.db"
 
     def rename_bank(self, old_name: str, new_name: str) -> Path:
@@ -145,6 +148,7 @@ class BankManager:
         Raises:
             ValueError: If old_name doesn't exist or new_name is taken.
         """
+        self._validate_name(old_name)
         if old_name == "default":
             raise ValueError("Cannot rename 'default' bank")
         self._validate_name(new_name)

--- a/tests/test_memory_banks.py
+++ b/tests/test_memory_banks.py
@@ -62,6 +62,41 @@ class TestBankManager:
             with pytest.raises(ValueError):
                 mgr.create_bank("bank.with.dots")
 
+    @pytest.mark.parametrize(
+        ("name", "error"),
+        [
+            ("", "Bank name cannot be empty"),
+            ("../outside", "Invalid bank name"),
+            ("bank/with/slashes", "Invalid bank name"),
+            ("bank.with.dots", "Invalid bank name"),
+        ],
+    )
+    def test_path_based_operations_reject_invalid_bank_names(self, name, error):
+        """Path-based bank operations must not resolve invalid names."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir) / "data"
+            data_dir.mkdir()
+            outside = Path(tmpdir) / "outside"
+            outside.mkdir()
+            sentinel = outside / "keep.txt"
+            sentinel.write_text("do not delete")
+
+            mgr = BankManager(data_dir)
+
+            with pytest.raises(ValueError, match=error):
+                mgr.delete_bank(name, force=True)
+            with pytest.raises(ValueError, match=error):
+                mgr.bank_exists(name)
+            with pytest.raises(ValueError, match=error):
+                mgr.get_bank_db_path(name)
+            with pytest.raises(ValueError, match=error):
+                mgr.get_bank_stats(name)
+            with pytest.raises(ValueError, match=error):
+                mgr.rename_bank(name, "safe_name")
+
+            assert sentinel.exists()
+            assert outside.exists()
+
     def test_list_banks_includes_default(self):
         """list_banks() should always include 'default'."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- validate bank names before path-based BankManager operations resolve filesystem paths
- reject empty bank names consistently while preserving the explicit `default` special case
- cover delete/exists/path/stats/rename with invalid bank names and specific validation errors
- assert invalid traversal-shaped names do not affect sibling directories

## Tests

- `uv run --no-sync --with pytest pytest tests/test_memory_banks.py -q` → 30 passed
- `python3 -m py_compile mnemosyne/core/banks.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of bank names across deletion, existence checks, database path resolution, stats lookup, and renaming.
  * Prevents invalid or path-like names from being routed to legacy paths or triggering filesystem actions outside the managed data area.
* **Tests**
  * Added coverage to ensure invalid bank names/paths (e.g., empty, traversal, slashes, dotted names) are rejected with `ValueError` and do not alter or remove files outside the app’s data directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->