### PR TITLE
fix(plugins): enable auto_sleep by default in Hermes Mnemosyne plugin (#59836)

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -809,7 +809,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
     def get_config_schema(self) -> List[Dict[str, Any]]:
         return [
-            {"key": "auto_sleep", "description": "Auto-run sleep() when working memory exceeds threshold. Set true to enable. Backward-compatible with MNEMOSYNE_AUTO_SLEEP_ENABLED env var.", "default": False},
+            {"key": "auto_sleep", "description": "Auto-run sleep() when working memory exceeds threshold. Set true to enable. Backward-compatible with MNEMOSYNE_AUTO_SLEEP_ENABLED env var.", "default": True},
             {"key": "sleep_threshold", "description": "Working memory count before auto-sleep triggers", "default": 50},
             {"key": "reflect", "description": "Reflection/sleep guardrails. Supports disabled_for_cron (default true) and max_calls_per_session (default 3; negative disables cap). Env: MNEMOSYNE_REFLECT_DISABLED_FOR_CRON, MNEMOSYNE_REFLECT_MAX_CALLS_PER_SESSION.", "default": {"disabled_for_cron": True, "max_calls_per_session": 3}},
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},


### PR DESCRIPTION
## Summary

The Hermes Mnemosyne plugin (`integrations/hermes/src/mnemosyne_hermes/__init__.py`) defines `auto_sleep` with `default: False` in `get_config_schema()`, overriding Mnemosyne core's default of `True`. This prevents automatic cross-session memory consolidation on fresh Hermes+Mnemosyne installations.

## Root Cause

Line 812 of `integrations/hermes/src/mnemosyne_hermes/__init__.py`:
```python
{"key": "auto_sleep", "description": "...", "default": False},
```

Mnemosyne core default is `True` — consolidation runs on session start and end. The Hermes plugin imposes `False` with no notice.

## Fix

Changed `"default": False` to `"default": True` on line 812.

## Impact

- **Before:** Fresh install: memory appears to work but never consolidates. Users discover it when the agent keeps forgetting cross-session context.
- **After:** auto_sleep defaults to `True`, matching Mnemosyne core behavior. Memory consolidates automatically.

Fixes NousResearch/hermes-agent#59836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the default setting for automatic sleep behavior to be enabled, so new setups will now pause more reliably without requiring manual configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->