### PR TITLE
test(hermes): avoid HERMES_HOME leak in CLI bank test

### DIFF
--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -107,7 +107,7 @@ def test_get_provider_class_standalone_fallback(monkeypatch):
     assert hasattr(cls, "_sanitize_bank_name")
 
 
-def test_standalone_load_via_spec_resolves_profile_bank(tmp_path):
+def test_standalone_load_via_spec_resolves_profile_bank(tmp_path, monkeypatch):
     """End-to-end standalone load: CLI module loaded from file path
     (no __package__) resolves the active profile bank."""
     home = tmp_path / "profiles" / "work"
@@ -134,16 +134,11 @@ def test_standalone_load_via_spec_resolves_profile_bank(tmp_path):
     assert cls is not None
     assert hasattr(cls, "_sanitize_bank_name")
 
-    # Verify bank resolution works end-to-end
-    old_home = "HERMES_HOME" in __import__("os").environ
-    saved = __import__("os").environ.pop("HERMES_HOME", None)
-    try:
-        __import__("os").environ["HERMES_HOME"] = str(home)
-        result = mod._resolve_cli_bank(_args(bank=None), "stats")
-        assert result == "work", (
-            f"standalone load: expected 'work', got {result!r}. "
-            "This indicates the absolute-import fallback failed."
-        )
-    finally:
-        if old_home and saved is not None:
-            __import__("os").environ["HERMES_HOME"] = saved
+    # Verify bank resolution works end-to-end without leaking HERMES_HOME
+    # into later tests.
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    result = mod._resolve_cli_bank(_args(bank=None), "stats")
+    assert result == "work", (
+        f"standalone load: expected 'work', got {result!r}. "
+        "This indicates the absolute-import fallback failed."
+    )


### PR DESCRIPTION
## Summary
- follow up on #395 reviewer hygiene note
- use pytest monkeypatch to set HERMES_HOME in the standalone CLI bank test
- remove manual environment save/restore logic that could leave HERMES_HOME set when it was previously unset

## Validation
- `PYTHONPATH=integrations/hermes/src:. python3 -m pytest integrations/hermes/tests/test_cli_bank.py -q`
- `python3 -m py_compile integrations/hermes/tests/test_cli_bank.py`
- `git diff --check`

## Notes
- Test-only cleanup; no runtime behavior change.
- Follow-up to maintainer comment on #395.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR is a test-only cleanup in the Hermes CLI integration suite. It replaces manual `HERMES_HOME` save/restore logic with `pytest`’s `monkeypatch`, preventing environment leakage between tests.

Impact assessment:
- Core memory architecture: no change
- Privacy posture: neutral to slightly improved in test isolation
- Local-first guarantees: preserved
- Agent integration surfaces (Hermes/MCP/CLI): no runtime surface changes; Hermes CLI test coverage is improved
- Tiered memory / retrieval / consolidation / veracity / sync / benchmarks: no change

Architecturally, this is the right call: it reduces flaky test behavior and improves maintainability without affecting production behavior. No local-first regressions are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->