### PR TITLE
fix(beam): do not hold the SQLite write lock across consolidation LLM calls

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -454,7 +454,14 @@ def _get_connection(db_path: Path = None) -> sqlite3.Connection:
         )
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA busy_timeout=5000")
+        # Configurable so deployments with long consolidation write windows
+        # can let tool calls ride them out instead of failing with
+        # "database is locked" after a hardcoded 5s.
+        try:
+            _busy_ms = int(os.environ.get("MNEMOSYNE_BUSY_TIMEOUT_MS", "5000"))
+        except ValueError:
+            _busy_ms = 5000
+        conn.execute(f"PRAGMA busy_timeout={_busy_ms}")
         if _SQLITE_VEC_AVAILABLE:
             try:
                 conn.enable_load_extension(True)
@@ -4148,6 +4155,12 @@ class BeamMemory:
         # Strip closed <think>...</think> blocks that some LLMs emit
         import re as _re
         summary = _re.sub(r"<think>.*?</think>", "", summary, flags=_re.DOTALL).strip()
+        # Compute the embedding BEFORE the INSERT opens the write transaction.
+        # embed() can be a network call (API embeddings, 30s timeout) or a
+        # heavy CPU call; running it after the INSERT held the SQLite write
+        # lock across the whole call, starving every other connection
+        # (busy_timeout default 5s) for the duration of sleep().
+        vec = _embeddings.embed([summary]) if _embeddings.available() else None
         cursor = self.conn.cursor()
         cursor.execute("""
             INSERT INTO episodic_memory
@@ -4159,34 +4172,32 @@ class BeamMemory:
               self.author_id, self.author_type, self.channel_id, ep_type, row_veracity))
         rowid = cursor.lastrowid
 
-        if _embeddings.available():
-            vec = _embeddings.embed([summary])
-            if vec is not None:
-                if _vec_available(self.conn):
-                    try:
-                        _vec_insert(self.conn, rowid, np.asarray(vec[0]).tolist())
-                    except Exception as _vec_exc:
-                        logger.warning(
-                            "vec_episodes insert failed (rowid=%s): %s",
-                            rowid, _vec_exc,
-                        )
-                else:
-                    # Fallback: store in memory_embeddings table for in-memory search
-                    cursor.execute("""
-                        INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model)
-                        VALUES (?, ?, ?)
-                    """, (memory_id, _embeddings.serialize(np.asarray(vec[0])), _embeddings._DEFAULT_MODEL))
+        if vec is not None:
+            if _vec_available(self.conn):
+                try:
+                    _vec_insert(self.conn, rowid, np.asarray(vec[0]).tolist())
+                except Exception as _vec_exc:
+                    logger.warning(
+                        "vec_episodes insert failed (rowid=%s): %s",
+                        rowid, _vec_exc,
+                    )
+            else:
+                # Fallback: store in memory_embeddings table for in-memory search
+                cursor.execute("""
+                    INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model)
+                    VALUES (?, ?, ?)
+                """, (memory_id, _embeddings.serialize(np.asarray(vec[0])), _embeddings._DEFAULT_MODEL))
 
-                # Binary vector compression (Phase 2 -- 32x reduction)
-                if _mib is not None:
-                    try:
-                        bv = _mib(np.asarray(vec[0]))
-                        cursor.execute(
-                            "UPDATE episodic_memory SET binary_vector = ? WHERE rowid = ?",
-                            (bv, rowid)
-                        )
-                    except Exception:
-                        pass  # Non-blocking
+            # Binary vector compression (Phase 2 -- 32x reduction)
+            if _mib is not None:
+                try:
+                    bv = _mib(np.asarray(vec[0]))
+                    cursor.execute(
+                        "UPDATE episodic_memory SET binary_vector = ? WHERE rowid = ?",
+                        (bv, rowid)
+                    )
+                except Exception:
+                    pass  # Non-blocking
 
         self.conn.commit()
 
@@ -8112,6 +8123,15 @@ class BeamMemory:
                     f"WHERE id IN ({group_placeholders})",
                     tuple(ids),
                 )
+                # Commit the claim-clear NOW. Leaving this UPDATE uncommitted
+                # opened an implicit write transaction that stayed open across
+                # the NEXT group's LLM calls (validate_conflict_pair /
+                # summarize_memories — remote API seconds-to-minutes, local
+                # GGUF fallback unbounded), holding the SQLite write lock the
+                # whole time and failing every concurrent tool call with
+                # "database is locked". Observed wedging a live instance for
+                # 7+ hours with a frozen 52MB WAL.
+                self.conn.commit()
             consolidated_ids.extend(ids)
             summaries_created += 1
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4160,7 +4160,19 @@ class BeamMemory:
         # heavy CPU call; running it after the INSERT held the SQLite write
         # lock across the whole call, starving every other connection
         # (busy_timeout default 5s) for the duration of sleep().
-        vec = _embeddings.embed([summary]) if _embeddings.available() else None
+        # An embed failure must not abort the insert: the summary row is the
+        # payload, the vector is an index. Fall back to vec = None like the
+        # other embed call sites (remember, remember_batch, update_working).
+        vec = None
+        if _embeddings.available():
+            try:
+                vec = _embeddings.embed([summary])
+            except Exception as exc:
+                logger.warning(
+                    "consolidate_to_episodic: embedding failed, storing "
+                    "summary without vector (%s): %s",
+                    type(exc).__name__, exc,
+                )
         cursor = self.conn.cursor()
         cursor.execute("""
             INSERT INTO episodic_memory

--- a/tests/test_sleep_lock_hygiene.py
+++ b/tests/test_sleep_lock_hygiene.py
@@ -123,3 +123,33 @@ class TestSleepLockHygiene:
             other.commit()
         finally:
             other.close()
+
+    def test_embed_failure_does_not_drop_summary(self, temp_db, monkeypatch):
+        """The pre-INSERT embed() call must not abort the episodic insert.
+        embed() can raise on the local path (model load failures re-raise
+        as RuntimeError); the summary row is the payload and must land,
+        just without a vector."""
+        from mnemosyne.core import embeddings as _emb
+
+        beam = BeamMemory(session_id="lock-hygiene", db_path=temp_db)
+
+        monkeypatch.setattr(_emb, "available", lambda: True)
+
+        def raising_embed(texts):
+            raise RuntimeError("Failed to load embedding model")
+
+        monkeypatch.setattr(_emb, "embed", raising_embed)
+
+        beam.consolidate_to_episodic(
+            summary="summary that must survive an embed failure",
+            source_wm_ids=["lh-x-0"],
+            source="sleep_consolidation",
+        )
+
+        row = beam.conn.execute(
+            "SELECT content FROM episodic_memory WHERE source = ?",
+            ("sleep_consolidation",),
+        ).fetchone()
+        assert row is not None
+        assert "must survive" in row["content"]
+        assert beam.conn.in_transaction is False

--- a/tests/test_sleep_lock_hygiene.py
+++ b/tests/test_sleep_lock_hygiene.py
@@ -1,0 +1,125 @@
+"""Regression tests for consolidation write-lock hygiene in sleep().
+
+sleep() processes eligible working_memory rows in per-source groups. After
+each group it clears the group's consolidation_claimed_at markers with an
+UPDATE. Pre-fix, that UPDATE was never committed, so it opened an implicit
+write transaction that stayed open across the NEXT group's LLM summarization
+calls (remote API: seconds to minutes per chunk; the local GGUF fallback has
+no timeout at all). While that transaction was open, every other connection
+failed with "database is locked" after busy_timeout, and the WAL could not
+checkpoint. Observed in production as a multi-hour wedge with a frozen WAL.
+
+The fix commits immediately after the claim-clear UPDATE, so no write
+transaction is open on the beam connection while an LLM call runs.
+"""
+
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core import local_llm
+from mnemosyne.core.beam import BeamMemory
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+def _seed_old_wm(db_path, session_id, source, n, start=0):
+    """Insert n old working_memory rows for the given session/source."""
+    conn = sqlite3.connect(str(db_path))
+    ts = (datetime.now() - timedelta(hours=200)).isoformat()
+    rows = [
+        (
+            f"lh-{source}-{i}",
+            f"lock-hygiene content {source} {i}",
+            source,
+            ts,
+            session_id,
+        )
+        for i in range(start, start + n)
+    ]
+    conn.executemany(
+        "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestSleepLockHygiene:
+
+    def test_no_open_write_txn_during_llm_summarization(self, temp_db, monkeypatch):
+        """Each group's LLM summarize call must run with NO open transaction
+        on the beam connection. Pre-fix, group N's claim-clear UPDATE was
+        left uncommitted, so group N+1's summarize call ran inside an open
+        write transaction that held the SQLite write lock for the whole
+        (potentially unbounded) LLM call."""
+        beam = BeamMemory(session_id="lock-hygiene", db_path=temp_db)
+        # Skip the model-refresh proposal LLM path; this test targets the
+        # summarization path only.
+        beam.agent_context = "cron"
+
+        # Two sources -> two consolidation groups -> at least two
+        # summarize calls, so the second observes the state the first
+        # group's claim-clear left behind.
+        _seed_old_wm(temp_db, "lock-hygiene", "conversation", n=2)
+        _seed_old_wm(temp_db, "lock-hygiene", "notes", n=2)
+
+        txn_open_during_summarize = []
+
+        monkeypatch.setattr(local_llm, "llm_available", lambda: True)
+        monkeypatch.setattr(
+            local_llm,
+            "chunk_memories_by_budget",
+            lambda lines, source=None: [lines],
+        )
+
+        def fake_summarize(lines, source=None):
+            txn_open_during_summarize.append(beam.conn.in_transaction)
+            return f"summary of {len(lines)} items"
+
+        monkeypatch.setattr(local_llm, "summarize_memories", fake_summarize)
+
+        result = beam.sleep()
+
+        assert result["status"] == "consolidated"
+        assert result["summaries_created"] == 2
+        assert len(txn_open_during_summarize) == 2
+        assert txn_open_during_summarize == [False, False], (
+            "sleep() held an open write transaction on the beam connection "
+            "while an LLM summarization call ran; the claim-clear UPDATE "
+            f"was not committed. States: {txn_open_during_summarize}"
+        )
+
+    def test_sleep_leaves_no_open_transaction(self, temp_db, monkeypatch):
+        """After sleep() returns, the beam connection has no open
+        transaction, so other connections can write and the WAL can
+        checkpoint."""
+        beam = BeamMemory(session_id="lock-hygiene", db_path=temp_db)
+        beam.agent_context = "cron"
+        _seed_old_wm(temp_db, "lock-hygiene", "conversation", n=3)
+
+        monkeypatch.setattr(local_llm, "llm_available", lambda: False)
+
+        result = beam.sleep()
+
+        assert result["status"] == "consolidated"
+        assert beam.conn.in_transaction is False
+
+        # A second connection must be able to write immediately.
+        other = sqlite3.connect(str(temp_db), timeout=1.0)
+        try:
+            other.execute(
+                "UPDATE working_memory SET last_recalled = ? WHERE session_id = ?",
+                (datetime.now().isoformat(), "lock-hygiene"),
+            )
+            other.commit()
+        finally:
+            other.close()


### PR DESCRIPTION
## Problem

On a live deployment with consolidation enabled, every Mnemosyne tool call can start failing with "database is locked" and stay that way for hours, and the WAL never checkpoints until the host process restarts. This is the symptom set described in #382. The root cause we found is sharper than connection cleanup: `sleep()` holds an open SQLite write transaction across LLM calls.

## Mechanism

`sleep()` (`mnemosyne/core/beam.py:7840`) processes eligible working_memory rows in per-source groups. After each group it clears the group's claim markers with an UPDATE (`beam.py:8111`) that is never committed. Under sqlite3's default `isolation_level`, that UPDATE opens an implicit write transaction which then stays open while the loop moves on to the NEXT group and runs its LLM calls (`validate_conflict_pair`, `summarize_memories`). A remote API call takes seconds to minutes per chunk, and the local GGUF path in `local_llm.py` has no timeout at all, so the write lock is held continuously for the duration of the whole consolidation pass.

While that transaction is open, every other connection gives up after `busy_timeout=5000` (`beam.py:457`) and fails with "database is locked". That includes recall, which writes `last_recalled`, so reads fail too. And because a writer transaction is open the WAL can never checkpoint, so it grows and stays frozen.

A secondary offender: `consolidate_to_episodic()` (`beam.py:4113`) ran `embed()` after the episodic INSERT, i.e. inside the write transaction. `embed()` can be a network call or heavy CPU work, extending the lock window further.

## Fix

1. `sleep()`: commit immediately after the per-group claim-clear UPDATE, so no write transaction is open while LLM calls run.
2. `consolidate_to_episodic()`: compute the summary embedding before the INSERT opens the write transaction.
3. `_get_connection()`: make `busy_timeout` configurable via `MNEMOSYNE_BUSY_TIMEOUT_MS` (default unchanged at 5000), so deployments with long write windows can let tool calls ride them out.

## Verification

New `tests/test_sleep_lock_hygiene.py`. The key test seeds two consolidation groups and monkeypatches `local_llm.summarize_memories` to record `conn.in_transaction` at each call. On unpatched main the second group's call observes an open transaction (`[False, True]`); with the fix both observe `[False, False]`. A second test asserts that after `sleep()` returns there is no open transaction and a separate connection can write immediately. `tests/test_beam_e3_additive_sleep.py` and `tests/test_consolidate_fact_concurrency.py` still pass (34 tests).

## Incident evidence

A production deployment wedged for more than 7 hours with a frozen 52 MB WAL until process restart, with every memory tool call (including recall) failing "database is locked" for the duration.

Closes the root cause behind the symptoms in #382 for the in-process provider; the connection-cleanup suggestions there are complementary but were not sufficient, since the lock holder here is a live, never-committed transaction rather than a leaked idle connection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced “database is locked” errors during background consolidation and sleep by improving write-transaction timing.
  * Made SQLite busy-wait duration configurable via `MNEMOSYNE_BUSY_TIMEOUT_MS`, with a safe default when invalid.
  * Ensured consolidation summaries are preserved even if embedding generation fails, without blocking subsequent steps.

* **Tests**
  * Added regression tests to verify sleep/consolidation do not leave open write transactions during long summarization work and that embed failures don’t prevent summary insertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->