### PR TITLE
fix: preserve Hermes provider defaults after config autoseed

### DIFF
--- a/mnemosyne/core/config.py
+++ b/mnemosyne/core/config.py
@@ -270,12 +270,17 @@ DEFAULTS: Dict[str, Any] = {
     "sync_port": 8765,
     "sync_key": "",
     "sync_encrypt": False,
-    "sync_roles": "user,assistant",
+    # Match the Hermes provider default. Auto-seeding must not start
+    # persisting assistant transcripts for existing provider users.
+    "sync_roles": "user",
     # Provider
     "auto_sleep_enabled": True,
     "reflect_disabled_for_cron": True,
     "reflect_max_calls_per_session": 3,
-    "skip_contexts": "",
+    # Match the Hermes provider's non-primary-context safety default.
+    # An auto-seeded config must not make cron/subagent sessions initialize
+    # a memory beam merely because it now outranks the provider default.
+    "skip_contexts": "cron,flush,subagent,background,skill_loop",
     "prefetch_content_chars": 2000,
     "sync_turn_user_limit": 10,
     "sync_turn_assistant_limit": 10,

--- a/tests/test_hermes_memory_provider.py
+++ b/tests/test_hermes_memory_provider.py
@@ -114,6 +114,58 @@ def test_initialize_skips_for_non_primary_context(monkeypatch):
     assert provider._beam is None   # But no beam initialized
 
 
+@pytest.mark.parametrize("agent_context", ["cron", "flush", "subagent", "background", "skill_loop"])
+def test_auto_seeded_core_config_preserves_provider_safety_defaults(monkeypatch, tmp_path, agent_context):
+    """Core config auto-seeding must not override Hermes provider defaults."""
+    from mnemosyne.core.config import MnemosyneConfig
+
+    expected_skip_contexts = {"cron", "flush", "subagent", "background", "skill_loop"}
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+    MnemosyneConfig.reset_instance()
+    provider = None
+    try:
+        provider = MnemosyneMemoryProvider()
+        with patch("hermes_memory_provider.hermes_llm_adapter.register_hermes_host_llm"):
+            provider.initialize(session_id="x", agent_context=agent_context)
+
+        assert (tmp_path / "config.yaml").exists()
+        assert provider._skip_contexts == expected_skip_contexts
+        assert provider._beam is None
+        assert provider._sync_roles == {"user"}
+
+        import yaml
+        seeded = yaml.safe_load((tmp_path / "config.yaml").read_text())
+        assert seeded["skip_contexts"] == "cron,flush,subagent,background,skill_loop"
+        assert seeded["sync_roles"] == "user"
+    finally:
+        if provider is not None:
+            with patch("hermes_memory_provider.hermes_llm_adapter.unregister_hermes_host_llm"):
+                provider.shutdown()
+        MnemosyneConfig.reset_instance()
+
+
+def test_auto_seeded_core_config_does_not_skip_primary_context(monkeypatch, tmp_path):
+    """The seeded skip-context list must leave primary sessions active."""
+    from mnemosyne.core.config import MnemosyneConfig
+
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr("hermes_memory_provider._get_beam_class", lambda: lambda **_: MagicMock())
+    MnemosyneConfig.reset_instance()
+    provider = None
+    try:
+        provider = MnemosyneMemoryProvider()
+        with patch("hermes_memory_provider.hermes_llm_adapter.register_hermes_host_llm"):
+            provider.initialize(session_id="x", agent_context="primary")
+
+        assert "primary" not in provider._skip_contexts
+        assert provider._beam is not None
+    finally:
+        if provider is not None:
+            with patch("hermes_memory_provider.hermes_llm_adapter.unregister_hermes_host_llm"):
+                provider.shutdown()
+        MnemosyneConfig.reset_instance()
+
+
 # ---------------------------------------------------------------------------
 # shutdown() unregistration (decision C7)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Align auto-seeded `sync_roles` and `skip_contexts` with the existing Hermes provider defaults.
- Prevent a newly seeded Core config from initializing memory in cron, flush, subagent, background, or skill-loop contexts.
- Preserve user-only automatic turn capture after first access.

## Verification

```text
PYTHONPATH=. uv run --no-sync --with pytest --with pyyaml pytest \
  tests/test_beam.py::TestProviderContextSafety::test_subagent_context_does_not_initialize_or_write \
  tests/test_hermes_memory_provider.py \
  tests/test_sync_roles.py \
  tests/test_config_profiles.py \
  tests/test_hermes_provider_parity.py -q

214 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates Mnemosyne’s core `config.yaml` auto-seeding defaults to mirror Hermes provider safety semantics. Seeded `sync_roles` is narrowed to `"user"` and seeded `skip_contexts` is set to `"cron,flush,subagent,background,skill_loop"`, so non-primary operational contexts won’t initialize Hermes BEAM/memory injection behavior. Primary/interactive sessions are left active, preserving automatic user-turn capture after first access.

## Architecture and integration impact

- **Core memory architecture / tiering (working/episodic/BEAM):** No changes to tiering or retrieval/consolidation logic. The behavioral change is strictly about **preventing BEAM/working-memory “memory-beam” initialization** in the Hermes provider for non-primary `agent_context` values.
- **Sync layer / roles:** By seeding `sync_roles` to `"user"` (instead of including `"assistant"`), the auto-seeded config aligns the sync eligibility surface with Hermes’ intended safety boundary, reducing unintended syncing of non-user/internal turns in these defaulted contexts.
- **Privacy posture & local-first guarantees:** Strengthens local-first safety by ensuring auto-generated configs don’t enable memory writes/injection during background-like workflows (cron/background/subagent/flush/skill-loop), where the system should not be ingesting new memory.
- **Agent integration surfaces (Hermes, MCP, CLI):** Changes are targeted at the **Hermes integration pathway** via core config seeding; MCP and CLI behavior are not implicated by the code/test updates shown.

## Maintainability

- Adds in-code documentation in `mnemosyne/core/config.py` explicitly stating that auto-seeded configs must match Hermes non-primary safety defaults.
- Introduces regression tests that:
  - seed an auto-generated `config.yaml` and assert Hermes provider fields (`_skip_contexts`, `_sync_roles`, `_beam`) across the non-primary contexts, and
  - verify that `"primary"` remains unskipped and initializes BEAM.
  
Verification: **214 tests passed**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->