### PR TITLE
ci: install sync extra for sync tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[embeddings,mcp,test]"
+          pip install -e ".[embeddings,mcp,sync,test]"
           pip install -e ./integrations/hermes
 
       - name: Pre-download embedding model


### PR DESCRIPTION
## Summary
- install the `sync` extra in the CI test matrix
- make encryption-sync test dependencies explicit rather than relying on transitive runner packages

## Validation
- `uv pip install -e ".[sync,test]"` in a clean venv
- `pytest tests/test_sync.py -q` (22 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates CI to install the `sync` extra alongside embeddings, MCP, and test dependencies.
- Makes encryption-sync test dependencies explicit rather than relying on transitive runner packages.
- No changes to tiered memory, retrieval, consolidation, veracity, Hermes, MCP, CLI, or benchmark methodology.
- Preserves Mnemosyne’s privacy and local-first guarantees; this is a CI reliability improvement, not a runtime architecture change.
- Improves long-term maintainability by making sync test requirements reproducible and explicit.

## Validation

- `uv pip install -e ".[sync,test]"` succeeded in a clean environment.
- `pytest tests/test_sync.py -q` passed: 22 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->