### PR TITLE
Fix issue #421 cross-session recall and CLI default scope

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -64,6 +64,14 @@ def _get_memory():
     return Mnemosyne(db_path=os.path.join(DATA_DIR, "mnemosyne.db"))
 
 
+def _resolve_default_scope() -> str:
+    """Resolve the default scope for CLI store calls."""
+    raw = os.environ.get("MNEMOSYNE_DEFAULT_SCOPE", "").strip().lower()
+    if raw in ("session", "global"):
+        return raw
+    return "session"
+
+
 def cmd_store(args):
     """Store a new memory."""
     if not args:
@@ -77,6 +85,7 @@ def cmd_store(args):
         content,
         source=source,
         importance=importance,
+        scope=_resolve_default_scope(),
         extract_entities=True,
     )
     print(f"Stored: {memory_id}")

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -406,17 +406,31 @@ _warn_about_veracity_weight_overrides()
 _CROSS_SESSION = os.environ.get("MNEMOSYNE_CROSS_SESSION", "0") == "1"
 
 
+def _cross_session_enabled() -> bool:
+    """Return whether session scoping should be disabled for recall."""
+    return _CROSS_SESSION or os.environ.get("MNEMOSYNE_CROSS_SESSION", "0") == "1"
+
+
 def _session_scope_filter(extra_col: str = "") -> str:
     """Return a WHERE clause for session scoping.
 
-    When _CROSS_SESSION is enabled, returns (1=1) to disable filtering.
+    When cross-session recall is enabled, returns (1=1) to disable filtering.
     Otherwise returns (session_id = ? OR scope = 'global'[ OR col = ?]).
     """
-    if _CROSS_SESSION:
+    if _cross_session_enabled():
         return "(1=1)"
     if extra_col:
         return f"(session_id = ? OR scope = 'global' OR {extra_col} = ?)"
     return "(session_id = ? OR scope = 'global')"
+
+
+def _session_scope_params(session_id: str, extra_value=None) -> list:
+    """Return bind params matching _session_scope_filter()."""
+    if _cross_session_enabled():
+        return []
+    if extra_value is not None:
+        return [session_id, extra_value]
+    return [session_id]
 
 # Vector compression: float32 | int8 | bit
 VEC_TYPE = os.environ.get("MNEMOSYNE_VEC_TYPE", "int8").lower()
@@ -5397,12 +5411,12 @@ class BeamMemory:
         # Author-only searches have no session/channel restriction.
         if channel_id:
             wm_where_clauses.append(_session_scope_filter("channel_id"))
-            wm_params.extend([self.session_id, channel_id])
+            wm_params.extend(_session_scope_params(self.session_id, channel_id))
         elif author_id or author_type:
             wm_where_clauses.append("(1=1)")
         else:
             wm_where_clauses.append(_session_scope_filter())
-            wm_params.append(self.session_id)
+            wm_params.extend(_session_scope_params(self.session_id))
         
         if from_date:
             wm_where_clauses.append("timestamp >= ?")
@@ -5655,13 +5669,13 @@ class BeamMemory:
             em_placeholders = ",".join("?" * len(entity_memory_ids))
             if channel_id:
                 em_entity_scope = _session_scope_filter("channel_id")
-                em_entity_params = [*tuple(entity_memory_ids), self.session_id, channel_id]
+                em_entity_params = [*tuple(entity_memory_ids), *_session_scope_params(self.session_id, channel_id)]
             elif author_id or author_type:
                 em_entity_scope = "(1=1)"
                 em_entity_params = [*tuple(entity_memory_ids)]
             else:
                 em_entity_scope = _session_scope_filter()
-                em_entity_params = [*tuple(entity_memory_ids), self.session_id]
+                em_entity_params = [*tuple(entity_memory_ids), *_session_scope_params(self.session_id)]
             em_entity_params.extend([datetime.now().isoformat()])
             cursor.execute(f"""
                 SELECT id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope, author_id, author_type, channel_id, veracity, memory_type
@@ -5777,13 +5791,13 @@ class BeamMemory:
             # Also check episodic memory for fact matches
             if channel_id:
                 fact_em_scope = _session_scope_filter("channel_id")
-                fact_em_params = [*tuple(fact_memory_ids), self.session_id, channel_id]
+                fact_em_params = [*tuple(fact_memory_ids), *_session_scope_params(self.session_id, channel_id)]
             elif author_id or author_type:
                 fact_em_scope = "(1=1)"
                 fact_em_params = [*tuple(fact_memory_ids)]
             else:
                 fact_em_scope = _session_scope_filter()
-                fact_em_params = [*tuple(fact_memory_ids), self.session_id]
+                fact_em_params = [*tuple(fact_memory_ids), *_session_scope_params(self.session_id)]
             fact_em_params.extend([datetime.now().isoformat()])
             cursor.execute(f"""
                 SELECT id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope, author_id, author_type, channel_id, veracity, memory_type
@@ -5900,12 +5914,12 @@ class BeamMemory:
         # Author-only searches have no session/channel restriction.
         if channel_id:
             em_where_clauses.append(_session_scope_filter("channel_id"))
-            em_params.extend([self.session_id, channel_id])
+            em_params.extend(_session_scope_params(self.session_id, channel_id))
         elif author_id or author_type:
             em_where_clauses.append("(1=1)")
         else:
             em_where_clauses.append(_session_scope_filter())
-            em_params.append(self.session_id)
+            em_params.extend(_session_scope_params(self.session_id))
         
         if from_date:
             em_where_clauses.append("timestamp >= ?")
@@ -6351,9 +6365,9 @@ class BeamMemory:
             placeholders = ",".join("?" * len(wm_ids))
             rec_params = [now_iso, *tuple(wm_ids)]
             if channel_id:
-                rec_params.extend([self.session_id, channel_id])
+                rec_params.extend(_session_scope_params(self.session_id, channel_id))
             elif not (author_id or author_type):
-                rec_params.append(self.session_id)
+                rec_params.extend(_session_scope_params(self.session_id))
             cursor.execute(f"""
                 UPDATE working_memory
                 SET recall_count = recall_count + 1, last_recalled = ?
@@ -6363,9 +6377,9 @@ class BeamMemory:
             placeholders = ",".join("?" * len(em_ids))
             rec_params = [now_iso, *tuple(em_ids)]
             if channel_id:
-                rec_params.extend([self.session_id, channel_id])
+                rec_params.extend(_session_scope_params(self.session_id, channel_id))
             elif not (author_id or author_type):
-                rec_params.append(self.session_id)
+                rec_params.extend(_session_scope_params(self.session_id))
             cursor.execute(f"""
                 UPDATE episodic_memory
                 SET recall_count = recall_count + 1, last_recalled = ?
@@ -6954,10 +6968,10 @@ class BeamMemory:
 
         def _rec_scope_params() -> List:
             if channel_id:
-                return [self.session_id, channel_id]
+                return _session_scope_params(self.session_id, channel_id)
             if author_id or author_type:
                 return []
-            return [self.session_id]
+            return _session_scope_params(self.session_id)
 
         # Update recall_count / last_recalled for engine results too --
         # the linear path updates them and downstream features (decay

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -7056,7 +7056,7 @@ class BeamMemory:
         Conditional filters: caller-supplied kwargs.
         """
         # Session scope filter (honors MNEMOSYNE_CROSS_SESSION).
-        if not _CROSS_SESSION:
+        if not _cross_session_enabled():
             row_session = row_dict.get("session_id") if "session_id" in row_dict else None
             row_scope = row_dict.get("scope") or "session"
             if row_scope != "global" and row_session is not None and row_session != self.session_id:

--- a/tests/test_issue_421_scope.py
+++ b/tests/test_issue_421_scope.py
@@ -1,0 +1,75 @@
+"""Regression tests for issue #421 cross-session/default-scope bugs."""
+
+import sqlite3
+
+from mnemosyne.core.beam import BeamMemory
+
+
+def _contents(results):
+    return [r.get("content", "") for r in results]
+
+
+def test_cross_session_recall_does_not_bind_session_params_when_filter_disabled(tmp_path, monkeypatch):
+    """MNEMOSYNE_CROSS_SESSION=1 should not leave stale bind params behind."""
+    monkeypatch.setenv("MNEMOSYNE_CROSS_SESSION", "1")
+    db_path = tmp_path / "mnemosyne.db"
+
+    writer = BeamMemory(session_id="session-a", db_path=db_path)
+    reader = BeamMemory(session_id="session-b", db_path=db_path)
+    writer.remember(
+        "issue421 cross session visible sentinel",
+        source="test",
+        importance=0.9,
+        scope="session",
+    )
+
+    results = reader.recall("issue421 sentinel", top_k=10)
+
+    assert any("cross session visible sentinel" in c for c in _contents(results))
+
+
+def test_non_cross_session_recall_still_shows_only_session_and_global_scope(tmp_path, monkeypatch):
+    """The issue #421 fix must preserve default session/global visibility."""
+    monkeypatch.delenv("MNEMOSYNE_CROSS_SESSION", raising=False)
+    db_path = tmp_path / "mnemosyne.db"
+
+    session_a = BeamMemory(session_id="session-a", db_path=db_path)
+    session_b = BeamMemory(session_id="session-b", db_path=db_path)
+    session_a.remember(
+        "issue421 private sentinel",
+        source="test",
+        importance=0.9,
+        scope="session",
+    )
+    session_a.remember(
+        "issue421 global sentinel",
+        source="test",
+        importance=0.9,
+        scope="global",
+    )
+
+    results = session_b.recall("issue421 sentinel", top_k=10)
+    contents = _contents(results)
+
+    assert any("global sentinel" in c for c in contents)
+    assert not any("private sentinel" in c for c in contents)
+
+
+def test_cli_store_honors_mnemosyne_default_scope_global(tmp_path, monkeypatch):
+    """mnemosyne store should match MCP's MNEMOSYNE_DEFAULT_SCOPE behavior."""
+    from mnemosyne import cli
+
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(cli, "DATA_DIR", str(data_dir))
+    monkeypatch.setenv("MNEMOSYNE_DEFAULT_SCOPE", "global")
+
+    cli.cmd_store(["issue421 cli global sentinel", "cli", "0.8"])
+
+    db_path = data_dir / "mnemosyne.db"
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT scope FROM working_memory WHERE content = ?",
+            ("issue421 cli global sentinel",),
+        ).fetchone()
+
+    assert row == ("global",)


### PR DESCRIPTION
## Summary
- fix cross-session recall so disabled session filters do not leave stale SQLite bind params behind
- make `mnemosyne store` honor `MNEMOSYNE_DEFAULT_SCOPE=session|global`, matching MCP remember behavior
- add focused regressions for issue #421, including preserved default session/global visibility

Fixes #421.

## Tests
- `python3 -m py_compile mnemosyne/core/beam.py mnemosyne/cli.py tests/test_issue_421_scope.py`
- `PYTHONPATH=. uv run --no-sync --with pytest pytest -q tests/test_issue_421_scope.py tests/test_cli_usage_errors.py tests/test_default_scope.py tests/test_beam_e5_polyphonic_recall.py::TestE5FilterEnforcement`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable default memory scope via environment settings, with automatic normalization and safe fallback.
* **Bug Fixes**
  * Improved recall scoping consistency across sessions, ensuring session/global items are handled correctly and preventing improper reuse of session-specific parameters.
  * Updated CLI store behavior so saved items honor the configured default scope.
* **Tests**
  * Added regression coverage for cross-session/default-scope behavior and CLI store scope persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->