### PR TITLE
fix: repair cross-session recall scope handling

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -73,10 +73,13 @@ def cmd_store(args):
     importance = _parse_float(args[2], "importance") if len(args) > 2 else 0.5
 
     mem = _get_memory()
+    from mnemosyne.mcp_tools import _resolve_default_scope
+
     memory_id = mem.remember(
         content,
         source=source,
         importance=importance,
+        scope=_resolve_default_scope(),
         extract_entities=True,
     )
     print(f"Stored: {memory_id}")

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -400,8 +400,10 @@ _warn_about_veracity_weight_overrides()
 
 
 # Cross-session recall toggle. When enabled via MNEMOSYNE_CROSS_SESSION=1,
-# the session filter (session_id = ? OR scope = 'global') is replaced with
-# (1=1), making all working and episodic memories visible across sessions.
+# the session filter is replaced with an always-true expression that still
+# consumes the same placeholders as the normal session filter. That keeps the
+# shared call sites' parameter binding unchanged while making all working and
+# episodic memories visible across sessions.
 # Default off preserves backward compatibility.
 _CROSS_SESSION = os.environ.get("MNEMOSYNE_CROSS_SESSION", "0") == "1"
 
@@ -409,11 +411,14 @@ _CROSS_SESSION = os.environ.get("MNEMOSYNE_CROSS_SESSION", "0") == "1"
 def _session_scope_filter(extra_col: str = "") -> str:
     """Return a WHERE clause for session scoping.
 
-    When _CROSS_SESSION is enabled, returns (1=1) to disable filtering.
+    When _CROSS_SESSION is enabled, returns an always-true predicate that
+    preserves the normal placeholder count to match existing caller params.
     Otherwise returns (session_id = ? OR scope = 'global'[ OR col = ?]).
     """
     if _CROSS_SESSION:
-        return "(1=1)"
+        if extra_col:
+            return "(? IS NOT NULL OR ? IS NOT NULL OR 1=1)"
+        return "(? IS NOT NULL OR 1=1)"
     if extra_col:
         return f"(session_id = ? OR scope = 'global' OR {extra_col} = ?)"
     return "(session_id = ? OR scope = 'global')"

--- a/tests/test_issue421_cross_session_scope.py
+++ b/tests/test_issue421_cross_session_scope.py
@@ -1,0 +1,52 @@
+"""Regression tests for issue #421 cross-session visibility bugs."""
+
+import importlib
+import os
+import sqlite3
+
+
+def _reload_beam_with_cross_session(enabled: bool):
+    if enabled:
+        os.environ["MNEMOSYNE_CROSS_SESSION"] = "1"
+    else:
+        os.environ.pop("MNEMOSYNE_CROSS_SESSION", None)
+
+    import mnemosyne.core.beam as beam
+
+    return importlib.reload(beam)
+
+
+def test_cross_session_recall_does_not_misbind_sql_params(tmp_path):
+    beam = _reload_beam_with_cross_session(True)
+    try:
+        db_path = tmp_path / "cross_session.db"
+        session_a = beam.BeamMemory(db_path=db_path, session_id="session-a")
+        session_a.remember("issue 421 cross session memory", scope="global")
+
+        session_b = beam.BeamMemory(db_path=db_path, session_id="session-b")
+        results = session_b.recall("issue 421 cross session memory")
+
+        assert any("issue 421 cross session memory" in r["content"] for r in results)
+    finally:
+        _reload_beam_with_cross_session(False)
+
+
+def test_cli_store_honors_default_scope_global(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("MNEMOSYNE_DEFAULT_SCOPE", "global")
+
+    import mnemosyne.cli as cli
+
+    data_dir = tmp_path / "mnemosyne-data"
+    data_dir.mkdir()
+    monkeypatch.setattr(cli, "DATA_DIR", str(data_dir))
+
+    cli.cmd_store(["issue 421 cli global scope memory"])
+    capsys.readouterr()
+
+    with sqlite3.connect(data_dir / "mnemosyne.db") as conn:
+        scope = conn.execute(
+            "SELECT scope FROM working_memory WHERE content = ?",
+            ("issue 421 cli global scope memory",),
+        ).fetchone()[0]
+
+    assert scope == "global"


### PR DESCRIPTION
## Summary

- fix `MNEMOSYNE_CROSS_SESSION=1` recall by preserving SQL placeholder counts while disabling session filtering
- make CLI `mnemosyne store` honor `MNEMOSYNE_DEFAULT_SCOPE`, matching the MCP remember path
- add focused regression tests for both issue #421 cases

## Tests

- `uv run --extra test --with pyyaml pytest tests/test_issue421_cross_session_scope.py tests/test_default_scope.py tests/test_recall_explain.py -q`
- `uv run --extra test --with pyyaml pytest tests/test_issue421_cross_session_scope.py -q`
- `python3 -m py_compile mnemosyne/core/beam.py mnemosyne/cli.py tests/test_issue421_cross_session_scope.py`
- `git diff --check`

Fixes #421.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-session memory lookups so saved items remain accessible when switching sessions.
  * Improved consistency when storing memories by honoring the configured default scope.
  * Reduced the chance of incorrect search results caused by parameter mismatches in session-aware queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->