### PR TITLE
fix(hermes): align pip sync adapter parity

### DIFF
--- a/hermes_memory_provider/sync_adapter.py
+++ b/hermes_memory_provider/sync_adapter.py
@@ -144,12 +144,13 @@ class SyncAdapter:
             return raw
 
         # 2. Key source routing
-        source = self._string("key_source", "env").lower()
+        raw_source = self._string("key_source", "env")
+        source = raw_source.lower()
 
         if source == "env":
             return os.environ.get("MNEMOSYNE_SYNC_KEY", "").strip()
         elif source.startswith("file:"):
-            path = source[5:]
+            path = raw_source[5:]
             try:
                 return Path(os.path.expanduser(path)).read_text().strip()
             except Exception as exc:
@@ -283,7 +284,7 @@ class SyncAdapter:
             return json.dumps(result)
 
         accepted = result.get("accepted", 0)
-        cursor = result.get("next_cursor") or changes.get("next_cursor", "")
+        cursor = result.get("next_cursor") or changes.get("next_cursor") or ""
 
         if cursor:
             self._engine._meta_set("last_sync_cursor", cursor)

--- a/hermes_memory_provider/sync_adapter.py
+++ b/hermes_memory_provider/sync_adapter.py
@@ -133,7 +133,7 @@ class SyncAdapter:
         host = os.environ.get("MNEMOSYNE_SYNC_HOST", "").strip()
         port = os.environ.get("MNEMOSYNE_SYNC_PORT", "").strip()
         if host and port:
-            return f"http://{host}:{port}"
+            return f"https://{host}:{port}"
         return ""
 
     def _resolve_key(self) -> str:
@@ -186,7 +186,7 @@ class SyncAdapter:
 
             encryption = None
             if self.encrypt_enabled and self.encryption_key:
-                encryption = SyncEncryption(key=self.encryption_key)
+                encryption = SyncEncryption.from_config(key_source=self.encryption_key)
                 logger.info("Sync encryption enabled (key length: %d)", len(self.encryption_key))
             elif self.encrypt_enabled and not self.encryption_key:
                 logger.warning(
@@ -322,7 +322,7 @@ class SyncAdapter:
         # Apply locally
         push_result = self._engine.push_changes(incoming)
         accepted = push_result.get("accepted", 0)
-        cursor = result.get("next_cursor", "")
+        cursor = result.get("next_cursor") or ""
 
         if cursor:
             self._engine._meta_set("last_sync_cursor", cursor)

--- a/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
@@ -144,12 +144,13 @@ class SyncAdapter:
             return raw
 
         # 2. Key source routing
-        source = self._string("key_source", "env").lower()
+        raw_source = self._string("key_source", "env")
+        source = raw_source.lower()
 
         if source == "env":
             return os.environ.get("MNEMOSYNE_SYNC_KEY", "").strip()
         elif source.startswith("file:"):
-            path = source[5:]
+            path = raw_source[5:]
             try:
                 return Path(os.path.expanduser(path)).read_text().strip()
             except Exception as exc:
@@ -283,7 +284,7 @@ class SyncAdapter:
             return json.dumps(result)
 
         accepted = result.get("accepted", 0)
-        cursor = result.get("next_cursor") or changes.get("next_cursor", "")
+        cursor = result.get("next_cursor") or changes.get("next_cursor") or ""
 
         if cursor:
             self._engine._meta_set("last_sync_cursor", cursor)

--- a/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
@@ -1,8 +1,27 @@
 """
-Sync adapter for the standalone mnemosyne-hermes plugin.
+Mnemosyne Sync Adapter for Hermes
+==================================
+Wraps Mnemosyne's SyncEngine with encryption, HTTP transport, and Hermes
+MemoryProvider lifecycle integration.
 
-Same API as hermes_memory_provider.sync_adapter.SyncAdapter but uses
-standard pip-installed imports (mnemosyne-memory core, not path-hacked).
+Exposes three tools to Hermes agents:
+- mnemosyne_sync_push   — push local changes to a remote
+- mnemosyne_sync_pull   — pull remote changes to local
+- mnemosyne_sync_status — show sync state (device, cursor, event count)
+
+Lifecycle:
+    from mnemosyne_hermes.sync_adapter import SyncAdapter
+    adapter = SyncAdapter(beam, config={...})
+    # ... adapter runs in background, tools auto-registered
+    adapter.shutdown()
+
+Config (env vars, then config.yaml, then defaults):
+    MNEMOSYNE_SYNC_REMOTE     — remote sync server URL (https://host:port)
+    MNEMOSYNE_SYNC_ENCRYPT    — '1'/'true' to enable client-side encryption
+    MNEMOSYNE_SYNC_KEY        — raw key string (Fernet-compatible, 32 bytes base64)
+    MNEMOSYNE_SYNC_KEY_SOURCE — 'env' | 'keyring' | 'prompt' | 'file:<path>'
+    MNEMOSYNE_SYNC_TOKEN      — auth token for the remote server
+    MNEMOSYNE_SYNC_MODE        — 'bidirectional' | 'pull' | 'push'
 """
 
 from __future__ import annotations
@@ -13,28 +32,139 @@ import os
 import threading
 import urllib.request
 import urllib.error
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
 
-class SyncAdapter:
-    """Standalone sync adapter wrapping Mnemosyne's SyncEngine."""
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
 
-    def __init__(self, beam_instance=None, config: Optional[Dict[str, Any]] = None):
+SYNC_PUSH_SCHEMA = {
+    "name": "mnemosyne_sync_push",
+    "description": (
+        "Push local memory changes to a remote Mnemosyne sync server. "
+        "Only events created since the last sync are sent. Requires a "
+        "configured remote sync server (configured via config.yaml or "
+        "MNEMOSYNE_SYNC_REMOTE env var)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+SYNC_PULL_SCHEMA = {
+    "name": "mnemosyne_sync_pull",
+    "description": (
+        "Pull remote memory changes from the configured Mnemosyne sync server. "
+        "Applies incoming events locally with timestamp + importance conflict "
+        "resolution."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+SYNC_STATUS_SCHEMA = {
+    "name": "mnemosyne_sync_status",
+    "description": (
+        "Show Mnemosyne sync status: device ID, last cursor, event count, "
+        "remote URL, and encryption state."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+ALL_SYNC_TOOL_SCHEMAS = [SYNC_PUSH_SCHEMA, SYNC_PULL_SCHEMA, SYNC_STATUS_SCHEMA]
+
+
+# ---------------------------------------------------------------------------
+# SyncAdapter
+# ---------------------------------------------------------------------------
+
+class SyncAdapter:
+    """Hermes-side adapter wrapping Mnemosyne's SyncEngine.
+
+    Call start() after construction. Call shutdown() on agent exit.
+    Failure to construct is non-fatal — tools are simply not registered.
+    """
+
+    def __init__(self, beam_instance, config: Optional[Dict[str, Any]] = None):
+        """Initialize the adapter.
+
+        Args:
+            beam_instance: A BeamMemory instance (already initialized).
+            config: Optional dict of overrides. Keys map to env vars:
+                remote, encrypt, key, key_source, token, mode.
+        """
         self._beam = beam_instance
         self._config = config or {}
         self._engine: Any = None
         self._error: Optional[str] = None
+        self._lock = threading.Lock()
 
-        self.remote = self._string("remote", "")
+        # Resolve configuration: explicit config > env vars > defaults
+        self.remote = self._resolve_remote()
         self.encrypt_enabled = self._resolve_bool("encrypt", False)
-        self.encryption_key = self._string("key", "")
+        self.encryption_key = self._resolve_key()
         self.auth_token = self._string("token", "")
         self.mode = self._string("mode", "bidirectional")
 
+        # Build the engine
         self._build_engine()
+
+    # --- Config resolution ------------------------------------------------
+
+    def _resolve_remote(self) -> str:
+        remote = self._string("remote", "")
+        if remote:
+            return remote
+        # Fallback: check MNEMOSYNE_SYNC_HOST + MNEMOSYNE_SYNC_PORT
+        host = os.environ.get("MNEMOSYNE_SYNC_HOST", "").strip()
+        port = os.environ.get("MNEMOSYNE_SYNC_PORT", "").strip()
+        if host and port:
+            return f"http://{host}:{port}"
+        return ""
+
+    def _resolve_key(self) -> str:
+        """Resolve encryption key from config > env > keyring > file."""
+        # 1. Explicit config
+        raw = self._string("key", "")
+        if raw:
+            return raw
+
+        # 2. Key source routing
+        source = self._string("key_source", "env").lower()
+
+        if source == "env":
+            return os.environ.get("MNEMOSYNE_SYNC_KEY", "").strip()
+        elif source.startswith("file:"):
+            path = source[5:]
+            try:
+                return Path(os.path.expanduser(path)).read_text().strip()
+            except Exception as exc:
+                logger.warning("Sync key file %s unreadable: %s", path, exc)
+                return ""
+        elif source == "keyring":
+            try:
+                import keyring
+                return keyring.get_password("mnemosyne-sync", "encryption-key") or ""
+            except Exception:
+                return ""
+        elif source == "prompt":
+            return ""  # Caller must supply via config at construction time
+
+        return ""
 
     def _string(self, key: str, default: str = "") -> str:
         env_key = f"MNEMOSYNE_SYNC_{key.upper()}"
@@ -47,101 +177,219 @@ class SyncAdapter:
         val = self._string(key, str(default)).lower()
         return val in ("1", "true", "yes", "on")
 
+    # --- Engine construction -----------------------------------------------
+
     def _build_engine(self) -> None:
+        """Construct the SyncEngine, encryption layer, and verify readiness."""
         try:
             from mnemosyne.core.sync import SyncEngine, SyncEncryption
+
             encryption = None
             if self.encrypt_enabled and self.encryption_key:
                 encryption = SyncEncryption(key=self.encryption_key)
+                logger.info("Sync encryption enabled (key length: %d)", len(self.encryption_key))
+            elif self.encrypt_enabled and not self.encryption_key:
+                logger.warning(
+                    "Sync encryption enabled but no key configured. "
+                    "Set MNEMOSYNE_SYNC_KEY or use key_source=keyring/file."
+                )
+                # Don't fail — engine still works plaintext
 
-            # Use a BeamMemory bound to the default DB
-            from mnemosyne.core.beam import BeamMemory
-            beam = BeamMemory(session_id="sync-adapter")
-            self._engine = SyncEngine(beam_instance=beam, encryption=encryption)
+            self._engine = SyncEngine(
+                beam_instance=self._beam,
+                encryption=encryption,
+            )
+            logger.info(
+                "SyncAdapter initialized: device=%s, remote=%s, encrypt=%s",
+                getattr(self._engine, "device_id", "?"),
+                self.remote or "(unconfigured)",
+                self.encrypt_enabled,
+            )
+
         except Exception as exc:
             self._error = str(exc)
+            logger.debug("SyncAdapter init failed: %s", exc)
+
+    # --- Lifecycle ---------------------------------------------------------
+
+    def start(self) -> bool:
+        """Called after construction. Returns True if ready."""
+        if self._engine is None:
+            logger.debug("SyncAdapter not started: %s", self._error or "no engine")
+            return False
+        return True
+
+    def shutdown(self) -> None:
+        """Called on agent exit. No-op for now (engine is connection-scoped)."""
+        self._engine = None
+        logger.debug("SyncAdapter shut down")
 
     @property
     def is_ready(self) -> bool:
         return self._engine is not None
 
+    @property
+    def tool_schemas(self) -> List[Dict[str, Any]]:
+        if self.is_ready:
+            return list(ALL_SYNC_TOOL_SCHEMAS)
+        return []
+
+    # --- Tool dispatch -----------------------------------------------------
+
     def handle_tool_call(self, tool_name: str, args: dict) -> str:
         if not self.is_ready:
             return json.dumps({
                 "status": "error",
-                "error": f"Sync unavailable: {self._error or 'not initialized'}",
+                "error": f"Sync adapter not available: {self._error or 'not initialized'}",
             })
 
         try:
             if tool_name == "mnemosyne_sync_push":
-                return self._push()
+                return self._handle_push()
             elif tool_name == "mnemosyne_sync_pull":
-                return self._pull()
+                return self._handle_pull()
             elif tool_name == "mnemosyne_sync_status":
-                return self._status()
+                return self._handle_status()
+            else:
+                return json.dumps({"status": "error", "error": f"Unknown tool: {tool_name}"})
         except Exception as exc:
+            logger.debug("Sync tool %s failed: %s", tool_name, exc)
             return json.dumps({"status": "error", "error": str(exc)})
-        return json.dumps({"status": "error", "error": f"Unknown: {tool_name}"})
 
-    def _push(self) -> str:
+    # --- Push --------------------------------------------------------------
+
+    def _handle_push(self) -> str:
         if not self.remote:
-            return json.dumps({"status": "error", "error": "No remote configured."})
+            return json.dumps({
+                "status": "error",
+                "error": "No remote configured. Set MNEMOSYNE_SYNC_REMOTE env var.",
+            })
+
+        # Last cursor from sync_meta
         cursor = self._engine._meta_get("last_sync_cursor") or ""
         changes = self._engine.pull_changes(since_cursor=cursor or None, limit=500)
+
         events = changes.get("events", [])
         if not events:
-            return json.dumps({"status": "ok", "pushed": 0})
-        result = self._post("/sync/push", {"events": events})
+            return json.dumps({
+                "status": "ok",
+                "pushed": 0,
+                "message": "No local changes to push.",
+            })
+
+        # Push to remote
+        result = self._http_post("/sync/push", {"events": events})
+        if result.get("status") != "ok":
+            return json.dumps(result)
+
         accepted = result.get("accepted", 0)
         cursor = result.get("next_cursor") or changes.get("next_cursor", "")
+
         if cursor:
             self._engine._meta_set("last_sync_cursor", cursor)
-        return json.dumps({"status": "ok", "pushed": accepted})
 
-    def _pull(self) -> str:
-        if not self.remote:
-            return json.dumps({"status": "error", "error": "No remote configured."})
-        cursor = self._engine._meta_get("last_sync_cursor") or ""
-        result = self._post("/sync/pull", {"since_token": cursor or None})
-        incoming = result.get("events", [])
-        if not incoming:
-            return json.dumps({"status": "ok", "pulled": 0})
-        push_result = self._engine.push_changes(incoming)
-        cursor = result.get("next_cursor", "")
-        if cursor:
-            self._engine._meta_set("last_sync_cursor", cursor)
-        return json.dumps({"status": "ok", "pulled": push_result.get("accepted", 0)})
-
-    def _status(self) -> str:
-        cursor = self._engine._meta_get("last_sync_cursor") or ""
-        device = getattr(self._engine, "device_id", "unknown")
-        try:
-            row = self._engine.conn.execute("SELECT COUNT(*) FROM memory_events").fetchone()
-            count = row[0] if row else 0
-        except Exception:
-            count = 0
         return json.dumps({
             "status": "ok",
-            "device_id": device,
+            "pushed": accepted,
+            "duplicates": result.get("duplicates", 0),
+            "conflicts": result.get("conflicts", 0),
+            "next_cursor": cursor[:30] + "..." if len(cursor) > 30 else cursor,
+        })
+
+    # --- Pull --------------------------------------------------------------
+
+    def _handle_pull(self) -> str:
+        if not self.remote:
+            return json.dumps({
+                "status": "error",
+                "error": "No remote configured. Set MNEMOSYNE_SYNC_REMOTE env var.",
+            })
+
+        cursor = self._engine._meta_get("last_sync_cursor") or ""
+        result = self._http_post("/sync/pull", {"since_token": cursor or None})
+
+        if result.get("status") != "ok":
+            return json.dumps(result)
+
+        incoming = result.get("events", [])
+        if not incoming:
+            return json.dumps({
+                "status": "ok",
+                "pulled": 0,
+                "message": "No remote changes to pull.",
+            })
+
+        # Apply locally
+        push_result = self._engine.push_changes(incoming)
+        accepted = push_result.get("accepted", 0)
+        cursor = result.get("next_cursor", "")
+
+        if cursor:
+            self._engine._meta_set("last_sync_cursor", cursor)
+
+        return json.dumps({
+            "status": "ok",
+            "pulled": accepted,
+            "duplicates": push_result.get("duplicates", 0),
+            "conflicts": push_result.get("conflicts", 0),
+            "next_cursor": cursor[:30] + "..." if len(cursor) > 30 else cursor,
+        })
+
+    # --- Status ------------------------------------------------------------
+
+    def _handle_status(self) -> str:
+        engine = self._engine
+        if not engine:
+            return json.dumps({"status": "error", "error": "No engine"})
+
+        cursor = engine._meta_get("last_sync_cursor") or ""
+        device_id = getattr(engine, "device_id", "unknown")
+
+        # Count local events
+        try:
+            row = engine.conn.execute(
+                "SELECT COUNT(*) FROM memory_events"
+            ).fetchone()
+            event_count = row[0] if row else 0
+        except Exception:
+            event_count = 0
+
+        return json.dumps({
+            "status": "ok",
+            "device_id": device_id,
             "remote": self.remote or "(unconfigured)",
             "encryption": "enabled" if self.encrypt_enabled else "disabled",
             "mode": self.mode,
-            "local_events": count,
+            "local_events": event_count,
             "last_cursor": cursor[:30] + "..." if len(cursor) > 30 else (cursor or "none"),
         })
 
-    def _post(self, path: str, payload: dict) -> dict:
+    # --- HTTP transport (stdlib-only, no external deps) --------------------
+
+    def _http_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """POST JSON to the remote sync server. Never raises."""
         url = self.remote.rstrip("/") + path
         data = json.dumps(payload).encode("utf-8")
+
         headers = {
             "Content-Type": "application/json",
-            "User-Agent": "mnemosyne-hermes-sync/0.2.0",
+            "User-Agent": f"mnemosyne-sync/{getattr(self._engine, 'device_id', 'hermes')}",
         }
         if self.auth_token:
             headers["Authorization"] = f"Bearer {self.auth_token}"
+
         req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+
         try:
             with urllib.request.urlopen(req, timeout=30) as resp:
                 return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            logger.debug("Sync HTTP %d from %s: %s", exc.code, url, exc.reason)
+            body = exc.read().decode("utf-8", errors="replace")
+            try:
+                return json.loads(body)
+            except json.JSONDecodeError:
+                return {"status": "error", "error": f"HTTP {exc.code}: {exc.reason}"}
         except Exception as exc:
+            logger.debug("Sync request failed: %s", exc)
             return {"status": "error", "error": str(exc)}

--- a/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/sync_adapter.py
@@ -133,7 +133,7 @@ class SyncAdapter:
         host = os.environ.get("MNEMOSYNE_SYNC_HOST", "").strip()
         port = os.environ.get("MNEMOSYNE_SYNC_PORT", "").strip()
         if host and port:
-            return f"http://{host}:{port}"
+            return f"https://{host}:{port}"
         return ""
 
     def _resolve_key(self) -> str:
@@ -186,7 +186,7 @@ class SyncAdapter:
 
             encryption = None
             if self.encrypt_enabled and self.encryption_key:
-                encryption = SyncEncryption(key=self.encryption_key)
+                encryption = SyncEncryption.from_config(key_source=self.encryption_key)
                 logger.info("Sync encryption enabled (key length: %d)", len(self.encryption_key))
             elif self.encrypt_enabled and not self.encryption_key:
                 logger.warning(
@@ -322,7 +322,7 @@ class SyncAdapter:
         # Apply locally
         push_result = self._engine.push_changes(incoming)
         accepted = push_result.get("accepted", 0)
-        cursor = result.get("next_cursor", "")
+        cursor = result.get("next_cursor") or ""
 
         if cursor:
             self._engine._meta_set("last_sync_cursor", cursor)

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -297,8 +297,12 @@ class _FakeSyncEngine:
 
 
 class _FakeSyncEncryption:
-    def __init__(self, key):
-        self.key = key
+    def __init__(self, key_source):
+        self.key_source = key_source
+
+    @classmethod
+    def from_config(cls, key_source=None, **_kwargs):
+        return cls(key_source)
 
 
 class _UnexpectedBeam:
@@ -307,7 +311,7 @@ class _UnexpectedBeam:
         self.kwargs = kwargs
 
 
-def test_sync_adapter_uses_provider_beam_for_both_surfaces(monkeypatch, sync_modules):
+def _install_fake_sync_modules(monkeypatch):
     import types
 
     fake_sync = types.ModuleType("mnemosyne.core.sync")
@@ -318,11 +322,36 @@ def test_sync_adapter_uses_provider_beam_for_both_surfaces(monkeypatch, sync_mod
     monkeypatch.setitem(sys.modules, "mnemosyne.core.sync", fake_sync)
     monkeypatch.setitem(sys.modules, "mnemosyne.core.beam", fake_beam)
 
+
+def test_sync_adapter_uses_provider_beam_for_both_surfaces(monkeypatch, sync_modules):
+    _install_fake_sync_modules(monkeypatch)
+
     provider_beam = object()
     for module in sync_modules.values():
         adapter = module.SyncAdapter(provider_beam, {})
         assert adapter.is_ready is True
         assert adapter._engine.beam_instance is provider_beam
+
+
+def test_sync_adapter_config_resolution_matches(monkeypatch, sync_modules):
+    _install_fake_sync_modules(monkeypatch)
+    monkeypatch.delenv("MNEMOSYNE_SYNC_REMOTE", raising=False)
+    monkeypatch.setenv("MNEMOSYNE_SYNC_HOST", "sync.example")
+    monkeypatch.setenv("MNEMOSYNE_SYNC_PORT", "443")
+
+    observed = {}
+    for name, module in sync_modules.items():
+        adapter = module.SyncAdapter(object(), {"encrypt": True, "key": "encoded-key"})
+        observed[name] = {
+            "remote": adapter.remote,
+            "encryption_key_source": adapter._engine.encryption.key_source,
+        }
+
+    assert observed["mnemosyne_hermes"] == observed["hermes_memory_provider"]
+    assert observed["hermes_memory_provider"] == {
+        "remote": "https://sync.example:443",
+        "encryption_key_source": "encoded-key",
+    }
 
 
 class _ToolEngine:
@@ -352,7 +381,7 @@ class _ToolEngine:
         return (3,)
 
 
-def _adapter_with_tool_engine(module):
+def _adapter_with_tool_engine(module, *, next_cursor: str | None = "remote-cursor"):
     adapter = module.SyncAdapter.__new__(module.SyncAdapter)
     adapter._engine = _ToolEngine()
     adapter._error = None
@@ -368,7 +397,7 @@ def _adapter_with_tool_engine(module):
             "duplicates": 1,
             "conflicts": 1,
             "events": [{"id": "remote-1"}, {"id": "remote-2"}],
-            "next_cursor": "remote-cursor",
+            "next_cursor": next_cursor,
         }
 
     adapter._http_post = fake_post
@@ -402,6 +431,23 @@ def test_sync_adapter_tool_results_match(sync_modules):
         "conflicts": 1,
         "next_cursor": "remote-cursor",
     }
+
+
+def test_sync_adapter_pull_tolerates_null_next_cursor(sync_modules):
+    observed = {}
+    for name, module in sync_modules.items():
+        adapter = _adapter_with_tool_engine(module, next_cursor=None)
+        observed[name] = json.loads(adapter.handle_tool_call("mnemosyne_sync_pull", {}))
+
+    assert observed["mnemosyne_hermes"] == observed["hermes_memory_provider"]
+    assert observed["hermes_memory_provider"] == {
+        "status": "ok",
+        "pulled": 2,
+        "duplicates": 1,
+        "conflicts": 1,
+        "next_cursor": "",
+    }
+
 
 
 def _save_mnemosyne_modules():

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -54,6 +54,14 @@ def provider_modules():
     }
 
 
+@pytest.fixture(scope="module")
+def sync_modules():
+    return {
+        "hermes_memory_provider": _import_module("hermes_memory_provider.sync_adapter", PROJECT_ROOT),
+        "mnemosyne_hermes": _import_module("mnemosyne_hermes.sync_adapter", INTEGRATION_SRC),
+    }
+
+
 def _tool_schemas(module):
     return {schema["name"]: schema for schema in module.ALL_TOOL_SCHEMAS}
 
@@ -264,6 +272,136 @@ def test_provider_sync_turn_zero_limit_means_untruncated(monkeypatch, provider_m
         "[USER] user-content",
         "[ASSISTANT] assistant-content",
     ]
+
+
+def test_sync_adapter_schema_and_lifecycle_surface_match(sync_modules):
+    root_sync = sync_modules["hermes_memory_provider"]
+    integration_sync = sync_modules["mnemosyne_hermes"]
+
+    assert _json_stable(integration_sync.ALL_SYNC_TOOL_SCHEMAS) == _json_stable(root_sync.ALL_SYNC_TOOL_SCHEMAS)
+
+    for module in sync_modules.values():
+        adapter = module.SyncAdapter.__new__(module.SyncAdapter)
+        adapter._engine = object()
+        assert adapter.start() is True
+        assert _json_stable(adapter.tool_schemas) == _json_stable(root_sync.ALL_SYNC_TOOL_SCHEMAS)
+        adapter.shutdown()
+        assert adapter.tool_schemas == []
+
+
+class _FakeSyncEngine:
+    def __init__(self, beam_instance, encryption=None):
+        self.beam_instance = beam_instance
+        self.encryption = encryption
+        self.device_id = "fake-device"
+
+
+class _FakeSyncEncryption:
+    def __init__(self, key):
+        self.key = key
+
+
+class _UnexpectedBeam:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+def test_sync_adapter_uses_provider_beam_for_both_surfaces(monkeypatch, sync_modules):
+    import types
+
+    fake_sync = types.ModuleType("mnemosyne.core.sync")
+    fake_sync.SyncEngine = _FakeSyncEngine
+    fake_sync.SyncEncryption = _FakeSyncEncryption
+    fake_beam = types.ModuleType("mnemosyne.core.beam")
+    fake_beam.BeamMemory = _UnexpectedBeam
+    monkeypatch.setitem(sys.modules, "mnemosyne.core.sync", fake_sync)
+    monkeypatch.setitem(sys.modules, "mnemosyne.core.beam", fake_beam)
+
+    provider_beam = object()
+    for module in sync_modules.values():
+        adapter = module.SyncAdapter(provider_beam, {})
+        assert adapter.is_ready is True
+        assert adapter._engine.beam_instance is provider_beam
+
+
+class _ToolEngine:
+    device_id = "device-1"
+
+    def __init__(self):
+        self.meta = {"last_sync_cursor": "cursor-previous"}
+        self.conn = self
+
+    def _meta_get(self, key):
+        return self.meta.get(key)
+
+    def _meta_set(self, key, value):
+        self.meta[key] = value
+
+    def pull_changes(self, since_cursor=None, limit=500):
+        return {"events": [{"id": "e1"}], "next_cursor": "local-cursor"}
+
+    def push_changes(self, events):
+        self.pushed_events = events
+        return {"accepted": 2, "duplicates": 1, "conflicts": 1}
+
+    def execute(self, _sql):
+        return self
+
+    def fetchone(self):
+        return (3,)
+
+
+def _adapter_with_tool_engine(module):
+    adapter = module.SyncAdapter.__new__(module.SyncAdapter)
+    adapter._engine = _ToolEngine()
+    adapter._error = None
+    adapter.remote = "https://sync.example"
+    adapter.encrypt_enabled = False
+    adapter.mode = "bidirectional"
+    adapter.auth_token = ""
+
+    def fake_post(_path, _payload):
+        return {
+            "status": "ok",
+            "accepted": 2,
+            "duplicates": 1,
+            "conflicts": 1,
+            "events": [{"id": "remote-1"}, {"id": "remote-2"}],
+            "next_cursor": "remote-cursor",
+        }
+
+    adapter._http_post = fake_post
+    adapter._post = fake_post
+    return adapter
+
+
+def test_sync_adapter_tool_results_match(sync_modules):
+    observed = {}
+    for name, module in sync_modules.items():
+        adapter = _adapter_with_tool_engine(module)
+        observed[name] = {
+            "push": json.loads(adapter.handle_tool_call("mnemosyne_sync_push", {})),
+            "pull": json.loads(adapter.handle_tool_call("mnemosyne_sync_pull", {})),
+            "status": json.loads(adapter.handle_tool_call("mnemosyne_sync_status", {})),
+            "unknown": json.loads(adapter.handle_tool_call("mnemosyne_sync_unknown", {})),
+        }
+
+    assert observed["mnemosyne_hermes"] == observed["hermes_memory_provider"]
+    assert observed["hermes_memory_provider"]["push"] == {
+        "status": "ok",
+        "pushed": 2,
+        "duplicates": 1,
+        "conflicts": 1,
+        "next_cursor": "remote-cursor",
+    }
+    assert observed["hermes_memory_provider"]["pull"] == {
+        "status": "ok",
+        "pulled": 2,
+        "duplicates": 1,
+        "conflicts": 1,
+        "next_cursor": "remote-cursor",
+    }
 
 
 def _save_mnemosyne_modules():

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -354,12 +354,27 @@ def test_sync_adapter_config_resolution_matches(monkeypatch, sync_modules):
     }
 
 
+def test_sync_adapter_key_source_file_preserves_path_case(tmp_path, sync_modules):
+    key_file = tmp_path / "MixedCaseSync.key"
+    key_file.write_text("file-key")
+
+    observed = {}
+    for name, module in sync_modules.items():
+        adapter = module.SyncAdapter.__new__(module.SyncAdapter)
+        adapter._config = {"key_source": f"FILE:{key_file}"}
+        observed[name] = adapter._resolve_key()
+
+    assert observed["mnemosyne_hermes"] == observed["hermes_memory_provider"]
+    assert observed["hermes_memory_provider"] == "file-key"
+
+
 class _ToolEngine:
     device_id = "device-1"
 
-    def __init__(self):
+    def __init__(self, *, local_next_cursor: str | None = "local-cursor"):
         self.meta = {"last_sync_cursor": "cursor-previous"}
         self.conn = self
+        self.local_next_cursor = local_next_cursor
 
     def _meta_get(self, key):
         return self.meta.get(key)
@@ -368,7 +383,7 @@ class _ToolEngine:
         self.meta[key] = value
 
     def pull_changes(self, since_cursor=None, limit=500):
-        return {"events": [{"id": "e1"}], "next_cursor": "local-cursor"}
+        return {"events": [{"id": "e1"}], "next_cursor": self.local_next_cursor}
 
     def push_changes(self, events):
         self.pushed_events = events
@@ -381,9 +396,14 @@ class _ToolEngine:
         return (3,)
 
 
-def _adapter_with_tool_engine(module, *, next_cursor: str | None = "remote-cursor"):
+def _adapter_with_tool_engine(
+    module,
+    *,
+    next_cursor: str | None = "remote-cursor",
+    local_next_cursor: str | None = "local-cursor",
+):
     adapter = module.SyncAdapter.__new__(module.SyncAdapter)
-    adapter._engine = _ToolEngine()
+    adapter._engine = _ToolEngine(local_next_cursor=local_next_cursor)
     adapter._error = None
     adapter.remote = "https://sync.example"
     adapter.encrypt_enabled = False
@@ -431,6 +451,23 @@ def test_sync_adapter_tool_results_match(sync_modules):
         "conflicts": 1,
         "next_cursor": "remote-cursor",
     }
+
+
+def test_sync_adapter_push_tolerates_null_next_cursor(sync_modules):
+    observed = {}
+    for name, module in sync_modules.items():
+        adapter = _adapter_with_tool_engine(module, next_cursor=None, local_next_cursor=None)
+        observed[name] = json.loads(adapter.handle_tool_call("mnemosyne_sync_push", {}))
+
+    assert observed["mnemosyne_hermes"] == observed["hermes_memory_provider"]
+    assert observed["hermes_memory_provider"] == {
+        "status": "ok",
+        "pushed": 2,
+        "duplicates": 1,
+        "conflicts": 1,
+        "next_cursor": "",
+    }
+
 
 
 def test_sync_adapter_pull_tolerates_null_next_cursor(sync_modules):


### PR DESCRIPTION
## Summary

- align the pip/integration Hermes `SyncAdapter` surface with the root provider adapter
- keep sync tool schemas, lifecycle helpers, tool dispatch, provider-beam wiring, and result payloads in parity
- harden both sync adapters for secure host/port fallback, encryption initialization, null remote cursors, and case-preserving `file:` key sources
- add focused provider parity tests so future root/integration drift is caught

## Context

This is the small follow-up parity cleanup for the pip `SyncAdapter` drift noted after the recent Mnemosyne/Hermes integration work. The change is intentionally narrow: it keeps both provider sync adapters aligned and adds regression coverage around that contract.

## Tests

- `uv run --extra test --extra sync --with pyyaml pytest tests/test_sync.py tests/test_sync_turn_diagnostics.py tests/test_sync_turn_content_limit.py tests/test_sync_roles.py tests/test_hermes_provider_parity.py -q` → 80 passed
- `python3 -m py_compile hermes_memory_provider/sync_adapter.py integrations/hermes/src/mnemosyne_hermes/sync_adapter.py tests/test_hermes_provider_parity.py`
- `git diff --check`
- normalized adapter parity check: `hermes_memory_provider/sync_adapter.py` with package-name replacement equals `integrations/hermes/src/mnemosyne_hermes/sync_adapter.py`

## Review

Read-only reviewer pass (`reviewer-claude`/Opus): APPROVE, no blockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes sync now supports starting and shutting down cleanly, with sync actions available only when the adapter is ready.
  * Sync status now shows more useful connection and local sync details.

* **Bug Fixes**
  * Improved sync push/pull behavior when no changes are returned, including better handling of missing next cursors.
  * Encryption key loading is more reliable across different key sources.
  * Remote sync connections now default to a secure HTTPS endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->