### PR TITLE
docs: add CLA and update CONTRIBUTING.md with CLA requirement

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,70 @@
+### Individual Contributor License Agreement (CLA)
+### Mnemosyne — mnemosyne-oss (the "Project")
+
+Thank you for your interest in contributing to Mnemosyne.
+
+This CLA clarifies the intellectual property rights granted by You (the Contributor) to the Project. By submitting a contribution, You agree to the following terms. This CLA is adapted from the Apache Software Foundation's Individual CLA.
+
+---
+
+### 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized by the copyright owner making this Agreement.
+
+**"Contribution"** means any original work of authorship, including modifications or additions to existing work, submitted by You to the Project.
+
+**"Submit"** means any form of electronic, verbal, or written communication sent to the Project maintainers or any platform designated for contributions (GitHub pull requests, issues, mailing lists, etc.).
+
+**"Project"** means the Mnemosyne open-source project and any successor or affiliated entity formed to steward the project (including any formal company, foundation, or organization).
+
+---
+
+### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the Project and to recipients of software distributed by the Project a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable** copyright license to:
+
+- Reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+- Re-license Your Contributions under any license chosen by the Project, including but not limited to the MIT License (current), or any future open-source or commercial license.
+
+---
+
+### 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the Project and to recipients of software distributed by the Project a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable** patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination of Your Contribution with the Work to which such Contribution was submitted.
+
+---
+
+### 4. Representations
+
+You represent that:
+
+- (a) Each Contribution You submit is Your original creation.
+- (b) You are legally entitled to grant the above license.
+- (c) If Your employer has rights to intellectual property that You create, You have received permission to make Contributions on behalf of that employer, or Your employer has waived such rights.
+- (d) Your Contributions include complete details of any third-party license or other restriction (including related patents and trademarks) of which You are personally aware.
+
+---
+
+### 5. No Obligation
+
+The Project is under no obligation to accept or use Your Contribution. You are not obligated to provide support for Your Contribution.
+
+---
+
+### 6. Retention of Ownership
+
+You retain all ownership rights in Your Contributions. This CLA grants a license, not an assignment of copyright.
+
+---
+
+### 7. Successor Entities
+
+You acknowledge that the Project may, at the discretion of its founder(s) and lead maintainer(s), be transferred to a formal legal entity (company, foundation, or organization) formed to steward the Project. This CLA shall remain in full force and effect with such successor entity as the beneficiary of the licenses granted herein.
+
+---
+
+**By submitting a Contribution, You confirm You have read and agree to this CLA.**
+
+---
+
+*Last updated: 2026-07-13*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,16 @@ These are not mandates — just directions where help would be valuable:
 - **Issues & bugs:** [GitHub Issues](https://github.com/AxDSan/mnemosyne/issues)
 - **Feature ideas & questions:** [Join our Discord](https://discord.gg/Cgzpw9x3R) or open an issue
 
+## Contributor License Agreement (CLA)
+
+All new contributions require signing the [Contributor License Agreement](CLA.md). This is effective as of 2026-07-13.
+
+The CLA grants the project a license to use, relicense, and distribute your contributions while you retain full ownership. It is adapted from the Apache Software Foundation's Individual CLA.
+
+Past contributions made before this date remain under the MIT License and are not affected.
+
+By submitting a pull request, you confirm you have read and agree to the CLA.
+
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+Mnemosyne is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Adds the Contributor License Agreement (CLA.md) and updates CONTRIBUTING.md to require CLA signing for all new contributions.

**What's included:**
- CLA.md: Apache-style Individual CLA with successor entity clause for future company formation
- CONTRIBUTING.md: New CLA section explaining the requirement. Past contributions remain MIT. New contributions require CLA.

**CLA Gist for CLA Assistant:** https://gist.github.com/AxDSan/2faa82a0db9c38bf249ff5d5fde754a7