### PR TITLE
diagnose: report orphaned memory references

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -3216,14 +3216,18 @@ class MnemosyneMemoryProvider(MemoryProvider):
             )
             try:
                 import sqlite3
+                from mnemosyne.diagnose import _memory_orphan_diagnostics
                 con = sqlite3.connect(str(active_db))
-                cur = con.cursor()
-                result["active_provider_counts"] = {
-                    "working_memory": cur.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0],
-                    "episodic_memory": cur.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0],
-                    "facts": cur.execute("SELECT COUNT(*) FROM facts").fetchone()[0],
-                }
-                con.close()
+                try:
+                    cur = con.cursor()
+                    result["active_provider_counts"] = {
+                        "working_memory": cur.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0],
+                        "episodic_memory": cur.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0],
+                        "facts": cur.execute("SELECT COUNT(*) FROM facts").fetchone()[0],
+                    }
+                    result["active_provider_orphan_diagnostics"] = _memory_orphan_diagnostics(con)
+                finally:
+                    con.close()
                 try:
                     from mnemosyne.core.beam import repair_vec_working as _repair_vec_working, vec_working_coverage
                     if repair_requested and self._beam is not None:

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -2171,14 +2171,18 @@ class MnemosyneMemoryProvider(MemoryProvider):
             )
             try:
                 import sqlite3
+                from mnemosyne.diagnose import _memory_orphan_diagnostics
                 con = sqlite3.connect(str(active_db))
-                cur = con.cursor()
-                result["active_provider_counts"] = {
-                    "working_memory": cur.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0],
-                    "episodic_memory": cur.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0],
-                    "facts": cur.execute("SELECT COUNT(*) FROM facts").fetchone()[0],
-                }
-                con.close()
+                try:
+                    cur = con.cursor()
+                    result["active_provider_counts"] = {
+                        "working_memory": cur.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0],
+                        "episodic_memory": cur.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0],
+                        "facts": cur.execute("SELECT COUNT(*) FROM facts").fetchone()[0],
+                    }
+                    result["active_provider_orphan_diagnostics"] = _memory_orphan_diagnostics(con)
+                finally:
+                    con.close()
             except Exception as exc:
                 result["active_provider_counts_error"] = str(exc)
 

--- a/mnemosyne/diagnose.py
+++ b/mnemosyne/diagnose.py
@@ -62,6 +62,76 @@ def _safe_env(name: str) -> str:
     return "set" if val else "unset"
 
 
+def _memory_orphan_diagnostics(conn) -> Dict[str, int]:
+    """Return read-only memory reference integrity diagnostics."""
+    foreign_keys_enabled = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    tables = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    live_id_tables = [
+        table
+        for table in ("working_memory", "memories", "episodic_memory")
+        if table in tables
+    ]
+    live_ids = set()
+    for table in live_id_tables:
+        live_ids.update(
+            row[0]
+            for row in conn.execute(f"SELECT id FROM {table} WHERE id IS NOT NULL")
+        )
+
+    diagnostics = {
+        "gists_total": 0,
+        "gists_with_memory_id": 0,
+        "gists_orphan_memory_id": 0,
+        "memory_embeddings_total": 0,
+        "memory_embeddings_orphan_memory_id": 0,
+        "orphan_memory_id_overlap": 0,
+    }
+
+    orphan_gist_ids = set()
+    if "gists" in tables:
+        diagnostics["gists_total"] = int(
+            conn.execute("SELECT COUNT(*) FROM gists").fetchone()[0]
+        )
+        gist_memory_ids = [
+            row[0]
+            for row in conn.execute(
+                "SELECT memory_id FROM gists WHERE memory_id IS NOT NULL"
+            )
+        ]
+        diagnostics["gists_with_memory_id"] = len(gist_memory_ids)
+        orphan_gist_ids = {mid for mid in gist_memory_ids if mid not in live_ids}
+        diagnostics["gists_orphan_memory_id"] = sum(
+            1 for mid in gist_memory_ids if mid in orphan_gist_ids
+        )
+
+    orphan_embedding_ids = set()
+    if "memory_embeddings" in tables:
+        diagnostics["memory_embeddings_total"] = int(
+            conn.execute("SELECT COUNT(*) FROM memory_embeddings").fetchone()[0]
+        )
+        embedding_memory_ids = [
+            row[0]
+            for row in conn.execute(
+                "SELECT memory_id FROM memory_embeddings WHERE memory_id IS NOT NULL"
+            )
+        ]
+        orphan_embedding_ids = {mid for mid in embedding_memory_ids if mid not in live_ids}
+        diagnostics["memory_embeddings_orphan_memory_id"] = sum(
+            1 for mid in embedding_memory_ids if mid in orphan_embedding_ids
+        )
+
+    diagnostics["orphan_memory_id_overlap"] = len(
+        orphan_gist_ids.intersection(orphan_embedding_ids)
+    )
+    diagnostics["foreign_keys_enabled"] = int(foreign_keys_enabled)
+    return diagnostics
+
+
 def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False) -> Dict:
     """
     Run full diagnostic scan and write PII-safe log.
@@ -183,6 +253,18 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False) 
         log("db", "episodic_vectors", str(ep.get("vectors", 0)))
         log("db", "episodic_vec_type", ep.get("vec_type", "none"))
         log("db", "db_path", stats.get("database", "unknown"))
+
+        try:
+            orphan_diag = _memory_orphan_diagnostics(mem.beam.conn)
+            log("db", "foreign_keys_enabled", "YES" if orphan_diag["foreign_keys_enabled"] else "NO")
+            log("db", "gists_total", str(orphan_diag["gists_total"]))
+            log("db", "gists_with_memory_id", str(orphan_diag["gists_with_memory_id"]))
+            log("db", "gists_orphan_memory_id", str(orphan_diag["gists_orphan_memory_id"]))
+            log("db", "memory_embeddings_total", str(orphan_diag["memory_embeddings_total"]))
+            log("db", "memory_embeddings_orphan_memory_id", str(orphan_diag["memory_embeddings_orphan_memory_id"]))
+            log("db", "orphan_memory_id_overlap", str(orphan_diag["orphan_memory_id_overlap"]))
+        except Exception as exc:
+            log("db", "memory_orphan_diagnostics", "ERROR", str(exc))
 
         try:
             from mnemosyne.core.beam import repair_vec_working as _repair_vec_working, vec_working_coverage

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -1,6 +1,10 @@
+import sqlite3
+
 import mnemosyne
 
 from mnemosyne import diagnose
+from mnemosyne.core.beam import BeamMemory
+from mnemosyne.core.memory import init_db
 
 
 def _entry(summary, check):
@@ -29,3 +33,84 @@ def test_diagnose_treats_ctransformers_as_optional(tmp_path, monkeypatch):
     if ctransformers["status"] == "OPTIONAL":
         assert "local-GGUF fallback" in ctransformers["detail"]
     assert ctransformers["status"] not in {"MISSING", "ERROR"}
+
+
+def test_memory_orphan_diagnostics_tolerates_missing_optional_tables(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE memories (id TEXT PRIMARY KEY, content TEXT)")
+    conn.execute("INSERT INTO memories (id, content) VALUES (?, ?)", ("legacy-live", "legacy row"))
+    conn.commit()
+
+    result = diagnose._memory_orphan_diagnostics(conn)
+
+    assert result["foreign_keys_enabled"] == 0
+    assert result["gists_total"] == 0
+    assert result["gists_with_memory_id"] == 0
+    assert result["gists_orphan_memory_id"] == 0
+    assert result["memory_embeddings_total"] == 0
+    assert result["memory_embeddings_orphan_memory_id"] == 0
+    assert result["orphan_memory_id_overlap"] == 0
+
+
+def test_diagnose_reports_memory_orphans_without_mutating_rows(tmp_path, monkeypatch):
+    monkeypatch.setattr(diagnose, "LOG_DIR", tmp_path / "logs")
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+    db_path = data_dir / "mnemosyne.db"
+    init_db(db_path)
+    beam = BeamMemory(session_id="diagnose-orphans", db_path=db_path)
+    conn = beam.conn
+
+    conn.execute(
+        "INSERT INTO working_memory (id, content, source) VALUES (?, ?, ?)",
+        ("wm-live", "working row", "test"),
+    )
+    conn.execute(
+        "INSERT INTO memories (id, content, source) VALUES (?, ?, ?)",
+        ("legacy-live", "legacy row", "test"),
+    )
+    conn.execute(
+        "INSERT INTO episodic_memory (id, content, source) VALUES (?, ?, ?)",
+        ("em-live", "episodic row", "test"),
+    )
+    conn.execute(
+        "INSERT INTO gists (id, text, memory_id) VALUES (?, ?, ?)",
+        ("gist-live", "valid gist", "wm-live"),
+    )
+    conn.execute(
+        "INSERT INTO gists (id, text, memory_id) VALUES (?, ?, ?)",
+        ("gist-null", "gist with no source", None),
+    )
+    conn.execute(
+        "INSERT INTO gists (id, text, memory_id) VALUES (?, ?, ?)",
+        ("gist-orphan", "orphan gist", "missing-memory"),
+    )
+    conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        ("legacy-live", "[1.0]", "test"),
+    )
+    conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        ("missing-memory", "[0.0]", "test"),
+    )
+    conn.commit()
+
+    before_counts = {
+        table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        for table in ("working_memory", "memories", "episodic_memory", "gists", "memory_embeddings")
+    }
+
+    summary = diagnose.run_diagnostics()
+
+    after_counts = {
+        table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        for table in ("working_memory", "memories", "episodic_memory", "gists", "memory_embeddings")
+    }
+    assert after_counts == before_counts
+    assert _entry(summary, "foreign_keys_enabled")["status"] == "NO"
+    assert _entry(summary, "gists_total")["status"] == "3"
+    assert _entry(summary, "gists_orphan_memory_id")["status"] == "1"
+    assert _entry(summary, "memory_embeddings_total")["status"] == "2"
+    assert _entry(summary, "memory_embeddings_orphan_memory_id")["status"] == "1"
+    assert _entry(summary, "orphan_memory_id_overlap")["status"] == "1"

--- a/tests/test_hermes_memory_provider_diagnose_active_db.py
+++ b/tests/test_hermes_memory_provider_diagnose_active_db.py
@@ -86,6 +86,45 @@ def test_diagnose_reports_count_error_without_failing(tmp_path, monkeypatch):
 
 
 
+def test_diagnose_reports_active_provider_orphans_without_mutating_rows(tmp_path, monkeypatch):
+    provider, _db_path = _provider_with_beam(tmp_path)
+    assert provider._beam is not None
+    conn = provider._beam.conn
+    conn.execute(
+        "INSERT INTO working_memory (id, content, source) VALUES (?, ?, ?)",
+        ("wm-live", "working row", "test"),
+    )
+    conn.execute(
+        "INSERT INTO gists (id, text, memory_id) VALUES (?, ?, ?)",
+        ("gist-orphan", "orphan gist", "missing-memory"),
+    )
+    conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        ("missing-memory", "[0.0]", "test"),
+    )
+    conn.commit()
+    monkeypatch.setattr(
+        "mnemosyne.diagnose.run_diagnostics",
+        lambda **_kwargs: {"checks_total": 1, "key_findings": [], "entries": []},
+    )
+    before_counts = {
+        table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        for table in ("working_memory", "gists", "memory_embeddings")
+    }
+
+    result = json.loads(provider._handle_diagnose({}))
+
+    after_counts = {
+        table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        for table in ("working_memory", "gists", "memory_embeddings")
+    }
+    assert after_counts == before_counts
+    assert result["active_provider_orphan_diagnostics"]["foreign_keys_enabled"] == 0
+    assert result["active_provider_orphan_diagnostics"]["gists_orphan_memory_id"] == 1
+    assert result["active_provider_orphan_diagnostics"]["memory_embeddings_orphan_memory_id"] == 1
+    assert result["active_provider_orphan_diagnostics"]["orphan_memory_id_overlap"] == 1
+
+
 def test_diagnose_can_repair_active_provider_vec_working_gap(tmp_path, monkeypatch):
     provider, _db_path = _provider_with_beam(tmp_path)
     np = pytest.importorskip("numpy")


### PR DESCRIPTION
## Summary

- add read-only diagnose checks for memory reference integrity
- report `PRAGMA foreign_keys`, gist orphan counts, memory embedding orphan counts, and overlap
- include the same orphan diagnostics in the active Hermes provider DB diagnose payload

## Context

Follow-up for #408. This intentionally does **not** perform cleanup, schema migration, or FK enforcement. It only makes the current state visible so existing installs can assess whether they have orphaned `gists` / `memory_embeddings` rows before a separate repair or migration change.

## Tests

- `uv run --extra test python -m pytest tests/test_diagnose_optional_deps.py tests/test_hermes_memory_provider_diagnose_active_db.py tests/test_sync_turn_diagnostics.py tests/test_provider_all_15_tools.py::TestDiagnose -q` → 14 passed, 1 skipped
- `uv run --extra test python -m compileall -q mnemosyne/diagnose.py hermes_memory_provider/__init__.py integrations/hermes/src/mnemosyne_hermes/__init__.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deeper memory-database diagnostics, including counts of orphaned references and overlap across memory sides.
  * Active-provider diagnostics now include orphan diagnostics in addition to existing totals.

* **Bug Fixes**
  * Improved diagnostics reliability by ensuring the diagnostics SQLite connection is always closed after evaluation.
  * Diagnostics now gracefully handle databases missing optional tables.

* **Tests**
  * Added tests for orphan diagnostics on both legacy and fully populated databases, including foreign-key state handling and “no row mutation” guarantees.
  * Added tests verifying active-provider orphan diagnostics report expected metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->