### PR TITLE
feat: add Zero agent integration

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -11,6 +11,7 @@ Mnemosyne runs everywhere. Pick your platform:
 | [OpenWebUI](openwebui-tool.md) | Native @tool | Workspace tool config |
 | [Pi](pi.md) | Pi extension + skill | `pi install npm:@mnemosyne-oss/pi-mnemosyne` |
 | [Hermes Agent](hermes-mcp.md) | MCP + Plugin | `~/.hermes/config.yaml` |
+| [Zero](zero.md) | Plugin (tools + hooks) | `.zero/plugins/mnemosyne/` |
 
 ## Quick Start (any MCP client)
 

--- a/docs/integrations/integration-template.md
+++ b/docs/integrations/integration-template.md
@@ -125,6 +125,7 @@ Every platform has its own way of exposing tools. Here's how to find it:
 | Claude Code | MCP config (`claude.json`) | [claude-code-mcp.md](claude-code-mcp.md) |
 | Cursor | MCP config (`.cursor/mcp.json`) | [cursor-mcp.md](cursor-mcp.md) |
 | Hermes | MCP config or plugin | [hermes-mcp.md](hermes-mcp.md) |
+| Zero | Plugin manifest (tools + hooks) | [zero.md](zero.md) |
 | Custom SDK | Direct Python import | Just call `adapter.remember()` |
 
 ## MCP Shortcut

--- a/docs/integrations/zero.md
+++ b/docs/integrations/zero.md
@@ -1,0 +1,89 @@
+# Mnemosyne + Zero
+
+Connect Mnemosyne to [Zero](https://github.com/Gitlawb/zero) for persistent
+cross-session memory. Zero is an open-source terminal coding agent with a
+plugin system, hooks, MCP client, and skills.
+
+## Setup
+
+1. Install Mnemosyne:
+
+```bash
+pip install mnemosyne-memory
+```
+
+2. Copy the plugin into Zero's plugin directory:
+
+**Project-scoped** (recommended):
+
+```bash
+cp -r integrations/zero /path/to/your-project/.zero/plugins/mnemosyne
+```
+
+**User-scoped**:
+
+```bash
+mkdir -p ~/.config/zero/plugins
+cp -r integrations/zero ~/.config/zero/plugins/mnemosyne
+```
+
+3. Launch Zero from the project root. The memory tools appear automatically.
+
+## What You Get
+
+Five tools registered in Zero's tool palette:
+
+| Tool | Purpose |
+|------|---------|
+| `memory_remember` | Store a durable fact or preference |
+| `memory_recall` | Semantic search of past memories |
+| `memory_stats` | Show memory statistics |
+| `memory_sleep` | Consolidate old memories into summaries |
+| `memory_forget` | Delete a stale memory by ID |
+
+Plus an `afterTool` hook that auto-captures file edits to memory.
+
+## Usage
+
+Ask Zero:
+
+- "Remember that I prefer tab-width 4 for Go files"
+- "What do you know about my development preferences?"
+- "Recall any notes about the deployment pipeline"
+
+## How It Works
+
+The plugin uses Zero's plugin tool system: each tool is a shell script that
+receives JSON arguments on stdin and writes results to stdout. The
+`${AGENT_PLUGIN_ROOT}` placeholder in the manifest expands to the plugin's
+install directory at activation time. Scripts call the `mnemosyne` CLI, which
+stores everything in a local SQLite database with vector + FTS5 hybrid search.
+
+The `afterTool` hook fires after every tool call, receives the tool name,
+status, and changed files as JSON on stdin, and stores a compact memory of
+file-editing actions. It skips read-only tools and failed operations.
+
+## Optional: Full MCP Server
+
+For the complete 35-tool surface (triples, graph traversal, scratchpad, sync),
+add the Mnemosyne MCP server to your Zero config:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "mnemosyne": {
+        "type": "stdio",
+        "command": "mnemosyne",
+        "args": ["mcp"]
+      }
+    }
+  }
+}
+```
+
+This is additive — MCP tools coexist with the plugin's 5 shell tools.
+
+## Source Code
+
+<https://github.com/mnemosyne-oss/mnemosyne/tree/main/integrations/zero>

--- a/integrations/zero/README.md
+++ b/integrations/zero/README.md
@@ -1,0 +1,183 @@
+<div align="center">
+
+# Mnemosyne for Zero
+
+*Persistent cross-session memory for [Zero](https://github.com/Gitlawb/zero). 5 tools. 1 hook. Zero cloud.*
+
+[![Zero](https://img.shields.io/badge/Zero-0.2+-blue.svg)](https://github.com/Gitlawb/zero)
+[![Python](https://img.shields.io/badge/Python-3.10+-blue.svg)](https://python.org)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/mnemosyne-oss/mnemosyne/blob/main/LICENSE)
+
+</div>
+
+**Mnemosyne** gives Zero a local-first memory layer that stores facts,
+preferences, and project context across sessions — then surfaces them with
+hybrid vector + FTS5 search. SQLite on your machine. No cloud. No API keys.
+
+---
+
+## The Problem
+
+Zero is a terminal coding agent. Like all agents, it loses context between
+sessions: preferences vanish, decisions are forgotten, the same bugs get
+re-investigated. Zero has no built-in cross-session memory — every `zero`
+launch starts tabula rasa.
+
+## What Mnemosyne Changes
+
+This plugin adds five memory tools and an auto-capture hook to Zero:
+
+- **memory_remember** — store a durable fact or preference
+- **memory_recall** — semantic search of past memories
+- **memory_stats** — show memory statistics
+- **memory_sleep** — consolidate old memories into episodic summaries
+- **memory_forget** — delete a stale memory by ID
+- **afterTool hook** — auto-captures file edits so the agent recalls what it
+  changed in future sessions
+
+The agent calls `memory_recall` before asking the user to repeat themselves,
+and `memory_remember` when it learns a stable fact. The hook silently records
+file-edit activity in the background.
+
+## How It Works
+
+### Plugin Tool Contract
+
+Zero's plugin system (`internal/plugins/activate.go`) executes each tool's
+`command` as a subprocess: JSON-encoded arguments on stdin, stdout/stderr
+captured as the tool result. The `${AGENT_PLUGIN_ROOT}` placeholder in the
+manifest expands to the plugin's install directory at activation time, so
+scripts resolve correctly regardless of the agent's workspace cwd.
+
+Each tool script reads JSON from stdin (via `jq`), calls the `mnemosyne` CLI,
+and writes the result to stdout. Exit code 0 = success; non-zero = error.
+
+### Hook Contract
+
+Zero's hooks system (`internal/hooks/dispatch.go`) fires shell commands on
+lifecycle events. The `afterTool` hook receives a JSON payload on stdin
+(tool name, status, changed files, session ID). The hook stores a compact
+memory of file-editing actions and exits 0 — afterTool hooks are advisory
+and never block.
+
+## Quickstart
+
+**Prerequisites:** Zero 0.2+, Mnemosyne CLI, `jq`.
+
+### 1. Install Mnemosyne CLI
+
+```bash
+pip install mnemosyne-memory
+```
+
+Verify:
+
+```bash
+mnemosyne stats
+```
+
+### 2. Install the plugin
+
+**Project-scoped** (recommended — committed to the repo, shared with the team):
+
+```bash
+cp -r integrations/zero /path/to/your-project/.zero/plugins/mnemosyne
+```
+
+**User-scoped** (follows you across projects):
+
+```bash
+mkdir -p ~/.config/zero/plugins
+cp -r integrations/zero ~/.config/zero/plugins/mnemosyne
+```
+
+### 3. Verify
+
+Launch Zero from the project root. The five `memory_*` tools appear in the
+agent's tool palette automatically. Ask:
+
+> "What do you remember about my preferences?"
+
+The agent calls `memory_recall`, finds any stored memories, and answers
+without you having to repeat yourself.
+
+## Configuration
+
+No required config. Memories default to `~/.hermes/mnemosyne/data/`. Override
+with the `MNEMOSYNE_DATA_DIR` environment variable.
+
+### Optional: Full MCP Server
+
+For the complete 35-tool Mnemosyne surface (triples, graph traversal,
+scratchpad, sync, canonical facts, persona management), add the MCP server to
+your Zero config (`~/.config/zero/config.json` or `.zero/config.json`):
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "mnemosyne": {
+        "type": "stdio",
+        "command": "mnemosyne",
+        "args": ["mcp"]
+      }
+    }
+  }
+}
+```
+
+This is additive — MCP tools coexist with the plugin's 5 shell tools.
+
+## Tools
+
+| Tool | Purpose | Permission |
+|------|---------|------------|
+| `memory_remember` | Store a durable memory | allow |
+| `memory_recall` | Semantic search of memories | allow |
+| `memory_stats` | Show memory statistics | allow |
+| `memory_sleep` | Run consolidation | allow |
+| `memory_forget` | Delete a memory by ID | allow |
+
+## File Structure
+
+```
+integrations/zero/
+├── plugin.json                      # Manifest: 5 tools, 1 hook, 1 skill
+├── tools/
+│   ├── remember.sh                  # memory_remember
+│   ├── recall.sh                    # memory_recall
+│   ├── stats.sh                     # memory_stats
+│   ├── sleep.sh                     # memory_sleep
+│   └── forget.sh                    # memory_forget
+├── hooks/
+│   └── after-tool.sh                # afterTool: auto-capture file edits
+└── skills/
+    └── mnemosyne/
+        └── SKILL.md                 # Model guidance for memory usage
+```
+
+## Known Limitations
+
+1. **Plugin skills are not yet discoverable by Zero's `skill` tool.** Zero's
+   plugin loader activates tools and hooks from plugin manifests, but the skill
+   loader does not yet merge plugin-declared skill paths into its discovery
+   root. Copy `skills/mnemosyne/SKILL.md` to
+   `~/.local/share/zero/skills/mnemosyne/SKILL.md` as a workaround.
+
+2. **sessionStart/sessionEnd hooks are defined but not dispatched.** Zero's
+   hook enum includes these events and the dispatcher supports them, but the
+   agent loop only currently fires `beforeTool`/`afterTool`. Auto-injection of
+   recalled memories at session start is therefore not yet possible via hooks
+   — the model calls `memory_recall` explicitly. When Zero adds session hook
+   dispatch, the manifest is ready: just add a `sessionStart` hook entry.
+
+3. **The `mnemosyne` binary must be on PATH.** If installed in a venv, symlink
+   it to `~/.local/bin/` or update the scripts to use the full path.
+
+## Contributing
+
+See the [Contributing Guidelines](https://github.com/mnemosyne-oss/mnemosyne/blob/main/CONTRIBUTING.md).
+
+## License
+
+MIT

--- a/integrations/zero/hooks/after-tool.sh
+++ b/integrations/zero/hooks/after-tool.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# after-tool hook — auto-captures file changes to Mnemosyne memory.
+#
+# Zero sends JSON on stdin with: event, tool, toolCallId, sessionId, cwd,
+# status, changedFiles. This hook stores a compact memory of file-editing
+# actions so the agent recalls what it changed in future sessions.
+#
+# Only captures tools that modify files (write, edit, patch, bash with changed
+# files). Read-only tools are skipped to avoid noise.
+set -euo pipefail
+
+input="$(cat)"
+
+tool="$(echo "$input" | jq -r '.tool // empty')"
+status="$(echo "$input" | jq -r '.status // empty')"
+changed_files="$(echo "$input" | jq -r '.changedFiles // [] | if length > 0 then .[] else empty end' 2>/dev/null)"
+session_id="$(echo "$input" | jq -r '.sessionId // "unknown"')"
+cwd="$(echo "$input" | jq -r '.cwd // empty')"
+
+# Skip if the tool didn't succeed — no point remembering failures.
+if [ "$status" != "ok" ] && [ "$status" != "success" ]; then
+  exit 0
+fi
+
+# Skip read-only tools. Only capture tools that change files.
+# Zero's write tools are named: write_file, edit_file, patch, bash.
+case "$tool" in
+  write_file|edit_file|patch|*write*|*edit*|*patch*)
+    ;;
+  *)
+    # For bash, check if changedFiles is non-empty.
+    if [ -z "$changed_files" ]; then
+      exit 0
+    fi
+    ;;
+esac
+
+# Build a compact memory content string.
+content="Zero session $session_id: tool '$tool' "
+if [ -n "$changed_files" ]; then
+  file_list="$(echo "$changed_files" | tr '\n' ',' | sed 's/,$//')"
+  content+="modified files: $file_list"
+else
+  content+="executed (no file changes tracked)"
+fi
+
+# Add the working directory for context.
+if [ -n "$cwd" ]; then
+  content+=" in $cwd"
+fi
+
+# Store silently — importance 0.3 (low) since this is auto-captured context.
+# Source tag "task" marks it as session activity.
+mnemosyne store "$content" "task" "0.3" >/dev/null 2>&1 || true
+
+# Exit 0 — afterTool hooks are advisory and must never block.
+exit 0

--- a/integrations/zero/hooks/after-tool.sh
+++ b/integrations/zero/hooks/after-tool.sh
@@ -3,19 +3,23 @@
 #
 # Zero sends JSON on stdin with: event, tool, toolCallId, sessionId, cwd,
 # status, changedFiles. This hook stores a compact memory of file-editing
-# actions so the agent recalls what it changed in future sessions.
+# actions so the agent recalls it changed in future sessions.
 #
 # Only captures tools that modify files (write, edit, patch, bash with changed
 # files). Read-only tools are skipped to avoid noise.
+#
+# All jq parsing is non-fatal: a malformed payload must never abort the hook
+# before it reaches `exit 0`, because afterTool hooks are advisory and must
+# never block tool execution.
 set -euo pipefail
 
 input="$(cat)"
 
-tool="$(echo "$input" | jq -r '.tool // empty')"
-status="$(echo "$input" | jq -r '.status // empty')"
-changed_files="$(echo "$input" | jq -r '.changedFiles // [] | if length > 0 then .[] else empty end' 2>/dev/null)"
-session_id="$(echo "$input" | jq -r '.sessionId // "unknown"')"
-cwd="$(echo "$input" | jq -r '.cwd // empty')"
+tool="$(echo "$input" | jq -r '.tool // empty' 2>/dev/null || echo '')"
+status="$(echo "$input" | jq -r '.status // empty' 2>/dev/null || echo '')"
+changed_files="$(echo "$input" | jq -r '.changedFiles // [] | if length > 0 then .[] else empty end' 2>/dev/null || echo '')"
+session_id="$(echo "$input" | jq -r '.sessionId // "unknown"' 2>/dev/null || echo 'unknown')"
+cwd="$(echo "$input" | jq -r '.cwd // empty' 2>/dev/null || echo '')"
 
 # Skip if the tool didn't succeed — no point remembering failures.
 if [ "$status" != "ok" ] && [ "$status" != "success" ]; then

--- a/integrations/zero/plugin.json
+++ b/integrations/zero/plugin.json
@@ -1,0 +1,125 @@
+{
+  "schemaVersion": 1,
+  "id": "mnemosyne",
+  "name": "Mnemosyne Memory",
+  "version": "1.0.0",
+  "description": "Local-first AI memory layer. Gives the agent persistent cross-session memory via the mnemosyne CLI — store, recall, consolidate, and auto-capture file edits.",
+  "enabled": true,
+  "tools": [
+    {
+      "name": "memory_remember",
+      "description": "Store a durable memory that persists across sessions. Use for: user preferences, project facts, environment details, tool quirks, stable conventions. Write declarative facts, not instructions. Returns the memory ID.",
+      "command": "${AGENT_PLUGIN_ROOT}/tools/remember.sh",
+      "args": [],
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "The memory content to store. Write as a declarative fact ('User prefers concise responses'), not an instruction ('Always respond concisely')."
+          },
+          "source": {
+            "type": "string",
+            "description": "Source tag: preference, fact, insight, identity, task, etc.",
+            "default": "fact"
+          },
+          "importance": {
+            "type": "number",
+            "description": "Importance 0.0-1.0. Higher surfaces more often. Default 0.5.",
+            "default": 0.5
+          }
+        },
+        "required": ["content"]
+      },
+      "permission": "allow"
+    },
+    {
+      "name": "memory_recall",
+      "description": "Search persistent memories by semantic similarity. Use before asking the user to repeat context — checks if a preference, fact, or past decision is already stored. Returns ranked matches.",
+      "command": "${AGENT_PLUGIN_ROOT}/tools/recall.sh",
+      "args": [],
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Natural language query to search for."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Max results to return. Default 5.",
+            "default": 5
+          }
+        },
+        "required": ["query"]
+      },
+      "permission": "allow"
+    },
+    {
+      "name": "memory_stats",
+      "description": "Show Mnemosyne memory statistics: working count, episodic count, knowledge triples, and bank info.",
+      "command": "${AGENT_PLUGIN_ROOT}/tools/stats.sh",
+      "args": [],
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      },
+      "permission": "allow"
+    },
+    {
+      "name": "memory_sleep",
+      "description": "Run memory consolidation: compresses old working memories into episodic summaries. Call after long sessions or when memory feels stale.",
+      "command": "${AGENT_PLUGIN_ROOT}/tools/sleep.sh",
+      "args": [],
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      },
+      "permission": "allow"
+    },
+    {
+      "name": "memory_forget",
+      "description": "Permanently delete a memory by ID. Use when a fact is stale, wrong, or no longer applies.",
+      "command": "${AGENT_PLUGIN_ROOT}/tools/forget.sh",
+      "args": [],
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The memory ID to delete."
+          }
+        },
+        "required": ["id"]
+      },
+      "permission": "allow"
+    }
+  ],
+  "hooks": [
+    {
+      "name": "auto-capture-edits",
+      "description": "After a file-editing tool runs, stores a memory of what changed so the agent recalls it in future sessions.",
+      "event": "afterTool",
+      "command": "${AGENT_PLUGIN_ROOT}/hooks/after-tool.sh",
+      "args": []
+    }
+  ],
+  "skills": [
+    {
+      "path": "${AGENT_PLUGIN_ROOT}/skills/mnemosyne/SKILL.md"
+    }
+  ],
+  "author": {
+    "name": "Mnemosyne",
+    "url": "https://github.com/mnemosyne-oss/mnemosyne"
+  },
+  "interface": {
+    "displayName": "Mnemosyne Memory",
+    "category": "memory",
+    "brandColor": "#7C3AED",
+    "defaultPrompts": [
+      "What do you remember about my preferences?",
+      "Store this for later: "
+    ]
+  }
+}

--- a/integrations/zero/plugin.json
+++ b/integrations/zero/plugin.json
@@ -26,7 +26,9 @@
           "importance": {
             "type": "number",
             "description": "Importance 0.0-1.0. Higher surfaces more often. Default 0.5.",
-            "default": 0.5
+            "default": 0.5,
+            "minimum": 0,
+            "maximum": 1
           }
         },
         "required": ["content"]
@@ -48,7 +50,8 @@
           "limit": {
             "type": "integer",
             "description": "Max results to return. Default 5.",
-            "default": 5
+            "default": 5,
+            "minimum": 1
           }
         },
         "required": ["query"]

--- a/integrations/zero/skills/mnemosyne/SKILL.md
+++ b/integrations/zero/skills/mnemosyne/SKILL.md
@@ -1,0 +1,80 @@
+---
+description: "Persistent cross-session memory via Mnemosyne — store, recall, and consolidate facts, preferences, and context."
+---
+
+# Mnemosyne Memory
+
+You have persistent memory across sessions via Mnemosyne. Use it to avoid making
+the user repeat themselves and to recall past decisions, preferences, and
+project context.
+
+## When to Use
+
+**memory_recall** — Call this FIRST when:
+- The user references something from a past conversation ("remember when…", "like last time")
+- You need to check if a preference or fact is already stored before asking
+- Starting a new session in a project you've worked on before
+
+**memory_remember** — Call this when:
+- The user states a preference ("I prefer…", "always use…", "never do…")
+- You learn a stable fact about the project, environment, or workflow
+- A decision is made that should persist (architecture choice, convention adopted)
+- You discover a tool quirk or workaround worth keeping
+
+**memory_forget** — Call this when:
+- A stored fact is stale, wrong, or superseded
+- The user corrects something you previously stored
+
+**memory_sleep** — Call this when:
+- After a long session with many memories stored
+- Memory recall feels stale or results seem outdated
+
+**memory_stats** — Call this to check the state of the memory system.
+
+## Principles
+
+1. **Recall before asking.** If the user might have already told you something,
+   search memory first. Only ask if recall returns nothing relevant.
+
+2. **Store declarative facts, not instructions.**
+   - ✅ "User prefers concise responses"
+   - ✅ "Project uses pytest with xdist, 4 workers"
+   - ❌ "Always respond concisely"
+   - ❌ "Run tests with pytest -n 4"
+
+3. **Importance matters.** User preferences and corrections = 0.8+. Project
+   facts = 0.5. Auto-captured session activity = 0.3. Reserve 0.9+ for
+   identity-level facts (name, role, core workflow).
+
+4. **Don't store one-off task progress.** "Fixed bug X", "submitted PR Y",
+   "Phase N done" will be stale in a week. Use memory for things that still
+   matter later.
+
+5. **The afterTool hook auto-captures file edits.** You don't need to manually
+   store "I edited file X" — that happens automatically. Focus your manual
+   memory_remember calls on preferences, decisions, and facts.
+
+## MCP Server (Optional Advanced)
+
+For the full 35-tool Mnemosyne surface (triples, graph traversal, scratchpad,
+sync, canonical facts, persona management), add the Mnemosyne MCP server to
+your Zero config:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "mnemosyne": {
+        "type": "stdio",
+        "command": "mnemosyne",
+        "args": ["mcp"]
+      }
+    }
+  }
+}
+```
+
+This exposes `mnemosyne_remember`, `mnemosyne_recall`, `mnemosyne_sleep`,
+`mnemosyne_triple_add`, `mnemosyne_graph_query`, `mnemosyne_scratchpad_*`,
+and 30 more tools. The plugin's 5 shell-based tools cover the common case;
+the MCP server is for power users who want the full surface.

--- a/integrations/zero/skills/mnemosyne/SKILL.md
+++ b/integrations/zero/skills/mnemosyne/SKILL.md
@@ -56,7 +56,7 @@ project context.
 
 ## MCP Server (Optional Advanced)
 
-For the full 35-tool Mnemosyne surface (triples, graph traversal, scratchpad,
+For the full Mnemosyne MCP surface (triples, graph traversal, scratchpad,
 sync, canonical facts, persona management), add the Mnemosyne MCP server to
 your Zero config:
 
@@ -74,7 +74,8 @@ your Zero config:
 }
 ```
 
-This exposes `mnemosyne_remember`, `mnemosyne_recall`, `mnemosyne_sleep`,
-`mnemosyne_triple_add`, `mnemosyne_graph_query`, `mnemosyne_scratchpad_*`,
-and 30 more tools. The plugin's 5 shell-based tools cover the common case;
-the MCP server is for power users who want the full surface.
+This exposes the full Mnemosyne tool surface including `mnemosyne_remember`,
+`mnemosyne_recall`, `mnemosyne_sleep`, `mnemosyne_triple_add`,
+`mnemosyne_graph_query`, `mnemosyne_scratchpad_*`, and many more. The plugin's
+5 shell-based tools cover the common case; the MCP server is for power users
+who want the full surface.

--- a/integrations/zero/tools/forget.sh
+++ b/integrations/zero/tools/forget.sh
@@ -4,7 +4,8 @@
 set -euo pipefail
 
 input="$(cat)"
-id="$(echo "$input" | jq -r '.id // empty')"
+
+id="$(jq -r '.id // empty' <<< "$input")"
 
 if [ -z "$id" ]; then
   echo "Error: id is required"

--- a/integrations/zero/tools/forget.sh
+++ b/integrations/zero/tools/forget.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# memory_forget — permanently delete a memory by ID.
+# Reads JSON args on stdin: {"id": "..."}
+set -euo pipefail
+
+input="$(cat)"
+id="$(echo "$input" | jq -r '.id // empty')"
+
+if [ -z "$id" ]; then
+  echo "Error: id is required"
+  exit 1
+fi
+
+mnemosyne delete "$id" 2>&1

--- a/integrations/zero/tools/recall.sh
+++ b/integrations/zero/tools/recall.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# memory_recall — semantic search of persistent memories.
+# Reads JSON args on stdin: {"query": "...", "limit": 5}
+set -euo pipefail
+
+input="$(cat)"
+
+query="$(echo "$input" | jq -r '.query // empty')"
+limit="$(echo "$input" | jq -r '.limit // 5')"
+
+if [ -z "$query" ]; then
+  echo "Error: query is required"
+  exit 1
+fi
+
+mnemosyne recall "$query" "$limit" 2>&1

--- a/integrations/zero/tools/recall.sh
+++ b/integrations/zero/tools/recall.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 
 input="$(cat)"
 
-query="$(echo "$input" | jq -r '.query // empty')"
-limit="$(echo "$input" | jq -r '.limit // 5')"
+IFS=$'\t' read -r query limit < <(
+  jq -r '[.query // empty, .limit // 5] | @tsv' <<< "$input"
+)
 
 if [ -z "$query" ]; then
   echo "Error: query is required"

--- a/integrations/zero/tools/remember.sh
+++ b/integrations/zero/tools/remember.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# memory_remember — store a durable memory via the mnemosyne CLI.
+# Reads JSON args on stdin: {"content": "...", "source": "fact", "importance": 0.5}
+set -euo pipefail
+
+input="$(cat)"
+
+content="$(echo "$input" | jq -r '.content // empty')"
+source_tag="$(echo "$input" | jq -r '.source // "fact"')"
+importance="$(echo "$input" | jq -r '.importance // 0.5')"
+
+if [ -z "$content" ]; then
+  echo "Error: content is required"
+  exit 1
+fi
+
+# Store the memory — mnemosyne store prints the memory ID on success.
+mnemosyne store "$content" "$source_tag" "$importance" 2>&1

--- a/integrations/zero/tools/remember.sh
+++ b/integrations/zero/tools/remember.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 
 input="$(cat)"
 
-content="$(echo "$input" | jq -r '.content // empty')"
-source_tag="$(echo "$input" | jq -r '.source // "fact"')"
-importance="$(echo "$input" | jq -r '.importance // 0.5')"
+IFS=$'\t' read -r content source_tag importance < <(
+  jq -r '[.content // empty, .source // "fact", .importance // 0.5] | @tsv' <<< "$input"
+)
 
 if [ -z "$content" ]; then
   echo "Error: content is required"

--- a/integrations/zero/tools/sleep.sh
+++ b/integrations/zero/tools/sleep.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# memory_sleep — run memory consolidation (working → episodic).
+set -euo pipefail
+mnemosyne sleep 2>&1

--- a/integrations/zero/tools/stats.sh
+++ b/integrations/zero/tools/stats.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# memory_stats — show Mnemosyne memory statistics.
+set -euo pipefail
+mnemosyne stats 2>&1


### PR DESCRIPTION
## Summary

Adds a self-contained Zero plugin at `integrations/zero/` that gives the [Zero](https://github.com/Gitlawb/zero) terminal coding agent persistent cross-session memory via the mnemosyne CLI.

### Plugin contents

| Component | File | Purpose |
|-----------|------|---------|
| Manifest | `plugin.json` | 5 tools, 1 afterTool hook, 1 skill — schemaVersion 1 |
| Tool | `tools/remember.sh` | `memory_remember` — store durable facts/preferences |
| Tool | `tools/recall.sh` | `memory_recall` — semantic search of past memories |
| Tool | `tools/stats.sh` | `memory_stats` — show memory statistics |
| Tool | `tools/sleep.sh` | `memory_sleep` — consolidate old memories into summaries |
| Tool | `tools/forget.sh` | `memory_forget` — delete a stale memory by ID |
| Hook | `hooks/after-tool.sh` | `afterTool` — auto-captures file edits to memory |
| Skill | `skills/mnemosyne/SKILL.md` | Model guidance for memory tool usage |

### How it works

Zero's plugin system (`internal/plugins/activate.go`) executes each tool's `command` as a subprocess: JSON-encoded arguments on stdin, stdout/stderr captured as the tool result. The `${AGENT_PLUGIN_ROOT}` placeholder in the manifest expands to the plugin's install directory at activation time, so scripts resolve correctly regardless of the agent's workspace cwd (critical because `pluginTool` implements `optionsAwareTool`, which overrides the plugin dir as cwd).

Each tool script reads JSON from stdin (via `jq`), calls the `mnemosyne` CLI, and writes the result to stdout. Exit code 0 = success; non-zero = error.

The `afterTool` hook receives a JSON payload on stdin (tool name, status, changed files, session ID), stores a compact memory of file-editing actions, and exits 0 — afterTool hooks are advisory and never block.

### Docs

- `docs/integrations/zero.md` — setup and usage guide
- `docs/integrations/README.md` — add Zero to the platform table
- `docs/integrations/integration-template.md` — add Zero to the platform table

### Testing

All tools and hooks tested end-to-end:
- ✅ `memory_remember` stores and returns an ID
- ✅ `memory_recall` finds stored memories by semantic search
- ✅ `memory_stats` reports counts
- ✅ `memory_forget` deletes and confirms
- ✅ `afterTool` hook captures file edits, skips read-only tools, skips failed tools
- ✅ Plugin JSON validates against Zero's manifest parser (schemaVersion 1)
- ✅ All scripts are executable

### Outstanding findings (filed on Zero repo)

Two architectural gaps in Zero were discovered during this integration, both filed as enhancement issues:

- **Gitlawb/zero#566** — Plugin-declared skills are not discoverable by the `skill` tool (the skill loader does not merge plugin skill paths into its discovery root)
- **Gitlawb/zero#567** — `sessionStart`/`sessionEnd` hooks are defined in the enum and dispatcher but never dispatched by the agent loop (only `beforeTool` and `afterTool` are fired)

The plugin is designed to work around both limitations today and automatically benefit when they are fixed: the manifest already declares a skill and is ready for a `sessionStart` hook entry.

### Checklist

- [x] Install: `pip install mnemosyne-memory` works
- [x] Connect: Database created at the default path
- [x] Remember: Storing a memory returns an ID
- [x] Recall: Semantic search returns results
- [x] Forget: Memory is removed
- [x] Config: Uses default data dir, overridable via `MNEMOSYNE_DATA_DIR`
- [x] Error handling: Bad inputs return errors, not crashes
- [x] No external deps: Only needs `mnemosyne` CLI and `jq`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Zero integration for Mnemosyne with setup guidance, plugin configuration, and a new skill guide.
  * Introduced memory tools to remember, recall, forget, sleep, and view memory stats.
  * Added automatic capture of successful file edits into Mnemosyne memory after supported tool runs.

* **Documentation**
  * Expanded Zero integration docs, including plugin templates, tool behavior contracts, limitations, and optional MCP server setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->