### PR TITLE
fix: make host LLM timeout configurable

### DIFF
--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -54,7 +54,7 @@ LLM_FALLBACK_API_KEY = os.environ.get("MNEMOSYNE_LLM_FALLBACK_API_KEY", "") or L
 HOST_LLM_ENABLED = os.environ.get("MNEMOSYNE_HOST_LLM_ENABLED", "false").lower() in ("1", "true", "yes")
 HOST_LLM_PROVIDER = os.environ.get("MNEMOSYNE_HOST_LLM_PROVIDER", "").strip() or None
 HOST_LLM_MODEL = os.environ.get("MNEMOSYNE_HOST_LLM_MODEL", "").strip() or None
-HOST_LLM_TIMEOUT = 15.0  # Per-attempt safety cap; not user-facing.
+HOST_LLM_TIMEOUT = float(os.environ.get("MNEMOSYNE_HOST_LLM_TIMEOUT", "15"))  # Configurable via env
 # Host context window: local-model-calibrated LLM_N_CTX (2048) is too small for
 # Codex/GPT-class aux models; use this larger budget when the host is the path.
 HOST_LLM_N_CTX = int(os.environ.get("MNEMOSYNE_HOST_LLM_N_CTX", "32000"))

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import sys
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -163,6 +165,25 @@ class TestSleepPromptOverride:
 
 class TestHostLLMBackend:
     """Tests for the host LLM adapter integration in summarize_memories()."""
+
+    def test_host_llm_timeout_can_be_configured_from_env(self):
+        """MNEMOSYNE_HOST_LLM_TIMEOUT overrides the host adapter timeout."""
+        env = os.environ.copy()
+        env["MNEMOSYNE_HOST_LLM_TIMEOUT"] = "120"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from mnemosyne.core import local_llm; print(local_llm.HOST_LLM_TIMEOUT)",
+            ],
+            capture_output=True,
+            check=True,
+            env=env,
+            text=True,
+        )
+
+        assert result.stdout.strip() == "120.0"
 
     def _enable_host(self, monkeypatch):
         monkeypatch.setattr(local_llm, "LLM_ENABLED", True)


### PR DESCRIPTION
## Summary
- make the host LLM adapter timeout configurable via `MNEMOSYNE_HOST_LLM_TIMEOUT`
- keep the existing 15s default when the env var is unset
- add regression coverage for env-based host timeout configuration

## Why
Long host-adapter consolidation prompts can take longer than the previous hardcoded 15s cap. This lets deployments raise the per-attempt host timeout without changing code while preserving current default behavior.

## Tests
- `python3 -m pytest tests/test_local_llm.py -q` → 39 passed
- `python3 -m pytest tests/test_local_llm.py::TestHostLLMBackend::test_host_llm_timeout_can_be_configured_from_env -q` → 1 passed
- `python3 -m pytest -q` → collection failed in this local checkout because `mnemosyne_hermes` package metadata was not installed
- `PYTHONPATH=integrations/hermes/src python3 -m pytest -q` → 1806 passed, 21 skipped, 1 failed (`mnemosyne-hermes` distribution metadata not installed locally)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the host LLM timeout via an environment variable, allowing the timeout to be adjusted without code changes.

* **Tests**
  * Added coverage to verify the timeout value is correctly read from the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->