### PR TITLE
feat: add read-only doctor hygiene signals

### DIFF
--- a/docs/api/configuration.mdx
+++ b/docs/api/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-version: 3.11.1
+version: 3.12.0
 generated_at: "auto"
 ---
 

--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -1,11 +1,11 @@
 ---
 title: "MCP Tool Schema"
-version: 3.11.1
+version: 3.12.0
 tool_count: 25
 generated_at: "auto"
 ---
 
-# MCP Tool Schema (v3.11.1)
+# MCP Tool Schema (v3.12.0)
 
 Mnemosyne exposes **25 MCP tools** for memory management, retrieval, and diagnostics.
 

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -710,13 +710,21 @@ def cmd_reindex(args):
 
 def cmd_hygiene(args):
     """hygiene audit|clean|restore — noise detection and safe cleanup (issue #428)."""
-    from mnemosyne.core.hygiene import audit_noise, clean_noise, NoiseCandidate, restore_archived
+    from mnemosyne.core.hygiene import (
+        NoiseCandidate,
+        audit_noise,
+        clean_noise,
+        hygiene_status,
+        restore_archived,
+    )
 
     if not args or args[0] in ("--help", "-h"):
-        print("Usage: mnemosyne hygiene audit|clean|restore [options]")
-        print("  audit [--limit N] [--min-score F] [--json]    Scan for noise (dry-run)")
+        print("Usage: mnemosyne hygiene audit|status|clean|restore [options]")
+        print("  audit [--limit N] [--offset N] [--all] [--batch-size N] [--min-score F] [--json]")
+        print("                                          Scan for noise (dry-run)")
+        print("  status [--limit N] [--json]             Show PII-safe hygiene status")
         print("  clean --action delete|archive|flag [--confirm] [--dry-run] <candidates.json>")
-        print("  restore [--limit N]                         Restore archived memories")
+        print("  restore [--limit N]                     Restore archived memories")
         return
 
     sub = args[0]
@@ -725,12 +733,24 @@ def cmd_hygiene(args):
     if sub == "audit":
         limit = 200
         min_score = 0.3
+        offset = 0
+        batch_size = 1000
+        scan_all = False
         as_json = False
         i = 0
         while i < len(rest):
             if rest[i] == "--limit" and i + 1 < len(rest):
                 limit = _parse_int(rest[i + 1], "limit")
                 i += 2
+            elif rest[i] == "--offset" and i + 1 < len(rest):
+                offset = _parse_int(rest[i + 1], "offset")
+                i += 2
+            elif rest[i] == "--batch-size" and i + 1 < len(rest):
+                batch_size = _parse_int(rest[i + 1], "batch-size")
+                i += 2
+            elif rest[i] == "--all":
+                scan_all = True
+                i += 1
             elif rest[i] == "--min-score" and i + 1 < len(rest):
                 min_score = _parse_float(rest[i + 1], "min-score")
                 i += 2
@@ -744,14 +764,24 @@ def cmd_hygiene(args):
         if not db_path.exists():
             _fail(f"Database not found at {db_path}")
 
-        report = audit_noise(db_path=db_path, limit=limit, min_score=min_score)
+        report = audit_noise(
+            db_path=db_path,
+            limit=limit,
+            min_score=min_score,
+            offset=offset,
+            scan_all=scan_all,
+            batch_size=batch_size,
+        )
 
         if as_json:
             print(json.dumps(report.to_dict(), indent=2))
         else:
-            print(f"Audited {report.total_scanned} rows across {report.tables_scanned}")
+            mode = "all rows" if scan_all else f"limit={limit} offset={offset}"
+            print(f"Audited {report.total_scanned} rows across {report.tables_scanned} ({mode})")
             print(f"Found {len(report.candidates)} noise candidates")
             print(f"  with secrets: {report.summary.get('with_secrets', 0)}")
+            for table, count in report.summary.get("by_table", {}).items():
+                print(f"  candidates in {table}: {count}")
             for action, count in report.summary.get("by_action", {}).items():
                 print(f"  suggested {action}: {count}")
             print()
@@ -762,6 +792,39 @@ def cmd_hygiene(args):
                     print(f"         SECRETS: {', '.join(c.secret_flags)}")
             if len(report.candidates) > 20:
                 print(f"  ... and {len(report.candidates) - 20} more (use --json for full list)")
+
+    elif sub == "status":
+        as_json = False
+        limit = 200
+        i = 0
+        while i < len(rest):
+            if rest[i] == "--json":
+                as_json = True
+                i += 1
+            elif rest[i] == "--limit" and i + 1 < len(rest):
+                limit = _parse_int(rest[i + 1], "limit")
+                i += 2
+            else:
+                i += 1
+        db_path = Path(DATA_DIR) / "mnemosyne.db"
+        if not db_path.exists():
+            _fail(f"Database not found at {db_path}")
+        status = hygiene_status(db_path=db_path, limit=limit)
+        if as_json:
+            print(json.dumps(status, indent=2))
+        else:
+            audit_log = status.get("audit_log", {})
+            print("Hygiene status")
+            print(f"  audit log present: {audit_log.get('present', False)}")
+            print(f"  audit log entries: {audit_log.get('total_entries', 0)}")
+            if audit_log.get("by_action"):
+                for action, count in audit_log["by_action"].items():
+                    print(f"  logged {action}: {count}")
+            noise = status.get("noise_summary", {})
+            print(f"  scanned rows: {noise.get('total_scanned', 0)}")
+            print(f"  noise candidates: {noise.get('total_candidates', 0)}")
+            print(f"  candidate ratio: {noise.get('candidate_ratio', 0.0)}")
+            print(f"  with secrets: {noise.get('with_secrets', 0)}")
 
     elif sub == "clean":
         action = "keep"
@@ -853,7 +916,7 @@ def cmd_hygiene(args):
         print(f"Restored {restored} archived memories.")
 
     else:
-        _fail(f"Unknown hygiene subcommand: {sub}. Use 'audit', 'clean', or 'restore'.")
+        _fail(f"Unknown hygiene subcommand: {sub}. Use 'audit', 'status', 'clean', or 'restore'.")
 
 
 def cmd_profile(args):

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -710,6 +710,8 @@ def cmd_reindex(args):
 
 def cmd_hygiene(args):
     """hygiene audit|clean|restore — noise detection and safe cleanup (issue #428)."""
+    import sqlite3
+
     from mnemosyne.core.hygiene import (
         NoiseCandidate,
         audit_noise,
@@ -720,8 +722,8 @@ def cmd_hygiene(args):
 
     if not args or args[0] in ("--help", "-h"):
         print("Usage: mnemosyne hygiene audit|status|clean|restore [options]")
-        print("  audit [--limit N] [--offset N] [--all] [--batch-size N] [--min-score F] [--json]")
-        print("                                          Scan for noise (dry-run)")
+        print("  audit [--limit N] [--offset N] [--all [--batch-size N]] [--min-score F] [--json]")
+        print("                                          Scan for noise (dry-run; --batch-size only affects --all)")
         print("  status [--limit N] [--json]             Show PII-safe hygiene status")
         print("  clean --action delete|archive|flag [--confirm] [--dry-run] <candidates.json>")
         print("  restore [--limit N]                     Restore archived memories")
@@ -773,7 +775,7 @@ def cmd_hygiene(args):
                 scan_all=scan_all,
                 batch_size=batch_size,
             )
-        except ValueError as e:
+        except (ValueError, sqlite3.Error) as e:
             _fail(str(e))
 
         if as_json:
@@ -814,7 +816,7 @@ def cmd_hygiene(args):
             _fail(f"Database not found at {db_path}")
         try:
             status = hygiene_status(db_path=db_path, limit=limit)
-        except ValueError as e:
+        except (ValueError, sqlite3.Error) as e:
             _fail(str(e))
         if as_json:
             print(json.dumps(status, indent=2))

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -764,14 +764,17 @@ def cmd_hygiene(args):
         if not db_path.exists():
             _fail(f"Database not found at {db_path}")
 
-        report = audit_noise(
-            db_path=db_path,
-            limit=limit,
-            min_score=min_score,
-            offset=offset,
-            scan_all=scan_all,
-            batch_size=batch_size,
-        )
+        try:
+            report = audit_noise(
+                db_path=db_path,
+                limit=limit,
+                min_score=min_score,
+                offset=offset,
+                scan_all=scan_all,
+                batch_size=batch_size,
+            )
+        except ValueError as e:
+            _fail(str(e))
 
         if as_json:
             print(json.dumps(report.to_dict(), indent=2))
@@ -809,7 +812,10 @@ def cmd_hygiene(args):
         db_path = Path(DATA_DIR) / "mnemosyne.db"
         if not db_path.exists():
             _fail(f"Database not found at {db_path}")
-        status = hygiene_status(db_path=db_path, limit=limit)
+        try:
+            status = hygiene_status(db_path=db_path, limit=limit)
+        except ValueError as e:
+            _fail(str(e))
         if as_json:
             print(json.dumps(status, indent=2))
         else:

--- a/mnemosyne/core/hygiene.py
+++ b/mnemosyne/core/hygiene.py
@@ -277,6 +277,7 @@ def audit_noise(
     limit: int = 200,
     tables: Optional[List[str]] = None,
     min_score: float = 0.3,
+    *,
     offset: int = 0,
     scan_all: bool = False,
     batch_size: int = 1000,

--- a/mnemosyne/core/hygiene.py
+++ b/mnemosyne/core/hygiene.py
@@ -27,7 +27,7 @@ import sqlite3
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from mnemosyne.core.filters import (
     DEFAULT_NOISE_PATTERNS,
@@ -227,6 +227,8 @@ def _scan_table(
     table_name: str,
     limit: int,
     offset: int = 0,
+    *,
+    after: Optional[Tuple[str, str]] = None,
 ) -> List[Dict[str, Any]]:
     """Scan a table for noise candidates. Returns rows as dicts."""
     cursor = conn.cursor()
@@ -234,11 +236,25 @@ def _scan_table(
     # working_memory, memories, and episodic_memory all share the core
     # (id, content, source, timestamp, session_id, importance, metadata_json)
     # shape, with episodic_memory having extra columns we don't need.
-    cursor.execute(
+    base_query = (
         f"SELECT id, content, source, timestamp, session_id, importance, metadata_json "
-        f"FROM {table_name} ORDER BY timestamp DESC LIMIT ? OFFSET ?",
-        (limit, offset),
+        f"FROM {table_name}"
     )
+    if after is None:
+        cursor.execute(
+            f"{base_query} ORDER BY timestamp DESC, id DESC LIMIT ? OFFSET ?",
+            (limit, offset),
+        )
+    else:
+        # Keyset pagination avoids repeatedly walking a growing OFFSET on large
+        # live tables; callers should process each batch before asking for more.
+        after_ts, after_id = after
+        cursor.execute(
+            f"{base_query} "
+            "WHERE timestamp < ? OR (timestamp = ? AND id < ?) "
+            "ORDER BY timestamp DESC, id DESC LIMIT ?",
+            (after_ts, after_ts, after_id, limit),
+        )
     columns = [desc[0] for desc in cursor.description]
     return [dict(zip(columns, row)) for row in cursor.fetchall()]
 
@@ -315,18 +331,27 @@ def audit_noise(
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
 
-    def scan_rows(table_name: str) -> List[Dict[str, Any]]:
+    def scan_batches(table_name: str) -> Iterator[List[Dict[str, Any]]]:
         if not scan_all:
-            return _scan_table(conn, table_name, limit, offset=offset)
-        rows: List[Dict[str, Any]] = []
+            yield _scan_table(conn, table_name, limit, offset=offset)
+            return
+
+        after: Optional[Tuple[str, str]] = None
         current_offset = offset
         while True:
-            batch = _scan_table(conn, table_name, batch_size, offset=current_offset)
+            batch = _scan_table(
+                conn,
+                table_name,
+                batch_size,
+                offset=current_offset if after is None else 0,
+                after=after,
+            )
             if not batch:
                 break
-            rows.extend(batch)
-            current_offset += len(batch)
-        return rows
+            yield batch
+            last = batch[-1]
+            after = (last.get("timestamp", "") or "", last.get("id", "") or "")
+            current_offset = 0
 
     try:
         for table in tables:
@@ -335,36 +360,38 @@ def audit_noise(
                 table_counts[table] = 0
                 continue
 
-            rows = scan_rows(table)
-            table_counts[table] = len(rows)
-            report.total_scanned += len(rows)
+            table_scanned = 0
+            for rows in scan_batches(table):
+                table_scanned += len(rows)
+                report.total_scanned += len(rows)
 
-            for row in rows:
-                content = row.get("content", "") or ""
-                importance = row.get("importance", 0.5) or 0.5
-                source = row.get("source", "") or ""
+                for row in rows:
+                    content = row.get("content", "") or ""
+                    importance = row.get("importance", 0.5) or 0.5
+                    source = row.get("source", "") or ""
 
-                score, reasons = _score_noise(content, importance, source)
-                secrets = detect_secrets(content)
+                    score, reasons = _score_noise(content, importance, source)
+                    secrets = detect_secrets(content)
 
-                if score < min_score and not secrets:
-                    continue
+                    if score < min_score and not secrets:
+                        continue
 
-                suggested = _suggest_action(score, secrets)
-                candidate = NoiseCandidate(
-                    memory_id=row.get("id", ""),
-                    table_name=table,
-                    content_preview=content[:200],
-                    noise_score=round(score, 4),
-                    noise_reasons=reasons,
-                    secret_flags=secrets,
-                    importance=importance,
-                    source=source,
-                    timestamp=row.get("timestamp", "") or "",
-                    suggested_action=suggested,
-                    content_length=len(content),
-                )
-                report.candidates.append(candidate)
+                    suggested = _suggest_action(score, secrets)
+                    candidate = NoiseCandidate(
+                        memory_id=row.get("id", ""),
+                        table_name=table,
+                        content_preview=content[:200],
+                        noise_score=round(score, 4),
+                        noise_reasons=reasons,
+                        secret_flags=secrets,
+                        importance=importance,
+                        source=source,
+                        timestamp=row.get("timestamp", "") or "",
+                        suggested_action=suggested,
+                        content_length=len(content),
+                    )
+                    report.candidates.append(candidate)
+            table_counts[table] = table_scanned
     finally:
         conn.close()
 

--- a/mnemosyne/core/hygiene.py
+++ b/mnemosyne/core/hygiene.py
@@ -8,9 +8,9 @@ points that bypassed it (MCP, SDK, CLI — fixed in the companion Layer 1 patch)
 
 Two operations:
 
-1. ``audit_noise()`` — scan ``working_memory`` + ``memories`` (primary ingest
-   targets), score each row for noise likelihood + secret presence, return
-   ranked candidates.  Dry-run by default.
+1. ``audit_noise()`` — scan ``working_memory`` + ``memories`` +
+   ``episodic_memory`` (when present), score each row for noise likelihood +
+   secret presence, return ranked candidates.  Dry-run by default.
 
 2. ``clean_noise()`` — process audit output in batches, apply one of three
    actions (delete / archive / keep), write a full audit log to
@@ -86,7 +86,7 @@ class AuditReport:
     total_scanned: int = 0
     candidates: List[NoiseCandidate] = field(default_factory=list)
     tables_scanned: List[str] = field(default_factory=list)
-    summary: Dict[str, int] = field(default_factory=dict)
+    summary: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -243,46 +243,99 @@ def _scan_table(
     return [dict(zip(columns, row)) for row in cursor.fetchall()]
 
 
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    )
+    return cursor.fetchone() is not None
+
+
+def _default_audit_tables() -> List[str]:
+    return ["working_memory", "memories", "episodic_memory"]
+
+
+def _build_audit_summary(
+    candidates: List[NoiseCandidate], *, table_counts: Dict[str, int]
+) -> Dict[str, Any]:
+    by_action: Dict[str, int] = {}
+    by_table: Dict[str, int] = {table: 0 for table in table_counts}
+    for c in candidates:
+        by_action[c.suggested_action] = by_action.get(c.suggested_action, 0) + 1
+        by_table[c.table_name] = by_table.get(c.table_name, 0) + 1
+    return {
+        "total_candidates": len(candidates),
+        "by_action": by_action,
+        "by_table": by_table,
+        "table_counts": table_counts,
+        "with_secrets": sum(1 for c in candidates if c.secret_flags),
+    }
+
+
 def audit_noise(
     db_path: Path,
     limit: int = 200,
     tables: Optional[List[str]] = None,
     min_score: float = 0.3,
+    offset: int = 0,
+    scan_all: bool = False,
+    batch_size: int = 1000,
 ) -> AuditReport:
     """Audit a memory database for noise.
 
-    Scans ``working_memory`` and ``memories`` (primary ingest targets) by
-    default.  Returns ranked candidates sorted by noise score descending.
+    Scans ``working_memory``, ``memories``, and ``episodic_memory`` by
+    default when those tables exist. Returns ranked candidates sorted by noise
+    score descending. The operation is read-only.
 
     Args:
         db_path: Path to the mnemosyne SQLite database.
-        limit: Maximum rows to scan per table.
-        tables: Override which tables to scan. Default: working_memory + memories.
+        limit: Maximum rows to scan per table unless ``scan_all`` is true.
+        tables: Override which tables to scan.
         min_score: Only include candidates with noise_score >= this threshold.
+        offset: Row offset per table for paginated scans.
+        scan_all: If true, page through all rows in each selected table.
+        batch_size: Batch size used when ``scan_all`` is true.
 
     Returns:
         ``AuditReport`` with ranked candidates.
     """
     if tables is None:
-        tables = ["working_memory", "memories"]
+        tables = _default_audit_tables()
+
+    if limit < 0:
+        raise ValueError("limit must be >= 0")
+    if offset < 0:
+        raise ValueError("offset must be >= 0")
+    if batch_size <= 0:
+        raise ValueError("batch_size must be > 0")
 
     report = AuditReport(tables_scanned=tables)
+    table_counts: Dict[str, int] = {}
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
 
+    def scan_rows(table_name: str) -> List[Dict[str, Any]]:
+        if not scan_all:
+            return _scan_table(conn, table_name, limit, offset=offset)
+        rows: List[Dict[str, Any]] = []
+        current_offset = offset
+        while True:
+            batch = _scan_table(conn, table_name, batch_size, offset=current_offset)
+            if not batch:
+                break
+            rows.extend(batch)
+            current_offset += len(batch)
+        return rows
+
     try:
         for table in tables:
-            # Check table exists
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-                (table,),
-            )
-            if cursor.fetchone() is None:
+            if not _table_exists(conn, table):
                 logger.debug("Table %s does not exist, skipping", table)
+                table_counts[table] = 0
                 continue
 
-            rows = _scan_table(conn, table, limit)
+            rows = scan_rows(table)
+            table_counts[table] = len(rows)
             report.total_scanned += len(rows)
 
             for row in rows:
@@ -314,20 +367,71 @@ def audit_noise(
     finally:
         conn.close()
 
-    # Sort by noise score descending (most likely noise first)
     report.candidates.sort(key=lambda c: c.noise_score, reverse=True)
-
-    # Build summary
-    report.summary = {
-        "total_candidates": len(report.candidates),
-        "by_action": {},
-        "with_secrets": sum(1 for c in report.candidates if c.secret_flags),
-    }
-    for c in report.candidates:
-        report.summary["by_action"][c.suggested_action] = \
-            report.summary["by_action"].get(c.suggested_action, 0) + 1
-
+    report.summary = _build_audit_summary(report.candidates, table_counts=table_counts)
     return report
+
+
+def noise_summary(
+    db_path: Path,
+    limit: int = 200,
+    tables: Optional[List[str]] = None,
+    min_score: float = 0.3,
+) -> Dict[str, Any]:
+    """Return a PII-safe noise summary without content previews."""
+    report = audit_noise(db_path=db_path, limit=limit, tables=tables, min_score=min_score)
+    table_counts = report.summary.get("table_counts", {})
+    candidates_by_table = report.summary.get("by_table", {})
+    ratios = {
+        table: (round(candidates_by_table.get(table, 0) / count, 4) if count else 0.0)
+        for table, count in table_counts.items()
+    }
+    return {
+        "status": "ok",
+        "tables_scanned": report.tables_scanned,
+        "total_scanned": report.total_scanned,
+        "total_candidates": len(report.candidates),
+        "candidate_ratio": round(len(report.candidates) / report.total_scanned, 4) if report.total_scanned else 0.0,
+        "by_table": candidates_by_table,
+        "table_counts": table_counts,
+        "candidate_ratio_by_table": ratios,
+        "by_action": report.summary.get("by_action", {}),
+        "with_secrets": report.summary.get("with_secrets", 0),
+        "min_score": min_score,
+        "limit_per_table": limit,
+    }
+
+
+def hygiene_status(
+    db_path: Path, *, include_noise_summary: bool = True, limit: int = 200
+) -> Dict[str, Any]:
+    """Return PII-safe hygiene status and optional current noise summary."""
+    status: Dict[str, Any] = {"status": "ok", "audit_log": {}}
+    conn = sqlite3.connect(str(db_path))
+    try:
+        if _table_exists(conn, "hygiene_audit_log"):
+            total = int(conn.execute("SELECT COUNT(*) FROM hygiene_audit_log").fetchone()[0])
+            by_action = {
+                row[0]: int(row[1])
+                for row in conn.execute(
+                    "SELECT action, COUNT(*) FROM hygiene_audit_log GROUP BY action"
+                ).fetchall()
+            }
+            last_ts = conn.execute("SELECT MAX(timestamp) FROM hygiene_audit_log").fetchone()[0]
+            status["audit_log"] = {
+                "present": True,
+                "total_entries": total,
+                "by_action": by_action,
+                "last_timestamp": last_ts,
+            }
+        else:
+            status["audit_log"] = {"present": False, "total_entries": 0, "by_action": {}}
+    finally:
+        conn.close()
+
+    if include_noise_summary:
+        status["noise_summary"] = noise_summary(db_path=db_path, limit=limit)
+    return status
 
 
 # ---------------------------------------------------------------------------

--- a/mnemosyne/diagnose.py
+++ b/mnemosyne/diagnose.py
@@ -137,8 +137,8 @@ def _memory_orphan_diagnostics(conn) -> Dict[str, int]:
 def _sqlite_integrity_diagnostics(conn) -> Dict[str, str]:
     """Return PII-safe SQLite integrity diagnostics."""
     try:
-        row = conn.execute("PRAGMA quick_check").fetchone()
-        result = str(row[0]) if row else "unknown"
+        rows = conn.execute("PRAGMA quick_check").fetchall()
+        result = "; ".join(str(row[0]) for row in rows) if rows else "unknown"
     except Exception as exc:
         return {"quick_check": "ERROR", "detail": str(exc)[:200]}
     return {"quick_check": result, "detail": ""}
@@ -292,11 +292,15 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False) 
 
         try:
             from mnemosyne.core.hygiene import noise_summary as _noise_summary
-            hygiene = _noise_summary(Path(stats.get("database", "")), limit=200)
-            log("db", "hygiene_noise_scanned", str(hygiene.get("total_scanned", 0)))
-            log("db", "hygiene_noise_candidates", str(hygiene.get("total_candidates", 0)))
-            log("db", "hygiene_noise_ratio", str(hygiene.get("candidate_ratio", 0.0)))
-            log("db", "hygiene_noise_with_secrets", str(hygiene.get("with_secrets", 0)))
+            db_path_str = stats.get("database")
+            if not db_path_str or db_path_str == "unknown":
+                log("db", "hygiene_noise_summary", "SKIPPED", "database path unavailable")
+            else:
+                hygiene = _noise_summary(Path(db_path_str), limit=200)
+                log("db", "hygiene_noise_scanned", str(hygiene.get("total_scanned", 0)))
+                log("db", "hygiene_noise_candidates", str(hygiene.get("total_candidates", 0)))
+                log("db", "hygiene_noise_ratio", str(hygiene.get("candidate_ratio", 0.0)))
+                log("db", "hygiene_noise_with_secrets", str(hygiene.get("with_secrets", 0)))
         except Exception as exc:
             log("db", "hygiene_noise_summary", "ERROR", str(exc))
 
@@ -364,6 +368,7 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False) 
     sqlite_quick_check = next((e for e in entries if e["check"] == "sqlite_quick_check"), None)
     hygiene_noise_candidates = next((e for e in entries if e["check"] == "hygiene_noise_candidates"), None)
     hygiene_noise_scanned = next((e for e in entries if e["check"] == "hygiene_noise_scanned"), None)
+    hygiene_noise_with_secrets = next((e for e in entries if e["check"] == "hygiene_noise_with_secrets"), None)
 
     if sqlite_quick_check and sqlite_quick_check["status"] != "OK":
         summary["key_findings"].append(
@@ -376,6 +381,10 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False) 
             summary["key_findings"].append(
                 f"Hygiene noise summary: {candidates} candidates across {scanned} scanned rows (read-only sample)"
             )
+            if hygiene_noise_with_secrets and int(hygiene_noise_with_secrets["status"]) > 0:
+                summary["key_findings"].append(
+                    f"Hygiene scan flagged {hygiene_noise_with_secrets['status']} rows with possible secrets - review before sharing/export"
+                )
 
     if not embed_ok:
         summary["key_findings"].append("fastembed not available - install with: pip install mnemosyne-memory[embeddings]")

--- a/mnemosyne/diagnose.py
+++ b/mnemosyne/diagnose.py
@@ -132,6 +132,18 @@ def _memory_orphan_diagnostics(conn) -> Dict[str, int]:
     return diagnostics
 
 
+
+
+def _sqlite_integrity_diagnostics(conn) -> Dict[str, str]:
+    """Return PII-safe SQLite integrity diagnostics."""
+    try:
+        row = conn.execute("PRAGMA quick_check").fetchone()
+        result = str(row[0]) if row else "unknown"
+    except Exception as exc:
+        return {"quick_check": "ERROR", "detail": str(exc)[:200]}
+    return {"quick_check": result, "detail": ""}
+
+
 def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False) -> Dict:
     """
     Run full diagnostic scan and write PII-safe log.
@@ -255,6 +267,18 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False) 
         log("db", "db_path", stats.get("database", "unknown"))
 
         try:
+            integrity = _sqlite_integrity_diagnostics(mem.beam.conn)
+            quick_check = integrity["quick_check"]
+            log(
+                "db",
+                "sqlite_quick_check",
+                "OK" if quick_check == "ok" else quick_check,
+                integrity.get("detail", ""),
+            )
+        except Exception as exc:
+            log("db", "sqlite_quick_check", "ERROR", str(exc))
+
+        try:
             orphan_diag = _memory_orphan_diagnostics(mem.beam.conn)
             log("db", "foreign_keys_enabled", "YES" if orphan_diag["foreign_keys_enabled"] else "NO")
             log("db", "gists_total", str(orphan_diag["gists_total"]))
@@ -265,6 +289,16 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False) 
             log("db", "orphan_memory_id_overlap", str(orphan_diag["orphan_memory_id_overlap"]))
         except Exception as exc:
             log("db", "memory_orphan_diagnostics", "ERROR", str(exc))
+
+        try:
+            from mnemosyne.core.hygiene import noise_summary as _noise_summary
+            hygiene = _noise_summary(Path(stats.get("database", "")), limit=200)
+            log("db", "hygiene_noise_scanned", str(hygiene.get("total_scanned", 0)))
+            log("db", "hygiene_noise_candidates", str(hygiene.get("total_candidates", 0)))
+            log("db", "hygiene_noise_ratio", str(hygiene.get("candidate_ratio", 0.0)))
+            log("db", "hygiene_noise_with_secrets", str(hygiene.get("with_secrets", 0)))
+        except Exception as exc:
+            log("db", "hygiene_noise_summary", "ERROR", str(exc))
 
         try:
             from mnemosyne.core.beam import repair_vec_working as _repair_vec_working, vec_working_coverage
@@ -327,6 +361,21 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False) 
     working_embedding_rows = next((e for e in entries if e["check"] == "working_embedding_rows"), None)
     vec_working_repair_status = next((e for e in entries if e["check"] == "vec_working_repair_status"), None)
     vec_working_repair_inserted = next((e for e in entries if e["check"] == "vec_working_repair_inserted"), None)
+    sqlite_quick_check = next((e for e in entries if e["check"] == "sqlite_quick_check"), None)
+    hygiene_noise_candidates = next((e for e in entries if e["check"] == "hygiene_noise_candidates"), None)
+    hygiene_noise_scanned = next((e for e in entries if e["check"] == "hygiene_noise_scanned"), None)
+
+    if sqlite_quick_check and sqlite_quick_check["status"] != "OK":
+        summary["key_findings"].append(
+            f"SQLite quick_check reported: {sqlite_quick_check['status']}"
+        )
+    if hygiene_noise_candidates and hygiene_noise_scanned:
+        candidates = int(hygiene_noise_candidates["status"])
+        scanned = int(hygiene_noise_scanned["status"])
+        if scanned:
+            summary["key_findings"].append(
+                f"Hygiene noise summary: {candidates} candidates across {scanned} scanned rows (read-only sample)"
+            )
 
     if not embed_ok:
         summary["key_findings"].append("fastembed not available - install with: pip install mnemosyne-memory[embeddings]")

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -938,12 +938,18 @@ def _handle_hygiene_audit(arguments: Dict[str, Any]) -> Dict[str, Any]:
     limit = arguments.get("limit", 200)
     min_score = arguments.get("min_score", 0.3)
     tables = arguments.get("tables") or None
+    offset = arguments.get("offset", 0)
+    scan_all = arguments.get("scan_all", False)
+    batch_size = arguments.get("batch_size", 1000)
 
     report = audit_noise(
         db_path=db_path,
         limit=limit,
         tables=tables,
         min_score=min_score,
+        offset=offset,
+        scan_all=scan_all,
+        batch_size=batch_size,
     )
     return {
         "status": "audited",

--- a/mnemosyne/tool_schemas.py
+++ b/mnemosyne/tool_schemas.py
@@ -754,8 +754,23 @@ HYGIENE_AUDIT_SCHEMA = {
         "properties": {
             "limit": {
                 "type": "integer",
-                "description": "Max rows to scan per table (default 200).",
+                "description": "Max rows to scan per table (default 200, ignored when scan_all is true).",
                 "default": 200,
+            },
+            "offset": {
+                "type": "integer",
+                "description": "Row offset per table for paginated audits (default 0).",
+                "default": 0,
+            },
+            "scan_all": {
+                "type": "boolean",
+                "description": "Scan all rows in each selected table using batches instead of a single limit.",
+                "default": False,
+            },
+            "batch_size": {
+                "type": "integer",
+                "description": "Batch size when scan_all is true (default 1000).",
+                "default": 1000,
             },
             "min_score": {
                 "type": "number",
@@ -768,7 +783,7 @@ HYGIENE_AUDIT_SCHEMA = {
                     "type": "string",
                     "enum": ["working_memory", "memories", "episodic_memory", "scratchpad"],
                 },
-                "description": "Tables to scan. Default: working_memory + memories.",
+                "description": "Tables to scan. Default: working_memory + memories + episodic_memory.",
             },
             "bank": {
                 "type": "string",

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -109,8 +109,11 @@ def test_diagnose_reports_memory_orphans_without_mutating_rows(tmp_path, monkeyp
     }
     assert after_counts == before_counts
     assert _entry(summary, "foreign_keys_enabled")["status"] == "NO"
+    assert _entry(summary, "sqlite_quick_check")["status"] == "OK"
     assert _entry(summary, "gists_total")["status"] == "3"
     assert _entry(summary, "gists_orphan_memory_id")["status"] == "1"
     assert _entry(summary, "memory_embeddings_total")["status"] == "2"
     assert _entry(summary, "memory_embeddings_orphan_memory_id")["status"] == "1"
     assert _entry(summary, "orphan_memory_id_overlap")["status"] == "1"
+    assert _entry(summary, "hygiene_noise_scanned")["status"] == "3"
+    assert int(_entry(summary, "hygiene_noise_candidates")["status"]) >= 0

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -116,4 +116,4 @@ def test_diagnose_reports_memory_orphans_without_mutating_rows(tmp_path, monkeyp
     assert _entry(summary, "memory_embeddings_orphan_memory_id")["status"] == "1"
     assert _entry(summary, "orphan_memory_id_overlap")["status"] == "1"
     assert _entry(summary, "hygiene_noise_scanned")["status"] == "3"
-    assert int(_entry(summary, "hygiene_noise_candidates")["status"]) >= 0
+    assert _entry(summary, "hygiene_noise_candidates")["status"] == "0"

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -232,6 +232,32 @@ class TestAuditNoise:
         assert full.total_scanned == 3
         assert {c.memory_id for c in full.candidates} == {"noise0", "noise1", "noise2"}
 
+    def test_audit_noise_rejects_invalid_pagination_args(self, temp_db):
+        db_path, beam = temp_db
+
+        with pytest.raises(ValueError, match="limit must be >= 0"):
+            audit_noise(db_path=db_path, limit=-1)
+        with pytest.raises(ValueError, match="offset must be >= 0"):
+            audit_noise(db_path=db_path, offset=-1)
+        with pytest.raises(ValueError, match="batch_size must be > 0"):
+            audit_noise(db_path=db_path, batch_size=0)
+
+    def test_hygiene_status_without_audit_log(self, temp_db):
+        db_path, beam = temp_db
+
+        status = hygiene_status(db_path=db_path, limit=10)
+
+        assert status["audit_log"]["present"] is False
+        assert status["audit_log"]["total_entries"] == 0
+        assert status["audit_log"]["by_action"] == {}
+
+    def test_hygiene_status_can_skip_noise_summary(self, temp_db):
+        db_path, beam = temp_db
+
+        status = hygiene_status(db_path=db_path, include_noise_summary=False)
+
+        assert "noise_summary" not in status
+
     def test_noise_summary_is_pii_safe(self, temp_db):
         db_path, beam = temp_db
         secret_content = "password = hunter2supersecret"  # nosec - test fixture

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -22,6 +22,8 @@ from mnemosyne.core.hygiene import (
     NoiseCandidate,
     audit_noise,
     clean_noise,
+    hygiene_status,
+    noise_summary,
     restore_archived,
     _score_noise,
     _suggest_action,
@@ -193,6 +195,81 @@ class TestAuditNoise:
 
         assert len(report.candidates) == 1
         assert report.candidates[0].table_name == "memories"
+
+    def test_audit_scans_episodic_memory_by_default(self, temp_db):
+        db_path, beam = temp_db
+        _insert_row(beam, "episodic_memory", "ep_noise", "heartbeat", source="heartbeat")
+
+        report = audit_noise(db_path=db_path, min_score=0.3)
+
+        assert "episodic_memory" in report.tables_scanned
+        assert report.summary["table_counts"]["episodic_memory"] == 1
+        assert any(c.table_name == "episodic_memory" for c in report.candidates)
+
+    def test_audit_offset_and_scan_all(self, temp_db):
+        db_path, beam = temp_db
+        for idx in range(3):
+            _insert_row(beam, "working_memory", f"noise{idx}", "heartbeat", source="heartbeat")
+
+        paged = audit_noise(db_path=db_path, limit=1, offset=1, tables=["working_memory"], min_score=0.3)
+        full = audit_noise(
+            db_path=db_path,
+            limit=1,
+            tables=["working_memory"],
+            min_score=0.3,
+            scan_all=True,
+            batch_size=2,
+        )
+
+        assert paged.total_scanned == 1
+        assert full.total_scanned == 3
+        assert len(full.candidates) == 3
+
+    def test_noise_summary_is_pii_safe(self, temp_db):
+        db_path, beam = temp_db
+        secret_content = "password = hunter2supersecret"  # nosec - test fixture
+        _insert_row(beam, "working_memory", "secret1", secret_content)
+
+        summary = noise_summary(db_path=db_path, min_score=0.0)
+
+        assert summary["total_candidates"] == 1
+        assert summary["with_secrets"] == 1
+        assert secret_content not in json.dumps(summary)
+        assert "content_preview" not in json.dumps(summary)
+
+    def test_hygiene_status_reports_audit_log_without_content(self, temp_db):
+        db_path, beam = temp_db
+        _insert_row(beam, "working_memory", "noise1", "heartbeat", source="heartbeat")
+        conn = beam.conn
+        conn.execute(
+            """
+            CREATE TABLE hygiene_audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                memory_id TEXT NOT NULL,
+                table_name TEXT NOT NULL,
+                action TEXT NOT NULL,
+                reason TEXT,
+                noise_score REAL,
+                secret_flags TEXT,
+                original_content_preview TEXT,
+                original_metadata TEXT,
+                timestamp TEXT NOT NULL,
+                session_id TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO hygiene_audit_log (memory_id, table_name, action, timestamp) VALUES (?, ?, ?, ?)",
+            ("noise1", "working_memory", "flagged", "2025-01-01T00:00:00"),
+        )
+        conn.commit()
+
+        status = hygiene_status(db_path=db_path, limit=10)
+
+        assert status["audit_log"]["present"] is True
+        assert status["audit_log"]["total_entries"] == 1
+        assert status["audit_log"]["by_action"]["flagged"] == 1
+        assert "heartbeat" not in json.dumps(status)
 
     def test_audit_min_score_filter(self, temp_db):
         db_path, beam = temp_db

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -209,7 +209,13 @@ class TestAuditNoise:
     def test_audit_offset_and_scan_all(self, temp_db):
         db_path, beam = temp_db
         for idx in range(3):
-            _insert_row(beam, "working_memory", f"noise{idx}", "heartbeat", source="heartbeat")
+            _insert_row(
+                beam,
+                "working_memory",
+                f"noise{idx}",
+                f"heartbeat page marker {idx}",
+                source="heartbeat",
+            )
 
         paged = audit_noise(db_path=db_path, limit=1, offset=1, tables=["working_memory"], min_score=0.3)
         full = audit_noise(
@@ -222,8 +228,9 @@ class TestAuditNoise:
         )
 
         assert paged.total_scanned == 1
+        assert [c.memory_id for c in paged.candidates] == ["noise1"]
         assert full.total_scanned == 3
-        assert len(full.candidates) == 3
+        assert {c.memory_id for c in full.candidates} == {"noise0", "noise1", "noise2"}
 
     def test_noise_summary_is_pii_safe(self, temp_db):
         db_path, beam = temp_db


### PR DESCRIPTION
## Summary

This is the read-only Phase 1 for #409 and the noise remediation discussion.

It keeps the first step intentionally boring and observable:

- expands hygiene audit coverage to include `episodic_memory` by default
- adds large-database audit support via `--offset`, `--all`, and `--batch-size`
- adds a PII-safe noise summary to `diagnose` / `doctor`
- adds `mnemosyne hygiene status` for audit-log aggregates + current read-only summary
- adds a SQLite `PRAGMA quick_check` signal to diagnostics
- updates MCP hygiene audit schema/handler for the new pagination flags

No repair, no auto-hygiene, no sleep integration, no semantic scoring, no schema migration, and no recall-ranking changes.

## Tests

- `python3 -m py_compile mnemosyne/core/hygiene.py mnemosyne/diagnose.py mnemosyne/cli.py mnemosyne/mcp_tools.py mnemosyne/tool_schemas.py`
- `PYTHONPATH=. uv run --no-sync --with pytest pytest tests/test_hygiene.py tests/test_diagnose_optional_deps.py -q`
- `PYTHONPATH=. uv run --no-sync --with pytest pytest tests/test_provider_all_15_tools.py -q`
- `PYTHONPATH=. uv run --no-sync --with pytest pytest tests/test_mcp_server.py -q`
- `python3 -m compileall -q mnemosyne tests`
- CLI smoke: `mnemosyne hygiene audit --json`, `mnemosyne hygiene status --json`, `mnemosyne diagnose` against a temporary DB
- `python3 scripts/generate-docs.py && python3 scripts/verify-docs.py`
- `git diff --check`

Closes #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR strengthens Mnemosyne’s local-first data-health surface and operator visibility without changing the core memory architecture or any retrieval/consolidation/verification logic.

- **Tiered memory coverage:** The hygiene/noise audit expands to include `episodic_memory` by default (alongside `working_memory` and `memories`). It skips non-existent tables, improving coverage across Mnemosyne’s local tiered storage **without touching BEAM, retrieval strategy, consolidation, veracity scoring, or sync/event flow**.
- **Scalable, read-only hygiene auditing:** Adds large-database support via pagination flags (`--offset`, `--all`/`scan_all`, `--batch-size`/`batch_size`) for both CLI and MCP. This is the right call for long-lived local stores: it keeps the audit practical at scale while staying strictly **read-only**.
- **Operator-facing, PII-safe reporting:** Introduces new read-only reporting surfaces—`mnemosyne hygiene status` plus a PII-safe noise aggregate (`diagnose`/`doctor` and `noise_summary`)—that focus on ratios/counts and secret-presence indicators rather than any content previews or leaked sensitive strings.
- **Diagnostics hardening:** Enhances `diagnose` with SQLite integrity probing using `PRAGMA quick_check`, and replaces content-bearing orphan-diagnostics with hygiene-noise metrics derived from the audit system.

Local-first guarantees & guardrails:
- The change set is explicitly **non-repair** and does not introduce auto-hygiene, schema migrations, sleep integration, semantic scoring, recall-ranking, or destructive repair flows—maintaining the “dry-run/read-only” safety boundary.
- Privacy posture is improved by removing/avoiding detailed candidate previews and ensuring noise reporting is aggregated and **PII-safe**.

Maintainability / integration consistency:
- Centralizes reporting via new helpers (`noise_summary`, `hygiene_status`) and updates the MCP tool schema/handler plus CLI dispatch so Hermes/MCP/CLI expose consistent, read-only hygiene controls—including the new pagination semantics.
- Adds test coverage around paging correctness, `episodic_memory` inclusion, and PII-safety to prevent regressions in the long-term.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->