### PR TITLE
fix(local_llm): set stream to false to prevent SSE errors

### DIFF
--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -500,7 +500,8 @@ def _call_remote_llm_with_model(
         "messages": [{"role": "user", "content": prompt}],
         "max_tokens": LLM_MAX_TOKENS,
         "temperature": temperature,
-        "stop": ["</s>", "<|user|>"]
+        "stop": ["</s>", "<|user|>"],
+        "stream": False
     }
 
     try:


### PR DESCRIPTION
## Summary

When Mnemosyne performs consolidation via a remote LLM endpoint, the HTTP client (`httpx.Client` or `urllib.request`) expects a standard JSON response. However, many OpenAI-compatible API proxies such as 9Router, OmniRoute, and certain self-hosted gateways return a Server-Sent Events (SSE) stream by default when the `stream` parameter is omitted. 

This unexpected chunked response causes a JSON parsing failure, forcing the consolidation cycle to silently fall back to the lossy AAAK encoding instead of utilizing the configured LLM. This PR explicitly sets `"stream": False` in the request payload to ensure a complete JSON response.

---

## Problem

In `mnemosyne/core/local_llm.py`, the `_call_remote_llm_with_model()` function constructs the API payload without defining the `stream` parameter:

```py
payload = {
    "model": model or "local",
    "messages": [{"role": "user", "content": prompt}],
    "max_tokens": LLM_MAX_TOKENS,
    "temperature": temperature,
    "stop": ["</s>", "<|user|>"]
}
```

Without an explicit `stream` parameter, the request inherits the server's default behavior. Proxies built on frameworks that default to streaming (e.g., 9Router) will automatically respond with an SSE stream (`Content-Type: text/event-stream`). 

When the HTTP clients attempt to parse these chunked events as standard JSON using `response.json()` for `httpx` (line 518) or `json.loads(resp.read().decode())` for `urllib.request` (line 533), it inevitably triggers a parsing error. These exceptions are caught by the generic `except Exception as exc` blocks (lines 519 and 536), which then return a tuple containing `None` for the data (e.g., `(None, status, exc)` or `(None, None, exc)`). Consequently, the calling system quietly bypasses the LLM and degrades to the inferior AAAK encoding fallback, silently degrading summary quality across every consolidation cycle without surfacing any error to the user.

Note on `Content-Type` header: Simply setting `headers = {"Content-Type": "application/json"}` does not solve this problem. Self-hosted routers and API proxies often ignore the request's `Content-Type` header when deciding the response format; they may still return `Content-Type: text/event-stream` regardless. The `stream` parameter in the request body is the only reliable way to signal the desired response format, as it is part of the standardized OpenAI API contract that these proxies actually respect.

---

## Fix

Added `"stream": False` to the request payload dict. This explicitly signals the remote API server to return a complete JSON body rather than an SSE stream.

```py
payload = {
    "model": model or "local",
    "messages": [{"role": "user", "content": prompt}],
    "max_tokens": LLM_MAX_TOKENS,
    "temperature": temperature,
    "stop": ["</s>", "<|user|>"],
    "stream": False  # explicitly request JSON, not SSE
}
```

This change is minimal, defensive, and fully backward-compatible. Providers that natively respond with non-streaming JSON (e.g., OpenAI, OpenRouter) will simply respect or ignore the parameter without any issues, while proxies that default to streaming will be forced to respond with a parseable JSON object that the client can handle properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Explicitly disables streaming for OpenAI-compatible remote LLM requests, ensuring consolidation receives complete JSON responses and avoiding unnecessary AAAK fallback.

## Architectural impact

- Strengthens the consolidation pipeline without changing its tiering, retrieval, veracity, or fallback architecture.
- Preserves working, episodic, and BEAM memory behavior.
- Maintains privacy and local-first guarantees: no new remote path or data exposure is introduced; local inference remains available.
- Leaves Hermes, MCP, CLI, sync, and memory event streaming interfaces unchanged.
- Improves maintainability by avoiding reliance on provider-specific streaming defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->