### PR TITLE
feat: write_approval gate for mnemosyne_remember and mnemosyne_batch

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1602,6 +1602,37 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
         return None
 
+    def _write_approval_enabled(self) -> bool:
+        """Check whether memory.write_approval is enabled in Hermes config.
+
+        Reads the top-level ``memory.write_approval`` boolean from Hermes
+        config.yaml (NOT ``memory.mnemosyne.write_approval``). Defaults to
+        ``False`` when the key is missing or unparsable.
+
+        This gates ALL memory writes (both legacy MEMORY.md and Mnemosyne
+        SQLite writes) through a single boolean, so users get consistent
+        protection regardless of which provider is active.
+        """
+        hermes_home = getattr(self, "_hermes_home", None)
+        if not hermes_home:
+            return False
+        config_path = os.path.join(hermes_home, "config.yaml")
+        if not os.path.exists(config_path):
+            return False
+        try:
+            import yaml
+        except ImportError:
+            return False
+        try:
+            with open(config_path) as f:
+                config = yaml.safe_load(f) or {}
+        except Exception:
+            return False
+        memory = config.get("memory")
+        if not isinstance(memory, dict):
+            return False
+        return bool(memory.get("write_approval", False))
+
     def _configured_tool_schemas(self) -> List[Dict[str, Any]]:
         """Return schemas filtered by memory.mnemosyne.tools, if configured.
 
@@ -2497,6 +2528,43 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         )
         if not content:
             return json.dumps({"error": "content is required"})
+
+        # ── Write-approval gate ──────────────────────────────────────
+        if self._write_approval_enabled():
+            import uuid as _uuid_mod
+            pid = _uuid_mod.uuid4().hex[:8]
+            record = {
+                "id": pid,
+                "subsystem": "memory",
+                "action": "add",
+                "summary": content[:200],
+                "origin": "mnemosyne_remember",
+                "created_at": time.time(),
+                "payload": {
+                    "target": args.get("target", "memory"),
+                    "content": content,
+                    "importance": importance,
+                    "source": source,
+                    "scope": scope,
+                    "valid_until": valid_until,
+                    "extract_entities": extract_entities,
+                    "extract": extract,
+                    "metadata": metadata,
+                    "veracity": veracity,
+                },
+            }
+            hermes_home = getattr(self, "_hermes_home", None) or os.path.expanduser("~/.hermes")
+            pending_dir = Path(hermes_home) / "pending" / "memory"
+            pending_dir.mkdir(parents=True, exist_ok=True)
+            pending_path = pending_dir / f"{pid}.json"
+            pending_path.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+            return json.dumps({
+                "staged": True,
+                "pending_id": pid,
+                "message": "Memory staged for approval. Review with /memory pending."
+            })
+        # ─────────────────────────────────────────────────────────────
+
         memory_id = self._beam.remember(
             content=content,
             importance=importance,
@@ -2530,6 +2598,35 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
         if bool(args.get("dry_run", False)):
             return json.dumps(dry_run_batch(normalized))
+
+        # ── Write-approval gate ──────────────────────────────────────
+        if self._write_approval_enabled():
+            import uuid as _uuid_mod
+            staged = []
+            hermes_home = getattr(self, "_hermes_home", None) or os.path.expanduser("~/.hermes")
+            pending_dir = Path(hermes_home) / "pending" / "memory"
+            pending_dir.mkdir(parents=True, exist_ok=True)
+            for op in normalized:
+                pid = _uuid_mod.uuid4().hex[:8]
+                record = {
+                    "id": pid,
+                    "subsystem": "memory",
+                    "action": op.get("action", "unknown"),
+                    "summary": str(op.get("content", ""))[:200],
+                    "origin": "mnemosyne_batch",
+                    "created_at": time.time(),
+                    "payload": op,
+                }
+                pending_path = pending_dir / f"{pid}.json"
+                pending_path.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+                staged.append(pid)
+            return json.dumps({
+                "staged": True,
+                "pending_ids": staged,
+                "count": len(staged),
+                "message": f"{len(staged)} operation(s) staged for approval. Review with /memory pending."
+            })
+        # ─────────────────────────────────────────────────────────────
 
         return json.dumps(apply_beam_batch(
             self._beam,

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -803,6 +803,37 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         """Read a single key from memory.mnemosyne in config.yaml."""
         return read_hermes_config_key(getattr(self, "_hermes_home", None), key)
 
+    def _write_approval_enabled(self) -> bool:
+        """Check whether memory.write_approval is enabled in Hermes config.
+
+        Reads the top-level ``memory.write_approval`` boolean from Hermes
+        config.yaml (NOT ``memory.mnemosyne.write_approval``). Defaults to
+        ``False`` when the key is missing or unparsable.
+
+        This gates ALL memory writes (both legacy MEMORY.md and Mnemosyne
+        SQLite writes) through a single boolean, so users get consistent
+        protection regardless of which provider is active.
+        """
+        hermes_home = getattr(self, "_hermes_home", None)
+        if not hermes_home:
+            return False
+        config_path = os.path.join(hermes_home, "config.yaml")
+        if not os.path.exists(config_path):
+            return False
+        try:
+            import yaml
+        except ImportError:
+            return False
+        try:
+            with open(config_path) as f:
+                config = yaml.safe_load(f) or {}
+        except Exception:
+            return False
+        memory = config.get("memory")
+        if not isinstance(memory, dict):
+            return False
+        return bool(memory.get("write_approval", False))
+
 
     def _configured_tool_schemas(self) -> List[Dict[str, Any]]:
         """Return schemas filtered by memory.mnemosyne.tools, if configured.
@@ -1523,6 +1554,43 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         )
         if not content:
             return json.dumps({"error": "content is required"})
+
+        # ── Write-approval gate ──────────────────────────────────────
+        if self._write_approval_enabled():
+            import uuid as _uuid_mod
+            pid = _uuid_mod.uuid4().hex[:8]
+            record = {
+                "id": pid,
+                "subsystem": "memory",
+                "action": "add",
+                "summary": content[:200],
+                "origin": "mnemosyne_remember",
+                "created_at": time.time(),
+                "payload": {
+                    "target": args.get("target", "memory"),
+                    "content": content,
+                    "importance": importance,
+                    "source": source,
+                    "scope": scope,
+                    "valid_until": valid_until,
+                    "extract_entities": extract_entities,
+                    "extract": extract,
+                    "metadata": metadata,
+                    "veracity": veracity,
+                },
+            }
+            hermes_home = getattr(self, "_hermes_home", None) or os.path.expanduser("~/.hermes")
+            pending_dir = Path(hermes_home) / "pending" / "memory"
+            pending_dir.mkdir(parents=True, exist_ok=True)
+            pending_path = pending_dir / f"{pid}.json"
+            pending_path.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+            return json.dumps({
+                "staged": True,
+                "pending_id": pid,
+                "message": "Memory staged for approval. Review with /memory pending."
+            })
+        # ─────────────────────────────────────────────────────────────
+
         memory_id = self._beam.remember(
             content=content,
             importance=importance,
@@ -1556,6 +1624,35 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
         if bool(args.get("dry_run", False)):
             return json.dumps(dry_run_batch(normalized))
+
+        # ── Write-approval gate ──────────────────────────────────────
+        if self._write_approval_enabled():
+            import uuid as _uuid_mod
+            staged = []
+            hermes_home = getattr(self, "_hermes_home", None) or os.path.expanduser("~/.hermes")
+            pending_dir = Path(hermes_home) / "pending" / "memory"
+            pending_dir.mkdir(parents=True, exist_ok=True)
+            for op in normalized:
+                pid = _uuid_mod.uuid4().hex[:8]
+                record = {
+                    "id": pid,
+                    "subsystem": "memory",
+                    "action": op.get("action", "unknown"),
+                    "summary": str(op.get("content", ""))[:200],
+                    "origin": "mnemosyne_batch",
+                    "created_at": time.time(),
+                    "payload": op,
+                }
+                pending_path = pending_dir / f"{pid}.json"
+                pending_path.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+                staged.append(pid)
+            return json.dumps({
+                "staged": True,
+                "pending_ids": staged,
+                "count": len(staged),
+                "message": f"{len(staged)} operation(s) staged for approval. Review with /memory pending."
+            })
+        # ─────────────────────────────────────────────────────────────
 
         return json.dumps(apply_beam_batch(
             self._beam,


### PR DESCRIPTION
Closes #456

## What this does

When `memory.write_approval: true` is set in Hermes config.yaml, Mnemosyne write tools now stage records to `pending/memory/<id>.json` instead of writing directly to the SQLite database.

Previously, `write_approval` only protected the legacy `MEMORY.md` / `USER.md` file writes while Mnemosyne SQLite writes bypassed the gate entirely. Users who enabled `write_approval` expecting protection got none with Mnemosyne as the active provider.

## Changes

- **`_write_approval_enabled()`** helper reads `memory.write_approval` from Hermes config.yaml (not `memory.mnemosyne.write_approval`)
- **`_handle_remember()`** stages to `pending/memory/<id>.json` when gated
- **`_handle_batch()`** stages each operation individually when gated
- Read-only tools (`recall`, `get`, `stats`, etc.) never gated
- `sync_turn()` autosave never gated (infrastructural, not agent-initiated)
- Both provider copies updated (standalone + bundled)

## Behavior

| `write_approval` | Mnemosyne behavior |
|---|---|
| `false` (default) | Writes directly to SQLite (unchanged) |
| `true` | Writes staged to `pending/memory/<id>.json` |

The pending store uses the same schema as the legacy `write_approval.stage_pending()` so the existing `/memory pending` slash command can review and approve/reject staged records.

## Verification

- [x] Both provider copies compile clean
- [x] No change to read-only tools
- [x] No change to sync_turn autosave
- [x] Default behavior unchanged (write_approval defaults to false)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds Hermes-wide `memory.write_approval` support to Mnemosyne write tools. When enabled, `mnemosyne_remember` and each operation in `mnemosyne_batch` are staged as pending memory records for approval; disabled or invalid configuration preserves direct SQLite writes.

## Architectural impact

- Protects Mnemosyne writes consistently with legacy memory-file writes using the existing pending-record schema and `/memory pending` workflow.
- Applies approval at the agent integration boundary while leaving read-only tools and `sync_turn()` autosave ungated.
- Updates both standalone and bundled Hermes provider implementations.
- Does not alter working, episodic, or BEAM tiering; retrieval, consolidation, veracity, synchronization, and benchmark behavior remain unchanged.
- Batch staging is per operation, improving reviewability and allowing individual approval decisions.

## Privacy and local-first posture

This is the right call for privacy and local-first guarantees: autonomous or background write requests no longer become durable local memory without explicit approval when the shared toggle is enabled. Pending records remain in the local Hermes directory, and no Mnemosyne-specific remote or service dependency is introduced.

The default remains local and immediate when approval is disabled. Because `sync_turn()` autosave is intentionally unchanged, some memory writes can still bypass the approval gate; this preserves existing behavior but leaves a narrower privacy boundary for automatic turn synchronization.

## Integration and maintainability

Hermes gains a single configuration surface without introducing provider-specific settings. MCP/CLI approval remains mediated through the existing pending-memory workflow rather than requiring new interfaces. Duplicating the implementation across standalone and bundled providers maintains distribution parity, though it increases future maintenance risk if the two copies diverge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->