### PR TITLE
fix: expand hyphenated recall query tokens

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1659,13 +1659,55 @@ _RECALL_SYNONYMS: Dict[str, tuple[str, ...]] = {
 }
 
 
+def _is_meaningful_recall_token(token: str) -> bool:
+    """Return whether a token is eligible for lexical recall matching."""
+    return len(token) >= 3 and token not in _FACT_MATCH_STOPWORDS and not token.isdigit()
+
+
 def _recall_tokens(text: str) -> List[str]:
     """Meaningful lexical tokens for precision gates and fallback scoring."""
     return [
         token
         for token in _RECALL_TOKEN_RE.findall(text.lower())
-        if len(token) >= 3 and token not in _FACT_MATCH_STOPWORDS and not token.isdigit()
+        if _is_meaningful_recall_token(token)
     ]
+
+
+def _hyphen_components(token: str) -> List[str]:
+    """Return unique hyphen components eligible for lexical recall matching."""
+    if "-" not in token:
+        return []
+    return list(dict.fromkeys(
+        part for part in token.split("-") if _is_meaningful_recall_token(part)
+    ))
+
+
+def _component_unit_weight(components: List[str]) -> int:
+    """Return the lexical-unit weight for a token's hyphen components."""
+    return len(components) if len(components) >= 2 else 1
+
+
+def _expand_hyphenated_tokens(tokens: List[str]) -> List[str]:
+    """Keep hyphenated tokens and add their meaningful components.
+
+    The full compound remains available for precise matches. Components make
+    differently-hyphenated forms such as ``orion-telemetrie`` and
+    ``orion-gateway ... telemetrie`` comparable at the lexical gate.
+    Other structured separators (paths, versions, identifiers) stay intact.
+    """
+    expanded: List[str] = []
+    seen: Set[str] = set()
+    for token in tokens:
+        # Preserve existing token semantics. Only newly exposed hyphen
+        # components need the same filtering as _recall_tokens.
+        if token not in seen:
+            seen.add(token)
+            expanded.append(token)
+        for candidate in _hyphen_components(token):
+            if candidate not in seen:
+                seen.add(candidate)
+                expanded.append(candidate)
+    return expanded
 
 
 def _expanded_query_tokens(tokens: List[str]) -> List[str]:
@@ -1676,7 +1718,7 @@ def _expanded_query_tokens(tokens: List[str]) -> List[str]:
     """
     expanded: List[str] = []
     seen: Set[str] = set()
-    for token in tokens:
+    for token in _expand_hyphenated_tokens(tokens):
         for candidate in (token, *_RECALL_SYNONYMS.get(token, ())):
             if candidate not in seen:
                 seen.add(candidate)
@@ -1776,6 +1818,13 @@ def _lexical_relevance(query_tokens: List[str], content: str, query_lower: str =
     }
     if not query_tokens and not query_cjk:
         return 0.0
+    # Callers pass raw _recall_tokens() output. Count each compound's
+    # meaningful components as separate lexical units so they can match a
+    # differently-hyphenated fact without outweighing the rest of the query.
+    component_groups = [_hyphen_components(token) for token in query_tokens]
+    lexical_unit_count = sum(
+        _component_unit_weight(components) for components in component_groups
+    )
     content_tokens = set(_recall_tokens(content_lower))
     # Structured MEMORIA contexts often encode keys as snake_case
     # (telemetry_api_latency_ms). Split separators so natural-language
@@ -1784,17 +1833,32 @@ def _lexical_relevance(query_tokens: List[str], content: str, query_lower: str =
     for token in list(content_tokens):
         expanded_content_tokens.update(
             part for part in re.split(r"[_:/.-]+", token)
-            if len(part) >= 3 and part not in _FACT_MATCH_STOPWORDS and not part.isdigit()
+            if _is_meaningful_recall_token(part)
         )
     content_tokens = expanded_content_tokens
     if not content_tokens and not query_cjk:
         return 0.0
 
-    exact = sum(1 for token in query_tokens if token in content_tokens)
+    exact = 0
     partial = 0.0
-    for token in query_tokens:
+    for token, components in zip(query_tokens, component_groups, strict=True):
         if token in content_tokens:
+            exact += _component_unit_weight(components)
             continue
+
+        component_hits = sum(part in content_tokens for part in components)
+        if len(components) >= 2 and component_hits >= 2:
+            # A differently-hyphenated fact must share at least two meaningful
+            # components. One generic component (e.g. "gateway") is not enough.
+            exact += component_hits
+            continue
+        if components:
+            # Reached when there are fewer than two meaningful components, or
+            # when fewer than two components match. Keep only an exact full
+            # token match; insufficient overlap must not gain synonym or
+            # substring fallback credit.
+            continue
+
         synonyms = _RECALL_SYNONYMS.get(token, ())
         if synonyms and any(syn in content_tokens for syn in synonyms):
             partial += 0.75
@@ -1807,7 +1871,7 @@ def _lexical_relevance(query_tokens: List[str], content: str, query_lower: str =
             partial += 0.4
 
     full_match = 1.0 if query_lower and query_lower in content_lower else 0.0
-    score = (exact + partial + full_match) / max(len(query_tokens), 1)
+    score = (exact + partial + full_match) / max(lexical_unit_count, 1)
 
     if score == 0.0:
         query_cjk = {

--- a/tests/test_multilingual_local_recall.py
+++ b/tests/test_multilingual_local_recall.py
@@ -1,5 +1,10 @@
 from mnemosyne.core import embeddings
-from mnemosyne.core.beam import _recall_tokens
+from mnemosyne.core.beam import (
+    _expanded_query_tokens,
+    _expand_hyphenated_tokens,
+    _lexical_relevance,
+    _recall_tokens,
+)
 
 
 def test_recall_tokens_preserve_unicode_words():
@@ -14,6 +19,117 @@ def test_recall_tokens_preserve_unicode_words():
     assert "sto" not in tokens
     assert "ften" not in tokens
     assert "rgeramt" not in tokens
+
+
+def test_hyphenated_query_terms_expand_for_candidate_recall_and_lexical_gate():
+    query = "Welche Portnummer gehört zur Orion-Telemetrie?"
+    fact = "Der Orion-Gateway nutzt Port 4831 für interne Telemetrie."
+    tokens = _recall_tokens(query)
+
+    expanded = _expanded_query_tokens(tokens)
+
+    assert "orion-telemetrie" in expanded
+    assert "orion" in expanded
+    assert "telemetrie" in expanded
+    score = _lexical_relevance(tokens, fact, query.lower())
+    assert 0.3 <= score <= 1.0
+
+
+def test_hyphen_component_score_stays_normalized_for_a_single_compound():
+    score = _lexical_relevance(
+        _recall_tokens("orion-telemetrie"),
+        "The Orion Telemetrie gateway is healthy.",
+        "orion-telemetrie",
+    )
+    assert score == 1.0
+
+
+def test_three_component_compound_is_normalized_to_its_component_units():
+    score = _lexical_relevance(
+        _recall_tokens("orion-telemetrie-gateway"),
+        "The Orion Telemetrie Gateway is healthy.",
+        "orion-telemetrie-gateway",
+    )
+    assert score == 1.0
+
+
+def test_partial_multi_component_overlap_yields_fractional_credit():
+    score = _lexical_relevance(
+        _recall_tokens("orion-telemetrie-gateway"),
+        "The Orion Telemetrie service is healthy.",
+        "orion-telemetrie-gateway",
+    )
+    assert score == 2 / 3
+
+
+def test_exact_compound_scores_at_least_as_high_as_split_components():
+    query = _recall_tokens("orion-gateway port")
+    exact = _lexical_relevance(query, "The orion-gateway uses port 4831.", "orion-gateway port")
+    split = _lexical_relevance(query, "The orion gateway uses port 4831.", "orion-gateway port")
+    assert exact == split == 1.0
+
+
+def test_non_hyphenated_scoring_is_unchanged():
+    assert _lexical_relevance(
+        _recall_tokens("atlas port"), "Atlas uses a port.", "atlas port"
+    ) == 1.0
+
+
+def test_hyphen_component_match_does_not_outweigh_unmatched_query_terms():
+    score = _lexical_relevance(
+        _recall_tokens("orion-telemetrie foobar"),
+        "The Orion Telemetrie gateway is healthy.",
+        "orion-telemetrie foobar",
+    )
+    assert score == 2 / 3
+
+
+def test_single_hyphen_component_does_not_admit_a_generic_distractor():
+    score = _lexical_relevance(
+        _recall_tokens("orion-gateway"),
+        "The gateway status page is healthy.",
+        "orion-gateway",
+    )
+    assert score == 0.0
+
+
+def test_duplicate_hyphen_components_do_not_count_as_distinct_matches():
+    score = _lexical_relevance(
+        _recall_tokens("orion-orion"),
+        "The Orion status page is healthy.",
+        "orion-orion",
+    )
+    assert score == 0.0
+
+
+def test_hyphen_expansion_preserves_existing_non_hyphen_tokens():
+    assert _expand_hyphenated_tokens(["4831", "ai", "orion-telemetrie"]) == [
+        "4831", "ai", "orion-telemetrie", "orion", "telemetrie"
+    ]
+    assert _expand_hyphenated_tokens(["port-4831"]) == ["port-4831", "port"]
+    assert _lexical_relevance(
+        _recall_tokens("port-4831"), "The port is open.", "port-4831"
+    ) == 0.0
+
+
+def test_hyphen_expansion_filters_stopword_components_and_composes_synonyms():
+    assert _expand_hyphenated_tokens(["orion-and"]) == ["orion-and", "orion"]
+
+    expanded = _expanded_query_tokens(["branding-current"])
+    assert "branding" in expanded
+    assert "current" in expanded
+    assert "positioning" in expanded
+    assert "latest" in expanded
+
+
+def test_two_hyphenated_compounds_share_their_total_lexical_unit_count():
+    query = _recall_tokens("orion-telemetrie atlas-cache")
+    score = _lexical_relevance(
+        query,
+        "Orion Telemetrie runs beside the Atlas cache.",
+        "orion-telemetrie atlas-cache",
+    )
+    assert score == 1.0
 
 
 def test_sentence_transformers_multilingual_dimensions_are_known():

--- a/tests/test_multilingual_local_recall.py
+++ b/tests/test_multilingual_local_recall.py
@@ -6,6 +6,7 @@ from mnemosyne.core.beam import (
     _expand_hyphenated_tokens,
     _lexical_relevance,
     _recall_tokens,
+    BeamMemory,
 )
 
 
@@ -136,15 +137,30 @@ def test_two_hyphenated_compounds_share_their_total_lexical_unit_count():
 
 @pytest.mark.parametrize(
     "content",
-    (
+    [
         "The orion_telemetrie_api is healthy.",
         "The orion.telemetrie.api is healthy.",
         "The orion/telemetrie/api is healthy.",
-    ),
+    ],
 )
 def test_hyphenated_query_matches_structured_key_separators(content):
     query = _recall_tokens("orion-telemetrie")
     assert _lexical_relevance(query, content, "orion-telemetrie") == 1.0
+
+
+def test_hyphenated_query_recalls_split_components_via_public_api(tmp_path):
+    beam = BeamMemory(session_id="hyphenated-recall", db_path=tmp_path / "memory.db")
+    expected_id = beam.remember(
+        "Orion Gateway handles Telemetrie packets.", source="test", importance=0.5
+    )
+    distractor_id = beam.remember(
+        "Gateway health is stable without Orion details.", source="test", importance=0.5
+    )
+
+    results = beam.recall("orion-telemetrie", top_k=5)
+
+    assert results[0]["id"] == expected_id
+    assert all(result["id"] != distractor_id for result in results)
 
 
 def test_sentence_transformers_multilingual_dimensions_are_known():

--- a/tests/test_multilingual_local_recall.py
+++ b/tests/test_multilingual_local_recall.py
@@ -132,6 +132,16 @@ def test_two_hyphenated_compounds_share_their_total_lexical_unit_count():
     assert score == 1.0
 
 
+def test_hyphenated_query_matches_structured_key_separators():
+    query = _recall_tokens("orion-telemetrie")
+    for content in (
+        "The orion_telemetrie_api is healthy.",
+        "The orion.telemetrie.api is healthy.",
+        "The orion/telemetrie/api is healthy.",
+    ):
+        assert _lexical_relevance(query, content, "orion-telemetrie") == 1.0
+
+
 def test_sentence_transformers_multilingual_dimensions_are_known():
     assert embeddings._get_embedding_dim(
         "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"

--- a/tests/test_multilingual_local_recall.py
+++ b/tests/test_multilingual_local_recall.py
@@ -1,3 +1,5 @@
+import pytest
+
 from mnemosyne.core import embeddings
 from mnemosyne.core.beam import (
     _expanded_query_tokens,
@@ -132,14 +134,17 @@ def test_two_hyphenated_compounds_share_their_total_lexical_unit_count():
     assert score == 1.0
 
 
-def test_hyphenated_query_matches_structured_key_separators():
-    query = _recall_tokens("orion-telemetrie")
-    for content in (
+@pytest.mark.parametrize(
+    "content",
+    (
         "The orion_telemetrie_api is healthy.",
         "The orion.telemetrie.api is healthy.",
         "The orion/telemetrie/api is healthy.",
-    ):
-        assert _lexical_relevance(query, content, "orion-telemetrie") == 1.0
+    ),
+)
+def test_hyphenated_query_matches_structured_key_separators(content):
+    query = _recall_tokens("orion-telemetrie")
+    assert _lexical_relevance(query, content, "orion-telemetrie") == 1.0
 
 
 def test_sentence_transformers_multilingual_dimensions_are_known():


### PR DESCRIPTION
## Description

Expands hyphenated recall-query compounds into meaningful components for FTS candidate generation and lexical scoring, while preserving the complete token.

The lexical gate requires two meaningful component matches, normalizes compound components against the same unit count, and rejects generic one-component distractors. This fixes differently-hyphenated German phrasing such as `Orion-Telemetrie` versus `Orion-Gateway ... Telemetrie` without broadening single-component matches.

## Related Issue

None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / performance
- [x] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Targeted existing regression tests:
  `tests/test_multilingual_local_recall.py`, `tests/test_cyrillic_fts.py`, `tests/test_recall_precision_regressions.py`, and `tests/test_fact_recall_integration.py` — 61 passed, 4 subtests passed.
- [x] New regression tests for compound expansion, exact-vs-split parity, multi-component normalization, unmatched-term dilution, generic-distractor rejection, and digit components.
- [x] Manual isolated `BeamMemory` smoke: the query `Welche Portnummer gehört zur Orion-Telemetrie?` retrieves the stored Port-4831 fact.

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py` (not needed for this focused bug fix)
- [ ] `CHANGELOG.md` updated with a brief entry (not needed for this focused bug fix)
- [ ] README updated if user-facing behavior changed (not needed; internal recall correctness fix)
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Improves Mnemosyne/BEAM recall accuracy for hyphenated query compounds by expanding eligible hyphenated query tokens into meaningful component “lexical units” for both FTS candidate generation and lexical scoring, while retaining the original compound token. The BEAM lexical gate is now component-aware: it filters recall components to require ≥3 characters, excludes stopwords and digit-only segments, de-duplicates eligible hyphen-separated components, normalizes scoring by a component “lexical unit count,” and applies stricter precision for hyphenated compounds (full credit for exact compound matches, and—when hyphen components exist—credit only when at least two meaningful components match in content; if overlap is insufficient, prior synonym/substring partial-promotion is skipped rather than falling back). This prevents generic one-component distractors from “winning,” and fixes parity issues across different hyphenated German phrasing/FTS tokenization.

Adds regression coverage for compound expansion outputs, exact-vs-split scoring parity, multi-component normalization, unmatched-term dilution, generic-distractor rejection, digit components, and matching across structured key separators (e.g., underscore/dot/slash variants). Existing targeted regression tests pass, plus a manual BeamMemory Orion telemetry recall smoke check.

## Architecture impact

- **Memory tiers (working/episodic/BEAM):** Changes are confined to the **BEAM retrieval/ranking path**—query-time token expansion and the lexical relevance gate used to score recall candidates. No tier storage behavior or BEAM pipeline state/consolidation logic changes.
- **Retrieval strategies:** Enhances **BEAM candidate recall accuracy** and ranking precision by:
  - expanding hyphenated query tokens into a bounded list of meaningful components (plus the original hyphenated token),
  - computing lexical relevance using per-token hyphen component groups and normalizing by component “lexical unit count,”
  - requiring sufficient multi-component overlap for hyphenated compounds and suppressing weaker fallback promotions when overlap is inadequate.
- **Consolidation pipeline / veracity system:** No changes.
- **Sync layer:** No changes.
- **Benchmark methodology:** No changes.

## Privacy & local-first guarantees

Preserved. The update is strictly a local, query-time tokenization/scoring refinement within BEAM recall—no added network calls, background jobs, or changes to data movement, retention, or synchronization behavior.

## Agent integration surfaces (Hermes, MCP, CLI)

No integration-surface changes. Agent/connector behavior is unaffected because the update is internal to BEAM recall token handling and lexical ranking.

## Long-term maintainability

Improves maintainability by encapsulating hyphen handling and recall-component eligibility behind dedicated internal helpers and backing behavior with focused multilingual/local recall regression tests that cover expansion outputs and scoring normalization edge cases—reducing the risk of future precision regressions for hyphenated queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->