### PR TITLE
fix(hermes): install bundled memory override skill

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -106,6 +106,12 @@ hermes memory status
 #   Plugin:    installed ✓
 ```
 
+The installer also deploys the bundled `mnemosyne-memory-override` skill to
+`$HERMES_HOME/skills/memory/mnemosyne-memory-override/SKILL.md`. The skill is a
+behavioral guardrail that nudges agents away from the legacy `memory` tool for
+durable facts. Existing user-edited copies are skipped by default; `install
+--force` overwrites the skill only after writing `SKILL.md.bak` next to it.
+
 ### How it works
 
 When you install via pipx, the package registers two entry points:

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -52,7 +52,7 @@ Repository = "https://github.com/AxDSan/mnemosyne"
 where = ["src"]
 
 [tool.setuptools.package-data]
-mnemosyne_hermes = ["plugin.yaml"]
+mnemosyne_hermes = ["plugin.yaml", "skills/mnemosyne-memory-override/SKILL.md"]
 
 [tool.ruff]
 line-length = 100

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib
+from importlib import resources
 import os
 import re
 import shutil
@@ -16,6 +18,9 @@ from typing import Optional
 
 
 PLUGIN_NAME = "mnemosyne"
+SKILL_NAME = "mnemosyne-memory-override"
+SKILL_CATEGORY = "memory"
+BUNDLED_SKILL_RESOURCE = ("skills", SKILL_NAME, "SKILL.md")
 
 
 @dataclass(frozen=True)
@@ -32,6 +37,26 @@ class PluginState:
     wrapper_site_packages: Path | None = None
     wrapper_import_ok: bool | None = None
     wrapper_import_error: str | None = None
+
+
+@dataclass(frozen=True)
+class SkillState:
+    """Detailed installation state for the bundled Hermes skill."""
+
+    status: str
+    installed: bool
+    target: Path
+    message: str
+
+
+@dataclass(frozen=True)
+class SkillInstallResult:
+    """Result of installing, skipping, or planning the bundled skill."""
+
+    action: str
+    changed: bool
+    target: Path
+    message: str
 
 
 def hermes_home() -> Path:
@@ -61,6 +86,156 @@ def plugin_target_dir(hermes_home_path: str | Path | None = None) -> Path:
     """
     base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
     return base / "plugins" / PLUGIN_NAME
+
+
+def skill_target_file(hermes_home_path: str | Path | None = None) -> Path:
+    """Return the deterministic install target for the bundled Hermes skill.
+
+    Hermes supports categorized skill directories under ``skills/<category>/<name>/SKILL.md``;
+    keep this memory guardrail in the memory category rather than the package's historical
+    flat source-tree ``skills/*.md`` location.
+    """
+    base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
+    return base / "skills" / SKILL_CATEGORY / SKILL_NAME / "SKILL.md"
+
+
+def bundled_skill_resource():
+    """Return the importlib resource for the bundled memory override skill."""
+    resource = resources.files("mnemosyne_hermes")
+    for part in BUNDLED_SKILL_RESOURCE:
+        resource = resource.joinpath(part)
+    return resource
+
+
+def bundled_skill_text() -> str:
+    """Read the bundled memory override skill from package data."""
+    source = bundled_skill_resource()
+    if not source.is_file():
+        raise FileNotFoundError(
+            "Bundled Mnemosyne memory override skill is missing from package data: "
+            f"{'/'.join(BUNDLED_SKILL_RESOURCE)}"
+        )
+    return source.read_text(encoding="utf-8")
+
+
+def skill_state(*, hermes_home_path: str | Path | None = None) -> SkillState:
+    """Return state for the bundled Hermes skill install target."""
+    target = skill_target_file(hermes_home_path)
+    if target.is_file():
+        return SkillState(
+            status="installed",
+            installed=True,
+            target=target,
+            message="Bundled memory override skill is installed.",
+        )
+    if target.exists():
+        return SkillState(
+            status="invalid_target",
+            installed=False,
+            target=target,
+            message=f"Skill target exists but is not a file: {target}",
+        )
+    return SkillState(
+        status="missing",
+        installed=False,
+        target=target,
+        message=f"No bundled memory override skill at {target}.",
+    )
+
+
+def _skill_backup_file(target: Path) -> Path:
+    """Return the backup path used before overwriting a user-editable skill."""
+    return target.with_name(f"{target.name}.bak")
+
+
+def _skill_hash_file(target: Path) -> Path:
+    """Return the sidecar path used to track installer-managed skill content."""
+    return target.with_name(f"{target.name}.sha256")
+
+
+def _sha256_text(content: str) -> str:
+    """Return a stable digest for UTF-8 skill content."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _is_managed_skill_copy(target: Path) -> bool:
+    """Return whether target still matches the installer-managed sidecar hash."""
+    if not target.is_file():
+        return False
+    hash_file = _skill_hash_file(target)
+    if not hash_file.is_file():
+        return False
+    try:
+        expected = hash_file.read_text(encoding="utf-8").strip()
+        return expected == _sha256_text(target.read_text(encoding="utf-8"))
+    except OSError:
+        return False
+
+
+def _write_skill_hash(target: Path, content: str) -> None:
+    """Record the digest for installer-managed skill content."""
+    _skill_hash_file(target).write_text(_sha256_text(content) + "\n", encoding="utf-8")
+
+
+def install_bundled_skill(
+    *,
+    hermes_home_path: str | Path | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> SkillInstallResult:
+    """Install the bundled memory override skill into Hermes' skills directory."""
+    target = skill_target_file(hermes_home_path)
+    exists = target.exists()
+    backup = _skill_backup_file(target)
+    content = bundled_skill_text()
+    managed_copy = _is_managed_skill_copy(target)
+    up_to_date = target.is_file() and target.read_text(encoding="utf-8") == content
+
+    if exists and not force and not managed_copy:
+        if up_to_date:
+            _write_skill_hash(target, content)
+            return SkillInstallResult(
+                action="skip",
+                changed=False,
+                target=target,
+                message=f"Skill already exists at {target}; already up to date.",
+            )
+        return SkillInstallResult(
+            action="skip",
+            changed=False,
+            target=target,
+            message=f"Skill already exists at {target}; skipped (use --force to overwrite).",
+        )
+
+    action = "refresh" if exists and managed_copy else ("overwrite" if exists else "install")
+    if dry_run:
+        backup_note = f" Existing file would be backed up to {backup}." if target.is_file() and force else ""
+        return SkillInstallResult(
+            action=action,
+            changed=False,
+            target=target,
+            message=f"Would {action} bundled skill at {target}.{backup_note}",
+        )
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    backup_note = ""
+    if exists and target.is_file() and force:
+        shutil.copy2(target, backup)
+        backup_note = f" Backup written to {backup}."
+    elif exists and not target.is_file():
+        if target.is_dir():
+            shutil.rmtree(target)
+        else:
+            target.unlink()
+    target.write_text(content, encoding="utf-8")
+    _write_skill_hash(target, content)
+    verb = {"install": "Installed", "overwrite": "Overwrote", "refresh": "Refreshed"}[action]
+    return SkillInstallResult(
+        action=action,
+        changed=True,
+        target=target,
+        message=f"{verb} bundled skill at {target}.{backup_note}",
+    )
 
 
 def _provider_init_is_valid(init_file: Path) -> bool:
@@ -767,7 +942,10 @@ def _parser() -> argparse.ArgumentParser:
     install.add_argument(
         "--force",
         action="store_true",
-        help="Replace an existing Mnemosyne plugin directory.",
+        help=(
+            "Replace an existing Mnemosyne plugin directory. Also overwrites the "
+            "bundled memory override skill after writing a SKILL.md.bak backup."
+        ),
     )
     install.add_argument(
         "--dry-run",
@@ -876,6 +1054,10 @@ def run_install(
         mode=mode,
         python=python,
     )
+    skill_result = install_bundled_skill(
+        hermes_home_path=hermes_home_path,
+        force=force,
+    )
     if mode == "wrapper":
         state = plugin_state(hermes_home_path=hermes_home_path)
         print(f"Installed. Wrapper directory at {target}")
@@ -886,6 +1068,7 @@ def run_install(
     else:
         print(f"Installed. Symlink at {target}")
         print(f"  -> {os.readlink(str(target))}")
+    print(f"  Skill: {skill_result.message}")
     print("Done. Next steps:")
     print("  hermes config set memory.provider mnemosyne")
     print("  hermes memory status")
@@ -904,10 +1087,19 @@ def main(argv: list[str] | None = None) -> int:
             hermes_python = _find_hermes_python()
             target = plugin_target_dir(args.hermes_home)
             if getattr(args, "dry_run", False):
+                skill = skill_state(hermes_home_path=args.hermes_home)
+                skill_plan = install_bundled_skill(
+                    hermes_home_path=args.hermes_home,
+                    force=getattr(args, "force", False),
+                    dry_run=True,
+                )
                 print(f"  Plugin target dir: {target}")
                 print(f"  Hermes Python: {hermes_python or 'not found'}")
                 print(f"  Currently installed: {'yes' if is_installed(hermes_home_path=args.hermes_home) else 'no'}")
                 print(f"  Install mode: {getattr(args, 'mode', 'symlink')}")
+                print(f"  Skill target file: {skill.target}")
+                print(f"  Skill state: {skill.status}")
+                print(f"  Skill action: {skill_plan.message}")
                 if getattr(args, "mode", "symlink") == "wrapper":
                     wrapper_python = Path(getattr(args, "python", None) or sys.executable).expanduser()
                     print(f"  Wrapper Python: {wrapper_python}")
@@ -964,6 +1156,12 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  NOT installed: {state.message}")
                 if state.link_target is not None:
                     print(f"  Broken target: {state.link_target}")
+            skill = skill_state(hermes_home_path=args.hermes_home)
+            print(f"  Skill path: {skill.target}")
+            if skill.installed:
+                print("  Skill:     installed ✓")
+            else:
+                print(f"  Skill:     {skill.status} ✗ ({skill.message})")
             print(f"  Core library: {'OK' if check_mnemosyne_core() else 'MISSING'}")
             print(f"  This Python: {sys.executable} ({sys.version.split()[0]})")
             if hermes_python:

--- a/integrations/hermes/src/mnemosyne_hermes/skills/mnemosyne-memory-override/SKILL.md
+++ b/integrations/hermes/src/mnemosyne_hermes/skills/mnemosyne-memory-override/SKILL.md
@@ -6,7 +6,7 @@ description: |
   and project conventions. Use memory ONLY for ephemeral session state.
 trigger: |
   Whenever you would use memory(action="add|replace|remove") for anything
-  that should survive across sessions, STOP and use mnemosyne_remember instead.
+  that should survive across sessions, STOP and use the Mnemosyne memory tools instead.
 ---
 
 # Mnemosyne Memory Override
@@ -25,8 +25,8 @@ all durable user data.
 |-----------------|----------------|
 | `memory(action="add", target="user", ...)` | `mnemosyne_remember(content=..., importance=0.9+, source="preference")` |
 | `memory(action="add", target="memory", ...)` | `mnemosyne_remember(content=..., importance=0.7+, source="fact")` |
-| `memory(action="replace", ...)` | `mnemosyne_remember` with updated content |
-| `memory(action="remove", ...)` | Not needed — Mnemosyne ages out low-importance entries |
+| `memory(action="replace", ...)` | Use the relevant Mnemosyne update flow: recall the current entry, then store corrected content with `mnemosyne_remember`; use an explicit update tool/flow when the integration exposes one. |
+| `memory(action="remove", ...)` | Use the relevant Mnemosyne invalidation/forget flow: mark the obsolete fact invalid, supersede it with corrected content, or call the integration's forget/remove tool when available. Do not rely on passive aging for known-wrong durable data. |
 
 ## When to use legacy memory (rare)
 
@@ -40,7 +40,7 @@ in your training. Before EVERY memory tool call, pause and ask:
 
 > "Is this durable? Would I want this next session?"
 
-If yes → use `mnemosyne_remember`
+If yes → use Mnemosyne
 If no (temp flag, todo state) → `memory` is acceptable
 
 ## Migration Cleanup
@@ -50,15 +50,10 @@ When moving data from legacy memory to Mnemosyne:
 2. Then REMOVE the old entry from `memory` with `memory(action="remove")`
 3. This prevents stale duplicates and confusion
 
-## Committing Changes
-
-The user expects fixes to be committed and pushed individually.
-Do not claim a fix is done until it is committed to its respective repo.
-
 ## Enforcement
 
 If you catch yourself typing `memory(action=` for durable data:
 1. CANCEL that tool call
-2. Use `mnemosyne_remember` instead
+2. Use Mnemosyne instead
 3. Set importance >= 0.7 for anything that matters later
 4. If you already polluted legacy memory, remove the entry immediately

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -1,7 +1,120 @@
+import hashlib
 import sys
 from pathlib import Path
 
 from mnemosyne_hermes import install
+
+
+def _hash_text(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def test_bundled_memory_override_skill_resource_is_discoverable():
+    text = install.bundled_skill_text()
+
+    assert "name: mnemosyne-memory-override" in text
+    assert "The user expects fixes" not in text
+    assert "invalidation/forget" in text
+
+
+def test_install_bundled_skill_copies_when_missing(tmp_path):
+    result = install.install_bundled_skill(hermes_home_path=tmp_path)
+    target = install.skill_target_file(tmp_path)
+
+    assert result.action == "install"
+    assert result.changed is True
+    assert result.target == target
+    assert target.read_text(encoding="utf-8") == install.bundled_skill_text()
+    assert target.with_name("SKILL.md.sha256").is_file()
+
+
+def test_install_bundled_skill_skips_existing_without_force(tmp_path):
+    target = install.skill_target_file(tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text("user custom skill\n", encoding="utf-8")
+
+    result = install.install_bundled_skill(hermes_home_path=tmp_path)
+
+    assert result.action == "skip"
+    assert result.changed is False
+    assert target.read_text(encoding="utf-8") == "user custom skill\n"
+
+
+def test_install_bundled_skill_refreshes_managed_copy_without_force(tmp_path):
+    target = install.skill_target_file(tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text("old bundled content\n", encoding="utf-8")
+    target.with_name("SKILL.md.sha256").write_text(
+        _hash_text("old bundled content\n") + "\n",
+        encoding="utf-8",
+    )
+
+    result = install.install_bundled_skill(hermes_home_path=tmp_path)
+
+    assert result.action == "refresh"
+    assert result.changed is True
+    assert target.read_text(encoding="utf-8") == install.bundled_skill_text()
+    assert target.with_name("SKILL.md.sha256").read_text(encoding="utf-8").strip() == _hash_text(install.bundled_skill_text())
+    assert not target.with_name("SKILL.md.bak").exists()
+
+
+def test_install_bundled_skill_preserves_user_edited_managed_copy_without_force(tmp_path):
+    target = install.skill_target_file(tmp_path)
+    target.parent.mkdir(parents=True)
+    target.write_text("old bundled content plus user edit\n", encoding="utf-8")
+    target.with_name("SKILL.md.sha256").write_text(
+        _hash_text("old bundled content\n") + "\n",
+        encoding="utf-8",
+    )
+
+    result = install.install_bundled_skill(hermes_home_path=tmp_path)
+
+    assert result.action == "skip"
+    assert result.changed is False
+    assert target.read_text(encoding="utf-8") == "old bundled content plus user edit\n"
+
+
+def test_install_bundled_skill_force_overwrites_existing_with_backup(tmp_path):
+    target = install.skill_target_file(tmp_path)
+    backup = target.with_name("SKILL.md.bak")
+    target.parent.mkdir(parents=True)
+    target.write_text("stale bundled skill\n", encoding="utf-8")
+
+    result = install.install_bundled_skill(hermes_home_path=tmp_path, force=True)
+
+    assert result.action == "overwrite"
+    assert result.changed is True
+    assert "Backup written" in result.message
+    assert target.read_text(encoding="utf-8") == install.bundled_skill_text()
+    assert backup.read_text(encoding="utf-8") == "stale bundled skill\n"
+
+
+def test_install_dry_run_reports_skill_action_without_writing(tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr(install, "_find_hermes_python", lambda: None)
+
+    rc = install.main(["--hermes-home", str(tmp_path), "install", "--dry-run"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Skill target file:" in out
+    assert "Skill action: Would install bundled skill" in out
+    assert not install.skill_target_file(tmp_path).exists()
+
+
+def test_status_reports_skill_state(tmp_path, capsys, monkeypatch):
+    target = tmp_path / "plugins" / "mnemosyne"
+    target.mkdir(parents=True)
+    (target / "__init__.py").write_text("class MnemosyneMemoryProvider: pass\n")
+    install.install_bundled_skill(hermes_home_path=tmp_path)
+    monkeypatch.setattr(install, "check_mnemosyne_core", lambda: True)
+    monkeypatch.setattr(install, "_find_hermes_python", lambda: None)
+
+    rc = install.main(["--hermes-home", str(tmp_path), "status"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Skill path:" in out
+    assert "Skill:     installed" in out
 
 
 def test_plugin_state_reports_broken_symlink(tmp_path):


### PR DESCRIPTION
## Summary

- package the bundled `mnemosyne-memory-override` skill inside `mnemosyne-hermes`
- install it to `$HERMES_HOME/skills/memory/mnemosyne-memory-override/SKILL.md`
- skip existing user-edited skills by default, and back them up to `SKILL.md.bak` before `--force` overwrite
- show skill action/state in `install --dry-run` and `status`
- keep `uninstall` from deleting user skills in v1

Fixes #407.

## Tests

- `PYTHONPATH=integrations/hermes/src:. uv run --no-sync --with pytest --with PyYAML --with-editable integrations/hermes pytest -q integrations/hermes/tests/test_install_status.py integrations/hermes/tests/test_install_hermes.py integrations/hermes/tests/test_install_cli_entrypoint.py`
- `PYTHONPATH=integrations/hermes/src:. python3 -m py_compile integrations/hermes/src/mnemosyne_hermes/install.py integrations/hermes/tests/test_install_status.py`
- `git diff --check upstream/main...HEAD`
- built `integrations/hermes` wheel and verified it contains `mnemosyne_hermes/skills/mnemosyne-memory-override/SKILL.md`
- manual temp `$HERMES_HOME` smoke for `install --dry-run`, wrapper install, `status`, and `uninstall` preserving the skill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes now installs a bundled memory-override skill alongside the main integration setup.
  * Status and dry-run output now include the bundled skill’s installation state and planned action.

* **Bug Fixes**
  * Improved handling for existing user-edited skill files by skipping them unless forced.
  * Added backup creation when overwriting the bundled skill with force enabled.

* **Documentation**
  * Updated the Hermes quickstart to describe the bundled skill and its installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->