### PR TITLE
fix(beam): roll back the recall-touch transaction on failure

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -3780,14 +3780,28 @@ class BeamMemory:
             ts = new_last.isoformat()
             updates.setdefault(ts, []).append(row["id"])
 
-        cursor.execute("BEGIN TRANSACTION")
-        for ts, ids in updates.items():
-            placeholders = ",".join("?" for _ in ids)
-            cursor.execute(
-                f"UPDATE working_memory SET recall_count = recall_count + 1, last_recalled = ? WHERE id IN ({placeholders})",
-                (ts, *ids)
-            )
-        self.conn.commit()
+        # Roll back on ANY failure inside this explicit transaction. Left
+        # unprotected, a "database is locked" here (e.g. while a consolidation
+        # pass is writing) abandons the connection inside an open, stale
+        # transaction -- and because the connection is a long-lived thread
+        # local, EVERY later write on this thread then fails "database is
+        # locked" instantly (stale-snapshot upgrade; the busy handler is not
+        # consulted) until something resets it.
+        try:
+            cursor.execute("BEGIN TRANSACTION")
+            for ts, ids in updates.items():
+                placeholders = ",".join("?" for _ in ids)
+                cursor.execute(
+                    f"UPDATE working_memory SET recall_count = recall_count + 1, last_recalled = ? WHERE id IN ({placeholders})",
+                    (ts, *ids)
+                )
+            self.conn.commit()
+        except Exception:
+            try:
+                self.conn.rollback()
+            except Exception:
+                pass  # rollback of a dead connection must not mask the cause
+            raise
         return rows
 
     def invalidate(self, memory_id: str, replacement_id: str = None) -> bool:

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1190,6 +1190,38 @@ class _BeamConnection(sqlite3.Connection):
 
 
 @contextlib.contextmanager
+def _guarded_transaction(conn: sqlite3.Connection):
+    """Run the enclosed statements as one transaction, rolling back on ANY
+    failure before re-raising.
+
+    Centralizes the guarded commit/rollback pattern shared by
+    ``get_context()``'s recall touch and ``forget_working()``'s cascade
+    delete. Left unguarded, a failure mid-transaction (for example
+    "database is locked" while a consolidation pass is writing) abandons
+    the long-lived thread-local connection inside an open, stale
+    transaction, and every later write on that thread fails
+    "database is locked" instantly (stale-snapshot upgrade; the busy
+    handler is not consulted) until something resets it. The rollback is
+    itself guarded so a dead connection cannot mask the original
+    exception.
+
+    Not used by ``_deferred_commits()``: that context manager implements
+    commit-DEFERRAL semantics (suppressing nested commits behind a
+    per-connection flag), which is a different mechanism from a plain
+    guarded transaction.
+    """
+    try:
+        yield
+        conn.commit()
+    except Exception:
+        try:
+            conn.rollback()
+        except sqlite3.Error:
+            pass  # rollback of a dead connection must not mask the cause
+        raise
+
+
+@contextlib.contextmanager
 def _deferred_commits(conn: sqlite3.Connection):
     """Suppress nested commit() calls so the caller can wrap many
     sub-helpers in a single transaction.
@@ -3780,14 +3812,11 @@ class BeamMemory:
             ts = new_last.isoformat()
             updates.setdefault(ts, []).append(row["id"])
 
-        # Roll back on ANY failure inside this explicit transaction. Left
-        # unprotected, a "database is locked" here (e.g. while a consolidation
-        # pass is writing) abandons the connection inside an open, stale
-        # transaction -- and because the connection is a long-lived thread
-        # local, EVERY later write on this thread then fails "database is
-        # locked" instantly (stale-snapshot upgrade; the busy handler is not
-        # consulted) until something resets it.
-        try:
+        # Guarded: a failure here (e.g. "database is locked" while a
+        # consolidation pass is writing) must roll back rather than abandon
+        # the thread-local connection inside an open, stale transaction --
+        # see _guarded_transaction.
+        with _guarded_transaction(self.conn):
             cursor.execute("BEGIN TRANSACTION")
             for ts, ids in updates.items():
                 placeholders = ",".join("?" for _ in ids)
@@ -3795,13 +3824,6 @@ class BeamMemory:
                     f"UPDATE working_memory SET recall_count = recall_count + 1, last_recalled = ? WHERE id IN ({placeholders})",
                     (ts, *ids)
                 )
-            self.conn.commit()
-        except Exception:
-            try:
-                self.conn.rollback()
-            except Exception:
-                pass  # rollback of a dead connection must not mask the cause
-            raise
         return rows
 
     def invalidate(self, memory_id: str, replacement_id: str = None) -> bool:
@@ -4110,6 +4132,8 @@ class BeamMemory:
         return None
 
     def forget_working(self, memory_id: str) -> bool:
+        """Delete a session-authorized working memory row and its cascade
+        (vector, annotations, embeddings) atomically."""
         # E6.a: the cascade-delete of annotations must be authorized by the
         # session-scoped working_memory DELETE. The annotations table has no
         # session_id column, so an unconditional `DELETE FROM annotations
@@ -4126,7 +4150,7 @@ class BeamMemory:
         # uncommitted on the connection for a later unrelated commit to
         # silently include.
         cursor = self.conn.cursor()
-        try:
+        with _guarded_transaction(self.conn):
             authorized_row = cursor.execute(
                 "SELECT rowid FROM working_memory WHERE id = ? AND (session_id = ? OR scope = 'global')",
                 (memory_id, self.session_id),
@@ -4143,10 +4167,6 @@ class BeamMemory:
                     "DELETE FROM annotations WHERE memory_id = ?", (memory_id,)
                 )
                 cursor.execute("DELETE FROM memory_embeddings WHERE memory_id = ?", (memory_id,))
-            self.conn.commit()
-        except Exception:
-            self.conn.rollback()
-            raise
         return wm_rows > 0
 
     # ------------------------------------------------------------------

--- a/tests/test_sleep_lock_hygiene.py
+++ b/tests/test_sleep_lock_hygiene.py
@@ -182,6 +182,17 @@ class TestRecallTouchRollback:
             beam.get_context(limit=5)
         monkeypatch.setattr(beam.conn, "commit", real_commit)
 
+        # The failed touch must have been ROLLED BACK, not merely abandoned:
+        # the seeded row's recall bookkeeping is unchanged.
+        row = beam.conn.execute(
+            "SELECT recall_count, last_recalled FROM working_memory "
+            "WHERE content = ?",
+            ("touch rollback seed",),
+        ).fetchone()
+        assert row is not None
+        assert row["recall_count"] == 0
+        assert row["last_recalled"] is None
+
         # Pre-fix: the connection is still inside the touch transaction here,
         # and this write fails "database is locked" (stale snapshot) or
         # "cannot start a transaction within a transaction".

--- a/tests/test_sleep_lock_hygiene.py
+++ b/tests/test_sleep_lock_hygiene.py
@@ -153,3 +153,39 @@ class TestSleepLockHygiene:
         assert row is not None
         assert "must survive" in row["content"]
         assert beam.conn.in_transaction is False
+
+
+class TestRecallTouchRollback:
+    """The recall touch in get_context() runs an explicit transaction.
+    Pre-fix, a failure inside it (e.g. "database is locked" while a
+    consolidation pass is writing) propagated with the transaction still
+    open on the long-lived thread-local connection, so every later write
+    on that thread failed "database is locked" instantly until something
+    reset it. Observed in production as a self-healing storm of instant
+    tool failures minutes after the real writer had finished."""
+
+    def test_touch_failure_leaves_no_open_transaction(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="touch-rollback", db_path=temp_db)
+        beam.remember("touch rollback seed", source="test")
+
+        real_commit = beam.conn.commit
+        calls = {"n": 0}
+
+        def failing_commit():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise sqlite3.OperationalError("database is locked")
+            return real_commit()
+
+        monkeypatch.setattr(beam.conn, "commit", failing_commit)
+        with pytest.raises(sqlite3.OperationalError):
+            beam.get_context(limit=5)
+        monkeypatch.setattr(beam.conn, "commit", real_commit)
+
+        # Pre-fix: the connection is still inside the touch transaction here,
+        # and this write fails "database is locked" (stale snapshot) or
+        # "cannot start a transaction within a transaction".
+        assert not beam.conn.in_transaction
+        beam.remember("write after failed touch", source="test")
+        rows = beam.get_context(limit=5)
+        assert any("write after failed touch" in r["content"] for r in rows)


### PR DESCRIPTION
## Problem

Follow-up to #432, same lock-hygiene family, different call site. After a transient write collision, every Mnemosyne write on the affected thread can start failing "database is locked" instantly (milliseconds, not after busy_timeout), continuing for minutes after the original writer has finished, then self-healing. Observed live on 2026-07-09: a 95-second storm of instant lock failures on `recall`/`remember` roughly half an hour after a consolidation pass completed.

## Mechanism

`get_context()`'s recall touch bumps `recall_count` and `last_recalled` inside an explicit `BEGIN TRANSACTION ... commit` with no error handling (`mnemosyne/core/beam.py:3783`). If any statement in that window fails — for example "database is locked" while a consolidation pass is writing — the exception propagates with the transaction still open on the long-lived thread-local connection.

From then on that connection is poisoned: it holds a read snapshot that predates any subsequent writer, so each later write attempt takes the stale-snapshot upgrade path and returns SQLITE_BUSY immediately, without consulting the busy handler. No busy_timeout setting helps. The condition persists until something resets the transaction, which is why the storms self-heal after minutes.

## Fix

Wrap the touch transaction with rollback-on-error so a transient collision costs one failed call instead of poisoning the connection. The rollback itself is guarded so a dead connection cannot mask the original exception.

## Verification

New regression test in `tests/test_sleep_lock_hygiene.py` (`TestRecallTouchRollback`): a failing commit inside the touch path must leave no open transaction, and the connection must accept writes immediately afterward. Red on unpatched main (the connection is left in a transaction and the follow-up write fails), green with the fix. The existing lock-hygiene suite still passes (4 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves Mnemosyne’s core BEAM lock hygiene by introducing a shared `_guarded_transaction(conn)` helper that explicitly rolls back on any exception. It applies this to (1) the recall “touch” transaction inside `BeamMemory.get_context()` and (2) the cascading working-memory delete path inside `BeamMemory.forget_working()`, preventing transient lock/commit failures from leaving thread-local SQLite connections in a poisoned “open transaction / immediate SQLITE_BUSY” state.

Architecturally, this is the right call for local-first reliability: it contains concurrency/locking failures to the current operation without changing tiered-memory semantics (working vs episodic vs BEAM), retrieval strategy, consolidation pipeline, veracity logic, or any sync/agent integration surface (Hermes/MCP/CLI). It also strengthens long-term maintainability by centralizing the guarded-transaction pattern and adding rollback-on-error behavior where it matters most for long-lived connections.

The added regression test (`TestRecallTouchRollback`) verifies both that the failed recall touch leaves no open transaction and that the seeded row’s `recall_count` / `last_recalled` are unchanged, confirming rollback correctness, followed by successful subsequent writes and context retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->