### PR TITLE
fix(hermes): default auto_sleep on across providers

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1243,7 +1243,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             "in_flight": 0,
         }
         self._auto_sleep_threshold = 50
-        self._auto_sleep_enabled = os.environ.get("MNEMOSYNE_AUTO_SLEEP_ENABLED", "").strip().lower() in ("1", "true", "yes", "on")
+        self._auto_sleep_enabled = _parse_env_bool("MNEMOSYNE_AUTO_SLEEP_ENABLED", True)
         # Reflection/sleep guardrails.  "reflection" maps to Mnemosyne's
         # sleep/consolidation path in the Hermes provider.  Cron skipping is
         # default-on per issue #337; max_calls_per_session defaults to 3 and
@@ -1378,16 +1378,14 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
         Precedence: kwargs > config.yaml > env var > hardcoded defaults.
         """
-        # auto_sleep: prefer kwargs, then config.yaml, then env var
+        # auto_sleep: prefer kwargs, then config.yaml, then env var, defaulting
+        # on to match Mnemosyne core's consolidation behavior for fresh installs.
         auto_sleep = kwargs.get("auto_sleep")
         if auto_sleep is None:
             auto_sleep = self._read_config_key("auto_sleep")
         if auto_sleep is not None:
-            if isinstance(auto_sleep, str):
-                self._auto_sleep_enabled = auto_sleep.lower() in ("true", "1", "yes", "on")
-            else:
-                self._auto_sleep_enabled = bool(auto_sleep)
-        # env var is already applied in __init__, so it is the base default
+            self._auto_sleep_enabled = _coerce_bool(auto_sleep, self._auto_sleep_enabled)
+        # env var/default is already applied in __init__, so it is the base default
 
         # sleep_threshold: prefer kwargs, then config.yaml, then default 50
         sleep_threshold = kwargs.get("sleep_threshold")
@@ -1601,7 +1599,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
     def get_config_schema(self) -> List[Dict[str, Any]]:
         return [
-            {"key": "auto_sleep", "description": "Auto-run sleep() when working memory exceeds threshold. Set true to enable. Backward-compatible with MNEMOSYNE_AUTO_SLEEP_ENABLED env var.", "default": False},
+            {"key": "auto_sleep", "description": "Auto-run sleep() when working memory exceeds threshold. Set false to disable. Backward-compatible with MNEMOSYNE_AUTO_SLEEP_ENABLED env var.", "default": True},
             {"key": "sleep_threshold", "description": "Working memory count before auto-sleep triggers", "default": 50},
             {"key": "reflect", "description": "Reflection/sleep guardrails. Supports disabled_for_cron (default true) and max_calls_per_session (default 3; negative disables cap). Env: MNEMOSYNE_REFLECT_DISABLED_FOR_CRON, MNEMOSYNE_REFLECT_MAX_CALLS_PER_SESSION.", "default": {"disabled_for_cron": True, "max_calls_per_session": 3}},
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},
@@ -1625,6 +1623,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             with open(config_path, "r") as f:
                 config = yaml.safe_load(f) or {}
             memory_cfg = config.setdefault("memory", {}).setdefault("mnemosyne", {})
+            memory_cfg.setdefault("auto_sleep", _parse_env_bool("MNEMOSYNE_AUTO_SLEEP_ENABLED", True))
             memory_cfg.update(values)
             with open(config_path, "w") as f:
                 yaml.safe_dump(config, f, default_flow_style=False, allow_unicode=True)

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -467,7 +467,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             "in_flight": 0,
         }
         self._auto_sleep_threshold = 50
-        self._auto_sleep_enabled = os.environ.get("MNEMOSYNE_AUTO_SLEEP_ENABLED", "").strip().lower() in ("1", "true", "yes", "on")
+        self._auto_sleep_enabled = _parse_env_bool("MNEMOSYNE_AUTO_SLEEP_ENABLED", True)
         # Reflection/sleep guardrails. "Reflection" maps to Mnemosyne's
         # sleep/consolidation path in the Hermes provider. Cron skipping is
         # default-on per issue #337; max_calls_per_session defaults to 3 and
@@ -597,16 +597,14 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
         Precedence: kwargs > config.yaml > env var > hardcoded defaults.
         """
-        # auto_sleep: prefer kwargs, then config.yaml, then env var
+        # auto_sleep: prefer kwargs, then config.yaml, then env var, defaulting
+        # on to match Mnemosyne core's consolidation behavior for fresh installs.
         auto_sleep = kwargs.get("auto_sleep")
         if auto_sleep is None:
             auto_sleep = self._read_config_key("auto_sleep")
         if auto_sleep is not None:
-            if isinstance(auto_sleep, str):
-                self._auto_sleep_enabled = auto_sleep.lower() in ("true", "1", "yes", "on")
-            else:
-                self._auto_sleep_enabled = bool(auto_sleep)
-        # env var is already applied in __init__, so it is the base default
+            self._auto_sleep_enabled = _coerce_bool(auto_sleep, self._auto_sleep_enabled)
+        # env var/default is already applied in __init__, so it is the base default
 
         # sleep_threshold: prefer kwargs, then config.yaml, then default 50
         sleep_threshold = kwargs.get("sleep_threshold")
@@ -809,7 +807,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
 
     def get_config_schema(self) -> List[Dict[str, Any]]:
         return [
-            {"key": "auto_sleep", "description": "Auto-run sleep() when working memory exceeds threshold. Set true to enable. Backward-compatible with MNEMOSYNE_AUTO_SLEEP_ENABLED env var.", "default": False},
+            {"key": "auto_sleep", "description": "Auto-run sleep() when working memory exceeds threshold. Set false to disable. Backward-compatible with MNEMOSYNE_AUTO_SLEEP_ENABLED env var.", "default": True},
             {"key": "sleep_threshold", "description": "Working memory count before auto-sleep triggers", "default": 50},
             {"key": "reflect", "description": "Reflection/sleep guardrails. Supports disabled_for_cron (default true) and max_calls_per_session (default 3; negative disables cap). Env: MNEMOSYNE_REFLECT_DISABLED_FOR_CRON, MNEMOSYNE_REFLECT_MAX_CALLS_PER_SESSION.", "default": {"disabled_for_cron": True, "max_calls_per_session": 3}},
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},
@@ -833,6 +831,7 @@ class MnemosyneMemoryProvider(MemoryProvider):
             with open(config_path, "r") as f:
                 config = yaml.safe_load(f) or {}
             memory_cfg = config.setdefault("memory", {}).setdefault("mnemosyne", {})
+            memory_cfg.setdefault("auto_sleep", _parse_env_bool("MNEMOSYNE_AUTO_SLEEP_ENABLED", True))
             memory_cfg.update(values)
             with open(config_path, "w") as f:
                 yaml.safe_dump(config, f, default_flow_style=False, allow_unicode=True)

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -113,10 +114,126 @@ def test_provider_config_defaults_match(provider_modules):
     integration_config = _config_schema(provider_modules["mnemosyne_hermes"])
 
     assert _json_stable(root_config) == _json_stable(integration_config)
+    assert root_config["auto_sleep"]["default"] is True
     assert root_config["sync_roles"]["default"] == ["user"]
     assert root_config["default_scope"]["choices"] == ["session", "global"]
     assert root_config["default_scope"]["default"] == "session"
     assert root_config["tools"]["default"] is None
+
+
+def test_auto_sleep_runtime_default_enabled(monkeypatch, provider_modules):
+    monkeypatch.delenv("MNEMOSYNE_AUTO_SLEEP_ENABLED", raising=False)
+
+    for module in provider_modules.values():
+        provider = module.MnemosyneMemoryProvider()
+        assert provider._auto_sleep_enabled is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+def test_auto_sleep_env_can_disable_default(monkeypatch, provider_modules, value):
+    monkeypatch.setenv("MNEMOSYNE_AUTO_SLEEP_ENABLED", value)
+
+    for module in provider_modules.values():
+        provider = module.MnemosyneMemoryProvider()
+        assert provider._auto_sleep_enabled is False
+
+
+@pytest.mark.parametrize("configured", [False, "false", 0])
+def test_auto_sleep_config_can_disable_default(tmp_path, monkeypatch, provider_modules, configured):
+    monkeypatch.delenv("MNEMOSYNE_AUTO_SLEEP_ENABLED", raising=False)
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"memory": {"provider": "mnemosyne", "mnemosyne": {"auto_sleep": configured}}})
+    )
+
+    for module in provider_modules.values():
+        provider = _provider_for_config(module, tmp_path)
+        provider._apply_provider_config({})
+        assert provider._auto_sleep_enabled is False
+
+
+@pytest.mark.parametrize(
+    ("env_value", "config_value", "kwarg_value", "expected"),
+    [
+        ("0", False, True, True),
+        ("1", True, False, False),
+        ("0", False, "true", True),
+        ("1", True, "false", False),
+    ],
+)
+def test_auto_sleep_kwargs_have_highest_precedence(
+    tmp_path, monkeypatch, provider_modules, env_value, config_value, kwarg_value, expected
+):
+    monkeypatch.setenv("MNEMOSYNE_AUTO_SLEEP_ENABLED", env_value)
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"memory": {"provider": "mnemosyne", "mnemosyne": {"auto_sleep": config_value}}})
+    )
+
+    for module in provider_modules.values():
+        provider = _provider_for_config(module, tmp_path)
+        provider._apply_provider_config({"auto_sleep": kwarg_value})
+        assert provider._auto_sleep_enabled is expected
+
+
+def test_save_config_persists_auto_sleep_default_when_missing(tmp_path, provider_modules):
+    (tmp_path / "config.yaml").write_text(
+        "memory:\n"
+        "  provider: mnemosyne\n"
+        "  mnemosyne:\n"
+        "    sleep_threshold: 75\n"
+    )
+
+    for name, module in provider_modules.items():
+        hermes_home = tmp_path / name
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text((tmp_path / "config.yaml").read_text())
+
+        provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+        provider.save_config({}, str(hermes_home))
+
+        cfg = yaml.safe_load((hermes_home / "config.yaml").read_text())
+        mnemosyne_cfg = cfg["memory"]["mnemosyne"]
+        assert mnemosyne_cfg["auto_sleep"] is True
+        assert mnemosyne_cfg["sleep_threshold"] == 75
+
+
+def test_save_config_respects_auto_sleep_env_opt_out(tmp_path, monkeypatch, provider_modules):
+    monkeypatch.setenv("MNEMOSYNE_AUTO_SLEEP_ENABLED", "0")
+
+    for name, module in provider_modules.items():
+        hermes_home = tmp_path / name
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  provider: mnemosyne\n"
+            "  mnemosyne:\n"
+            "    sleep_threshold: 75\n"
+        )
+
+        provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+        provider.save_config({}, str(hermes_home))
+
+        cfg = yaml.safe_load((hermes_home / "config.yaml").read_text())
+        mnemosyne_cfg = cfg["memory"]["mnemosyne"]
+        assert mnemosyne_cfg["auto_sleep"] is False
+        assert mnemosyne_cfg["sleep_threshold"] == 75
+
+
+def test_save_config_preserves_explicit_auto_sleep_false(tmp_path, provider_modules):
+    for name, module in provider_modules.items():
+        hermes_home = tmp_path / name
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  provider: mnemosyne\n"
+            "  mnemosyne:\n"
+            "    auto_sleep: false\n"
+        )
+
+        provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+        provider.save_config({}, str(hermes_home))
+
+        cfg = yaml.safe_load((hermes_home / "config.yaml").read_text())
+        assert cfg["memory"]["mnemosyne"]["auto_sleep"] is False
 
 
 def test_tool_whitelist_omitted_exposes_all_tools(tmp_path, provider_modules):


### PR DESCRIPTION
## Summary
- default `auto_sleep` to `True` in both Hermes provider surfaces
- keep env/config opt-outs working via shared boolean coercion
- persist `auto_sleep: true` when provider config is saved and the key is missing
- add parity/runtime/config regression coverage for both provider packages

## Tests
- `uv run --no-sync --with pytest --with pyyaml pytest tests/test_hermes_provider_parity.py -q`
- `PYTHONPATH=. uv run --no-sync --with pytest --with pyyaml pytest tests/test_hermes_memory_provider.py::test_auto_sleep_timeout_default_is_5 tests/test_hermes_memory_provider.py::test_auto_sleep_timeout_env_override tests/test_hermes_memory_provider.py::test_auto_sleep_timeout_invalid_env_falls_back tests/test_reflection_guardrails.py tests/test_sync_turn_diagnostics.py tests/test_sync_roles.py -q`

Follow-up to #420.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `auto_sleep` now defaults to **enabled** when no setting is provided (including unset/invalid environment and missing config).
  * Improved consistent boolean parsing for `auto_sleep` across environment values and config/override inputs.
  * Persisted configuration now backfills `auto_sleep: true` by default, while preserving explicit `auto_sleep: false`.

* **Tests**
  * Expanded Hermes/Mnemosyne parity coverage for `auto_sleep`, including precedence and persistence scenarios (default enablement, opt-out, and explicit disablement).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->