### PR TITLE
fix: exclude consolidated rows from hot context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ## [Unreleased]
 
+### Changed
+
+- **Default prompt context excludes consolidated working-memory rows.**
+  `BeamMemory.get_context()` no longer includes rows where
+  `consolidated_at IS NOT NULL`, preventing already-consolidated originals
+  from competing with hot unconsolidated memories in the context window.
+  Consolidated rows remain fully recallable through `recall()`. Set
+  `MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED=1` to temporarily restore legacy
+  injection behavior (truthy values: `1`, `true`, `yes`, `on`).
+
 ## [3.11.1] — 2026-07-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ When client-side encryption is enabled, the remote sync server sees **only metad
 | `MNEMOSYNE_IMPORTANCE_WEIGHT` | `0.2` | Importance weight |
 | `MNEMOSYNE_WM_MAX_ITEMS` | `10000` | Working memory limit |
 | `MNEMOSYNE_RECENCY_HALFLIFE` | `168` | Decay halflife in hours |
+| `MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED` | *(unset)* | Include consolidated working-memory rows in `get_context()` prompt injection. Default: excluded. Truthy values: `1`, `true`, `yes`, `on`. Does not affect `recall()`. |
 
 | `MNEMOSYNE_EMBEDDING_API_URL` | `${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}` | Preferred name for custom embedding API endpoint (OpenAI-compatible). Falls back to `OPENROUTER_BASE_URL`. |
 | `MNEMOSYNE_EMBEDDING_API_KEY` | `${OPENROUTER_API_KEY:-${OPENAI_API_KEY:-}}` | Preferred name for embedding API key. Falls back to `OPENROUTER_API_KEY`, then `OPENAI_API_KEY`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,9 @@ This path defaults to `~/.hermes/` because Hermes persists that directory across
 | `MNEMOSYNE_WM_MAX_ITEMS` | `10000` | Maximum **unconsolidated** items in working memory before eviction |
 | `MNEMOSYNE_WM_TTL_HOURS` | `24` | TTL in hours for **unconsolidated** working memory entries |
 
-Consolidated rows (those stamped `consolidated_at` by `sleep()`) are exempt from both limits. They remain queryable until explicitly removed via `forget()`. This is by design — the E3 additive memory contract guarantees that consolidated content persists.
+Consolidated rows (those stamped `consolidated_at` by `sleep()`) are exempt from both limits. They remain queryable through `recall()` until explicitly removed via `forget()`. This is by design — the E3 additive memory contract guarantees that consolidated content persists.
+
+By default, consolidated working-memory rows are **excluded** from hot prompt-injection context (`get_context()`), so they do not compete with unconsolidated memories. Set `MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED=1` to restore legacy behavior where consolidated rows appear in `get_context()`. This override does not affect `recall()` — consolidated rows are always recallable.
 
 If you see `working.total: 673` and wonder why it's above `WM_MAX_ITEMS`, run `mnemosyne_stats` to check the consolidated vs unconsolidated breakdown (available in v3.5.0+).
 

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.11.1"
+__version__ = "3.12.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -3699,7 +3699,14 @@ class BeamMemory:
         # each branch instead of scanning working_memory and building a temp
         # B-tree for the CASE-based ORDER BY.
         select_cols = "id, content, source, timestamp, importance, scope, last_recalled"
-        common_predicate = "(valid_until IS NULL OR valid_until > ?) AND superseded_by IS NULL"
+        include_consolidated = _env_truthy("MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED")
+        predicates = [
+            "(valid_until IS NULL OR valid_until > ?)",
+            "superseded_by IS NULL",
+        ]
+        if not include_consolidated:
+            predicates.append("consolidated_at IS NULL")
+        common_predicate = " AND ".join(predicates)
 
         cursor.execute(f"""
             SELECT {select_cols}

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -517,6 +517,7 @@ class TestWorkingMemory:
                 WHERE scope = 'global'
                   AND (valid_until IS NULL OR valid_until > ?)
                   AND superseded_by IS NULL
+                  AND consolidated_at IS NULL
                 ORDER BY importance DESC, timestamp DESC
                 LIMIT ?
                 """,
@@ -534,6 +535,7 @@ class TestWorkingMemory:
                   AND (scope IS NULL OR scope != 'global')
                   AND (valid_until IS NULL OR valid_until > ?)
                   AND superseded_by IS NULL
+                  AND consolidated_at IS NULL
                 ORDER BY importance DESC, timestamp DESC
                 LIMIT ?
                 """,

--- a/tests/test_get_context_consolidated.py
+++ b/tests/test_get_context_consolidated.py
@@ -1,0 +1,112 @@
+"""
+Tests for get_context() consolidated working-memory exclusion.
+
+Covers the default exclusion of consolidated rows and the
+MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED compatibility override.
+"""
+
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        yield db_path
+
+
+class TestGetContextConsolidatedExclusion:
+    def test_get_context_includes_unconsolidated_working_row(self, temp_db, monkeypatch):
+        """Unconsolidated working rows (consolidated_at IS NULL) appear in get_context()."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        now = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance) "
+            "VALUES (?, ?, 'conversation', ?, ?, ?)",
+            ("unconsol-1", "hot memory", now, "s1", 0.9),
+        )
+        beam.conn.commit()
+
+        monkeypatch.delenv("MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED", raising=False)
+
+        results = beam.get_context(limit=10)
+        assert len(results) == 1
+        assert results[0]["id"] == "unconsol-1"
+
+    def test_get_context_excludes_consolidated_working_row_by_default(self, temp_db, monkeypatch):
+        """Consolidated working rows (consolidated_at IS NOT NULL) are excluded from get_context() by default."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        now = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance) "
+            "VALUES (?, ?, 'conversation', ?, ?, ?)",
+            ("unconsol-1", "hot memory", now, "s1", 0.9),
+        )
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance, consolidated_at) "
+            "VALUES (?, ?, 'conversation', ?, ?, ?, ?)",
+            ("consol-1", "old memory", now, "s1", 0.8, now),
+        )
+        beam.conn.commit()
+
+        monkeypatch.delenv("MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED", raising=False)
+
+        results = beam.get_context(limit=10)
+        assert len(results) == 1
+        assert results[0]["id"] == "unconsol-1"
+        ids = [r["id"] for r in results]
+        assert "consol-1" not in ids
+
+    def test_get_context_includes_consolidated_when_env_override_enabled(self, temp_db, monkeypatch):
+        """When MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED=1, consolidated rows appear in get_context()."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        now = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance) "
+            "VALUES (?, ?, 'conversation', ?, ?, ?)",
+            ("unconsol-1", "hot memory", now, "s1", 0.9),
+        )
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance, consolidated_at) "
+            "VALUES (?, ?, 'conversation', ?, ?, ?, ?)",
+            ("consol-1", "old memory", now, "s1", 0.8, now),
+        )
+        beam.conn.commit()
+
+        monkeypatch.setenv("MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED", "1")
+
+        results = beam.get_context(limit=10)
+        assert len(results) == 2
+        ids = [r["id"] for r in results]
+        assert "unconsol-1" in ids
+        assert "consol-1" in ids
+
+    def test_recall_still_finds_consolidated_working_row(self, temp_db, monkeypatch):
+        """recall() can still find consolidated working-memory rows (provenance preserved)."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        now = datetime.now().isoformat()
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance, consolidated_at) "
+            "VALUES (?, ?, 'conversation', ?, ?, ?, ?)",
+            ("consol-recall", "unique marker zorblax recall test", now, "s1", 0.7, now),
+        )
+        beam.conn.commit()
+
+        monkeypatch.delenv("MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED", raising=False)
+
+        context = beam.get_context(limit=10)
+        context_ids = [r["id"] for r in context]
+        assert "consol-recall" not in context_ids, "get_context should exclude consolidated rows by default"
+
+        results = beam.recall("zorblax", top_k=10)
+        found = [r for r in results if "zorblax" in (r.get("content") or "").lower()]
+        assert len(found) >= 1, (
+            f"recall('zorblax') should find the consolidated working row. "
+            f"Got {len(results)} results: {[r.get('id') for r in results]}"
+        )


### PR DESCRIPTION
## Description

Exclude consolidated working-memory rows from `BeamMemory.get_context()` by default, preventing already-summarised originals from competing with unconsolidated memories in the prompt-injection context window.

### What changed

- **`mnemosyne/core/beam.py`** — `get_context()` now conditionally adds `AND consolidated_at IS NULL` to its shared predicate builder. Consolidated rows are excluded by default but can be re-included via `MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED=1`.
- **`tests/test_get_context_consolidated.py`** — New focused test file with 4 tests covering: unconsolidated inclusion, consolidated exclusion by default, env override inclusion, and recall/provenance preservation.
- **`tests/test_beam.py`** — Updated `test_get_context_query_shapes_use_context_indexes` to reflect the new default predicate shape in EXPLAIN QUERY PLAN assertions.
- **`CHANGELOG.md`** — Added `[Unreleased]` / `### Changed` entry.
- **`README.md`** — Documented `MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED` in the environment variable table.
- **`docs/configuration.md`** — Updated Working Memory section to clarify default exclusion from prompt injection while preserving recall/provenance.
- **`mnemosyne/__init__.py`** — Version bumped to `3.12.0` per Simple Versioning policy.

### Compatibility

This is a soft breaking change: default prompt context shrinks for users with consolidated memories, but:

- Recall/provenance behaviour is unchanged — consolidated rows remain fully queryable through `recall()`
- A one-line environment variable (`MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED=1`) restores legacy inclusion in `get_context()`
- No schema changes, no migration required

## Related Issue

Closes #426

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / performance
- [x] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Existing tests still pass (`pytest tests/ -v`)
- [x] New tests added for any new functionality
- [x] Manual verification (see below)

### Local Validation Results

| Test suite | Result |
|---|---|
| `tests/test_get_context_consolidated.py` (4 new tests) | **4/4 passed** in 1.84s |
| `test_beam.py::TestWorkingMemory::test_get_context_query_shapes_use_context_indexes` | **passed** in 1.04s |
| Full `tests/test_beam.py` (85 tests) | **85/85 passed** in 5.20s |
| Full test suite (`tests/`) | **1777 passed, 1 pre-existing failure** in 107s |

### Pre-existing Unrelated Failure

One test fails on upstream/main as well and is unrelated to this change:

```
tests/test_hermes_llm_adapter.py::test_complete_returns_none_when_agent_import_unavailable
AssertionError: assert 'No new information provided to consolidate.' is None
```

This tests Hermes LLM adapter behaviour when no agent import is available. It exists on the upstream baseline and is not introduced by this PR.

### Manual Verification

- Confirmed `get_context()` excludes consolidated rows by default with a direct SQLite query against a test database containing both consolidated and unconsolidated working-memory entries.
- Confirmed `MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED=1` restores legacy inclusion.
- Confirmed `recall()` still surfaces consolidated rows for provenance.

## Checklist

- [x] Version bumped in `mnemosyne/__init__.py` (`3.11.1` → `3.12.0`)
- [x] `CHANGELOG.md` updated with a brief entry under `[Unreleased]` / `### Changed`
- [x] README updated if user-facing behavior changed (env var table + docs/configuration.md)
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to include or exclude consolidated working-memory items in prompt context.
  * Prompt context now excludes consolidated items by default, while preserving the ability to retrieve them through recall.

* **Documentation**
  * Updated the changelog, README, and configuration docs to explain the new default behavior and the opt-in override.

* **Tests**
  * Added coverage for default exclusion, opt-in inclusion, and unchanged recall behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->