### PR TITLE
feat: add safe doctor and selected repair workflow

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -27,7 +27,6 @@ def _default_data_dir() -> str:
 
 
 DATA_DIR = _default_data_dir()
-os.makedirs(DATA_DIR, exist_ok=True)
 
 
 def _fail(message: str, exit_code: int = 2) -> NoReturn:
@@ -73,6 +72,50 @@ def _resolve_bank_name(bank_override: str | None = None) -> str:
     """Resolve the selected memory bank from an override or MNEMOSYNE_BANK."""
     value = bank_override if bank_override is not None else os.environ.get("MNEMOSYNE_BANK", "")
     return value.strip() or "default"
+
+
+def _resolve_doctor_bank_db_path(bank_name: str) -> Path:
+    """Resolve an existing bank DB without constructing ``BankManager``.
+
+    ``BankManager`` eagerly creates ``data_dir/banks`` in its constructor,
+    which is correct for mutating CLI commands but violates doctor's strict
+    read-only contract.  Keep this small lookup local to the doctor command:
+    validation and path inspection are the only filesystem operations.
+    """
+
+    from mnemosyne.core.banks import _validate_bank_name
+
+    _validate_bank_name(bank_name)
+    data_dir = Path(DATA_DIR)
+    if bank_name == "default":
+        return data_dir / "mnemosyne.db"
+    bank_dir = data_dir / "banks" / bank_name
+    if not bank_dir.is_dir():
+        _fail(f"Bank '{bank_name}' does not exist", exit_code=1)
+    return bank_dir / "mnemosyne.db"
+
+
+def _doctor_output_target_is_database(output_path: Path, db_path: Path) -> bool:
+    """Return whether an existing output target is the inspected DB itself.
+
+    Path resolution protects aliases for absent targets and symlinks, but it
+    cannot identify a hardlink. For an existing directory entry, compare
+    filesystem identity and fail closed if that comparison is unavailable.
+    """
+    try:
+        output_path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        _fail(f"Unable to safely inspect Doctor output path {output_path}: {error}")
+
+    try:
+        return os.path.samefile(output_path, db_path)
+    except OSError as error:
+        _fail(
+            "Unable to determine filesystem identity for existing Doctor "
+            f"output path {output_path}: {error}"
+        )
 
 
 def _get_memory():
@@ -258,6 +301,227 @@ def cmd_diagnose(args):
                 print("  Nothing to fix - all dependencies are healthy.")
     except Exception as e:
         print(f"Diagnostic failed: {e}")
+
+
+def cmd_doctor(args):
+    """Render a bounded, read-only health report for one existing database."""
+
+    usage = (
+        "Usage: mnemosyne doctor [--db PATH | --bank NAME] "
+        "[--format json|markdown|both] [--json-out PATH] [--markdown-out PATH] "
+        "[--scan-limit N] [--sample-limit N] [--all] [--include-candidates]"
+    )
+    db_override = None
+    bank_override = None
+    output_format = "both"
+    json_out = None
+    markdown_out = None
+    scan_limit = 200
+    sample_limit = 20
+    scan_all = False
+    include_candidates = False
+    scan_limit_set = False
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--db":
+            db_override, i = _require_value(args, i, "--db", lambda value, _name: value)
+        elif arg == "--bank":
+            bank_override, i = _require_value(args, i, "--bank", lambda value, _name: value)
+        elif arg == "--format":
+            output_format, i = _require_value(args, i, "--format", lambda value, _name: value)
+        elif arg == "--json-out":
+            json_out, i = _require_value(args, i, "--json-out", lambda value, _name: value)
+        elif arg == "--markdown-out":
+            markdown_out, i = _require_value(args, i, "--markdown-out", lambda value, _name: value)
+        elif arg == "--scan-limit":
+            scan_limit, i = _require_value(args, i, "--scan-limit", _parse_int)
+            scan_limit_set = True
+        elif arg == "--sample-limit":
+            sample_limit, i = _require_value(args, i, "--sample-limit", _parse_int)
+        elif arg == "--all":
+            scan_all = True
+            i += 1
+        elif arg == "--include-candidates":
+            include_candidates = True
+            i += 1
+        else:
+            _usage(f"{usage}\nUnknown doctor option: {arg}")
+
+    if db_override is not None and bank_override is not None:
+        _fail("--db and --bank cannot be used together")
+    if output_format not in {"json", "markdown", "both"}:
+        _fail("--format must be one of: json, markdown, both")
+    if not isinstance(scan_limit, int) or scan_limit < 1:
+        _fail("--scan-limit must be a positive integer")
+    if not isinstance(sample_limit, int) or sample_limit < 0:
+        _fail("--sample-limit must be a non-negative integer")
+    if scan_limit > 10_000:
+        _fail("--scan-limit must not exceed 10000")
+    if sample_limit > 100:
+        _fail("--sample-limit must not exceed 100")
+    if output_format == "json" and markdown_out is not None:
+        _fail("--markdown-out requires --format markdown or both")
+    if output_format == "markdown" and json_out is not None:
+        _fail("--json-out requires --format json or both")
+
+    # ``--all`` remains bounded: it requests the largest safe report scan
+    # budget unless the operator selected an explicit, smaller/larger limit.
+    if scan_all and not scan_limit_set:
+        scan_limit = 10_000
+
+    if db_override is not None:
+        db_path = Path(db_override).expanduser()
+        bank_name = "default"
+    else:
+        bank_name = _resolve_bank_name(bank_override)
+        try:
+            db_path = _resolve_doctor_bank_db_path(bank_name)
+        except ValueError as error:
+            _fail(str(error))
+    if not db_path.is_file():
+        _fail(f"Database not found: {db_path}", exit_code=1)
+
+    resolved_db = db_path.resolve()
+    resolved_json_path = (
+        Path(json_out).expanduser() if json_out else Path.cwd() / "mnemosyne-doctor.json"
+    )
+    resolved_markdown_path = (
+        Path(markdown_out).expanduser() if markdown_out else Path.cwd() / "mnemosyne-doctor.md"
+    )
+    if output_format == "both":
+        output_paths = [resolved_json_path, resolved_markdown_path]
+    elif output_format == "json" and json_out:
+        output_paths = [resolved_json_path]
+    elif output_format == "markdown" and markdown_out:
+        output_paths = [resolved_markdown_path]
+    else:
+        output_paths = []
+    if output_format == "both" and resolved_json_path.resolve() == resolved_markdown_path.resolve():
+        _fail("JSON and Markdown output paths must be different")
+    if any(path.resolve() == resolved_db for path in output_paths):
+        _fail("Doctor output path must not overwrite the inspected database")
+    if any(_doctor_output_target_is_database(path, db_path) for path in output_paths):
+        _fail("Doctor output path must not overwrite the inspected database")
+
+    from mnemosyne.doctor import (
+        build_doctor_report,
+        doctor_report_payload,
+        render_doctor_json,
+        render_doctor_markdown,
+        write_doctor_artifacts_atomically,
+    )
+
+    try:
+        report = build_doctor_report(
+            bank_name,
+            db_path,
+            scan_limit=scan_limit,
+            candidate_limit=sample_limit if include_candidates else 0,
+        )
+        payload = doctor_report_payload(report, include_candidates=include_candidates)
+        json_text = render_doctor_json(payload)
+        markdown_text = render_doctor_markdown(payload)
+        if output_format == "both":
+            write_doctor_artifacts_atomically(
+                json_path=resolved_json_path,
+                json_text=json_text,
+                markdown_path=resolved_markdown_path,
+                markdown_text=markdown_text,
+            )
+            print(f"Doctor JSON: {resolved_json_path}")
+            print(f"Doctor Markdown: {resolved_markdown_path}")
+        elif output_format == "json":
+            if json_out:
+                resolved_json_path.write_text(json_text, encoding="utf-8", newline="\n")
+                print(f"Doctor JSON: {resolved_json_path}")
+            else:
+                print(json_text, end="")
+        elif markdown_out:
+            resolved_markdown_path.write_text(markdown_text, encoding="utf-8", newline="\n")
+            print(f"Doctor Markdown: {resolved_markdown_path}")
+        else:
+            print(markdown_text, end="")
+    except (OSError, ValueError) as error:
+        _fail(f"Doctor report failed: {error}", exit_code=1)
+
+
+def cmd_repair(args):
+    """Apply one narrow, explicitly selected doctor-gated repair action."""
+
+    usage = (
+        "Usage: mnemosyne repair --report REPORT.json --select working_memory:ID "
+        "[--select working_memory:ID ...] [--db PATH | --bank NAME] "
+        "[--action backfill-vec-working|expire] [--dry-run|--apply] [--backup PATH]"
+    )
+    db_override = None
+    bank_override = None
+    report_path = None
+    selections = []
+    action = "backfill-vec-working"
+    apply = False
+    dry_run_seen = False
+    backup_path = None
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--db":
+            db_override, i = _require_value(args, i, "--db", lambda value, _name: value)
+        elif arg == "--bank":
+            bank_override, i = _require_value(args, i, "--bank", lambda value, _name: value)
+        elif arg == "--report":
+            report_path, i = _require_value(args, i, "--report", lambda value, _name: value)
+        elif arg == "--select":
+            selection, i = _require_value(args, i, "--select", lambda value, _name: value)
+            selections.append(selection)
+        elif arg == "--action":
+            action, i = _require_value(args, i, "--action", lambda value, _name: value)
+        elif arg == "--backup":
+            backup_path, i = _require_value(args, i, "--backup", lambda value, _name: value)
+        elif arg == "--apply":
+            apply = True
+            i += 1
+        elif arg == "--dry-run":
+            dry_run_seen = True
+            i += 1
+        else:
+            _usage(f"{usage}\nUnknown repair option")
+
+    if db_override is not None and bank_override is not None:
+        _fail("--db and --bank cannot be used together")
+    if apply and dry_run_seen:
+        _fail("--apply and --dry-run cannot be used together")
+    if report_path is None:
+        _fail("--report is required")
+    if not selections:
+        _fail("At least one complete --select working_memory:ID is required")
+    if db_override is not None:
+        db_path = Path(db_override).expanduser()
+        bank_name = "default"
+    else:
+        bank_name = _resolve_bank_name(bank_override)
+        try:
+            db_path = _resolve_doctor_bank_db_path(bank_name)
+        except ValueError:
+            _fail("Invalid bank name")
+    if not db_path.is_file():
+        _fail("Database not found", exit_code=1)
+
+    from mnemosyne.repair import RepairError, render_repair_json, run_repair
+
+    try:
+        result = run_repair(
+            db_path=db_path,
+            bank_name=bank_name,
+            report_path=report_path,
+            selections=selections,
+            action=action,
+            apply=apply,
+            backup_path=backup_path,
+        )
+    except RepairError as error:
+        _fail(str(error), exit_code=1)
+    print(render_repair_json(result), end="")
 
 
 def cmd_export(args):
@@ -1149,7 +1413,8 @@ COMMANDS = {
     "sleep": cmd_sleep,
     "consolidate": cmd_sleep,
     "diagnose": cmd_diagnose,
-    "doctor": cmd_diagnose,
+    "doctor": cmd_doctor,
+    "repair": cmd_repair,
     "export": cmd_export,
     "import": cmd_import,
     "import-hindsight": cmd_import_hindsight,
@@ -1175,6 +1440,9 @@ COMMANDS = {
 def run_cli():
     """Main CLI entry point."""
     if len(sys.argv) < 2 or sys.argv[1] in ("--help", "-h", "help"):
+        # Keep historical setup behavior for non-doctor CLI entry points while
+        # leaving module import and the doctor path free of mkdir side effects.
+        os.makedirs(DATA_DIR, exist_ok=True)
         print("Mnemosyne - Local AI Memory System\n")
         print("Usage: mnemosyne <command> [args]\n")
         print("Commands:")
@@ -1185,6 +1453,8 @@ def run_cli():
         print("  stats                                  Show statistics")
         print("  sleep                                  Run consolidation")
         print("  diagnose [--fix] [--dry-run] [--repair-vec-working]  Run diagnostics / optional repairs")
+        print("  doctor [--db PATH|--bank NAME] [--format json|markdown|both]  Read-only report")
+        print("  repair --report REPORT.json --select working_memory:ID [--apply]  Narrow doctor-gated repair")
         print("  export [--include-sync-events] [file.json]    Export memories")
         print("  import <file.json>                     Import memories")
         print("  import-hindsight <file|url> [bank]     Import Hindsight memories")
@@ -1210,6 +1480,8 @@ def run_cli():
         return
 
     command = sys.argv[1]
+    if command not in {"doctor", "repair"}:
+        os.makedirs(DATA_DIR, exist_ok=True)
     handler = COMMANDS.get(command)
 
     if handler:

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -409,6 +409,7 @@ def cmd_doctor(args):
         doctor_report_payload,
         render_doctor_json,
         render_doctor_markdown,
+        write_doctor_artifact_atomically,
         write_doctor_artifacts_atomically,
     )
 
@@ -433,12 +434,12 @@ def cmd_doctor(args):
             print(f"Doctor Markdown: {resolved_markdown_path}")
         elif output_format == "json":
             if json_out:
-                resolved_json_path.write_text(json_text, encoding="utf-8", newline="\n")
+                write_doctor_artifact_atomically(path=resolved_json_path, text=json_text)
                 print(f"Doctor JSON: {resolved_json_path}")
             else:
                 print(json_text, end="")
         elif markdown_out:
-            resolved_markdown_path.write_text(markdown_text, encoding="utf-8", newline="\n")
+            write_doctor_artifact_atomically(path=resolved_markdown_path, text=markdown_text)
             print(f"Doctor Markdown: {resolved_markdown_path}")
         else:
             print(markdown_text, end="")

--- a/mnemosyne/core/hygiene.py
+++ b/mnemosyne/core/hygiene.py
@@ -27,7 +27,7 @@ import sqlite3
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from mnemosyne.core.filters import (
     DEFAULT_NOISE_PATTERNS,
@@ -240,12 +240,10 @@ def _scan_table(
     """Scan a table for noise candidates. Returns rows as dicts."""
     cursor = conn.cursor()
     quoted_table = _quote_identifier(table_name)
-    # We deliberately select all columns we need; the schemas for
-    # working_memory, memories, and episodic_memory all share the core
-    # (id, content, source, timestamp, session_id, importance, metadata_json)
-    # shape, with episodic_memory having extra columns we don't need.
+    # Audit scoring needs only this fixed contract. Metadata is intentionally
+    # excluded so a read-only doctor scan never loads raw metadata.
     base_query = (
-        f"SELECT id, content, source, timestamp, session_id, importance, metadata_json "
+        f"SELECT id, content, source, timestamp, session_id, importance "
         f"FROM {quoted_table}"
     )
     if after is None:
@@ -305,6 +303,8 @@ def audit_noise(
     offset: int = 0,
     scan_all: bool = False,
     batch_size: int = 1000,
+    conn: Optional[sqlite3.Connection] = None,
+    content_preview_transform: Optional[Callable[[str], str]] = None,
 ) -> AuditReport:
     """Audit a memory database for noise.
 
@@ -320,6 +320,8 @@ def audit_noise(
         offset: Row offset per table for paginated scans.
         scan_all: If true, page through all rows in each selected table.
         batch_size: Batch size used when ``scan_all`` is true.
+        content_preview_transform: Optional bounded preview renderer for a
+            caller with a stricter content-safety contract.
 
     Returns:
         ``AuditReport`` with ranked candidates.
@@ -336,8 +338,10 @@ def audit_noise(
 
     report = AuditReport(tables_scanned=tables)
     table_counts: Dict[str, int] = {}
-    conn = sqlite3.connect(str(db_path))
-    conn.row_factory = sqlite3.Row
+    owns_connection = conn is None
+    if conn is None:
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
 
     def scan_batches(table_name: str) -> Iterator[List[Dict[str, Any]]]:
         if not scan_all:
@@ -390,7 +394,11 @@ def audit_noise(
                     candidate = NoiseCandidate(
                         memory_id=row.get("id", ""),
                         table_name=table,
-                        content_preview=content[:200],
+                        content_preview=(
+                            content_preview_transform(content)
+                            if content_preview_transform is not None
+                            else content[:200]
+                        ),
                         noise_score=round(score, 4),
                         noise_reasons=reasons,
                         secret_flags=secrets,
@@ -403,7 +411,8 @@ def audit_noise(
                     report.candidates.append(candidate)
             table_counts[table] = table_scanned
     finally:
-        conn.close()
+        if owns_connection:
+            conn.close()
 
     report.candidates.sort(key=lambda c: c.noise_score, reverse=True)
     report.summary = _build_audit_summary(report.candidates, table_counts=table_counts)
@@ -415,9 +424,17 @@ def noise_summary(
     limit: int = 200,
     tables: Optional[List[str]] = None,
     min_score: float = 0.3,
+    *,
+    conn: Optional[sqlite3.Connection] = None,
 ) -> Dict[str, Any]:
     """Return a PII-safe noise summary without content previews."""
-    report = audit_noise(db_path=db_path, limit=limit, tables=tables, min_score=min_score)
+    report = audit_noise(
+        db_path=db_path,
+        limit=limit,
+        tables=tables,
+        min_score=min_score,
+        conn=conn,
+    )
     table_counts = report.summary.get("table_counts", {})
     candidates_by_table = report.summary.get("by_table", {})
     ratios = {
@@ -437,6 +454,62 @@ def noise_summary(
         "with_secrets": report.summary.get("with_secrets", 0),
         "min_score": min_score,
         "limit_per_table": limit,
+    }
+
+
+def doctor_hygiene_summary(
+    db_path: Path,
+    limit: int = 200,
+    candidate_limit: int = 20,
+    min_score: float = 0.3,
+    *,
+    conn: Optional[sqlite3.Connection] = None,
+) -> Dict[str, Any]:
+    """Return a bounded, redacted hygiene view for the read-only doctor.
+
+    A caller may supply the doctor's ``mode=ro``/``query_only`` connector.
+    This helper owns no mutation path and omits raw metadata, embeddings,
+    BLOBs, sources, and timestamps from candidates.
+    """
+
+    if not isinstance(candidate_limit, int) or isinstance(candidate_limit, bool) or candidate_limit < 0:
+        raise ValueError("candidate_limit must be a non-negative integer")
+    from mnemosyne.doctor import safe_preview
+
+    try:
+        report = audit_noise(
+            db_path=db_path,
+            limit=limit,
+            min_score=min_score,
+            conn=conn,
+            content_preview_transform=lambda content: safe_preview(content, max_length=120),
+        )
+    except sqlite3.Error:
+        return {"status": "unavailable", "error_class": "sqlite_error", "candidates": []}
+    except Exception:
+        return {"status": "unknown", "error_class": "runtime_error", "candidates": []}
+
+    summary = report.summary
+    return {
+        "status": "ok",
+        "total_scanned": report.total_scanned,
+        "total_candidates": len(report.candidates),
+        "candidate_ratio": round(len(report.candidates) / report.total_scanned, 4) if report.total_scanned else 0.0,
+        "with_secrets": summary.get("with_secrets", 0),
+        "limit_per_table": limit,
+        "candidate_limit": candidate_limit,
+        "candidates": [
+            {
+                "id": safe_preview(candidate.memory_id, max_length=120),
+                "table": candidate.table_name,
+                "noise_score": candidate.noise_score,
+                "reasons": list(candidate.noise_reasons),
+                "secret_flags": list(candidate.secret_flags),
+                "suggested_action": candidate.suggested_action,
+                "preview": safe_preview(candidate.content_preview, max_length=120),
+            }
+            for candidate in report.candidates[:candidate_limit]
+        ],
     }
 
 

--- a/mnemosyne/core/hygiene.py
+++ b/mnemosyne/core/hygiene.py
@@ -500,7 +500,6 @@ def doctor_hygiene_summary(
         "candidate_limit": candidate_limit,
         "candidates": [
             {
-                "id": safe_preview(candidate.memory_id, max_length=120),
                 "table": candidate.table_name,
                 "noise_score": candidate.noise_score,
                 "reasons": list(candidate.noise_reasons),

--- a/mnemosyne/diagnose.py
+++ b/mnemosyne/diagnose.py
@@ -17,7 +17,9 @@ import sys
 import platform
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
+
+from mnemosyne.runtime_diagnostics import collect_runtime_diagnostics
 
 LOG_DIR = Path.home() / ".hermes" / "mnemosyne" / "logs"
 
@@ -174,82 +176,9 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False, 
         entries.append(entry)
         return entry
 
-    # --- Python environment ---
-    log("env", "python_version", sys.version.split()[0])
-    log("env", "platform", platform.platform())
-    log("env", "python_executable", sys.executable)
-
-    # --- Mnemosyne package ---
-    try:
-        import mnemosyne
-        version = getattr(mnemosyne, "__version__", None)
-        if not version:
-            version = importlib.metadata.version("mnemosyne-memory")
-        log("package", "mnemosyne_version", str(version))
-    except Exception as e:
-        log("package", "mnemosyne_version", "ERROR", str(e))
-
-    # --- Core dependencies ---
-    required_deps = {
-        "fastembed": "fastembed",
-        "sqlite_vec": "sqlite_vec",
-        "numpy": "numpy",
-        "huggingface_hub": "huggingface_hub",
-    }
-    optional_deps = {
-        # Optional local-GGUF fallback only. Host/remote LLM paths and the
-        # non-LLM fallback work without it, so absence should not fail the
-        # installation health check.
-        "ctransformers": "ctransformers",
-    }
-    for name, module in required_deps.items():
-        try:
-            mod = __import__(module)
-            ver = getattr(mod, "__version__", "unknown")
-            log("deps", name, "OK", f"version={ver}")
-        except ImportError:
-            log("deps", name, "MISSING")
-        except Exception as e:
-            log("deps", name, "ERROR", str(e))
-    for name, module in optional_deps.items():
-        try:
-            mod = __import__(module)
-            ver = getattr(mod, "__version__", "unknown")
-            log("deps", name, "OK", f"version={ver}")
-        except ImportError:
-            log("deps", name, "OPTIONAL", "optional local-GGUF fallback dependency not installed")
-        except Exception as e:
-            log("deps", name, "ERROR", str(e))
-
-    # --- Mnemosyne core components ---
-    try:
-        from mnemosyne.core import embeddings as _embeddings
-        log("core", "embeddings_available", "YES" if _embeddings.available() else "NO")
-        log("core", "embeddings_model", _embeddings._DEFAULT_MODEL)
-    except Exception as e:
-        log("core", "embeddings", "ERROR", str(e))
-
-    try:
-        from mnemosyne.core.beam import _SQLITE_VEC_AVAILABLE
-        # _SQLITE_VEC_AVAILABLE only checks whether the pip package imports.
-        # It doesn't verify that the running sqlite3 module can actually load
-        # the extension (required for Python builds without
-        # --enable-loadable-sqlite-extensions). Do a runtime check here.
-        _vec_can_load = False
-        if _SQLITE_VEC_AVAILABLE:
-            try:
-                import sqlite3 as _sqlite3
-                _test_conn = _sqlite3.connect(":memory:")
-                _test_conn.enable_load_extension(True)
-                _vec_can_load = True
-                _test_conn.close()
-            except Exception:
-                _vec_can_load = False
-        log("core", "sqlite_vec_available", "YES" if _vec_can_load else "NO")
-        if _SQLITE_VEC_AVAILABLE and not _vec_can_load:
-            log("core", "sqlite_vec_warning", "Package imports but extension cannot load. Rebuild Python with --enable-loadable-sqlite-extensions.")
-    except Exception as e:
-        log("core", "sqlite_vec", "ERROR", str(e))
+    # --- Pure runtime/dependency/capability checks (no provider construction) ---
+    for check in collect_runtime_diagnostics()["checks"]:
+        log(check["category"], check["check"], check["status"], check["detail"])
 
     # --- Database state ---
     try:

--- a/mnemosyne/doctor.py
+++ b/mnemosyne/doctor.py
@@ -1,0 +1,1509 @@
+"""Read-only, content-safe foundations for future Mnemosyne doctor reports.
+
+This module deliberately contains no CLI registration, database repair, or
+``Mnemosyne`` construction.  It only models report data and opens existing
+SQLite databases with read-only safeguards for inspection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sqlite3
+import stat
+import tempfile
+from typing import Any
+
+from mnemosyne.core.filters import SECRET_LABELED_PATTERNS
+
+
+STATUS_OK = "ok"
+STATUS_WARNING = "warning"
+STATUS_ERROR = "error"
+STATUS_UNKNOWN = "unknown"
+STATUS_PRESENT_BUT_UNLOADABLE = "present_but_unloadable"
+
+SEVERITY_INFO = "info"
+SEVERITY_WARNING = "warning"
+SEVERITY_ERROR = "error"
+SEVERITY_CRITICAL = "critical"
+
+_VEC0_VIRTUAL_TABLE = re.compile(
+    r"^\s*CREATE\s+VIRTUAL\s+TABLE\b.*\bUSING\s+vec0\b", re.IGNORECASE | re.DOTALL
+)
+_VEC0_UNAVAILABLE_ERROR = re.compile(r"\bno such module:\s*vec0\b", re.IGNORECASE)
+_SAFE_DETAIL_OPERATIONS = frozenset({"schema_metadata", "table_introspection"})
+_SAFE_DETAIL_ERROR_CLASSES = frozenset(
+    {"sqlite_error", "operational_error", "database_error"}
+)
+_ERROR_CLASS_ALIASES = {
+    "error": "sqlite_error",
+    "sqlite_error": "sqlite_error",
+    "operationalerror": "operational_error",
+    "operational_error": "operational_error",
+    "databaseerror": "database_error",
+    "database_error": "database_error",
+}
+_PREVIEW_SECRET_ASSIGNMENT = re.compile(
+    r"\b(password|passphrase|secret|token|api[_-]?key|authorization)\b"
+    r"\s*([:=])\s*(?:bearer\s+)?[^\s,;]+",
+    re.IGNORECASE,
+)
+_PREVIEW_EMAIL = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_PREVIEW_PHONE = re.compile(r"\b(?:\+?\d[\d .()-]{7,}\d)\b")
+_PREVIEW_STANDALONE_TOKEN = re.compile(
+    r"\b(?:sk|ghp|github_pat|xox[bap]|AIza)[-_A-Za-z0-9]{16,}\b"
+)
+_PREVIEW_CANONICAL_SECRET_PATTERNS = tuple(
+    (label, re.compile(pattern, re.IGNORECASE))
+    for label, pattern in SECRET_LABELED_PATTERNS
+)
+
+# Adapter SQL is deliberately limited to these known contracts. Catalog
+# metadata only proves that one of these names exists; it never turns an
+# arbitrary application table into a doctor query target.
+DEFAULT_SCAN_LIMIT = 200
+_DOCTOR_TABLE_COLUMNS: dict[str, frozenset[str]] = {
+    "working_memory": frozenset({"id", "valid_until", "superseded_by"}),
+    "memories": frozenset({"id"}),
+    "episodic_memory": frozenset({"id", "binary_vector"}),
+    "memory_embeddings": frozenset({"memory_id"}),
+    "vec_working": frozenset(),
+    "vec_episodes": frozenset(),
+    "graph_edges": frozenset({"source", "target"}),
+    "canonical_facts": frozenset({"owner_id", "category", "name", "valid_until"}),
+    "triples": frozenset({"valid_from", "valid_until"}),
+}
+_DOCTOR_TABLES = tuple(_DOCTOR_TABLE_COLUMNS)
+
+
+@dataclass
+class Finding:
+    """A content-safe result from one diagnostic check.
+
+    Details are deliberately restricted to safe diagnostic enums.  Free-form
+    strings and arbitrary values are excluded so report producers cannot leak
+    memory content, exception text, or non-JSON values through this field.
+    """
+
+    code: str
+    status: str
+    severity: str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.details = _sanitize_finding_details(self.details)
+
+
+@dataclass
+class RepairCandidate:
+    """A future, explicit repair proposal; this model never performs a repair."""
+
+    id: str
+    description: str
+    bank_name: str | None = None
+    finding_codes: list[str] = field(default_factory=list)
+    requires_explicit_confirmation: bool = True
+
+
+@dataclass
+class ColumnFingerprint:
+    """Schema-only metadata for one table column."""
+
+    name: str
+    declared_type: str = ""
+    not_null: bool = False
+    primary_key_position: int = 0
+
+
+@dataclass
+class TableFingerprint:
+    """Schema-only metadata for one SQLite table or virtual table."""
+
+    name: str
+    object_type: str = "table"
+    status: str = STATUS_OK
+    columns: list[ColumnFingerprint] = field(default_factory=list)
+    foreign_keys: list[dict[str, Any]] = field(default_factory=list)
+    detail: str = ""
+    error_class: str = ""
+    columns_truncated: bool = False
+    foreign_keys_truncated: bool = False
+
+
+@dataclass
+class TriggerFingerprint:
+    """Content-free identity for one trigger that can change repair semantics."""
+
+    name: str
+    table_name: str
+    sql_digest: str
+
+
+@dataclass
+class SchemaFingerprint:
+    """Structured schema metadata used to gate future repair decisions."""
+
+    tables: list[TableFingerprint] = field(default_factory=list)
+    status: str = STATUS_OK
+    detail: str = ""
+    error_class: str = ""
+    tables_truncated: bool = False
+    triggers: list[TriggerFingerprint] = field(default_factory=list)
+    triggers_truncated: bool = False
+
+
+@dataclass
+class DoctorReport:
+    """Serializable, content-safe report envelope for a selected memory bank."""
+
+    bank_name: str
+    # st_dev/st_ino authorize this report for one on-disk database, not merely
+    # another same-schema database selected with ``--db``.
+    database_identity: dict[str, int] = field(default_factory=dict)
+    findings: list[Finding] = field(default_factory=list)
+    repair_candidates: list[RepairCandidate] = field(default_factory=list)
+    schema_fingerprint: SchemaFingerprint = field(default_factory=SchemaFingerprint)
+    runtime_diagnostics: dict[str, Any] = field(default_factory=dict)
+    sqlite_health: dict[str, Any] = field(default_factory=dict)
+    reference_contracts: dict[str, Any] = field(default_factory=dict)
+    vector_coverage: dict[str, Any] = field(default_factory=dict)
+    hygiene_summary: dict[str, Any] = field(default_factory=dict)
+    execution: dict[str, bool] = field(
+        default_factory=lambda: {"read_only": True, "query_only": True, "dry_run": True}
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return plain JSON-compatible containers without executing any action."""
+
+        return asdict(self)
+
+
+def _database_identity(db_path: str | Path) -> dict[str, int]:
+    """Return only the stable filesystem identity used by repair authorization."""
+
+    info = os.stat(Path(db_path), follow_symlinks=True)
+    if not stat.S_ISREG(info.st_mode):
+        raise OSError("database is not a regular file")
+    return {"st_dev": int(info.st_dev), "st_ino": int(info.st_ino)}
+
+
+def open_readonly_doctor_db(db_path: str | Path) -> sqlite3.Connection:
+    """Open an existing SQLite database with defense-in-depth read-only settings.
+
+    The URI ``mode=ro`` prevents filesystem writes and creation of a missing
+    database.  ``query_only`` independently rejects write SQL, while foreign
+    key enforcement makes schema-oriented reads reflect normal SQLite
+    constraint behavior.  The caller owns and must close the connection.
+    """
+
+    uri = f"{Path(db_path).absolute().as_uri()}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def safe_preview(value: Any, max_length: int = 120) -> str:
+    """Redact likely secrets and PII in bounded internal hygiene previews.
+
+    Report artifacts apply the stricter ``_content_free_hygiene_candidates``
+    boundary and never serialize memory text. Structured values and binary
+    payloads are not rendered here either.
+    """
+
+    if not isinstance(max_length, int) or isinstance(max_length, bool) or max_length < 1:
+        raise ValueError("max_length must be a positive integer")
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        text = "[binary data redacted]"
+    elif isinstance(value, str):
+        text = value
+    else:
+        text = "[structured value redacted]"
+
+    text = _PREVIEW_SECRET_ASSIGNMENT.sub(r"\1\2<redacted>", text)
+    text = _PREVIEW_STANDALONE_TOKEN.sub("<redacted>", text)
+    for label, pattern in _PREVIEW_CANONICAL_SECRET_PATTERNS:
+        if label in {"env_secret_assignment", "private_key_block"}:
+            # The canonical env matcher intentionally identifies only the
+            # assignment prefix, while a private-key match identifies only
+            # its header.  Redact their values/bodies too, before truncation.
+            for match in reversed(tuple(pattern.finditer(text))):
+                end = len(text) if label == "private_key_block" else text.find("\n", match.end())
+                if end < 0:
+                    end = len(text)
+                text = text[:match.start()] + "<redacted>" + text[end:]
+        else:
+            text = pattern.sub("<redacted>", text)
+    text = _PREVIEW_EMAIL.sub("<redacted-email>", text)
+    text = _PREVIEW_PHONE.sub("<redacted-phone>", text)
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 1] + "…" if max_length > 1 else "…"
+
+
+def inspect_schema_fingerprint(
+    conn: sqlite3.Connection, scan_limit: int = DEFAULT_SCAN_LIMIT
+) -> SchemaFingerprint:
+    """Inspect bounded table metadata without reading memory rows or contents.
+
+    A virtual table can be listed in SQLite metadata even when its extension is
+    unavailable in the current Python runtime.  In that case, an
+    ``OperationalError`` during table-specific introspection is represented as
+    ``present_but_unloadable`` rather than being interpreted as corruption.
+    """
+
+    scan_limit = _validate_scan_limit(scan_limit)
+    try:
+        cursor = conn.execute(
+            "SELECT name, type, sql FROM sqlite_master "
+            "WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name LIMIT ?",
+            (scan_limit + 1,),
+        )
+        table_rows, tables_truncated = _bounded_metadata_rows(cursor, scan_limit)
+        trigger_cursor = conn.execute(
+            "SELECT name, tbl_name, sql FROM sqlite_master "
+            "WHERE type = 'trigger' ORDER BY name LIMIT ?",
+            (scan_limit + 1,),
+        )
+        trigger_rows, triggers_truncated = _bounded_metadata_rows(trigger_cursor, scan_limit)
+    except sqlite3.Error as error:
+        return SchemaFingerprint(
+            status=STATUS_UNKNOWN,
+            detail="SQLite schema metadata could not be inspected by this runtime.",
+            error_class=_safe_sqlite_error_class(error),
+        )
+
+    tables: list[TableFingerprint] = []
+    for row in table_rows:
+        table_name = str(row[0])
+        table = TableFingerprint(name=table_name, object_type=str(row[1]))
+        table_sql = str(row[2] or "")
+        quoted_name = _quote_identifier(table_name)
+        try:
+            column_rows, table.columns_truncated = _bounded_metadata_rows(
+                conn.execute(f"PRAGMA table_xinfo({quoted_name})"), scan_limit
+            )
+            table.columns = [
+                ColumnFingerprint(
+                    name=str(column[1]),
+                    declared_type=str(column[2] or ""),
+                    not_null=bool(column[3]),
+                    primary_key_position=int(column[5]),
+                )
+                for column in column_rows
+            ]
+            foreign_key_rows, table.foreign_keys_truncated = _bounded_metadata_rows(
+                conn.execute(f"PRAGMA foreign_key_list({quoted_name})"), scan_limit
+            )
+            table.foreign_keys = [
+                {
+                    "id": int(foreign_key[0]),
+                    "seq": int(foreign_key[1]),
+                    "table": str(foreign_key[2]),
+                    "from": str(foreign_key[3]),
+                    "to": str(foreign_key[4]),
+                    "on_update": str(foreign_key[5]),
+                    "on_delete": str(foreign_key[6]),
+                    "match": str(foreign_key[7]),
+                }
+                for foreign_key in foreign_key_rows
+            ]
+        except sqlite3.Error as error:
+            table.status = (
+                STATUS_PRESENT_BUT_UNLOADABLE
+                if _is_confirmed_vec0_unloadable(table_sql, error)
+                else STATUS_UNKNOWN
+            )
+            table.columns = []
+            table.foreign_keys = []
+            table.columns_truncated = False
+            table.foreign_keys_truncated = False
+            table.detail = (
+                "SQLite vec0 virtual table is present but unavailable in this runtime."
+                if table.status == STATUS_PRESENT_BUT_UNLOADABLE
+                else "SQLite table metadata could not be inspected by this runtime."
+            )
+            table.error_class = _safe_sqlite_error_class(error)
+        tables.append(table)
+
+    triggers = [
+        TriggerFingerprint(
+            name=str(row[0]),
+            table_name=str(row[1]),
+            # Trigger bodies can contain literals. A stable digest detects a
+            # semantic change without putting arbitrary SQL in a shareable report.
+            sql_digest=hashlib.sha256(str(row[2] or "").encode("utf-8")).hexdigest(),
+        )
+        for row in trigger_rows
+    ]
+    return SchemaFingerprint(
+        tables=tables,
+        tables_truncated=tables_truncated,
+        triggers=triggers,
+        triggers_truncated=triggers_truncated,
+    )
+
+
+def _quote_identifier(identifier: str) -> str:
+    """Return a SQLite double-quoted identifier from trusted schema metadata."""
+
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _is_confirmed_vec0_unloadable(table_sql: str, error: sqlite3.Error) -> bool:
+    """Return true only for vec0 metadata plus its specific unavailable signal."""
+
+    return (
+        isinstance(error, sqlite3.OperationalError)
+        and bool(_VEC0_VIRTUAL_TABLE.search(table_sql))
+        and bool(_VEC0_UNAVAILABLE_ERROR.search(str(error)))
+    )
+
+
+def _safe_sqlite_error_class(error: sqlite3.Error) -> str:
+    """Map SQLite exceptions to bounded labels without retaining exception text."""
+
+    if isinstance(error, sqlite3.OperationalError):
+        return "operational_error"
+    if isinstance(error, sqlite3.DatabaseError):
+        return "database_error"
+    return "sqlite_error"
+
+
+def _sanitize_finding_details(details: Any) -> dict[str, Any]:
+    """Keep only the explicit, JSON-safe finding detail schema.
+
+    ``operation`` and ``error_class`` are bounded enums; every other supplied
+    field is discarded and counted without preserving its name or value.
+    """
+
+    if not isinstance(details, dict):
+        return {"redacted_field_count": 1}
+
+    safe_details: dict[str, Any] = {}
+    redacted_field_count = 0
+    for key, value in details.items():
+        if key == "operation" and isinstance(value, str):
+            operation = value.strip().lower()
+            if operation in _SAFE_DETAIL_OPERATIONS:
+                safe_details[key] = operation
+                continue
+        elif key == "error_class" and isinstance(value, str):
+            error_class = _ERROR_CLASS_ALIASES.get(value.strip().lower())
+            if error_class in _SAFE_DETAIL_ERROR_CLASSES:
+                safe_details[key] = error_class
+                continue
+        redacted_field_count += 1
+
+    if redacted_field_count:
+        safe_details["redacted_field_count"] = redacted_field_count
+    return safe_details
+
+
+@dataclass
+class AdapterResult:
+    """Bounded, content-safe output shared by read-only doctor adapters."""
+
+    metrics: dict[str, Any] = field(default_factory=dict)
+    findings: list[Finding] = field(default_factory=list)
+    repair_candidates: list[RepairCandidate] = field(default_factory=list)
+
+
+_RUNTIME_CHECK_NAMES = frozenset(
+    {
+        "python_version",
+        "platform",
+        "python_executable",
+        "mnemosyne_version",
+        "fastembed",
+        "sqlite_vec",
+        "numpy",
+        "huggingface_hub",
+        "ctransformers",
+        "embeddings_available",
+        "embeddings_model",
+        "sqlite_vec_available",
+        "sqlite_vec_warning",
+    }
+)
+_RUNTIME_STATUSES = frozenset({"OK", "YES", "NO", "MISSING", "OPTIONAL", "ERROR"})
+
+
+class RuntimeDiagnosticsAdapter:
+    """Expose pure runtime/dependency checks without constructing Mnemosyne."""
+
+    def inspect(self) -> AdapterResult:
+        try:
+            from mnemosyne.runtime_diagnostics import collect_runtime_diagnostics
+
+            result = collect_runtime_diagnostics()
+        except Exception:
+            return AdapterResult(metrics={"status": STATUS_UNKNOWN, "error_class": "runtime_error"})
+        if not isinstance(result, dict) or not isinstance(result.get("checks"), list):
+            return AdapterResult(metrics={"status": STATUS_UNKNOWN, "error_class": "runtime_error"})
+        checks = [
+            {"check": entry["check"], "status": entry["status"]}
+            for entry in result["checks"]
+            if isinstance(entry, dict)
+            and entry.get("check") in _RUNTIME_CHECK_NAMES
+            and entry.get("status") in _RUNTIME_STATUSES
+        ]
+        status = result.get("status")
+        if status not in {STATUS_OK, STATUS_WARNING, "unavailable"}:
+            status = STATUS_UNKNOWN
+        return AdapterResult(metrics={"status": status, "checks": checks})
+
+
+class HygieneSummaryAdapter:
+    """Use only the bounded, content-safe hygiene doctor view on a supplied DB."""
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        db_path: str | Path,
+        scan_limit: int = DEFAULT_SCAN_LIMIT,
+        candidate_limit: int = 20,
+    ):
+        self.conn = conn
+        self.db_path = Path(db_path)
+        self.scan_limit = _validate_scan_limit(scan_limit)
+        if (
+            not isinstance(candidate_limit, int)
+            or isinstance(candidate_limit, bool)
+            or candidate_limit < 0
+        ):
+            raise ValueError("candidate_limit must be a non-negative integer")
+        self.candidate_limit = candidate_limit
+
+    def inspect(self) -> AdapterResult:
+        try:
+            from mnemosyne.core.hygiene import doctor_hygiene_summary
+
+            result = doctor_hygiene_summary(
+                self.db_path,
+                limit=self.scan_limit,
+                candidate_limit=self.candidate_limit,
+                conn=self.conn,
+            )
+        except Exception:
+            return AdapterResult(metrics={"status": STATUS_UNKNOWN, "error_class": "runtime_error", "candidates": []})
+        if not isinstance(result, dict) or result.get("status") not in {STATUS_OK, STATUS_UNKNOWN, "unavailable"}:
+            return AdapterResult(metrics={"status": STATUS_UNKNOWN, "error_class": "runtime_error", "candidates": []})
+        return AdapterResult(metrics=self._sanitize_summary(result))
+
+    def _sanitize_summary(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Keep the hygiene bridge bounded even if its implementation grows."""
+
+        status = result["status"]
+        if status != STATUS_OK:
+            return {
+                "status": status,
+                "error_class": result.get("error_class")
+                if result.get("error_class") in {"sqlite_error", "runtime_error"}
+                else "runtime_error",
+                "candidates": [],
+            }
+
+        def count(name: str) -> int:
+            value = result.get(name, 0)
+            return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+        candidates: list[dict[str, Any]] = []
+        raw_candidates = result.get("candidates", [])
+        if isinstance(raw_candidates, list):
+            for candidate in raw_candidates[: self.candidate_limit]:
+                if not isinstance(candidate, dict):
+                    continue
+                score = candidate.get("noise_score")
+                candidates.append(
+                    {
+                        "id": safe_preview(candidate.get("id"), max_length=120),
+                        "table": candidate.get("table")
+                        if candidate.get("table") in {"working_memory", "memories", "episodic_memory"}
+                        else "unknown",
+                        "noise_score": score
+                        if isinstance(score, (int, float)) and not isinstance(score, bool) and 0 <= score <= 1
+                        else 0.0,
+                        "reasons": [
+                            safe_preview(reason, max_length=120)
+                            for reason in candidate.get("reasons", [])
+                            if isinstance(reason, str)
+                        ][:20],
+                        "secret_flags": [
+                            safe_preview(flag, max_length=120)
+                            for flag in candidate.get("secret_flags", [])
+                            if isinstance(flag, str)
+                        ][:20],
+                        "suggested_action": candidate.get("suggested_action")
+                        if candidate.get("suggested_action") in {"delete", "archive", "keep", "flag"}
+                        else "keep",
+                        "preview": safe_preview(candidate.get("preview"), max_length=120),
+                    }
+                )
+        return {
+            "status": STATUS_OK,
+            "total_scanned": count("total_scanned"),
+            "total_candidates": count("total_candidates"),
+            "with_secrets": count("with_secrets"),
+            "limit_per_table": count("limit_per_table"),
+            "candidate_limit": self.candidate_limit,
+            "candidates": candidates,
+        }
+
+
+def build_doctor_report(
+    bank_name: str,
+    db_path: str | Path,
+    scan_limit: int = DEFAULT_SCAN_LIMIT,
+    candidate_limit: int = 20,
+) -> DoctorReport:
+    """Build a complete report using only runtime checks and a read-only DB.
+
+    The function intentionally does not invoke ``Mnemosyne``, provider setup,
+    diagnostics repair, cleanup, reindexing, or embedding work.
+    """
+
+    scan_limit = _validate_scan_limit(scan_limit)
+    report = DoctorReport(
+        bank_name=bank_name,
+        runtime_diagnostics=RuntimeDiagnosticsAdapter().inspect().metrics,
+    )
+    try:
+        report.database_identity = _database_identity(db_path)
+    except (OSError, ValueError):
+        # A report without a regular-file identity remains useful read-only
+        # diagnostics, but repair will deliberately reject it.
+        report.database_identity = {}
+    try:
+        conn = open_readonly_doctor_db(db_path)
+    except sqlite3.Error:
+        unavailable = {"status": "unavailable", "error_class": "sqlite_error"}
+        report.sqlite_health = dict(unavailable)
+        report.reference_contracts = dict(unavailable)
+        report.vector_coverage = dict(unavailable)
+        report.hygiene_summary = dict(unavailable, candidates=[])
+        return report
+    try:
+        report.schema_fingerprint = inspect_schema_fingerprint(conn, scan_limit=scan_limit)
+        sqlite_health = SQLiteHealthAdapter(conn, scan_limit=scan_limit).inspect()
+        reference_contracts = ReferenceContractRegistry(conn, scan_limit=scan_limit).inspect()
+        vector_coverage = VectorCoverageAdapter(conn, scan_limit=scan_limit).inspect()
+        report.sqlite_health = sqlite_health.metrics
+        report.reference_contracts = reference_contracts.metrics
+        report.vector_coverage = vector_coverage.metrics
+        report.findings.extend(sqlite_health.findings)
+        report.findings.extend(reference_contracts.findings)
+        report.findings.extend(vector_coverage.findings)
+        report.repair_candidates.extend(sqlite_health.repair_candidates)
+        report.repair_candidates.extend(reference_contracts.repair_candidates)
+        report.repair_candidates.extend(vector_coverage.repair_candidates)
+        report.hygiene_summary = HygieneSummaryAdapter(
+            conn,
+            db_path,
+            scan_limit=scan_limit,
+            candidate_limit=candidate_limit,
+        ).inspect().metrics
+    finally:
+        conn.close()
+    return report
+
+
+def doctor_report_payload(report: DoctorReport, *, include_candidates: bool = False) -> dict[str, Any]:
+    """Return the canonical JSON-safe doctor model used by every renderer."""
+
+    payload = report.to_dict()
+    hygiene = payload.get("hygiene_summary")
+    if isinstance(hygiene, dict):
+        hygiene["candidates"] = _content_free_hygiene_candidates(hygiene.get("candidates"))
+    payload["repair_candidates"] = _content_free_repair_candidates(
+        payload.get("repair_candidates")
+    )
+    if not include_candidates:
+        payload["repair_candidates"] = []
+        if isinstance(hygiene, dict):
+            hygiene["candidates"] = []
+    return payload
+
+
+def _content_free_hygiene_candidates(candidates: Any) -> list[dict[str, Any]]:
+    """Expose only fixed-schema hygiene metadata in report artifacts.
+
+    The hygiene adapter retains redacted previews for its internal audit
+    contract, but report files have a stricter boundary: they must never carry
+    memory text, even when that text is not secret.  Do not preserve IDs,
+    reasons, flags, or previews here because those fields can be derived from
+    arbitrary stored content.
+    """
+
+    if not isinstance(candidates, list):
+        return []
+
+    safe_candidates: list[dict[str, Any]] = []
+    for candidate in candidates[:100]:
+        if not isinstance(candidate, dict):
+            continue
+        score = candidate.get("noise_score")
+        reasons = candidate.get("reasons")
+        secret_flags = candidate.get("secret_flags")
+        safe_candidates.append(
+            {
+                "candidate_class": "hygiene",
+                "table": candidate.get("table")
+                if candidate.get("table") in {"working_memory", "memories", "episodic_memory"}
+                else "unknown",
+                "noise_score": score
+                if isinstance(score, (int, float)) and not isinstance(score, bool) and 0 <= score <= 1
+                else 0.0,
+                "reason_count": min(len(reasons), 20) if isinstance(reasons, list) else 0,
+                "secret_flag_count": min(len(secret_flags), 20) if isinstance(secret_flags, list) else 0,
+                "suggested_action": candidate.get("suggested_action")
+                if candidate.get("suggested_action") in {"delete", "archive", "keep", "flag"}
+                else "keep",
+            }
+        )
+    return safe_candidates
+
+
+def _content_free_repair_candidates(candidates: Any) -> list[dict[str, Any]]:
+    """Expose repair proposals without serializing their raw identifying data.
+
+    A future repair proposal may carry an ID, bank, description, or finding
+    references.  Those values are useful only to an explicit repair workflow;
+    they are neither needed nor safe in a shareable read-only report.  Retain
+    only a fixed class and the confirmation requirement.
+    """
+
+    if not isinstance(candidates, list):
+        return []
+
+    safe_candidates: list[dict[str, Any]] = []
+    for candidate in candidates[:100]:
+        if not isinstance(candidate, dict):
+            continue
+        safe_candidates.append(
+            {
+                "candidate_class": "repair",
+                "requires_explicit_confirmation": bool(
+                    candidate.get("requires_explicit_confirmation", True)
+                ),
+            }
+        )
+    return safe_candidates
+
+
+def render_doctor_json(payload: dict[str, Any]) -> str:
+    """Render the canonical doctor model deterministically as JSON."""
+
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def render_doctor_markdown(payload: dict[str, Any]) -> str:
+    """Render the canonical, content-safe doctor model deterministically."""
+
+    findings = payload.get("findings", [])
+    severity_counts = {
+        severity: sum(
+            1
+            for finding in findings
+            if isinstance(finding, dict) and finding.get("severity") == severity
+        )
+        for severity in (SEVERITY_CRITICAL, SEVERITY_ERROR, SEVERITY_WARNING, SEVERITY_INFO)
+    }
+    lines = [
+        "# Mnemosyne Doctor Report",
+        "",
+        "**Read-only / query_only / dry-run — no repair, migration, or database write was performed.**",
+        "",
+        "## Summary",
+        "",
+        f"- Bank: `{_markdown_scalar(payload.get('bank_name', 'default'))}`",
+        "- Findings: " + ", ".join(f"{name}={severity_counts[name]}" for name in severity_counts),
+        f"- Repair candidates requiring review: {len(payload.get('repair_candidates', []))}",
+        "",
+        "## SQLite",
+        "",
+    ]
+    sqlite_health = payload.get("sqlite_health", {})
+    if isinstance(sqlite_health, dict):
+        for name in ("quick_check", "foreign_key_check", "foreign_key_inventory", "vec0"):
+            if name in sqlite_health:
+                lines.append(f"- {name}: `{_compact_json(sqlite_health[name])}`")
+    else:
+        lines.append(f"- status: `{_compact_json(sqlite_health)}`")
+
+    lines.extend(["", "## References", ""])
+    _append_metric_lines(lines, payload.get("reference_contracts"))
+    lines.extend(["", "## Vector tiers", ""])
+    _append_metric_lines(lines, payload.get("vector_coverage"))
+
+    lines.extend(["", "## Hygiene", ""])
+    hygiene = payload.get("hygiene_summary", {})
+    if isinstance(hygiene, dict):
+        for name in ("status", "total_scanned", "total_candidates", "with_secrets", "limit_per_table"):
+            if name in hygiene:
+                lines.append(f"- {name}: `{_compact_json(hygiene[name])}`")
+        candidates = hygiene.get("candidates", [])
+        if isinstance(candidates, list) and candidates:
+            lines.append("- Redacted candidate samples:")
+            for candidate in candidates[:20]:
+                lines.append(f"  - `{_compact_json(candidate)}`")
+    else:
+        lines.append(f"- status: `{_compact_json(hygiene)}`")
+
+    notes = _degradation_notes(payload)
+    lines.extend(["", "## Degradations and review", ""])
+    if notes:
+        lines.extend(f"- {note}" for note in notes[:10])
+    else:
+        lines.append("- No bounded degradation signal was reported.")
+    if _contains_status(payload, STATUS_PRESENT_BUT_UNLOADABLE):
+        lines.append(
+            "- sqlite-vec tables are present but this runtime cannot load vec0; "
+            "review the sqlite-vec runtime installation before treating vector checks as unavailable."
+        )
+    lines.append("- Review the findings and explicit candidates before any future repair.")
+    lines.append("  Repairs must remain individually selected and explicitly confirmed; this report performs none.")
+
+    candidates = payload.get("repair_candidates", [])
+    if isinstance(candidates, list) and candidates:
+        lines.extend(["", "## Explicit repair candidates", ""])
+        for candidate in candidates[:20]:
+            lines.append(f"- `{_compact_json(candidate)}`")
+    return "\n".join(lines) + "\n"
+
+
+def write_doctor_artifacts_atomically(
+    *, json_path: str | Path, json_text: str, markdown_path: str | Path, markdown_text: str
+) -> None:
+    """Write both artifacts together and roll back a partial second replacement."""
+
+    targets = [(Path(json_path), json_text), (Path(markdown_path), markdown_text)]
+    if targets[0][0].resolve() == targets[1][0].resolve():
+        raise ValueError("JSON and Markdown output paths must be different")
+    for target, _ in targets:
+        if not target.parent.is_dir():
+            raise ValueError(f"Output directory does not exist: {target.parent}")
+
+    temporary_paths: set[Path] = set()
+    staged: dict[Path, Path] = {}
+    originals: dict[Path, bytes | None] = {}
+    committed: list[Path] = []
+    try:
+        for target, text in targets:
+            originals[target] = target.read_bytes() if target.exists() else None
+            fd, temporary = tempfile.mkstemp(prefix=f".{target.name}-", suffix=".tmp", dir=target.parent)
+            temporary_path = Path(temporary)
+            # Register immediately: failures in fdopen/write/flush/fsync must
+            # not leak a temp created before the old staged assignment point.
+            temporary_paths.add(temporary_path)
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(text)
+                handle.flush()
+                os.fsync(handle.fileno())
+            staged[target] = temporary_path
+        for target, _ in targets:
+            os.replace(staged[target], target)
+            committed.append(target)
+        for target, _ in targets:
+            _fsync_directory(target.parent)
+    except BaseException as error:
+        rollback_errors: list[BaseException] = []
+        for target in reversed(committed):
+            try:
+                original = originals[target]
+                if original is None:
+                    target.unlink(missing_ok=True)
+                    continue
+                fd, temporary = tempfile.mkstemp(
+                    prefix=f".{target.name}-restore-", suffix=".tmp", dir=target.parent
+                )
+                temporary_path = Path(temporary)
+                temporary_paths.add(temporary_path)
+                with os.fdopen(fd, "wb") as handle:
+                    handle.write(original)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(temporary_path, target)
+            except BaseException as rollback_error:
+                # Continue trying every committed target.  The original write
+                # error remains the public failure, with rollback trouble
+                # attached as diagnostic context rather than masking it.
+                rollback_errors.append(rollback_error)
+        if rollback_errors and hasattr(error, "add_note"):
+            error.add_note(
+                f"Doctor output rollback encountered {len(rollback_errors)} error(s)."
+            )
+        raise
+    finally:
+        for temporary in temporary_paths:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                # Cleanup is best effort under OS failures, but attempt every
+                # tracked path and never mask the primary write/rollback error.
+                pass
+
+
+def _append_metric_lines(lines: list[str], metrics: Any) -> None:
+    if isinstance(metrics, dict):
+        for name in sorted(metrics):
+            lines.append(f"- {name}: `{_compact_json(metrics[name])}`")
+    else:
+        lines.append(f"- status: `{_compact_json(metrics)}`")
+
+
+def _compact_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _markdown_scalar(value: Any) -> str:
+    return safe_preview(value, max_length=120).replace("`", "'")
+
+
+def _contains_status(value: Any, status: str) -> bool:
+    if isinstance(value, dict):
+        return value.get("status") == status or any(_contains_status(item, status) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_status(item, status) for item in value)
+    return False
+
+
+def _degradation_notes(payload: dict[str, Any]) -> list[str]:
+    notes: list[str] = []
+    for section in ("sqlite_health", "reference_contracts", "vector_coverage", "hygiene_summary"):
+        value = payload.get(section)
+        if not isinstance(value, dict):
+            continue
+        for name, metric in value.items():
+            status = metric.get("status") if isinstance(metric, dict) else None
+            if status in {STATUS_UNKNOWN, "unavailable", STATUS_PRESENT_BUT_UNLOADABLE, "scan_limited"}:
+                notes.append(f"{section}.{name}: `{status}`")
+    return notes
+
+
+def _fsync_directory(directory: Path) -> None:
+    """Best-effort directory sync for completed output replacements."""
+
+    try:
+        descriptor = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
+@dataclass(frozen=True)
+class _CatalogResult:
+    tables: dict[str, str] = field(default_factory=dict)
+    error_class: str | None = None
+
+
+@dataclass(frozen=True)
+class _ColumnsResult:
+    columns: frozenset[str] = frozenset()
+    error_class: str | None = None
+    truncated: bool = False
+
+
+@dataclass(frozen=True)
+class _BoundedCount:
+    value: int | None = None
+    truncated: bool = False
+    error_class: str | None = None
+
+
+def _validate_scan_limit(scan_limit: int) -> int:
+    if not isinstance(scan_limit, int) or isinstance(scan_limit, bool) or scan_limit < 1:
+        raise ValueError("scan_limit must be a positive integer")
+    return scan_limit
+
+
+def _bounded_metadata_rows(cursor: sqlite3.Cursor, scan_limit: int) -> tuple[list[Any], bool]:
+    """Read at most a metadata limit plus one sentinel without report growth."""
+
+    rows: list[Any] = []
+    for row in cursor:
+        if len(rows) == scan_limit:
+            return rows, True
+        rows.append(row)
+    return rows, False
+
+
+def _catalog(conn: sqlite3.Connection) -> _CatalogResult:
+    """Return only registry-approved adapter tables, never arbitrary catalog names."""
+
+    placeholders = ", ".join("?" for _ in _DOCTOR_TABLES)
+    try:
+        cursor = conn.execute(
+            "SELECT name, sql FROM sqlite_master WHERE type = 'table' "
+            f"AND name IN ({placeholders})",
+            _DOCTOR_TABLES,
+        )
+        tables: dict[str, str] = {}
+        for row in cursor:
+            name = str(row[0])
+            if name in _DOCTOR_TABLE_COLUMNS:
+                tables[name] = str(row[1] or "")
+        return _CatalogResult(tables=tables)
+    except sqlite3.Error as error:
+        return _CatalogResult(error_class=_safe_sqlite_error_class(error))
+
+
+def _table_columns(
+    conn: sqlite3.Connection, table: str, scan_limit: int = DEFAULT_SCAN_LIMIT
+) -> _ColumnsResult:
+    """Return bounded, registry-approved columns for a fixed doctor table."""
+
+    if table not in _DOCTOR_TABLE_COLUMNS:
+        raise ValueError("table is not in the doctor contract registry")
+    scan_limit = _validate_scan_limit(scan_limit)
+    try:
+        rows, truncated = _bounded_metadata_rows(
+            conn.execute(f"PRAGMA table_xinfo({_quote_identifier(table)})"), scan_limit
+        )
+        columns = frozenset(
+            str(row[1])
+            for row in rows
+            if str(row[1]) in _DOCTOR_TABLE_COLUMNS[table]
+        )
+        return _ColumnsResult(columns=columns, truncated=truncated)
+    except sqlite3.Error as error:
+        return _ColumnsResult(error_class=_safe_sqlite_error_class(error))
+
+
+def _bounded_count(conn: sqlite3.Connection, candidate_sql: str, scan_limit: int) -> _BoundedCount:
+    """Count at most ``scan_limit`` candidate rows without an unbounded result set."""
+
+    try:
+        cursor = conn.execute(f"SELECT 1 FROM ({candidate_sql}) LIMIT ?", (scan_limit + 1,))
+        count = 0
+        for _ in cursor:
+            count += 1
+        return _BoundedCount(value=min(count, scan_limit), truncated=count > scan_limit)
+    except sqlite3.Error as error:
+        return _BoundedCount(error_class=_safe_sqlite_error_class(error))
+
+
+def _with_counts(status: str, counts: dict[str, _BoundedCount]) -> dict[str, Any]:
+    error_class = next((count.error_class for count in counts.values() if count.error_class), None)
+    if error_class:
+        return {"status": STATUS_UNKNOWN, "error_class": error_class}
+    metric: dict[str, Any] = {
+        "status": "scan_limited" if any(count.truncated for count in counts.values()) else status
+    }
+    for name, count in counts.items():
+        metric[name] = count.value
+        if count.truncated:
+            metric[f"{name}_truncated"] = True
+    return metric
+
+
+def _vec_table_status(conn: sqlite3.Connection, table: str, ddl: str | None) -> tuple[str, str | None]:
+    """Classify a queryable, confirmed vec0 table; plain names are not vec tables."""
+
+    if ddl is None or not _VEC0_VIRTUAL_TABLE.search(ddl):
+        return "not_configured", None
+    try:
+        conn.execute(f"SELECT 1 FROM {_quote_identifier(table)} LIMIT 0").fetchone()
+        return "available", None
+    except sqlite3.Error as error:
+        if _is_confirmed_vec0_unloadable(ddl, error):
+            return STATUS_PRESENT_BUT_UNLOADABLE, _safe_sqlite_error_class(error)
+        return STATUS_UNKNOWN, _safe_sqlite_error_class(error)
+
+
+def _live_memory_tables(
+    conn: sqlite3.Connection, catalog: _CatalogResult, scan_limit: int
+) -> tuple[list[str], str | None, bool]:
+    """Return source tables with the fixed ``id`` contract or uncertainty state."""
+
+    live_tables: list[str] = []
+    for table in ("working_memory", "memories", "episodic_memory"):
+        if table not in catalog.tables:
+            continue
+        columns = _table_columns(conn, table, scan_limit)
+        if columns.error_class:
+            return [], columns.error_class, False
+        if "id" in columns.columns:
+            live_tables.append(table)
+        elif columns.truncated:
+            return [], None, True
+    return live_tables, None, False
+
+
+def _live_id_union(live_tables: list[str]) -> str:
+    return " UNION ".join(
+        f"SELECT id FROM {_quote_identifier(table)} WHERE id IS NOT NULL"
+        for table in live_tables
+    )
+
+
+class SQLiteHealthAdapter:
+    """Read-only health checks with a bounded diagnostic scan budget."""
+
+    def __init__(self, conn: sqlite3.Connection, scan_limit: int = DEFAULT_SCAN_LIMIT):
+        self.conn = conn
+        self.scan_limit = _validate_scan_limit(scan_limit)
+
+    def _pragma_rows(self, pragma: str) -> tuple[list[sqlite3.Row], bool, str | None]:
+        try:
+            rows: list[sqlite3.Row] = []
+            cursor = self.conn.execute(pragma)
+            for row in cursor:
+                if len(rows) == self.scan_limit:
+                    return rows, True, None
+                rows.append(row)
+            return rows, False, None
+        except sqlite3.Error as error:
+            return [], False, _safe_sqlite_error_class(error)
+
+    def inspect(self) -> AdapterResult:
+        catalog = _catalog(self.conn)
+        findings: list[Finding] = []
+        quick_rows, quick_truncated, quick_error = self._pragma_rows("PRAGMA quick_check")
+        if quick_error:
+            quick_check: dict[str, Any] = {"status": STATUS_UNKNOWN, "error_class": quick_error}
+        else:
+            quick_ok = bool(quick_rows) and all(str(row[0]).lower() == "ok" for row in quick_rows)
+            quick_check = {
+                "status": "truncated" if quick_truncated and quick_ok else "ok" if quick_ok else "failed",
+                "capability": "sqlite_integrity_primitive",
+                "runtime_cost": "potentially_global",
+            }
+            if quick_truncated:
+                quick_check["truncated"] = True
+
+        fk_rows, fk_truncated, fk_error = self._pragma_rows("PRAGMA foreign_key_check")
+        if fk_error:
+            foreign_key_check: dict[str, Any] = {"status": STATUS_UNKNOWN, "error_class": fk_error}
+        else:
+            foreign_key_check = {
+                "status": "violations" if fk_rows else "ok",
+                "count": len(fk_rows),
+            }
+            if fk_truncated:
+                foreign_key_check["truncated"] = True
+
+        if catalog.error_class:
+            inventory: dict[str, Any] | list[dict[str, Any]] = {
+                "status": STATUS_UNKNOWN,
+                "error_class": catalog.error_class,
+            }
+            vec0: dict[str, Any] = {"status": STATUS_UNKNOWN, "error_class": catalog.error_class}
+        else:
+            entries: list[dict[str, Any]] = []
+            inventory_error: str | None = None
+            for table in sorted(catalog.tables):
+                rows, truncated, error_class = self._pragma_rows(
+                    f"PRAGMA foreign_key_list({_quote_identifier(table)})"
+                )
+                if error_class:
+                    inventory_error = error_class
+                    break
+                if rows:
+                    entry: dict[str, Any] = {"table": table, "count": len(rows)}
+                    if truncated:
+                        entry["truncated"] = True
+                    entries.append(entry)
+            inventory = (
+                {"status": STATUS_UNKNOWN, "error_class": inventory_error}
+                if inventory_error
+                else entries
+            )
+            vec_tables = [
+                (name, ddl)
+                for name, ddl in catalog.tables.items()
+                if _VEC0_VIRTUAL_TABLE.search(ddl)
+            ]
+            if not vec_tables:
+                vec0 = {"status": "not_configured", "table_count": 0}
+            else:
+                statuses = [_vec_table_status(self.conn, name, ddl) for name, ddl in vec_tables]
+                status_values = [status for status, _ in statuses]
+                error_class = next((error for _, error in statuses if error), None)
+                vec_status = (
+                    STATUS_PRESENT_BUT_UNLOADABLE
+                    if STATUS_PRESENT_BUT_UNLOADABLE in status_values
+                    else STATUS_UNKNOWN if STATUS_UNKNOWN in status_values else "available"
+                )
+                vec0 = {"status": vec_status, "table_count": len(vec_tables)}
+                if error_class:
+                    vec0["error_class"] = error_class
+                if vec_status == STATUS_PRESENT_BUT_UNLOADABLE:
+                    findings.append(
+                        Finding(
+                            code="sqlite.vec0_capability",
+                            status=STATUS_PRESENT_BUT_UNLOADABLE,
+                            severity=SEVERITY_WARNING,
+                            message="SQLite vec0 tables are present but unavailable in this runtime.",
+                        )
+                    )
+        return AdapterResult(
+            metrics={
+                "quick_check": quick_check,
+                "foreign_key_check": foreign_key_check,
+                "foreign_key_inventory": inventory,
+                "vec0": vec0,
+            },
+            findings=findings,
+        )
+
+
+class ReferenceContractRegistry:
+    """Known reference contracts with bounded candidate scans only."""
+
+    def __init__(self, conn: sqlite3.Connection, scan_limit: int = DEFAULT_SCAN_LIMIT):
+        self.conn = conn
+        self.scan_limit = _validate_scan_limit(scan_limit)
+
+    @staticmethod
+    def _unknown_metrics(
+        error_class: str | None = None, *, columns_truncated: bool = False
+    ) -> dict[str, dict[str, Any]]:
+        metric: dict[str, Any] = {"status": STATUS_UNKNOWN}
+        if error_class:
+            metric["error_class"] = error_class
+        if columns_truncated:
+            metric["columns_truncated"] = True
+        return {
+            name: dict(metric)
+            for name in (
+                "memory_embeddings",
+                "vec_working",
+                "graph_edges",
+                "episodic_memory",
+                "canonical_facts",
+                "triples",
+            )
+        }
+
+    def inspect(self) -> AdapterResult:
+        catalog = _catalog(self.conn)
+        if catalog.error_class:
+            return AdapterResult(metrics=self._unknown_metrics(catalog.error_class))
+        live_tables, live_error, live_columns_truncated = _live_memory_tables(
+            self.conn, catalog, self.scan_limit
+        )
+        if live_error:
+            return AdapterResult(metrics=self._unknown_metrics(live_error))
+        if live_columns_truncated:
+            return AdapterResult(metrics=self._unknown_metrics(columns_truncated=True))
+        live_union = _live_id_union(live_tables)
+        metrics: dict[str, Any] = {}
+        findings: list[Finding] = []
+        candidates: list[RepairCandidate] = []
+        embedding_known_ids_sql = ""
+        embedding_error: str | None = None
+
+        embedding_columns = (
+            _table_columns(self.conn, "memory_embeddings", self.scan_limit)
+            if "memory_embeddings" in catalog.tables
+            else None
+        )
+        embedding_columns_truncated = bool(
+            embedding_columns
+            and embedding_columns.truncated
+            and "memory_id" not in embedding_columns.columns
+        )
+        if embedding_columns and embedding_columns.error_class:
+            metrics["memory_embeddings"] = {"status": STATUS_UNKNOWN, "error_class": embedding_columns.error_class}
+            embedding_error = embedding_columns.error_class
+        elif embedding_columns_truncated:
+            metrics["memory_embeddings"] = {"status": STATUS_UNKNOWN, "columns_truncated": True}
+        elif not embedding_columns or "memory_id" not in embedding_columns.columns:
+            metrics["memory_embeddings"] = {"status": "not_configured", "rows": 0, "orphan_rows": 0}
+        elif not live_union:
+            metrics["memory_embeddings"] = {"status": "unverifiable_contract", "rows": 0, "orphan_rows": 0}
+        else:
+            rows = _bounded_count(self.conn, "SELECT 1 FROM memory_embeddings", self.scan_limit)
+            orphans = _bounded_count(
+                self.conn,
+                "SELECT 1 FROM memory_embeddings me WHERE me.memory_id IS NOT NULL "
+                f"AND me.memory_id NOT IN ({live_union})",
+                self.scan_limit,
+            )
+            metrics["memory_embeddings"] = _with_counts("checked", {"rows": rows, "orphan_rows": orphans})
+            embedding_error = next((count.error_class for count in (rows, orphans) if count.error_class), None)
+            if not rows.error_class and not orphans.error_class:
+                embedding_known_ids_sql = "SELECT memory_id FROM memory_embeddings WHERE memory_id IS NOT NULL"
+                if orphans.value:
+                    findings.append(
+                        Finding(
+                            code="references.memory_embeddings_orphan",
+                            status=STATUS_WARNING,
+                            severity=SEVERITY_WARNING,
+                            message="Fallback embedding references missing from all known memory tiers.",
+                        )
+                    )
+
+        vec_status, vec_error = _vec_table_status(self.conn, "vec_working", catalog.tables.get("vec_working"))
+        if embedding_error and vec_status == "available":
+            metrics["vec_working"] = {"status": STATUS_UNKNOWN, "error_class": embedding_error}
+        elif embedding_columns_truncated and vec_status == "available":
+            metrics["vec_working"] = {"status": STATUS_UNKNOWN, "columns_truncated": True}
+        elif "working_memory" not in live_tables or vec_status == "not_configured":
+            metrics["vec_working"] = {"status": "not_configured", "orphan_rows": 0, "missing_backfill_rows": 0}
+        elif vec_status != "available":
+            metrics["vec_working"] = {"status": vec_status, "error_class": vec_error} if vec_error else {"status": vec_status}
+        elif not embedding_columns or embedding_columns.error_class or "memory_id" not in embedding_columns.columns:
+            metrics["vec_working"] = {"status": "unverifiable_contract"}
+        else:
+            orphan_rows = _bounded_count(
+                self.conn,
+                "SELECT 1 FROM vec_working vw LEFT JOIN working_memory wm ON wm.rowid = vw.rowid WHERE wm.rowid IS NULL",
+                self.scan_limit,
+            )
+            missing_rows = _bounded_count(
+                self.conn,
+                "SELECT 1 FROM working_memory wm JOIN memory_embeddings me ON me.memory_id = wm.id "
+                "LEFT JOIN vec_working vw ON vw.rowid = wm.rowid WHERE vw.rowid IS NULL",
+                self.scan_limit,
+            )
+            metrics["vec_working"] = _with_counts("checked", {"orphan_rows": orphan_rows, "missing_backfill_rows": missing_rows})
+            if not orphan_rows.error_class and not missing_rows.error_class and missing_rows.value:
+                candidates.append(
+                    RepairCandidate(
+                        id="backfill-vec-working",
+                        description="Backfill missing vec_working rows from existing fallback embeddings.",
+                        finding_codes=["references.vec_working_missing_backfill"],
+                    )
+                )
+
+        self._inspect_graph(
+            catalog,
+            live_union,
+            embedding_known_ids_sql,
+            embedding_error,
+            embedding_columns_truncated,
+            metrics,
+            findings,
+        )
+        self._inspect_unverifiable_stores(catalog, metrics)
+        return AdapterResult(metrics=metrics, findings=findings, repair_candidates=candidates)
+
+    def _inspect_graph(
+        self,
+        catalog: _CatalogResult,
+        live_union: str,
+        embedding_known_ids_sql: str,
+        embedding_error: str | None,
+        embedding_columns_truncated: bool,
+        metrics: dict[str, Any],
+        findings: list[Finding],
+    ) -> None:
+        if "graph_edges" not in catalog.tables:
+            metrics["graph_edges"] = {"status": "not_configured", "dangling_memory_endpoints": 0, "opaque_graph_node": 0}
+            return
+        columns = _table_columns(self.conn, "graph_edges", self.scan_limit)
+        if columns.error_class:
+            metrics["graph_edges"] = {"status": STATUS_UNKNOWN, "error_class": columns.error_class}
+        elif columns.truncated and not {"source", "target"}.issubset(columns.columns):
+            metrics["graph_edges"] = {"status": STATUS_UNKNOWN, "columns_truncated": True}
+        elif not {"source", "target"}.issubset(columns.columns):
+            metrics["graph_edges"] = {"status": "not_configured", "dangling_memory_endpoints": 0, "opaque_graph_node": 0}
+        elif embedding_error:
+            metrics["graph_edges"] = {"status": STATUS_UNKNOWN, "error_class": embedding_error}
+        elif embedding_columns_truncated:
+            metrics["graph_edges"] = {"status": STATUS_UNKNOWN, "columns_truncated": True}
+        elif not live_union or not embedding_known_ids_sql:
+            metrics["graph_edges"] = {"status": "unverifiable_contract", "dangling_memory_endpoints": 0, "opaque_graph_node": 0}
+        else:
+            known_ids = f"({live_union} UNION {embedding_known_ids_sql})"
+            nodes = "SELECT source AS node FROM graph_edges UNION ALL SELECT target AS node FROM graph_edges"
+            dangling = _bounded_count(self.conn, f"SELECT 1 FROM ({nodes}) nodes WHERE node IN {known_ids} AND node NOT IN ({live_union})", self.scan_limit)
+            opaque = _bounded_count(self.conn, f"SELECT 1 FROM ({nodes}) nodes WHERE node NOT IN {known_ids}", self.scan_limit)
+            metrics["graph_edges"] = _with_counts("checked", {"dangling_memory_endpoints": dangling, "opaque_graph_node": opaque})
+            if not dangling.error_class and dangling.value:
+                findings.append(Finding(code="references.graph_dangling_memory_endpoint", status=STATUS_WARNING, severity=SEVERITY_WARNING, message="Known graph memory endpoints are dangling; opaque graph nodes remain unverifiable."))
+
+    def _inspect_unverifiable_stores(self, catalog: _CatalogResult, metrics: dict[str, Any]) -> None:
+        metrics["episodic_memory"] = {"status": "unverifiable_parent" if "episodic_memory" in catalog.tables else "not_configured"}
+        for table, required, metric_name, sql, status in (
+            ("canonical_facts", {"owner_id", "category", "name", "valid_until"}, "duplicate_current_slots", "SELECT 1 FROM (SELECT 1 FROM canonical_facts WHERE valid_until IS NULL GROUP BY owner_id, category, name HAVING COUNT(*) > 1)", "unverifiable_contract"),
+            ("triples", {"valid_from", "valid_until"}, "invalid_temporal_ranges", "SELECT 1 FROM triples WHERE valid_until IS NOT NULL AND valid_from IS NOT NULL AND julianday(valid_until) < julianday(valid_from)", "not_a_memory_reference"),
+        ):
+            if table not in catalog.tables:
+                metrics[table] = {"status": "not_configured", metric_name: 0}
+                continue
+            columns = _table_columns(self.conn, table, self.scan_limit)
+            if columns.error_class:
+                metrics[table] = {"status": STATUS_UNKNOWN, "error_class": columns.error_class}
+            elif columns.truncated and not required.issubset(columns.columns):
+                metrics[table] = {"status": STATUS_UNKNOWN, "columns_truncated": True}
+            elif not required.issubset(columns.columns):
+                metrics[table] = {"status": "not_configured", metric_name: 0}
+            else:
+                metrics[table] = _with_counts(status, {metric_name: _bounded_count(self.conn, sql, self.scan_limit)})
+
+
+class VectorCoverageAdapter:
+    """Bounded coverage checks for working, episodic, and compatibility tiers."""
+
+    def __init__(self, conn: sqlite3.Connection, scan_limit: int = DEFAULT_SCAN_LIMIT):
+        self.conn = conn
+        self.scan_limit = _validate_scan_limit(scan_limit)
+
+    def inspect(self) -> AdapterResult:
+        catalog = _catalog(self.conn)
+        if catalog.error_class:
+            unknown = {"status": STATUS_UNKNOWN, "error_class": catalog.error_class}
+            return AdapterResult(metrics={name: dict(unknown) for name in ("working", "episodic", "legacy", "canonical", "triples")})
+        return AdapterResult(metrics={
+            "working": self._working(catalog),
+            "episodic": self._episodic(catalog),
+            "legacy": {"status": "compatibility_store" if "memories" in catalog.tables else "not_configured"},
+            "canonical": {"status": "not_applicable" if "canonical_facts" in catalog.tables else "not_configured"},
+            "triples": {"status": "not_applicable" if "triples" in catalog.tables else "not_configured"},
+        })
+
+    def _working(self, catalog: _CatalogResult) -> dict[str, Any]:
+        empty = {"status": "no_vectors", "active_source_rows": 0, "fallback_embedding_rows": 0, "vec_working_rows": 0, "missing_vec_working_rows": 0, "orphan_vec_working_rows": 0}
+        if "working_memory" not in catalog.tables:
+            return empty
+        columns = _table_columns(self.conn, "working_memory", self.scan_limit)
+        if columns.error_class:
+            return {"status": STATUS_UNKNOWN, "error_class": columns.error_class}
+        if "id" not in columns.columns:
+            if columns.truncated:
+                return {"status": STATUS_UNKNOWN, "columns_truncated": True}
+            return empty
+        if columns.truncated and not _DOCTOR_TABLE_COLUMNS["working_memory"].issubset(columns.columns):
+            return {"status": STATUS_UNKNOWN, "columns_truncated": True}
+        predicates = []
+        if "valid_until" in columns.columns:
+            predicates.append("(wm.valid_until IS NULL OR julianday(wm.valid_until) > julianday('now'))")
+        if "superseded_by" in columns.columns:
+            predicates.append("wm.superseded_by IS NULL")
+        active_where = " WHERE " + " AND ".join(predicates) if predicates else ""
+        source = _bounded_count(self.conn, "SELECT 1 FROM working_memory wm" + active_where, self.scan_limit)
+        if source.error_class:
+            return {"status": STATUS_UNKNOWN, "error_class": source.error_class}
+        result = dict(empty, active_source_rows=source.value)
+        if source.truncated:
+            result["active_source_rows_truncated"] = True
+        embedding_columns = (
+            _table_columns(self.conn, "memory_embeddings", self.scan_limit)
+            if "memory_embeddings" in catalog.tables
+            else None
+        )
+        if embedding_columns and embedding_columns.error_class:
+            return {"status": STATUS_UNKNOWN, "error_class": embedding_columns.error_class}
+        if (
+            embedding_columns
+            and embedding_columns.truncated
+            and "memory_id" not in embedding_columns.columns
+        ):
+            return {"status": STATUS_UNKNOWN, "columns_truncated": True}
+        if embedding_columns and "memory_id" in embedding_columns.columns:
+            fallback = _bounded_count(self.conn, "SELECT 1 FROM working_memory wm JOIN memory_embeddings me ON me.memory_id = wm.id" + active_where, self.scan_limit)
+            if fallback.error_class:
+                return {"status": STATUS_UNKNOWN, "error_class": fallback.error_class}
+            result["fallback_embedding_rows"] = fallback.value
+            if fallback.truncated:
+                result["fallback_embedding_rows_truncated"] = True
+        vec_status, vec_error = _vec_table_status(self.conn, "vec_working", catalog.tables.get("vec_working"))
+        if vec_status not in {"available", "not_configured"}:
+            if vec_status == STATUS_PRESENT_BUT_UNLOADABLE:
+                return {
+                    "status": "unavailable",
+                    "vec0_status": vec_status,
+                    "error_class": vec_error or "sqlite_error",
+                }
+            return {"status": STATUS_UNKNOWN, "error_class": vec_error or "sqlite_error"}
+        if vec_status == "available":
+            counts = {
+                "vec_working_rows": _bounded_count(self.conn, "SELECT 1 FROM vec_working", self.scan_limit),
+                "missing_vec_working_rows": _bounded_count(self.conn, "SELECT 1 FROM working_memory wm LEFT JOIN vec_working vw ON vw.rowid = wm.rowid" + active_where + (" AND " if active_where else " WHERE ") + "vw.rowid IS NULL", self.scan_limit),
+                "orphan_vec_working_rows": _bounded_count(self.conn, "SELECT 1 FROM vec_working vw LEFT JOIN working_memory wm ON wm.rowid = vw.rowid WHERE wm.rowid IS NULL", self.scan_limit),
+            }
+            if any(count.error_class for count in counts.values()):
+                return {"status": STATUS_UNKNOWN, "error_class": next(count.error_class for count in counts.values() if count.error_class)}
+            for name, count in counts.items():
+                result[name] = count.value
+                if count.truncated:
+                    result[f"{name}_truncated"] = True
+            if source.truncated or any(count.truncated for count in counts.values()):
+                result["status"] = "scan_limited"
+            elif source.value == 0:
+                result["status"] = "no_vectors"
+            elif result["fallback_embedding_rows"] and result["missing_vec_working_rows"]:
+                result["status"] = "backfill_available"
+            elif result["missing_vec_working_rows"] == 0:
+                result["status"] = "complete"
+        else:
+            if vec_status != "not_configured":
+                result["vec0_status"] = vec_status
+                if vec_error:
+                    result["vec0_error_class"] = vec_error
+            if result["fallback_embedding_rows"]:
+                result["status"] = "fallback_only"
+            elif source.value:
+                result["status"] = "unavailable"
+        return result
+
+    def _episodic(self, catalog: _CatalogResult) -> dict[str, Any]:
+        result = {"status": "not_configured", "source_rows": 0, "binary_vector_rows": 0, "vec_episode_rows": 0}
+        if "episodic_memory" not in catalog.tables:
+            return result
+        columns = _table_columns(self.conn, "episodic_memory", self.scan_limit)
+        if columns.error_class:
+            return {"status": STATUS_UNKNOWN, "error_class": columns.error_class}
+        if columns.truncated and "binary_vector" not in columns.columns:
+            return {"status": STATUS_UNKNOWN, "columns_truncated": True}
+        source = _bounded_count(self.conn, "SELECT 1 FROM episodic_memory", self.scan_limit)
+        if source.error_class:
+            return {"status": STATUS_UNKNOWN, "error_class": source.error_class}
+        result["source_rows"] = source.value
+        if source.truncated:
+            result["source_rows_truncated"] = True
+        if "binary_vector" in columns.columns:
+            binary = _bounded_count(self.conn, "SELECT 1 FROM episodic_memory WHERE binary_vector IS NOT NULL", self.scan_limit)
+            if binary.error_class:
+                return {"status": STATUS_UNKNOWN, "error_class": binary.error_class}
+            result["binary_vector_rows"] = binary.value
+            if binary.truncated:
+                result["binary_vector_rows_truncated"] = True
+        vec_status, vec_error = _vec_table_status(self.conn, "vec_episodes", catalog.tables.get("vec_episodes"))
+        if vec_status not in {"available", "not_configured"}:
+            if vec_status == STATUS_PRESENT_BUT_UNLOADABLE:
+                return {
+                    "status": "unavailable",
+                    "vec0_status": vec_status,
+                    "error_class": vec_error or "sqlite_error",
+                }
+            return {"status": STATUS_UNKNOWN, "error_class": vec_error or "sqlite_error"}
+        if vec_status == "available":
+            vec_rows = _bounded_count(self.conn, "SELECT 1 FROM vec_episodes", self.scan_limit)
+            if vec_rows.error_class:
+                return {"status": STATUS_UNKNOWN, "error_class": vec_rows.error_class}
+            result["vec_episode_rows"] = vec_rows.value
+            if vec_rows.truncated:
+                result["vec_episode_rows_truncated"] = True
+        if source.truncated:
+            result["status"] = "scan_limited"
+        elif source.value == 0:
+            result["status"] = "not_configured" if vec_status == "not_configured" else "no_vectors"
+        elif result["binary_vector_rows"] == source.value:
+            result["status"] = "complete"
+        elif result["binary_vector_rows"] or result["vec_episode_rows"]:
+            result["status"] = "partial"
+        elif vec_status == "not_configured":
+            result["status"] = "not_configured"
+        elif vec_status == STATUS_PRESENT_BUT_UNLOADABLE:
+            result["status"] = "unavailable"
+        else:
+            result["status"] = "fallback_only"
+        if vec_error and vec_status != "available":
+            result["vec0_error_class"] = vec_error
+        return result

--- a/mnemosyne/doctor.py
+++ b/mnemosyne/doctor.py
@@ -62,6 +62,9 @@ _PREVIEW_CANONICAL_SECRET_PATTERNS = tuple(
     (label, re.compile(pattern, re.IGNORECASE))
     for label, pattern in SECRET_LABELED_PATTERNS
 )
+_RUNTIME_ABSOLUTE_PATH = re.compile(
+    r"(?<![A-Za-z0-9_.-])(?:~[\\/]|(?:[A-Za-z]:)?[\\/])[^\s`<>\"']+"
+)
 
 # Adapter SQL is deliberately limited to these known contracts. Catalog
 # metadata only proves that one of these names exists; it never turns an
@@ -440,6 +443,42 @@ _RUNTIME_CHECK_NAMES = frozenset(
 _RUNTIME_STATUSES = frozenset({"OK", "YES", "NO", "MISSING", "OPTIONAL", "ERROR"})
 
 
+def _safe_runtime_detail(check: str, value: Any) -> str:
+    """Keep runtime metadata useful without serializing host-specific paths."""
+
+    if check == "python_executable" and isinstance(value, str):
+        return safe_preview(Path(value).name, max_length=240)
+    detail = safe_preview(value, max_length=240)
+    return _RUNTIME_ABSOLUTE_PATH.sub("<redacted-path>", detail)
+
+
+def _sanitize_runtime_diagnostics(runtime: Any) -> dict[str, Any]:
+    """Apply the Doctor report boundary to runtime checks from any producer."""
+
+    if not isinstance(runtime, dict):
+        return {}
+    if not runtime:
+        return {}
+    if not isinstance(runtime.get("checks"), list):
+        return {"status": STATUS_UNKNOWN, "error_class": "runtime_error"}
+
+    status = runtime.get("status")
+    if status not in {STATUS_OK, STATUS_WARNING, "unavailable"}:
+        status = STATUS_UNKNOWN
+    checks = [
+        {
+            "check": entry["check"],
+            "status": entry["status"],
+            "detail": _safe_runtime_detail(entry["check"], entry.get("detail", "")),
+        }
+        for entry in runtime["checks"]
+        if isinstance(entry, dict)
+        and entry.get("check") in _RUNTIME_CHECK_NAMES
+        and entry.get("status") in _RUNTIME_STATUSES
+    ]
+    return {"status": status, "checks": checks}
+
+
 class RuntimeDiagnosticsAdapter:
     """Expose pure runtime/dependency checks without constructing Mnemosyne."""
 
@@ -452,21 +491,7 @@ class RuntimeDiagnosticsAdapter:
             return AdapterResult(metrics={"status": STATUS_UNKNOWN, "error_class": "runtime_error"})
         if not isinstance(result, dict) or not isinstance(result.get("checks"), list):
             return AdapterResult(metrics={"status": STATUS_UNKNOWN, "error_class": "runtime_error"})
-        checks = [
-            {
-                "check": entry["check"],
-                "status": entry["status"],
-                "detail": safe_preview(entry.get("detail", ""), max_length=240),
-            }
-            for entry in result["checks"]
-            if isinstance(entry, dict)
-            and entry.get("check") in _RUNTIME_CHECK_NAMES
-            and entry.get("status") in _RUNTIME_STATUSES
-        ]
-        status = result.get("status")
-        if status not in {STATUS_OK, STATUS_WARNING, "unavailable"}:
-            status = STATUS_UNKNOWN
-        return AdapterResult(metrics={"status": status, "checks": checks})
+        return AdapterResult(metrics=_sanitize_runtime_diagnostics(result))
 
 
 class HygieneSummaryAdapter:
@@ -626,6 +651,7 @@ def doctor_report_payload(report: DoctorReport, *, include_candidates: bool = Fa
     """Return the canonical JSON-safe doctor model used by every renderer."""
 
     payload = report.to_dict()
+    payload["runtime_diagnostics"] = _sanitize_runtime_diagnostics(payload.get("runtime_diagnostics"))
     hygiene = payload.get("hygiene_summary")
     if isinstance(hygiene, dict):
         hygiene["candidates"] = _content_free_hygiene_candidates(hygiene.get("candidates"))

--- a/mnemosyne/doctor.py
+++ b/mnemosyne/doctor.py
@@ -959,7 +959,8 @@ def _degradation_notes(payload: dict[str, Any]) -> list[str]:
         value = payload.get(section)
         if not isinstance(value, dict):
             continue
-        for name, metric in value.items():
+        for name in sorted(value):
+            metric = value[name]
             status = metric.get("status") if isinstance(metric, dict) else None
             if status in {STATUS_UNKNOWN, "unavailable", STATUS_PRESENT_BUT_UNLOADABLE, "scan_limited"}:
                 notes.append(f"{section}.{name}: `{status}`")
@@ -967,16 +968,11 @@ def _degradation_notes(payload: dict[str, Any]) -> list[str]:
 
 
 def _fsync_directory(directory: Path) -> None:
-    """Best-effort directory sync for completed output replacements."""
+    """Durably sync a completed output replacement's parent directory."""
 
-    try:
-        descriptor = os.open(directory, os.O_RDONLY)
-    except OSError:
-        return
+    descriptor = os.open(directory, os.O_RDONLY)
     try:
         os.fsync(descriptor)
-    except OSError:
-        pass
     finally:
         os.close(descriptor)
 

--- a/mnemosyne/doctor.py
+++ b/mnemosyne/doctor.py
@@ -227,6 +227,10 @@ def safe_preview(value: Any, max_length: int = 120) -> str:
     else:
         text = "[structured value redacted]"
 
+    # Keep every regex pass bounded even when callers hand Doctor a very large
+    # string. This remains larger than the final preview so redaction happens
+    # before truncation for values that cross the final preview boundary.
+    text = text[: max_length * 4]
     text = _PREVIEW_SECRET_ASSIGNMENT.sub(r"\1\2<redacted>", text)
     text = _PREVIEW_STANDALONE_TOKEN.sub("<redacted>", text)
     for label, pattern in _PREVIEW_CANONICAL_SECRET_PATTERNS:
@@ -524,7 +528,6 @@ class HygieneSummaryAdapter:
                 score = candidate.get("noise_score")
                 candidates.append(
                     {
-                        "id": safe_preview(candidate.get("id"), max_length=120),
                         "table": candidate.get("table")
                         if candidate.get("table") in {"working_memory", "memories", "episodic_memory"}
                         else "unknown",
@@ -779,13 +782,12 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def write_doctor_artifacts_atomically(
-    *, json_path: str | Path, json_text: str, markdown_path: str | Path, markdown_text: str
-) -> None:
-    """Write both artifacts together and roll back a partial second replacement."""
+def _write_doctor_artifacts_atomically(targets: list[tuple[Path, str]]) -> None:
+    """Stage and replace one or more rendered Doctor artifacts safely."""
 
-    targets = [(Path(json_path), json_text), (Path(markdown_path), markdown_text)]
-    if targets[0][0].resolve() == targets[1][0].resolve():
+    if not targets:
+        raise ValueError("At least one Doctor output target is required")
+    if len({target.resolve() for target, _ in targets}) != len(targets):
         raise ValueError("JSON and Markdown output paths must be different")
     for target, _ in targets:
         if not target.parent.is_dir():
@@ -849,6 +851,22 @@ def write_doctor_artifacts_atomically(
                 # Cleanup is best effort under OS failures, but attempt every
                 # tracked path and never mask the primary write/rollback error.
                 pass
+
+
+def write_doctor_artifact_atomically(*, path: str | Path, text: str) -> None:
+    """Atomically replace one rendered Doctor artifact."""
+
+    _write_doctor_artifacts_atomically([(Path(path), text)])
+
+
+def write_doctor_artifacts_atomically(
+    *, json_path: str | Path, json_text: str, markdown_path: str | Path, markdown_text: str
+) -> None:
+    """Write both artifacts together and roll back a partial second replacement."""
+
+    _write_doctor_artifacts_atomically(
+        [(Path(json_path), json_text), (Path(markdown_path), markdown_text)]
+    )
 
 
 def _append_metric_lines(lines: list[str], metrics: Any) -> None:

--- a/mnemosyne/doctor.py
+++ b/mnemosyne/doctor.py
@@ -453,7 +453,11 @@ class RuntimeDiagnosticsAdapter:
         if not isinstance(result, dict) or not isinstance(result.get("checks"), list):
             return AdapterResult(metrics={"status": STATUS_UNKNOWN, "error_class": "runtime_error"})
         checks = [
-            {"check": entry["check"], "status": entry["status"]}
+            {
+                "check": entry["check"],
+                "status": entry["status"],
+                "detail": safe_preview(entry.get("detail", ""), max_length=240),
+            }
             for entry in result["checks"]
             if isinstance(entry, dict)
             and entry.get("check") in _RUNTIME_CHECK_NAMES
@@ -741,6 +745,24 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
     else:
         lines.append(f"- status: `{_compact_json(sqlite_health)}`")
 
+    lines.extend(["", "## Runtime", ""])
+    runtime_diagnostics = payload.get("runtime_diagnostics", {})
+    if isinstance(runtime_diagnostics, dict):
+        if "status" in runtime_diagnostics:
+            lines.append(f"- status: `{_compact_json(runtime_diagnostics['status'])}`")
+        checks = runtime_diagnostics.get("checks", [])
+        if isinstance(checks, list):
+            for check in checks:
+                if not isinstance(check, dict) or not isinstance(check.get("check"), str):
+                    continue
+                detail = safe_preview(check.get("detail", ""), max_length=240)
+                lines.append(
+                    f"- {_markdown_scalar(check['check'])}: "
+                    f"`{_compact_json({'status': check.get('status'), 'detail': detail})}`"
+                )
+    else:
+        lines.append(f"- status: `{_compact_json(runtime_diagnostics)}`")
+
     lines.extend(["", "## References", ""])
     _append_metric_lines(lines, payload.get("reference_contracts"))
     lines.extend(["", "## Vector tiers", ""])
@@ -782,6 +804,36 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _rollback_doctor_artifacts(
+    committed: list[Path], originals: dict[Path, bytes | None], temporary_paths: set[Path]
+) -> list[BaseException]:
+    """Best-effort restore of committed Doctor artifacts in reverse order."""
+
+    rollback_errors: list[BaseException] = []
+    for target in reversed(committed):
+        try:
+            original = originals[target]
+            if original is None:
+                target.unlink(missing_ok=True)
+                continue
+            fd, temporary = tempfile.mkstemp(
+                prefix=f".{target.name}-restore-", suffix=".tmp", dir=target.parent
+            )
+            temporary_path = Path(temporary)
+            temporary_paths.add(temporary_path)
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(original)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_path, target)
+        except BaseException as rollback_error:
+            # Continue trying every committed target.  The original write
+            # error remains the public failure, with rollback trouble
+            # attached as diagnostic context rather than masking it.
+            rollback_errors.append(rollback_error)
+    return rollback_errors
+
+
 def _write_doctor_artifacts_atomically(targets: list[tuple[Path, str]]) -> None:
     """Stage and replace one or more rendered Doctor artifacts safely."""
 
@@ -816,28 +868,7 @@ def _write_doctor_artifacts_atomically(targets: list[tuple[Path, str]]) -> None:
         for target, _ in targets:
             _fsync_directory(target.parent)
     except BaseException as error:
-        rollback_errors: list[BaseException] = []
-        for target in reversed(committed):
-            try:
-                original = originals[target]
-                if original is None:
-                    target.unlink(missing_ok=True)
-                    continue
-                fd, temporary = tempfile.mkstemp(
-                    prefix=f".{target.name}-restore-", suffix=".tmp", dir=target.parent
-                )
-                temporary_path = Path(temporary)
-                temporary_paths.add(temporary_path)
-                with os.fdopen(fd, "wb") as handle:
-                    handle.write(original)
-                    handle.flush()
-                    os.fsync(handle.fileno())
-                os.replace(temporary_path, target)
-            except BaseException as rollback_error:
-                # Continue trying every committed target.  The original write
-                # error remains the public failure, with rollback trouble
-                # attached as diagnostic context rather than masking it.
-                rollback_errors.append(rollback_error)
+        rollback_errors = _rollback_doctor_artifacts(committed, originals, temporary_paths)
         if rollback_errors and hasattr(error, "add_note"):
             error.add_note(
                 f"Doctor output rollback encountered {len(rollback_errors)} error(s)."

--- a/mnemosyne/doctor.py
+++ b/mnemosyne/doctor.py
@@ -447,7 +447,10 @@ def _safe_runtime_detail(check: str, value: Any) -> str:
     """Keep runtime metadata useful without serializing host-specific paths."""
 
     if check == "python_executable" and isinstance(value, str):
-        return safe_preview(Path(value).name, max_length=240)
+        # Runtime data can originate on a different OS than the Doctor host.
+        # Normalize Windows separators before extracting a portable basename.
+        executable_name = value.replace("\\", "/").rsplit("/", 1)[-1]
+        return safe_preview(executable_name, max_length=240)
     detail = safe_preview(value, max_length=240)
     return _RUNTIME_ABSOLUTE_PATH.sub("<redacted-path>", detail)
 

--- a/mnemosyne/repair.py
+++ b/mnemosyne/repair.py
@@ -1,0 +1,1028 @@
+"""Narrow, fail-closed repairs authorized by a Doctor JSON manifest.
+
+This module deliberately supports only an explicitly selected working-memory
+row: backfilling its already-stored fallback embedding into a confirmed vec0
+working index, or expiring that one row.  It never initializes Mnemosyne,
+reads memory content, re-embeds, deletes, changes schema, or touches another
+table's data.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import asdict, dataclass
+import json
+import math
+import os
+from pathlib import Path
+import re
+import sqlite3
+import stat
+import uuid
+from typing import Any
+
+from mnemosyne.doctor import (
+    _VEC0_VIRTUAL_TABLE,
+    build_doctor_report,
+    inspect_schema_fingerprint,
+    open_readonly_doctor_db,
+)
+
+
+BACKFILL_VEC_WORKING = "backfill-vec-working"
+EXPIRE = "expire"
+_ALLOWED_ACTIONS = frozenset({BACKFILL_VEC_WORKING, EXPIRE})
+_SELECTION_TABLE = "working_memory"
+_VECTOR_KIND = re.compile(
+    r"\bembedding\s+(float(?:32)?|int8|bit)\s*\[\s*(\d+)\s*\]", re.IGNORECASE
+)
+
+
+class RepairError(ValueError):
+    """A bounded, content-safe repair validation error suitable for the CLI."""
+
+
+def parse_selection(value: str) -> tuple[str, str]:
+    """Parse one strictly scoped ``working_memory:ID`` selection."""
+
+    if not isinstance(value, str) or ":" not in value:
+        raise RepairError("--select must use working_memory:ID")
+    table, memory_id = value.split(":", 1)
+    if table != _SELECTION_TABLE or not memory_id or "\x00" in memory_id:
+        raise RepairError("--select must use a non-empty working_memory:ID")
+    return table, memory_id
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+_MAX_MANIFEST_BYTES = 1_000_000
+
+
+@dataclass(frozen=True)
+class _RepairManifest:
+    bank_name: str
+    fingerprint: dict[str, Any]
+    database_identity: dict[str, int]
+
+
+@dataclass
+class _BoundDatabase:
+    """A private hardlink and retained FDs for the authorized database inode."""
+
+    stage_path: Path
+    source_fd: int
+    parent_fd: int
+    stage_dir_fd: int
+    stage_name: str
+    identity: dict[str, int]
+
+
+@dataclass
+class _AnchoredDatabase:
+    """Original parent/source FDs retained across the final binding gate."""
+
+    parent_fd: int
+    source_fd: int
+    name: str
+    identity: dict[str, int]
+
+
+@dataclass
+class _ReservedBackup:
+    """An exclusively created backup inode anchored to its opened parent FD."""
+
+    parent_fd: int
+    name: str
+    descriptor: int
+    identity: dict[str, int]
+    display_path: Path
+    installed: bool = False
+
+    def __fspath__(self) -> str:
+        """Support test-only SQLite verification without reopening in repair code."""
+
+        return os.fspath(self.display_path)
+
+    def is_file(self) -> bool:
+        try:
+            return stat.S_ISREG(os.fstat(self.descriptor).st_mode)
+        except OSError:
+            return False
+
+
+def _load_manifest(report_path: str | Path) -> _RepairManifest:
+    """Read one bounded regular-file manifest snapshot without following links."""
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        # A FIFO must be rejected from its FD metadata, not block the CLI while
+        # waiting for a writer.
+        flags |= os.O_NONBLOCK
+    try:
+        descriptor = os.open(Path(report_path), flags)
+        try:
+            info = os.fstat(descriptor)
+            if not stat.S_ISREG(info.st_mode) or info.st_size > _MAX_MANIFEST_BYTES:
+                raise RepairError("Repair report could not be safely read")
+            chunks: list[bytes] = []
+            remaining = _MAX_MANIFEST_BYTES + 1
+            while remaining:
+                chunk = os.read(descriptor, remaining)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                remaining -= len(chunk)
+            raw = b"".join(chunks)
+        finally:
+            os.close(descriptor)
+        if len(raw) > _MAX_MANIFEST_BYTES:
+            raise RepairError("Repair report could not be safely read")
+        payload = json.loads(raw.decode("utf-8"))
+    except RepairError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RepairError("Repair report could not be parsed") from error
+    if not isinstance(payload, dict):
+        raise RepairError("Repair report has no valid authorization manifest")
+    bank_name = payload.get("bank_name")
+    fingerprint = payload.get("schema_fingerprint")
+    identity = payload.get("database_identity")
+    if (
+        not isinstance(bank_name, str)
+        or not bank_name
+        or not isinstance(fingerprint, dict)
+        or not isinstance(identity, dict)
+        or any(
+            not isinstance(identity.get(key), int) or isinstance(identity.get(key), bool)
+            for key in ("st_dev", "st_ino")
+        )
+    ):
+        raise RepairError("Repair report has no valid authorization manifest")
+    try:
+        _canonical_json(fingerprint)
+    except (TypeError, ValueError) as error:
+        raise RepairError("Repair report has no valid authorization manifest") from error
+    return _RepairManifest(bank_name, fingerprint, {"st_dev": identity["st_dev"], "st_ino": identity["st_ino"]})
+
+
+def _verifiable_fingerprint(fingerprint: dict[str, Any]) -> bool:
+    """Reject incomplete or degraded schema snapshots instead of trusting them."""
+
+    if (
+        fingerprint.get("status") != "ok"
+        or fingerprint.get("tables_truncated") is not False
+        or fingerprint.get("triggers_truncated") is not False
+    ):
+        return False
+    tables = fingerprint.get("tables")
+    triggers = fingerprint.get("triggers")
+    if not isinstance(tables, list) or not isinstance(triggers, list):
+        return False
+    return all(
+        isinstance(table, dict)
+        and table.get("status") == "ok"
+        and table.get("columns_truncated") is False
+        and table.get("foreign_keys_truncated") is False
+        for table in tables
+    ) and all(
+        isinstance(trigger, dict)
+        and isinstance(trigger.get("name"), str)
+        and isinstance(trigger.get("table_name"), str)
+        and isinstance(trigger.get("sql_digest"), str)
+        for trigger in triggers
+    )
+
+
+def _database_identity(path: Path) -> dict[str, int]:
+    """Read one regular database identity without following pathname links."""
+
+    descriptor: int | None = None
+    parent_fd: int | None = None
+    try:
+        parent_fd = _open_safe_directory_fd(path.parent)
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        info = os.fstat(descriptor)
+    except (OSError, ValueError) as error:
+        raise RepairError("Database identity could not be verified") from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if parent_fd is not None:
+            os.close(parent_fd)
+    if not stat.S_ISREG(info.st_mode):
+        raise RepairError("Database identity could not be verified")
+    return _stat_identity(info)
+
+
+def _verify_report_gate(
+    manifest: _RepairManifest,
+    db_path: Path,
+    bank_name: str,
+    *,
+    conn: sqlite3.Connection | None = None,
+    bound_identity: dict[str, int] | None = None,
+) -> None:
+    """Fail closed unless this exact bank, file, and schema still match."""
+
+    if manifest.bank_name != bank_name:
+        raise RepairError("Repair report bank does not match the selected database")
+    # Before binding, the requested path is the only available identity.  Once
+    # a private hardlink has been made, *never* re-stat that attacker-mutable
+    # path while using the locked connection: the connection is authorized by
+    # the inode captured in ``bound_identity`` instead.
+    current_identity = bound_identity if conn is not None else _database_identity(db_path)
+    if manifest.database_identity != current_identity:
+        raise RepairError("Repair report does not authorize the selected database")
+    expected_fingerprint = manifest.fingerprint
+    if not _verifiable_fingerprint(expected_fingerprint):
+        raise RepairError("Repair report fingerprint is incomplete and cannot authorize a repair")
+    try:
+        current_fingerprint = (
+            asdict(inspect_schema_fingerprint(conn))
+            if conn is not None
+            else build_doctor_report(bank_name, db_path).to_dict()["schema_fingerprint"]
+        )
+    except (OSError, sqlite3.Error, ValueError, KeyError, TypeError) as error:
+        raise RepairError("Current database fingerprint could not be verified") from error
+    if not isinstance(current_fingerprint, dict) or not _verifiable_fingerprint(current_fingerprint):
+        raise RepairError("Current database fingerprint could not be verified")
+    if _canonical_json(expected_fingerprint) != _canonical_json(current_fingerprint):
+        raise RepairError("Repair report fingerprint does not match the current database")
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    try:
+        return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')}
+    except sqlite3.Error:
+        return set()
+
+
+def _working_row(conn: sqlite3.Connection, memory_id: str) -> tuple[sqlite3.Row | None, str | None]:
+    """Read the one selected active row only; malformed time data is inactive."""
+
+    columns = _table_columns(conn, _SELECTION_TABLE)
+    if not {"id", "valid_until"}.issubset(columns):
+        return None, "unloadable"
+    superseded = ", superseded_by" if "superseded_by" in columns else ""
+    try:
+        row = conn.execute(
+            "SELECT rowid, valid_until" + superseded + ", "
+            "CASE WHEN valid_until IS NULL OR julianday(valid_until) > julianday('now') "
+            "THEN 1 ELSE 0 END AS active "
+            "FROM working_memory WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+    except sqlite3.Error:
+        return None, "unloadable"
+    if row is None:
+        return None, "missing"
+    if "superseded_by" in row.keys() and row["superseded_by"] is not None:
+        return None, "already_inactive"
+    if not bool(row["active"]):
+        return None, "already_inactive"
+    return row, None
+
+
+def _confirmed_vec_working_kind(conn: sqlite3.Connection) -> tuple[str, int] | None:
+    """Confirm a live *virtual* vec0 table and its declared write contract."""
+
+    try:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'vec_working'"
+        ).fetchone()
+        if row is None or not isinstance(row[0], str) or not _VEC0_VIRTUAL_TABLE.search(row[0]):
+            return None
+        kind = _VECTOR_KIND.search(row[0])
+        if kind is None or int(kind.group(2)) < 1:
+            return None
+        # A normal table with forged sqlite_master DDL is not a vec0 contract.
+        table_list = conn.execute("PRAGMA table_list").fetchall()
+        if not any(str(item[1]) == "vec_working" and str(item[2]) == "virtual" for item in table_list):
+            return None
+        conn.execute('SELECT rowid, embedding FROM "vec_working" LIMIT 0').fetchone()
+        return kind.group(1).lower(), int(kind.group(2))
+    except (sqlite3.Error, ValueError, IndexError):
+        return None
+
+
+def _decode_embedding(value: Any) -> str | None:
+    """Validate and normalize fallback JSON without exposing it to callers."""
+
+    if not isinstance(value, str):
+        return None
+    try:
+        raw = json.loads(value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, list) or not raw:
+        return None
+    values: list[float] = []
+    for item in raw:
+        if isinstance(item, bool) or not isinstance(item, (int, float)):
+            return None
+        number = float(item)
+        if not math.isfinite(number):
+            return None
+        values.append(number)
+    magnitude = math.sqrt(sum(item * item for item in values))
+    if magnitude:
+        values = [item / magnitude for item in values]
+    return json.dumps(values, separators=(",", ":"))
+
+
+def _backfill_plan(conn: sqlite3.Connection, memory_id: str) -> tuple[dict[str, Any] | None, str | None]:
+    row, reason = _working_row(conn, memory_id)
+    if reason or row is None:
+        return None, reason
+    vec_contract = _confirmed_vec_working_kind(conn)
+    if vec_contract is None:
+        return None, "unloadable"
+    vector_kind, vector_dimension = vec_contract
+    if not {"memory_id", "embedding_json"}.issubset(_table_columns(conn, "memory_embeddings")):
+        return None, "unloadable"
+    try:
+        exists = conn.execute(
+            "SELECT 1 FROM vec_working WHERE rowid = ? LIMIT 1", (int(row["rowid"]),)
+        ).fetchone()
+        if exists is not None:
+            return None, "already_present"
+        embedding_row = conn.execute(
+            "SELECT embedding_json FROM memory_embeddings WHERE memory_id = ?", (memory_id,)
+        ).fetchone()
+    except sqlite3.Error:
+        return None, "unloadable"
+    if embedding_row is None:
+        return None, "missing_fallback_embedding"
+    embedding = _decode_embedding(embedding_row[0])
+    if embedding is None:
+        return None, "unloadable"
+    try:
+        if len(json.loads(embedding)) != vector_dimension:
+            return None, "unloadable"
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None, "unloadable"
+    return {
+        "rowid": int(row["rowid"]),
+        "embedding": embedding,
+        "vector_kind": vector_kind,
+        "vector_dimension": vector_dimension,
+    }, None
+
+
+def _expire_plan(conn: sqlite3.Connection, memory_id: str) -> tuple[dict[str, Any] | None, str | None]:
+    row, reason = _working_row(conn, memory_id)
+    if reason or row is None:
+        return None, reason
+    return {"rowid": int(row["rowid"])}, None
+
+
+def _plan_selection(conn: sqlite3.Connection, action: str, memory_id: str) -> tuple[dict[str, Any] | None, str | None]:
+    if action == BACKFILL_VEC_WORKING:
+        return _backfill_plan(conn, memory_id)
+    return _expire_plan(conn, memory_id)
+
+
+def _open_safe_directory_fd(path: Path) -> int:
+    """Open every directory component without resolving or following a link."""
+
+    flags = os.O_RDONLY | os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    absolute = os.path.abspath(os.fspath(path))
+    descriptor = os.open(os.sep, flags)
+    try:
+        for component in (part for part in absolute.split(os.sep) if part):
+            next_descriptor = os.open(component, flags, dir_fd=descriptor)
+            try:
+                if not stat.S_ISDIR(os.fstat(next_descriptor).st_mode):
+                    raise NotADirectoryError(component)
+            except BaseException:
+                os.close(next_descriptor)
+                raise
+            os.close(descriptor)
+            descriptor = next_descriptor
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _reject_original_sidecars(anchored: _AnchoredDatabase) -> None:
+    """Reject original-name SQLite sidecars through a verified parent FD.
+
+    A hardlink has a different basename, so SQLite cannot safely recover an
+    original rollback journal (or WAL/SHM pair) through the private pathname.
+    Recheck the retained source inode before inspecting its siblings; no public
+    pathname is used after this point.
+    """
+
+    try:
+        source_info = os.fstat(anchored.source_fd)
+        if not stat.S_ISREG(source_info.st_mode) or _stat_identity(source_info) != anchored.identity:
+            raise RepairError("Repair report does not authorize the selected database")
+        for suffix in ("-journal", "-wal", "-shm"):
+            try:
+                os.stat(anchored.name + suffix, dir_fd=anchored.parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            raise RepairError("Database sidecars prevent a safe repair")
+    except RepairError:
+        raise
+    except (OSError, ValueError) as error:
+        raise RepairError("Database sidecars could not be safely inspected") from error
+
+
+def _backup_is_owned(backup: _ReservedBackup) -> bool:
+    """Verify the final name still addresses the exclusively reserved inode."""
+
+    try:
+        actual = os.stat(backup.name, dir_fd=backup.parent_fd, follow_symlinks=False)
+        descriptor = os.fstat(backup.descriptor)
+    except OSError:
+        return False
+    return (
+        stat.S_ISREG(actual.st_mode)
+        and _stat_identity(actual) == backup.identity
+        and stat.S_ISREG(descriptor.st_mode)
+        and _stat_identity(descriptor) == backup.identity
+    )
+
+
+def _reserve_backup_destination(
+    db_path: Path, requested: str | Path | None
+) -> _ReservedBackup:
+    """Exclusively reserve a non-aliased backup inode through its parent FD."""
+
+    backup = (
+        Path(requested).expanduser()
+        if requested is not None
+        else db_path.with_name(f"{db_path.stem}.repair-backup-{uuid.uuid4().hex}.sqlite")
+    )
+    if os.path.abspath(os.fspath(backup)) == os.path.abspath(os.fspath(db_path)):
+        raise RepairError("Backup path must not be the inspected database")
+    if backup.name in {"", ".", ".."}:
+        raise RepairError("Backup path could not be safely inspected")
+    parent_fd: int | None = None
+    descriptor: int | None = None
+    try:
+        parent_fd = _open_safe_directory_fd(backup.parent)
+        try:
+            existing = os.stat(backup.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            if stat.S_ISLNK(existing.st_mode):
+                raise RepairError("Backup path must not use a symlink")
+            raise RepairError("Backup path must be a new file and must not overwrite an existing path")
+        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
+        descriptor = os.open(backup.name, flags, 0o600, dir_fd=parent_fd)
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+            raise RepairError("Backup could not be safely created")
+        reservation = _ReservedBackup(parent_fd, backup.name, descriptor, _stat_identity(info), backup)
+        parent_fd = None
+        descriptor = None
+        return reservation
+    except RepairError:
+        raise
+    except FileNotFoundError as error:
+        raise RepairError("Backup directory does not exist") from error
+    except (OSError, ValueError) as error:
+        raise RepairError("Backup path could not be safely inspected") from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if parent_fd is not None:
+            os.close(parent_fd)
+
+
+def _release_backup_destination(backup: _ReservedBackup, *, keep: bool) -> None:
+    """Close retained FDs and remove only our verified reservation on failure."""
+
+    try:
+        if not keep and _backup_is_owned(backup):
+            os.unlink(backup.name, dir_fd=backup.parent_fd)
+    except OSError:
+        pass
+    finally:
+        try:
+            os.close(backup.descriptor)
+        except OSError:
+            pass
+        try:
+            os.close(backup.parent_fd)
+        except OSError:
+            pass
+
+
+def _open_anchored_database(db_path: Path, identity: dict[str, int]) -> _AnchoredDatabase:
+    """Retain verified original parent/source FDs until binding consumes them."""
+
+    source_fd: int | None = None
+    parent_fd: int | None = None
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        parent_fd = _open_safe_directory_fd(db_path.parent)
+        source_fd = os.open(db_path.name, flags, dir_fd=parent_fd)
+        info = os.fstat(source_fd)
+        if not stat.S_ISREG(info.st_mode) or _stat_identity(info) != identity:
+            raise RepairError("Repair report does not authorize the selected database")
+        anchored = _AnchoredDatabase(parent_fd, source_fd, db_path.name, identity)
+        parent_fd = None
+        source_fd = None
+        return anchored
+    except RepairError:
+        raise
+    except (OSError, ValueError) as error:
+        raise RepairError("Database identity could not be verified") from error
+    finally:
+        if source_fd is not None:
+            os.close(source_fd)
+        if parent_fd is not None:
+            os.close(parent_fd)
+
+
+
+def _release_anchored_database(anchored: _AnchoredDatabase) -> None:
+    """Close original FDs unless successful binding transferred ownership."""
+
+    for descriptor_name in ("source_fd", "parent_fd"):
+        descriptor = getattr(anchored, descriptor_name)
+        if descriptor >= 0:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+            setattr(anchored, descriptor_name, -1)
+
+
+_AT_EMPTY_PATH = 0x1000
+
+
+def _link_open_fd(source_fd: int, directory_fd: int, name: str) -> None:
+    """Hardlink an already-open Linux file descriptor into a private directory.
+
+    ``/proc/self/fd/N`` is not a safe substitute: on common Linux systems it
+    crosses the procfs mount and ``link(2)`` fails with EXDEV.  ``linkat`` with
+    ``AT_EMPTY_PATH`` names the actual open inode, not a pathname that can be
+    swapped after it was checked.
+    """
+
+    try:
+        linkat = ctypes.CDLL(None, use_errno=True).linkat
+    except (AttributeError, OSError) as error:
+        raise OSError("linkat(AT_EMPTY_PATH) is unavailable") from error
+    linkat.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_int]
+    linkat.restype = ctypes.c_int
+    if linkat(source_fd, b"", directory_fd, os.fsencode(name), _AT_EMPTY_PATH) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+
+
+def _stat_identity(info: os.stat_result) -> dict[str, int]:
+    return {"st_dev": int(info.st_dev), "st_ino": int(info.st_ino)}
+
+
+def _remove_private_binding(bound: _BoundDatabase) -> None:
+    """Close and remove only files owned through retained private directory FDs."""
+
+    try:
+        os.close(bound.source_fd)
+    except OSError:
+        pass
+    for name in ("database.sqlite", "database.sqlite-journal", "database.sqlite-wal", "database.sqlite-shm"):
+        try:
+            info = os.stat(name, dir_fd=bound.stage_dir_fd, follow_symlinks=False)
+            if stat.S_ISREG(info.st_mode):
+                os.unlink(name, dir_fd=bound.stage_dir_fd)
+        except OSError:
+            pass
+    try:
+        stage_info = os.fstat(bound.stage_dir_fd)
+        named_info = os.stat(bound.stage_name, dir_fd=bound.parent_fd, follow_symlinks=False)
+        if stat.S_ISDIR(named_info.st_mode) and _stat_identity(named_info) == _stat_identity(stage_info):
+            os.rmdir(bound.stage_name, dir_fd=bound.parent_fd)
+    except OSError:
+        pass
+    finally:
+        for descriptor in (bound.stage_dir_fd, bound.parent_fd):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _discard_private_stage(parent_fd: int, stage_name: str, stage_dir_fd: int | None) -> None:
+    """Best-effort cleanup for a binding that failed before ownership transfer."""
+
+    if stage_dir_fd is not None:
+        for name in ("database.sqlite", "database.sqlite-journal", "database.sqlite-wal", "database.sqlite-shm"):
+            try:
+                info = os.stat(name, dir_fd=stage_dir_fd, follow_symlinks=False)
+                if stat.S_ISREG(info.st_mode):
+                    os.unlink(name, dir_fd=stage_dir_fd)
+            except OSError:
+                pass
+        try:
+            stage_info = os.fstat(stage_dir_fd)
+            named_info = os.stat(stage_name, dir_fd=parent_fd, follow_symlinks=False)
+            if stat.S_ISDIR(named_info.st_mode) and _stat_identity(named_info) == _stat_identity(stage_info):
+                os.rmdir(stage_name, dir_fd=parent_fd)
+        except OSError:
+            pass
+        return
+    try:
+        info = os.stat(stage_name, dir_fd=parent_fd, follow_symlinks=False)
+        if stat.S_ISDIR(info.st_mode):
+            os.rmdir(stage_name, dir_fd=parent_fd)
+    except OSError:
+        pass
+
+
+def _bind_authorized_database(anchored: _AnchoredDatabase) -> _BoundDatabase:
+    """Link retained authorized FDs only after the final sidecar recheck."""
+
+    directory_fd: int | None = None
+    bound: _BoundDatabase | None = None
+    stage_name = f".mnemosyne-repair-{uuid.uuid4().hex}"
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        directory_flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        directory_flags |= os.O_CLOEXEC
+    try:
+        source_info = os.fstat(anchored.source_fd)
+        if not stat.S_ISREG(source_info.st_mode) or _stat_identity(source_info) != anchored.identity:
+            raise RepairError("Repair report does not authorize the selected database")
+        os.mkdir(stage_name, 0o700, dir_fd=anchored.parent_fd)
+        directory_fd = os.open(stage_name, directory_flags, dir_fd=anchored.parent_fd)
+        stage_info = os.fstat(directory_fd)
+        if (
+            not stat.S_ISDIR(stage_info.st_mode)
+            or stat.S_IMODE(stage_info.st_mode) != 0o700
+            or stage_info.st_dev != source_info.st_dev
+        ):
+            raise RepairError("Database could not be safely bound for repair")
+        # Give SQLite a path anchored to this retained private directory FD,
+        # not its mutable parent-directory spelling.
+        stage_path = Path("/proc/self/fd") / str(directory_fd) / "database.sqlite"
+        # This is deliberately the final original-name operation: no public DB
+        # path is reopened between this dirfd recheck and linkat(AT_EMPTY_PATH).
+        _reject_original_sidecars(anchored)
+        _link_open_fd(anchored.source_fd, directory_fd, stage_path.name)
+        linked_info = os.stat(stage_path.name, dir_fd=directory_fd, follow_symlinks=False)
+        source_after_link = os.fstat(anchored.source_fd)
+        if (
+            not stat.S_ISREG(linked_info.st_mode)
+            or _stat_identity(linked_info) != anchored.identity
+            or _stat_identity(source_after_link) != anchored.identity
+            or linked_info.st_nlink < 2
+        ):
+            raise RepairError("Database could not be safely bound for repair")
+        bound = _BoundDatabase(
+            stage_path,
+            anchored.source_fd,
+            anchored.parent_fd,
+            directory_fd,
+            stage_name,
+            anchored.identity,
+        )
+        anchored.source_fd = -1
+        anchored.parent_fd = -1
+        directory_fd = None
+        return bound
+    except RepairError:
+        raise
+    except (OSError, ValueError) as error:
+        raise RepairError("Database could not be safely bound for repair") from error
+    finally:
+        if bound is None:
+            if anchored.parent_fd >= 0:
+                _discard_private_stage(anchored.parent_fd, stage_name, directory_fd)
+            _release_anchored_database(anchored)
+        if directory_fd is not None:
+            try:
+                os.close(directory_fd)
+            except OSError:
+                pass
+
+
+def _private_connection_is_safe(conn: sqlite3.Connection) -> bool:
+    """A private hardlink cannot safely replay another pathname's WAL file."""
+
+    try:
+        row = conn.execute("PRAGMA journal_mode").fetchone()
+        return row is not None and str(row[0]).lower() != "wal"
+    except sqlite3.Error:
+        return False
+
+
+def _has_working_memory_trigger(conn: sqlite3.Connection) -> bool:
+    """Do not execute selected-row UPDATEs when table triggers already exist."""
+
+    try:
+        return (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ? COLLATE NOCASE LIMIT 1",
+                (_SELECTION_TABLE,),
+            ).fetchone()
+            is not None
+        )
+    except sqlite3.Error as error:
+        raise RepairError("working_memory trigger safety could not be verified") from error
+
+
+def _create_validated_backup(source_fd: int, backup: _ReservedBackup) -> None:
+    """Populate the exclusively reserved destination through its retained FD.
+
+    SQLite never opens the caller's destination pathname. The destination FD
+    was created with ``O_CREAT|O_EXCL|O_NOFOLLOW`` through its retained parent
+    directory FD, so a later parent-directory rename cannot redirect the copy.
+
+    The caller holds ``BEGIN IMMEDIATE`` and supplies an already verified file
+    descriptor for the authorized database. Backing up from that same write
+    transaction deadlocks CPython's SQLite backup API, so the snapshot uses a
+    separate read-only connection through that FD while the write lock prevents
+    another writer from changing the planned database.
+    """
+
+    source: sqlite3.Connection | None = None
+    destination: sqlite3.Connection | None = None
+    try:
+        destination_info = os.fstat(backup.descriptor)
+        if not stat.S_ISREG(destination_info.st_mode) or _stat_identity(destination_info) != backup.identity:
+            raise RepairError("Backup could not be safely created")
+        # /proc/self/fd duplicates this exact open file description on Linux,
+        # keeping SQLite's destination bound to the reserved inode.
+        destination = sqlite3.connect(f"file:/proc/self/fd/{backup.descriptor}?mode=rw", uri=True)
+        source = sqlite3.connect(f"file:/proc/self/fd/{source_fd}?mode=ro", uri=True)
+        source.backup(destination)
+        row = destination.execute("PRAGMA quick_check").fetchone()
+        if row is None or str(row[0]).lower() != "ok":
+            raise RepairError("Backup validation failed")
+        destination.close()
+        destination = None
+        os.fsync(backup.descriptor)
+        if not _backup_is_owned(backup):
+            raise RepairError("Backup could not be safely created")
+        backup.installed = True
+
+    except RepairError:
+        raise
+    except (OSError, sqlite3.Error) as error:
+        raise RepairError("Backup could not be created or validated") from error
+    finally:
+        if destination is not None:
+            destination.close()
+        if source is not None:
+            source.close()
+
+
+def _result(status: str, reason: str | None = None) -> dict[str, str]:
+    """Use a fixed content-free result schema; never echo selected IDs/paths."""
+
+    result = {"table": _SELECTION_TABLE, "status": status}
+    if reason is not None:
+        result["reason"] = reason
+    return result
+
+
+def _read_only_plans(db_path: Path, action: str, selections: list[tuple[str, str]]) -> list[dict[str, str]]:
+    try:
+        conn = open_readonly_doctor_db(db_path)
+    except (OSError, ValueError, sqlite3.Error) as error:
+        raise RepairError("Database could not be safely opened for repair") from error
+    try:
+        results = []
+        for _table, memory_id in selections:
+            _plan, reason = _plan_selection(conn, action, memory_id)
+            results.append(_result("planned" if reason is None else "skipped", reason))
+        return results
+    except sqlite3.Error as error:
+        raise RepairError("Selected rows could not be safely read") from error
+    finally:
+        conn.close()
+
+
+def _open_writable_repair_db(database: Path) -> sqlite3.Connection:
+    """Open only an existing DB, mapping filesystem/SQLite failures to RepairError."""
+
+    try:
+        conn = sqlite3.connect(f"{database.absolute().as_uri()}?mode=rw", uri=True, timeout=5)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except (OSError, ValueError, sqlite3.Error) as error:
+        raise RepairError("Database could not be safely opened for repair") from error
+
+
+def _insert_vec_working(conn: sqlite3.Connection, plan: dict[str, Any]) -> None:
+    """Use the existing fallback embedding with the vec0 encoding declared in DDL."""
+
+    vector_kind = plan["vector_kind"]
+    if vector_kind == "int8":
+        conn.execute(
+            "INSERT INTO vec_working(rowid, embedding) VALUES (?, vec_quantize_int8(?, 'unit'))",
+            (plan["rowid"], plan["embedding"]),
+        )
+    elif vector_kind == "bit":
+        conn.execute(
+            "INSERT INTO vec_working(rowid, embedding) VALUES (?, vec_quantize_binary(?))",
+            (plan["rowid"], plan["embedding"]),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO vec_working(rowid, embedding) VALUES (?, ?)",
+            (plan["rowid"], plan["embedding"]),
+        )
+
+
+def _preflight_vec_write(conn: sqlite3.Connection, plan: dict[str, Any]) -> bool:
+    """Exercise the exact vec0 write in a rolled-back savepoint before backup."""
+
+    try:
+        conn.execute("SAVEPOINT repair_vec_write_preflight")
+        _insert_vec_working(conn, plan)
+        present = conn.execute(
+            "SELECT 1 FROM vec_working WHERE rowid = ? LIMIT 1", (plan["rowid"],)
+        ).fetchone()
+        conn.execute("ROLLBACK TO repair_vec_write_preflight")
+        conn.execute("RELEASE repair_vec_write_preflight")
+        return present is not None
+    except sqlite3.Error:
+        try:
+            conn.execute("ROLLBACK TO repair_vec_write_preflight")
+            conn.execute("RELEASE repair_vec_write_preflight")
+        except sqlite3.Error:
+            pass
+        return False
+
+
+def run_repair(
+    *,
+    db_path: str | Path,
+    bank_name: str,
+    report_path: str | Path,
+    selections: list[str],
+    action: str = BACKFILL_VEC_WORKING,
+    apply: bool = False,
+    backup_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Plan or apply only individually selected working-memory repairs.
+
+    The Doctor manifest is validated even for dry-run so it cannot become a
+    misleading plan preview.  Apply opens a write lock, re-reads every selected
+    condition under that lock, and creates a validated backup only if at least
+    one selected row remains actionable.
+    """
+
+    if action not in _ALLOWED_ACTIONS:
+        raise RepairError("--action must be backfill-vec-working or expire")
+    if not selections:
+        raise RepairError("At least one complete --select working_memory:ID is required")
+    parsed: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for value in selections:
+        selection = parse_selection(value)
+        if selection not in seen:
+            parsed.append(selection)
+            seen.add(selection)
+    database = Path(db_path).expanduser()
+    try:
+        _database_identity(database)
+    except RepairError:
+        raise RepairError("Database not found")
+    manifest = _load_manifest(report_path)
+    anchored: _AnchoredDatabase | None = None
+    if apply:
+        # Keep this exact original parent/source pair live while Doctor performs
+        # its permitted preflight reopen.  Binding later consumes the same FDs.
+        anchored = _open_anchored_database(database, manifest.database_identity)
+        try:
+            _reject_original_sidecars(anchored)
+            _verify_report_gate(manifest, database, bank_name)
+        except BaseException:
+            _release_anchored_database(anchored)
+            raise
+    else:
+        _verify_report_gate(manifest, database, bank_name)
+    base: dict[str, Any] = {
+        "mode": "apply" if apply else "dry_run",
+        "action": action,
+        "backup": False,
+        "applied": [],
+        "skipped": [],
+    }
+    if not apply:
+        for item in _read_only_plans(database, action, parsed):
+            (base["applied"] if item["status"] == "planned" else base["skipped"]).append(item)
+        return base
+
+    if anchored is None:  # pragma: no cover - apply establishes it above.
+        raise RepairError("Database could not be safely bound for repair")
+    bound = _bind_authorized_database(anchored)
+    conn: sqlite3.Connection | None = None
+    backup: _ReservedBackup | None = None
+    try:
+        conn = _open_writable_repair_db(bound.stage_path)
+        if not _private_connection_is_safe(conn):
+            raise RepairError("Database journal mode cannot be safely bound for repair")
+        conn.execute("BEGIN IMMEDIATE")
+        _verify_report_gate(
+            manifest,
+            database,
+            bank_name,
+            conn=conn,
+            bound_identity=bound.identity,
+        )
+        if _has_working_memory_trigger(conn):
+            raise RepairError("working_memory triggers prevent a safe repair")
+        plans: list[dict[str, Any]] = []
+        for _table, memory_id in parsed:
+            plan, reason = _plan_selection(conn, action, memory_id)
+            if reason is None and plan is not None:
+                plans.append(plan)
+            else:
+                base["skipped"].append(_result("skipped", reason or "unloadable"))
+        if not plans:
+            conn.rollback()
+            return base
+        if action == BACKFILL_VEC_WORKING and not all(_preflight_vec_write(conn, plan) for plan in plans):
+            conn.rollback()
+            return {
+                **base,
+                "skipped": base["skipped"] + [_result("skipped", "unloadable") for _ in plans],
+            }
+
+        backup = _reserve_backup_destination(database, backup_path)
+        _create_validated_backup(bound.source_fd, backup)
+        base["backup"] = True
+
+        for plan in plans:
+            try:
+                if action == BACKFILL_VEC_WORKING:
+                    _insert_vec_working(conn, plan)
+                    present = conn.execute(
+                        "SELECT 1 FROM vec_working WHERE rowid = ? LIMIT 1", (plan["rowid"],)
+                    ).fetchone()
+                    if present is None:
+                        raise sqlite3.DatabaseError("postcheck")
+                else:
+                    updated = conn.execute(
+                        "UPDATE working_memory SET valid_until = CURRENT_TIMESTAMP "
+                        "WHERE rowid = ? AND (valid_until IS NULL OR julianday(valid_until) > julianday('now'))",
+                        (plan["rowid"],),
+                    )
+                    if updated.rowcount != 1:
+                        raise sqlite3.DatabaseError("stale_selected_row")
+                    active = conn.execute(
+                        "SELECT CASE WHEN valid_until IS NULL OR julianday(valid_until) > julianday('now') "
+                        "THEN 1 ELSE 0 END FROM working_memory WHERE rowid = ?",
+                        (plan["rowid"],),
+                    ).fetchone()
+                    if active is None or bool(active[0]):
+                        raise sqlite3.DatabaseError("postcheck")
+                base["applied"].append(_result("applied"))
+            except sqlite3.Error:
+                # Do not continue after an uncertain selected mutation. Roll
+                # back the narrow transaction and keep errors content-free.
+                conn.rollback()
+                raise RepairError("Selected repair could not be applied safely")
+        conn.commit()
+        return base
+    except RepairError:
+        if conn is not None and conn.in_transaction:
+            conn.rollback()
+        raise
+    except sqlite3.Error as error:
+        if conn is not None and conn.in_transaction:
+            conn.rollback()
+        raise RepairError("Selected rows could not be safely locked or re-read") from error
+    finally:
+        if conn is not None:
+            conn.close()
+        if backup is not None:
+            _release_backup_destination(backup, keep=backup.installed)
+        _remove_private_binding(bound)
+
+
+def render_repair_json(result: dict[str, Any]) -> str:
+    """Render the fixed-schema, content-free structured repair result."""
+
+    return json.dumps(result, ensure_ascii=False, sort_keys=True) + "\n"

--- a/mnemosyne/repair.py
+++ b/mnemosyne/repair.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import re
 import sqlite3
 import stat
+import sys
 import uuid
 from typing import Any
 
@@ -237,7 +238,12 @@ def _verify_report_gate(
     # a private hardlink has been made, *never* re-stat that attacker-mutable
     # path while using the locked connection: the connection is authorized by
     # the inode captured in ``bound_identity`` instead.
-    current_identity = bound_identity if conn is not None else _database_identity(db_path)
+    if conn is None:
+        current_identity = _database_identity(db_path)
+    elif bound_identity is None:
+        raise RepairError("Database identity could not be verified")
+    else:
+        current_identity = bound_identity
     if manifest.database_identity != current_identity:
         raise RepairError("Repair report does not authorize the selected database")
     expected_fingerprint = manifest.fingerprint
@@ -892,6 +898,8 @@ def run_repair(
     one selected row remains actionable.
     """
 
+    if sys.platform != "linux":
+        raise RepairError("Repair is supported only on Linux")
     if action not in _ALLOWED_ACTIONS:
         raise RepairError("--action must be backfill-vec-working or expire")
     if not selections:

--- a/mnemosyne/runtime_diagnostics.py
+++ b/mnemosyne/runtime_diagnostics.py
@@ -20,9 +20,9 @@ def collect_runtime_diagnostics() -> dict[str, Any]:
     def add(category: str, check: str, status: str, detail: str = "") -> None:
         checks.append({"category": category, "check": check, "status": status, "detail": detail})
 
-    add("env", "python_version", sys.version.split()[0])
-    add("env", "platform", platform.platform())
-    add("env", "python_executable", sys.executable)
+    add("env", "python_version", "OK", sys.version.split()[0])
+    add("env", "platform", "OK", platform.platform())
+    add("env", "python_executable", "OK", sys.executable)
 
     try:
         import mnemosyne
@@ -30,7 +30,7 @@ def collect_runtime_diagnostics() -> dict[str, Any]:
         version = getattr(mnemosyne, "__version__", None)
         if not version:
             version = importlib.metadata.version("mnemosyne-memory")
-        add("package", "mnemosyne_version", str(version))
+        add("package", "mnemosyne_version", "OK", str(version))
     except Exception:
         add("package", "mnemosyne_version", "ERROR", "package version unavailable")
 
@@ -60,7 +60,7 @@ def collect_runtime_diagnostics() -> dict[str, Any]:
         from mnemosyne.core import embeddings as _embeddings
 
         add("core", "embeddings_available", "YES" if _embeddings.available() else "NO")
-        add("core", "embeddings_model", _embeddings._DEFAULT_MODEL)
+        add("core", "embeddings_model", "OK", _embeddings._DEFAULT_MODEL)
     except Exception:
         add("core", "embeddings_available", "ERROR", "embeddings capability unavailable")
 

--- a/mnemosyne/runtime_diagnostics.py
+++ b/mnemosyne/runtime_diagnostics.py
@@ -1,0 +1,89 @@
+"""Pure runtime diagnostics shared by doctor and legacy diagnose.
+
+This module intentionally has no logging, database, provider, repair, or CLI
+dependencies.  Keeping it neutral lets ``mnemosyne.doctor`` report runtime
+capabilities without importing the mutable ``mnemosyne.diagnose`` command.
+"""
+
+import importlib.metadata
+import platform
+import sqlite3
+import sys
+from typing import Any
+
+
+def collect_runtime_diagnostics() -> dict[str, Any]:
+    """Run pure runtime, dependency, and capability checks without a provider."""
+
+    checks: list[dict[str, str]] = []
+
+    def add(category: str, check: str, status: str, detail: str = "") -> None:
+        checks.append({"category": category, "check": check, "status": status, "detail": detail})
+
+    add("env", "python_version", sys.version.split()[0])
+    add("env", "platform", platform.platform())
+    add("env", "python_executable", sys.executable)
+
+    try:
+        import mnemosyne
+
+        version = getattr(mnemosyne, "__version__", None)
+        if not version:
+            version = importlib.metadata.version("mnemosyne-memory")
+        add("package", "mnemosyne_version", str(version))
+    except Exception:
+        add("package", "mnemosyne_version", "ERROR", "package version unavailable")
+
+    for name, module in {
+        "fastembed": "fastembed",
+        "sqlite_vec": "sqlite_vec",
+        "numpy": "numpy",
+        "huggingface_hub": "huggingface_hub",
+    }.items():
+        try:
+            dependency = __import__(module)
+            add("deps", name, "OK", f"version={getattr(dependency, '__version__', 'unknown')}")
+        except ImportError:
+            add("deps", name, "MISSING")
+        except Exception:
+            add("deps", name, "ERROR", "dependency import failed")
+
+    try:
+        dependency = __import__("ctransformers")
+        add("deps", "ctransformers", "OK", f"version={getattr(dependency, '__version__', 'unknown')}")
+    except ImportError:
+        add("deps", "ctransformers", "OPTIONAL", "optional local-GGUF fallback dependency not installed")
+    except Exception:
+        add("deps", "ctransformers", "ERROR", "dependency import failed")
+
+    try:
+        from mnemosyne.core import embeddings as _embeddings
+
+        add("core", "embeddings_available", "YES" if _embeddings.available() else "NO")
+        add("core", "embeddings_model", _embeddings._DEFAULT_MODEL)
+    except Exception:
+        add("core", "embeddings_available", "ERROR", "embeddings capability unavailable")
+
+    try:
+        from mnemosyne.core.beam import _SQLITE_VEC_AVAILABLE
+
+        vec_can_load = False
+        if _SQLITE_VEC_AVAILABLE:
+            try:
+                test_conn = sqlite3.connect(":memory:")
+                try:
+                    test_conn.enable_load_extension(True)
+                    vec_can_load = True
+                finally:
+                    test_conn.close()
+            except Exception:
+                vec_can_load = False
+        add("core", "sqlite_vec_available", "YES" if vec_can_load else "NO")
+        if _SQLITE_VEC_AVAILABLE and not vec_can_load:
+            add("core", "sqlite_vec_warning", "NO", "extension loading unavailable")
+    except Exception:
+        add("core", "sqlite_vec", "ERROR", "sqlite-vec capability unavailable")
+
+    statuses = {entry["status"] for entry in checks}
+    overall = "unavailable" if "ERROR" in statuses else "warning" if statuses & {"MISSING", "NO"} else "ok"
+    return {"status": overall, "checks": checks}

--- a/mnemosyne/runtime_diagnostics.py
+++ b/mnemosyne/runtime_diagnostics.py
@@ -70,9 +70,12 @@ def collect_runtime_diagnostics() -> dict[str, Any]:
         vec_can_load = False
         if _SQLITE_VEC_AVAILABLE:
             try:
+                import sqlite_vec
+
                 test_conn = sqlite3.connect(":memory:")
                 try:
                     test_conn.enable_load_extension(True)
+                    sqlite_vec.load(test_conn)
                     vec_can_load = True
                 finally:
                     test_conn.close()

--- a/mnemosyne/runtime_diagnostics.py
+++ b/mnemosyne/runtime_diagnostics.py
@@ -9,6 +9,7 @@ import importlib.metadata
 import platform
 import sqlite3
 import sys
+from pathlib import Path
 from typing import Any
 
 
@@ -22,7 +23,9 @@ def collect_runtime_diagnostics() -> dict[str, Any]:
 
     add("env", "python_version", "OK", sys.version.split()[0])
     add("env", "platform", "OK", platform.platform())
-    add("env", "python_executable", "OK", sys.executable)
+    # Report only the executable name: an absolute interpreter path can reveal
+    # a user's home directory or virtual-environment layout in diagnostics.
+    add("env", "python_executable", "OK", Path(sys.executable).name)
 
     try:
         import mnemosyne

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,17 @@ def _close_cached_connections():
     except Exception:
         pass
 
+    # MnemosyneConfig also caches the config path selected from the environment.
+    # A preceding test may initialize it using the ambient data directory while
+    # a later provider test swaps MNEMOSYNE_DATA_DIR to a temporary bank.  Keep
+    # that path selection test-local just like the database connection caches;
+    # otherwise the later provider reads stale skip_contexts configuration.
+    try:
+        from mnemosyne.core.config import MnemosyneConfig
+        MnemosyneConfig.reset_instance()
+    except Exception:
+        pass
+
     # Reset hermes_plugin singleton
     try:
         import hermes_plugin

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -19,7 +19,9 @@ def test_diagnose_version_falls_back_to_distribution_metadata(tmp_path, monkeypa
 
     summary = diagnose.run_diagnostics()
 
-    assert _entry(summary, "mnemosyne_version")["status"] == "9.9.9"
+    version = _entry(summary, "mnemosyne_version")
+    assert version["status"] == "OK"
+    assert version["detail"] == "9.9.9"
 
 
 def test_diagnose_treats_ctransformers_as_optional(tmp_path, monkeypatch):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,13 +2,17 @@
 
 import builtins
 import json
+import os
 import sqlite3
+import stat
 import sys
 import types
+from pathlib import Path
 from typing import cast
 
 import pytest
 
+from mnemosyne import doctor
 from mnemosyne.doctor import (
     DoctorReport,
     Finding,
@@ -29,6 +33,7 @@ from mnemosyne.doctor import (
     open_readonly_doctor_db,
     render_doctor_json,
     render_doctor_markdown,
+    write_doctor_artifacts_atomically,
 )
 
 
@@ -172,8 +177,8 @@ def test_runtime_diagnostics_marks_sqlite_vec_available_only_after_loading(monke
     ("raw_python_path", "safe_python_executable"),
     [
         ("/home/doctor-user/.venvs/mnemosyne/bin/python3.13", "python3.13"),
-        (r"C:\\Users\\doctor-user\\venvs\\mnemosyne\\python.exe", "python.exe"),
-        (r"\\\\server\\share\\venvs\\mnemosyne\\python.exe", "python.exe"),
+        (r"C:\Users\doctor-user\venvs\mnemosyne\python.exe", "python.exe"),
+        (r"\\server\share\venvs\mnemosyne\python.exe", "python.exe"),
     ],
 )
 def test_runtime_metadata_is_retained_in_safe_doctor_artifacts(
@@ -667,6 +672,106 @@ def test_report_payload_removes_all_raw_repair_candidate_fields_from_both_render
     ]
     assert all(raw not in json_report for raw in raw_values)
     assert all(raw not in markdown_report for raw in raw_values)
+
+
+def test_equivalent_payload_mapping_orders_render_byte_identical_artifacts():
+    """Renderer ordering must not depend on how an equivalent payload was built."""
+
+    payload = {
+        "bank_name": "work",
+        "sqlite_health": {
+            "quick_check": {"status": "ok"},
+            "foreign_key_check": {"status": "ok"},
+        },
+        "reference_contracts": {
+            "zeta": {"status": "unavailable"},
+            "alpha": {"status": "scan_limited"},
+        },
+        "vector_coverage": {
+            "working": {"status": "ok"},
+            "archive": {"status": "unknown"},
+        },
+        "hygiene_summary": {"status": "ok", "candidates": []},
+        "findings": [],
+        "repair_candidates": [],
+    }
+    reordered_payload = {
+        "repair_candidates": [],
+        "findings": [],
+        "hygiene_summary": {"candidates": [], "status": "ok"},
+        "vector_coverage": {
+            "archive": {"status": "unknown"},
+            "working": {"status": "ok"},
+        },
+        "reference_contracts": {
+            "alpha": {"status": "scan_limited"},
+            "zeta": {"status": "unavailable"},
+        },
+        "sqlite_health": {
+            "foreign_key_check": {"status": "ok"},
+            "quick_check": {"status": "ok"},
+        },
+        "bank_name": "work",
+    }
+
+    assert payload == reordered_payload
+    assert render_doctor_json(payload) == render_doctor_json(reordered_payload)
+    assert render_doctor_markdown(payload) == render_doctor_markdown(reordered_payload)
+
+
+@pytest.mark.parametrize(
+    ("failure", "error"),
+    [
+        ("replace", "simulated second target replace failure"),
+        ("file_fsync", "simulated staging file fsync failure"),
+        ("directory_fsync", "simulated directory fsync failure"),
+    ],
+)
+def test_atomic_two_target_failures_restore_existing_artifacts_and_clean_staging(
+    tmp_path, monkeypatch, failure, error
+):
+    """A failed pair write never leaves either old artifact replaced or staged."""
+
+    json_path = tmp_path / "doctor.json"
+    markdown_path = tmp_path / "doctor.md"
+    original_json = '{"previous": true}\n'
+    original_markdown = "# previous\n"
+    json_path.write_text(original_json)
+    markdown_path.write_text(original_markdown)
+
+    if failure == "replace":
+        real_replace = os.replace
+
+        def fail_second_replace(source, destination):
+            if Path(destination) == markdown_path:
+                raise OSError(error)
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(doctor.os, "replace", fail_second_replace)
+    else:
+        real_fsync = os.fsync
+
+        def fail_selected_fsync(descriptor):
+            is_directory = stat.S_ISDIR(os.fstat(descriptor).st_mode)
+            if (failure == "file_fsync" and not is_directory) or (
+                failure == "directory_fsync" and is_directory
+            ):
+                raise OSError(error)
+            return real_fsync(descriptor)
+
+        monkeypatch.setattr(doctor.os, "fsync", fail_selected_fsync)
+
+    with pytest.raises(OSError, match=error):
+        write_doctor_artifacts_atomically(
+            json_path=json_path,
+            json_text='{"safe": true}\n',
+            markdown_path=markdown_path,
+            markdown_text="# safe\n",
+        )
+
+    assert json_path.read_text() == original_json
+    assert markdown_path.read_text() == original_markdown
+    assert not list(tmp_path.glob(".doctor-*"))
 
 
 def test_finding_details_are_redacted_and_json_safe():

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -13,6 +13,7 @@ from mnemosyne.doctor import (
     DoctorReport,
     Finding,
     ReferenceContractRegistry,
+    RuntimeDiagnosticsAdapter,
     SQLiteHealthAdapter,
     VectorCoverageAdapter,
     RepairCandidate,
@@ -165,6 +166,42 @@ def test_runtime_diagnostics_marks_sqlite_vec_available_only_after_loading(monke
         }
         for check in result["checks"]
     )
+
+
+def test_runtime_metadata_is_retained_in_safe_doctor_artifacts(monkeypatch):
+    """Metadata checks use enum statuses while preserving their values as details."""
+
+    metadata = {
+        "python_version": "3.13.5",
+        "platform": "Linux-6.18.34-rpt-rpi-2712-aarch64-with-glibc2.40",
+        "python_executable": "/usr/bin/python3",
+        "mnemosyne_version": "1.2.3",
+        "embeddings_model": "BAAI/bge-small-en-v1.5",
+    }
+    monkeypatch.setattr(
+        "mnemosyne.runtime_diagnostics.collect_runtime_diagnostics",
+        lambda: {
+            "status": "ok",
+            "checks": [
+                {"check": check, "status": "OK", "detail": detail}
+                for check, detail in metadata.items()
+            ],
+        },
+    )
+
+    runtime = RuntimeDiagnosticsAdapter().inspect().metrics
+    payload = DoctorReport(bank_name="default", runtime_diagnostics=runtime).to_dict()
+    json_artifact = render_doctor_json(payload)
+    markdown_artifact = render_doctor_markdown(payload)
+
+    assert runtime["checks"] == [
+        {"check": check, "status": "OK", "detail": detail}
+        for check, detail in metadata.items()
+    ]
+    assert "## Runtime" in markdown_artifact
+    for detail in metadata.values():
+        assert detail in json_artifact
+        assert detail in markdown_artifact
 
 
 def test_safe_preview_caps_raw_text_before_regex_redaction(monkeypatch):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,951 @@
+"""Tests for the read-only, content-safe doctor foundations."""
+
+import builtins
+import json
+import sqlite3
+from typing import cast
+
+import pytest
+
+from mnemosyne.doctor import (
+    DoctorReport,
+    Finding,
+    ReferenceContractRegistry,
+    SQLiteHealthAdapter,
+    VectorCoverageAdapter,
+    RepairCandidate,
+    SEVERITY_WARNING,
+    STATUS_OK,
+    STATUS_PRESENT_BUT_UNLOADABLE,
+    STATUS_UNKNOWN,
+    SchemaFingerprint,
+    TableFingerprint,
+    build_doctor_report,
+    doctor_report_payload,
+    inspect_schema_fingerprint,
+    open_readonly_doctor_db,
+    render_doctor_json,
+    render_doctor_markdown,
+)
+
+
+def _readonly_fixture(tmp_path, ddl_and_rows):
+    db_path = tmp_path / "doctor-adapters.db"
+    writable = sqlite3.connect(db_path)
+    writable.executescript(ddl_and_rows)
+    writable.commit()
+    writable.close()
+    return open_readonly_doctor_db(db_path)
+
+
+def _queryable_vec0_fixture(
+    tmp_path,
+    ddl_and_rows,
+    *,
+    factory=sqlite3.Connection,
+    vector_table="vec_working",
+    verify_capability=True,
+):
+    """Simulate a vec0 DDL while retaining a queryable normal-table cache.
+
+    sqlite-vec is intentionally not a test dependency.  Rewriting the catalog
+    DDL after a normal table exists lets this connection prove both parts of
+    the doctor contract: metadata says vec0 and the exact table query is
+    usable.  A reopened connection correctly treats the same fixture as an
+    unavailable vec0 extension, which is covered separately below.
+    """
+
+    db_path = tmp_path / "queryable-vec0.db"
+    conn = sqlite3.connect(db_path, factory=factory)
+    conn.executescript(ddl_and_rows)
+    conn.execute("PRAGMA writable_schema = ON")
+    conn.execute(
+        "UPDATE sqlite_master SET sql = "
+        f"'CREATE VIRTUAL TABLE {vector_table} USING vec0(embedding float[3])' "
+        f"WHERE name = '{vector_table}'"
+    )
+    conn.execute("PRAGMA writable_schema = OFF")
+    assert "USING vec0" in conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = ?", (vector_table,)
+    ).fetchone()[0]
+    if verify_capability:
+        assert conn.execute(f'SELECT 1 FROM "{vector_table}" LIMIT 0').fetchone() is None
+    conn.execute("PRAGMA query_only = ON")
+    return conn
+
+
+def test_open_readonly_doctor_db_enables_read_safe_connection_options(tmp_path):
+    db_path = tmp_path / "doctor.db"
+    writable = sqlite3.connect(db_path)
+    writable.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, label TEXT)")
+    writable.execute("INSERT INTO items (label) VALUES ('safe fixture')")
+    writable.commit()
+    writable.close()
+
+    conn = open_readonly_doctor_db(db_path)
+    try:
+        row = conn.execute("SELECT id, label FROM items").fetchone()
+        assert isinstance(row, sqlite3.Row)
+        assert row["label"] == "safe fixture"
+        assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_open_readonly_doctor_db_rejects_schema_and_data_writes(tmp_path):
+    db_path = tmp_path / "doctor.db"
+    writable = sqlite3.connect(db_path)
+    writable.execute("CREATE TABLE existing_items (id INTEGER PRIMARY KEY)")
+    writable.commit()
+    writable.close()
+
+    conn = open_readonly_doctor_db(db_path)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("CREATE TABLE forbidden_items (id INTEGER PRIMARY KEY)")
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO existing_items (id) VALUES (1)")
+    finally:
+        conn.close()
+
+
+def test_open_readonly_doctor_db_does_not_create_a_missing_path(tmp_path):
+    db_path = tmp_path / "missing.db"
+
+    with pytest.raises(sqlite3.OperationalError):
+        open_readonly_doctor_db(db_path)
+
+    assert not db_path.exists()
+
+
+def test_doctor_runtime_dependency_failure_is_safe_and_unknown(tmp_path, monkeypatch):
+    db_path = tmp_path / "doctor.db"
+    sqlite3.connect(db_path).close()
+    raw_secret = "runtime-diagnostics-private-secret"  # nosec - regression fixture
+
+    def fail_runtime_diagnostics():
+        raise RuntimeError(f"dependency capability failed: password={raw_secret}")
+
+    monkeypatch.setattr("mnemosyne.runtime_diagnostics.collect_runtime_diagnostics", fail_runtime_diagnostics)
+
+    report = build_doctor_report("work", db_path)
+    payload = json.dumps(report.to_dict())
+
+    assert report.runtime_diagnostics == {
+        "status": STATUS_UNKNOWN,
+        "error_class": "runtime_error",
+    }
+    assert raw_secret not in payload
+    assert "dependency capability failed" not in payload
+
+
+def test_doctor_runtime_adapter_does_not_import_or_call_diagnose(tmp_path, monkeypatch):
+    """Doctor must rely only on the neutral runtime adapter, never diagnose."""
+
+    db_path = tmp_path / "doctor.db"
+    sqlite3.connect(db_path).close()
+    real_import = builtins.__import__
+
+    def reject_diagnose_import(name, *args, **kwargs):
+        if name == "mnemosyne.diagnose":
+            raise AssertionError("doctor must not import diagnose")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_diagnose_import)
+
+    report = build_doctor_report("work", db_path)
+
+    assert report.runtime_diagnostics["status"] in {"ok", "warning", "unavailable"}
+
+
+def test_schema_fingerprint_includes_tables_columns_and_foreign_keys(tmp_path):
+    db_path = tmp_path / "doctor.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE parent (id INTEGER PRIMARY KEY);
+        CREATE TABLE child (
+            id INTEGER PRIMARY KEY,
+            parent_id INTEGER NOT NULL,
+            FOREIGN KEY (parent_id) REFERENCES parent(id) ON DELETE CASCADE
+        );
+        """
+    )
+    conn.close()
+
+    readonly = open_readonly_doctor_db(db_path)
+    try:
+        fingerprint = inspect_schema_fingerprint(readonly)
+    finally:
+        readonly.close()
+
+    child = next(table for table in fingerprint.tables if table.name == "child")
+    assert child.status == STATUS_OK
+    assert [column.name for column in child.columns] == ["id", "parent_id"]
+    assert child.foreign_keys == [
+        {
+            "from": "parent_id",
+            "id": 0,
+            "match": "NONE",
+            "on_delete": "CASCADE",
+            "on_update": "NO ACTION",
+            "seq": 0,
+            "table": "parent",
+            "to": "id",
+        }
+    ]
+
+
+def test_schema_fingerprint_bounds_catalog_and_table_metadata_with_stable_signature(tmp_path):
+    conn = _readonly_fixture(
+        tmp_path,
+        """
+        CREATE TABLE parent_0 (id INTEGER PRIMARY KEY);
+        CREATE TABLE parent_1 (id INTEGER PRIMARY KEY);
+        CREATE TABLE parent_2 (id INTEGER PRIMARY KEY);
+        CREATE TABLE a_schema (
+          id INTEGER PRIMARY KEY,
+          first_ref TEXT REFERENCES parent_0(id),
+          second_ref TEXT REFERENCES parent_1(id),
+          third_ref TEXT REFERENCES parent_2(id)
+        );
+        CREATE TABLE b_schema (id INTEGER PRIMARY KEY);
+        CREATE TABLE c_schema (id INTEGER PRIMARY KEY);
+        """,
+    )
+    try:
+        first = inspect_schema_fingerprint(conn, scan_limit=2)
+        second = inspect_schema_fingerprint(conn, scan_limit=2)
+    finally:
+        conn.close()
+
+    payload = DoctorReport(bank_name="work", schema_fingerprint=first).to_dict()["schema_fingerprint"]
+    assert [table.name for table in first.tables] == ["a_schema", "b_schema"]
+    assert first.tables_truncated is True
+    assert [column.name for column in first.tables[0].columns] == ["id", "first_ref"]
+    assert first.tables[0].columns_truncated is True
+    assert len(first.tables[0].foreign_keys) == 2
+    assert first.tables[0].foreign_keys_truncated is True
+    assert json.dumps(payload, sort_keys=True, separators=(",", ":")) == json.dumps(
+        DoctorReport(bank_name="work", schema_fingerprint=second).to_dict()["schema_fingerprint"],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    assert "c_schema" not in json.dumps(payload)
+
+
+def test_schema_fingerprint_rejects_invalid_scan_limit(tmp_path):
+    conn = _readonly_fixture(tmp_path, "CREATE TABLE items (id INTEGER PRIMARY KEY);")
+    try:
+        with pytest.raises(ValueError, match="scan_limit"):
+            inspect_schema_fingerprint(conn, scan_limit=0)
+    finally:
+        conn.close()
+
+
+def test_schema_introspection_only_labels_confirmed_vec0_as_unloadable(tmp_path):
+    db_path = tmp_path / "doctor.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE vec_items (id INTEGER PRIMARY KEY)")
+    conn.execute("PRAGMA writable_schema=ON")
+    conn.execute(
+        "UPDATE sqlite_master SET sql = "
+        "'CREATE VIRTUAL TABLE vec_items USING vec0(id INTEGER PRIMARY KEY)' "
+        "WHERE name = 'vec_items'"
+    )
+    conn.execute("PRAGMA writable_schema=OFF")
+    conn.commit()
+    conn.close()
+
+    readonly = open_readonly_doctor_db(db_path)
+    try:
+        fingerprint = inspect_schema_fingerprint(readonly)
+    finally:
+        readonly.close()
+
+    vec_items = next(table for table in fingerprint.tables if table.name == "vec_items")
+    assert vec_items.status == STATUS_PRESENT_BUT_UNLOADABLE
+    assert vec_items.columns == []
+    assert vec_items.foreign_keys == []
+
+
+class _GenericOperationalErrorConnection(sqlite3.Connection):
+    """Simulate an unrelated runtime failure during table introspection."""
+
+    def execute(self, sql, parameters=()):
+        if sql.startswith('PRAGMA table_xinfo("vec_items")'):
+            raise sqlite3.OperationalError("disk I/O error: raw memory content")
+        return super().execute(sql, parameters)
+
+
+class _CatalogErrorConnection(sqlite3.Connection):
+    def execute(self, sql, parameters=()):
+        if sql.startswith("SELECT name, sql FROM sqlite_master"):
+            raise sqlite3.DatabaseError("catalog failure with private body")
+        return super().execute(sql, parameters)
+
+
+class _ColumnsErrorConnection(sqlite3.Connection):
+    def execute(self, sql, parameters=()):
+        if sql.startswith('PRAGMA table_xinfo("working_memory")'):
+            raise sqlite3.OperationalError("column failure with secret content")
+        return super().execute(sql, parameters)
+
+
+class _TrackingTableXinfoCursor:
+    def __init__(self, cursor, row_counts):
+        self._cursor = cursor
+        self._row_counts = row_counts
+
+    def __iter__(self):
+        for row in self._cursor:
+            self._row_counts[-1] += 1
+            yield row
+
+
+class _BoundedTableXinfoConnection(sqlite3.Connection):
+    table_xinfo_row_counts: list[int]
+
+    def execute(self, sql, parameters=()):
+        cursor = super().execute(sql, parameters)
+        if sql.startswith('PRAGMA table_xinfo("working_memory")'):
+            self.table_xinfo_row_counts.append(0)
+            return cast(
+                sqlite3.Cursor,
+                _TrackingTableXinfoCursor(cursor, self.table_xinfo_row_counts),
+            )
+        return cursor
+
+
+class _CountErrorConnection(sqlite3.Connection):
+    def execute(self, sql, parameters=()):
+        if sql.startswith("SELECT 1 FROM (SELECT 1 FROM memory_embeddings"):
+            raise sqlite3.OperationalError("count failure with embedding_json")
+        return super().execute(sql, parameters)
+
+
+class _VecWorkingCapabilityErrorConnection(sqlite3.Connection):
+    def execute(self, sql, parameters=()):
+        if sql == 'SELECT 1 FROM "vec_working" LIMIT 0':
+            raise sqlite3.OperationalError("vec read failure with private content")
+        return super().execute(sql, parameters)
+
+
+class _VecEpisodesCountErrorConnection(sqlite3.Connection):
+    def execute(self, sql, parameters=()):
+        if sql.startswith("SELECT 1 FROM (SELECT 1 FROM vec_episodes) LIMIT ?"):
+            raise sqlite3.OperationalError("vec count failure with private embedding")
+        return super().execute(sql, parameters)
+
+
+def test_schema_introspection_requires_the_vec0_error_signature(tmp_path):
+    db_path = tmp_path / "doctor.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE vec_items (id INTEGER PRIMARY KEY)")
+    conn.execute("PRAGMA writable_schema=ON")
+    conn.execute(
+        "UPDATE sqlite_master SET sql = "
+        "'CREATE VIRTUAL TABLE vec_items USING vec0(id INTEGER PRIMARY KEY)' "
+        "WHERE name = 'vec_items'"
+    )
+    conn.execute("PRAGMA writable_schema=OFF")
+    conn.commit()
+    conn.close()
+
+    readonly = sqlite3.connect(
+        f"{db_path.as_uri()}?mode=ro",
+        uri=True,
+        factory=_GenericOperationalErrorConnection,
+    )
+    try:
+        fingerprint = inspect_schema_fingerprint(readonly)
+    finally:
+        readonly.close()
+
+    vec_items = next(table for table in fingerprint.tables if table.name == "vec_items")
+    assert vec_items.status == STATUS_UNKNOWN
+    assert vec_items.error_class == "operational_error"
+    assert "raw memory content" not in vec_items.detail
+
+
+def test_schema_introspection_handles_a_non_sqlite_file_without_crashing(tmp_path):
+    db_path = tmp_path / "not-a-database.db"
+    db_path.write_bytes(b"not an sqlite database")
+
+    readonly = open_readonly_doctor_db(db_path)
+    try:
+        fingerprint = inspect_schema_fingerprint(readonly)
+    finally:
+        readonly.close()
+
+    assert fingerprint.status == STATUS_UNKNOWN
+    assert fingerprint.error_class == "database_error"
+    assert fingerprint.tables == []
+    assert "not an sqlite database" not in fingerprint.detail
+
+
+def test_adapter_catalog_errors_are_unknown_and_redacted():
+    conn = sqlite3.connect(":memory:", factory=_CatalogErrorConnection)
+    try:
+        result = ReferenceContractRegistry(conn).inspect()
+    finally:
+        conn.close()
+
+    assert set(result.metrics) == {
+        "memory_embeddings",
+        "vec_working",
+        "graph_edges",
+        "episodic_memory",
+        "canonical_facts",
+        "triples",
+    }
+    assert all(metric == {"status": STATUS_UNKNOWN, "error_class": "database_error"} for metric in result.metrics.values())
+    assert "private body" not in json.dumps(result.metrics)
+
+
+def test_adapter_column_errors_do_not_mask_contracts_as_empty_or_complete():
+    conn = sqlite3.connect(":memory:", factory=_ColumnsErrorConnection)
+    conn.execute("CREATE TABLE working_memory (id TEXT PRIMARY KEY)")
+    try:
+        result = ReferenceContractRegistry(conn).inspect()
+    finally:
+        conn.close()
+
+    assert all(metric == {"status": STATUS_UNKNOWN, "error_class": "operational_error"} for metric in result.metrics.values())
+    assert "secret content" not in json.dumps(result.metrics)
+
+
+def test_table_xinfo_scan_is_bounded_and_truncation_prevents_complete_contract_claims():
+    conn = sqlite3.connect(":memory:", factory=_BoundedTableXinfoConnection)
+    conn.table_xinfo_row_counts = []
+    conn.execute(
+        "CREATE TABLE working_memory (filler_one TEXT, filler_two TEXT, id TEXT PRIMARY KEY)"
+    )
+    try:
+        first_fingerprint = inspect_schema_fingerprint(conn, scan_limit=2)
+        second_fingerprint = inspect_schema_fingerprint(conn, scan_limit=2)
+        first_contracts = ReferenceContractRegistry(conn, scan_limit=2).inspect()
+        second_contracts = ReferenceContractRegistry(conn, scan_limit=2).inspect()
+        first_coverage = VectorCoverageAdapter(conn, scan_limit=2).inspect()
+        second_coverage = VectorCoverageAdapter(conn, scan_limit=2).inspect()
+    finally:
+        conn.close()
+
+    table = first_fingerprint.tables[0]
+    assert [column.name for column in table.columns] == ["filler_one", "filler_two"]
+    assert table.columns_truncated is True
+    assert conn.table_xinfo_row_counts == [3, 3, 3, 3, 3, 3]
+    assert all(
+        metric == {"status": STATUS_UNKNOWN, "columns_truncated": True}
+        for metric in first_contracts.metrics.values()
+    )
+    assert json.dumps(
+        DoctorReport(bank_name="work", schema_fingerprint=first_fingerprint).to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+    ) == json.dumps(
+        DoctorReport(bank_name="work", schema_fingerprint=second_fingerprint).to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    assert json.dumps(first_contracts.metrics, sort_keys=True, separators=(",", ":")) == json.dumps(
+        second_contracts.metrics, sort_keys=True, separators=(",", ":")
+    )
+    assert first_coverage.metrics["working"] == {
+        "status": STATUS_UNKNOWN,
+        "columns_truncated": True,
+    }
+    assert json.dumps(first_coverage.metrics, sort_keys=True, separators=(",", ":")) == json.dumps(
+        second_coverage.metrics, sort_keys=True, separators=(",", ":")
+    )
+
+
+def test_adapter_count_errors_remain_unknown_without_zero_counts():
+    conn = sqlite3.connect(":memory:", factory=_CountErrorConnection)
+    conn.executescript(
+        """
+        CREATE TABLE working_memory (id TEXT PRIMARY KEY);
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        INSERT INTO working_memory VALUES ('live');
+        INSERT INTO memory_embeddings VALUES ('live', '[private embedding_json]');
+        """
+    )
+    try:
+        result = ReferenceContractRegistry(conn).inspect()
+    finally:
+        conn.close()
+
+    assert result.metrics["memory_embeddings"] == {
+        "status": STATUS_UNKNOWN,
+        "error_class": "operational_error",
+    }
+    assert "rows" not in result.metrics["memory_embeddings"]
+    assert "embedding_json" not in json.dumps(result.metrics)
+
+
+def test_report_models_serialize_without_memory_content_or_repair_execution():
+    report = DoctorReport(
+        bank_name="work",
+        findings=[
+            Finding(
+                code="schema.table.vec_items",
+                status=STATUS_PRESENT_BUT_UNLOADABLE,
+                severity=SEVERITY_WARNING,
+                message="Vector table is present but unloadable by this runtime.",
+            )
+        ],
+        repair_candidates=[
+            RepairCandidate(
+                id="rebuild-vector-index",
+                bank_name="work",
+                description="Rebuild the vector index after an explicit future repair check.",
+            )
+        ],
+        schema_fingerprint=SchemaFingerprint(
+            tables=[TableFingerprint(name="vec_items", status=STATUS_PRESENT_BUT_UNLOADABLE)]
+        ),
+    )
+
+    payload = report.to_dict()
+    assert json.loads(json.dumps(payload)) == payload
+    assert payload["bank_name"] == "work"
+    assert payload["findings"][0]["status"] == STATUS_PRESENT_BUT_UNLOADABLE
+
+
+def test_report_payload_removes_all_raw_repair_candidate_fields_from_both_renderers():
+    raw_values = {
+        "repair-id-unique-8472",
+        "bank-name-unique-8472",
+        "repair-description-unique-8472",
+        "finding-code-unique-8472",
+    }
+    report = DoctorReport(
+        bank_name="work",
+        repair_candidates=[
+            RepairCandidate(
+                id="repair-id-unique-8472",
+                bank_name="bank-name-unique-8472",
+                description="repair-description-unique-8472",
+                finding_codes=["finding-code-unique-8472"],
+            )
+        ],
+    )
+
+    payload = doctor_report_payload(report, include_candidates=True)
+    json_report = render_doctor_json(payload)
+    markdown_report = render_doctor_markdown(payload)
+
+    assert payload["repair_candidates"] == [
+        {"candidate_class": "repair", "requires_explicit_confirmation": True}
+    ]
+    assert all(raw not in json_report for raw in raw_values)
+    assert all(raw not in markdown_report for raw in raw_values)
+
+
+def test_finding_details_are_redacted_and_json_safe():
+    report = DoctorReport(
+        bank_name="work",
+        findings=[
+            Finding(
+                code="schema.metadata",
+                status=STATUS_UNKNOWN,
+                severity=SEVERITY_WARNING,
+                message="Schema metadata could not be inspected.",
+                details={
+                    "operation": "schema_metadata",
+                    "error_class": "DatabaseError",
+                    "raw_memory": "alice@example.com secret-token",
+                    "opaque_value": object(),
+                },
+            )
+        ],
+    )
+
+    payload = report.to_dict()
+    serialized = json.dumps(payload)
+    assert payload["findings"][0]["details"] == {
+        "operation": "schema_metadata",
+        "error_class": "database_error",
+        "redacted_field_count": 2,
+    }
+    assert "alice@example.com" not in serialized
+    assert "secret-token" not in serialized
+
+
+def test_sqlite_health_adapter_reports_checks_fk_inventory_and_unloadable_vec0(tmp_path):
+    db_path = tmp_path / "health.db"
+    writable = sqlite3.connect(db_path)
+    writable.executescript(
+        """
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE working_memory (id TEXT PRIMARY KEY);
+        CREATE TABLE memory_embeddings (
+          memory_id TEXT REFERENCES working_memory(id), embedding_json TEXT
+        );
+        INSERT INTO memory_embeddings (memory_id, embedding_json) VALUES (404, '[0]');
+        CREATE TABLE vec_working (id INTEGER PRIMARY KEY);
+        PRAGMA writable_schema = ON;
+        UPDATE sqlite_master SET sql =
+          'CREATE VIRTUAL TABLE vec_working USING vec0(embedding float[3])'
+          WHERE name = 'vec_working';
+        PRAGMA writable_schema = OFF;
+        """
+    )
+    writable.commit()
+    writable.close()
+
+    readonly = open_readonly_doctor_db(db_path)
+    try:
+        result = SQLiteHealthAdapter(readonly).inspect()
+    finally:
+        readonly.close()
+
+    assert result.metrics["quick_check"]["status"] == "ok"
+    assert result.metrics["quick_check"]["runtime_cost"] == "potentially_global"
+    assert result.metrics["foreign_key_check"] == {"status": "violations", "count": 1}
+    assert result.metrics["foreign_key_inventory"] == [
+        {"table": "memory_embeddings", "count": 1}
+    ]
+    assert result.metrics["vec0"] == {
+        "status": STATUS_PRESENT_BUT_UNLOADABLE,
+        "table_count": 1,
+        "error_class": "operational_error",
+    }
+
+
+def test_sqlite_health_adapter_bounds_foreign_key_check_rows(tmp_path):
+    conn = _readonly_fixture(
+        tmp_path,
+        """
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE working_memory (id TEXT PRIMARY KEY);
+        CREATE TABLE memory_embeddings (memory_id TEXT REFERENCES working_memory(id));
+        INSERT INTO memory_embeddings VALUES ('missing-1');
+        INSERT INTO memory_embeddings VALUES ('missing-2');
+        INSERT INTO memory_embeddings VALUES ('missing-3');
+        """,
+    )
+    try:
+        result = SQLiteHealthAdapter(conn, scan_limit=2).inspect()
+    finally:
+        conn.close()
+
+    assert result.metrics["foreign_key_check"] == {
+        "status": "violations",
+        "count": 2,
+        "truncated": True,
+    }
+
+
+def test_reference_registry_uses_polymorphic_embedding_union_and_only_offers_vec_backfill(tmp_path):
+    conn = _queryable_vec0_fixture(
+        tmp_path,
+        """
+        CREATE TABLE working_memory (id TEXT PRIMARY KEY, consolidated_at TEXT);
+        CREATE TABLE memories (id TEXT PRIMARY KEY);
+        CREATE TABLE episodic_memory (id TEXT PRIMARY KEY);
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        CREATE TABLE vec_working (rowid INTEGER PRIMARY KEY);
+        INSERT INTO working_memory VALUES ('working-live', NULL);
+        INSERT INTO memories VALUES ('legacy-live');
+        INSERT INTO episodic_memory VALUES ('episodic-live');
+        INSERT INTO memory_embeddings VALUES ('working-live', '[0]');
+        INSERT INTO memory_embeddings VALUES ('legacy-live', '[0]');
+        INSERT INTO memory_embeddings VALUES ('episodic-live', '[0]');
+        INSERT INTO memory_embeddings VALUES ('embedding-orphan', '[0]');
+        """,
+    )
+    try:
+        result = ReferenceContractRegistry(conn).inspect()
+    finally:
+        conn.close()
+
+    assert result.metrics["memory_embeddings"] == {
+        "status": "checked",
+        "rows": 4,
+        "orphan_rows": 1,
+    }
+    assert result.metrics["vec_working"]["orphan_rows"] == 0
+    assert result.metrics["vec_working"]["missing_backfill_rows"] == 1
+    assert [candidate.id for candidate in result.repair_candidates] == ["backfill-vec-working"]
+
+
+def test_reference_registry_ignores_a_normal_table_named_vec_working(tmp_path):
+    conn = _readonly_fixture(
+        tmp_path,
+        """
+        CREATE TABLE working_memory (id TEXT PRIMARY KEY);
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        CREATE TABLE vec_working (rowid INTEGER PRIMARY KEY);
+        INSERT INTO working_memory VALUES ('working-live');
+        INSERT INTO memory_embeddings VALUES ('working-live', '[private embedding]');
+        INSERT INTO vec_working VALUES (999);
+        """,
+    )
+    try:
+        result = ReferenceContractRegistry(conn).inspect()
+    finally:
+        conn.close()
+
+    assert result.metrics["vec_working"] == {
+        "status": "not_configured",
+        "orphan_rows": 0,
+        "missing_backfill_rows": 0,
+    }
+    assert result.repair_candidates == []
+    assert "private embedding" not in json.dumps(result.metrics)
+
+
+def test_reference_registry_limits_counts_and_never_leaks_payloads(tmp_path):
+    conn = _readonly_fixture(
+        tmp_path,
+        """
+        CREATE TABLE working_memory (id TEXT PRIMARY KEY, content TEXT);
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        CREATE TABLE episodic_memory (id TEXT PRIMARY KEY, binary_vector BLOB);
+        CREATE TABLE canonical_facts (
+          owner_id TEXT, category TEXT, name TEXT, valid_until TEXT, body TEXT
+        );
+        INSERT INTO working_memory VALUES ('live', 'private content');
+        INSERT INTO memory_embeddings VALUES ('orphan-1', '[private embedding_json]');
+        INSERT INTO memory_embeddings VALUES ('orphan-2', '[private embedding_json]');
+        INSERT INTO memory_embeddings VALUES ('orphan-3', '[private embedding_json]');
+        INSERT INTO episodic_memory VALUES ('episode', X'DEADBEEF');
+        INSERT INTO canonical_facts VALUES ('owner', 'category', 'name', NULL, 'private body');
+        """,
+    )
+    try:
+        result = ReferenceContractRegistry(conn, scan_limit=2).inspect()
+    finally:
+        conn.close()
+
+    assert result.metrics["memory_embeddings"] == {
+        "status": "scan_limited",
+        "rows": 2,
+        "rows_truncated": True,
+        "orphan_rows": 2,
+        "orphan_rows_truncated": True,
+    }
+    serialized = json.dumps(result.metrics)
+    for secret in ("private content", "private embedding_json", "private body", "deadbeef"):
+        assert secret not in serialized
+
+
+def test_reference_registry_keeps_graph_nodes_and_unverifiable_stores_out_of_orphan_repairs(tmp_path):
+    conn = _readonly_fixture(
+        tmp_path,
+        """
+        CREATE TABLE working_memory (id TEXT PRIMARY KEY);
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        CREATE TABLE graph_edges (source TEXT, target TEXT);
+        CREATE TABLE episodic_memory (id TEXT PRIMARY KEY, valid_until TEXT);
+        CREATE TABLE canonical_facts (
+          owner_id TEXT, category TEXT, name TEXT, valid_until TEXT, body TEXT
+        );
+        CREATE TABLE triples (
+          subject TEXT, predicate TEXT, object TEXT, valid_from TEXT, valid_until TEXT
+        );
+        INSERT INTO working_memory VALUES ('live-memory');
+        INSERT INTO memory_embeddings VALUES ('known-but-gone', '[0]');
+        INSERT INTO graph_edges VALUES ('live-memory', 'known-but-gone');
+        INSERT INTO graph_edges VALUES ('entity:alice', 'topic:sqlite');
+        INSERT INTO canonical_facts VALUES ('owner', 'identity', 'name', NULL, 'private body');
+        INSERT INTO canonical_facts VALUES ('owner', 'identity', 'name', NULL, 'another private body');
+        INSERT INTO triples VALUES ('subject', 'predicate', 'object', '2026-02-01', '2026-01-01');
+        """,
+    )
+    try:
+        result = ReferenceContractRegistry(conn).inspect()
+    finally:
+        conn.close()
+
+    assert result.metrics["graph_edges"] == {
+        "status": "checked",
+        "dangling_memory_endpoints": 1,
+        "opaque_graph_node": 2,
+    }
+    assert result.metrics["episodic_memory"]["status"] == "unverifiable_parent"
+    assert result.metrics["canonical_facts"] == {
+        "status": "unverifiable_contract",
+        "duplicate_current_slots": 1,
+    }
+    assert result.metrics["triples"] == {
+        "status": "not_a_memory_reference",
+        "invalid_temporal_ranges": 1,
+    }
+    assert result.repair_candidates == []
+
+
+def test_vector_coverage_reports_backfill_orphans_optional_tables_and_compatibility_tiers(tmp_path):
+    conn = _queryable_vec0_fixture(
+        tmp_path,
+        """
+        CREATE TABLE working_memory (
+          id TEXT PRIMARY KEY, valid_until TEXT, superseded_by TEXT
+        );
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        CREATE TABLE vec_working (rowid INTEGER PRIMARY KEY);
+        CREATE TABLE episodic_memory (id TEXT PRIMARY KEY, binary_vector BLOB);
+        CREATE TABLE memories (id TEXT PRIMARY KEY);
+        INSERT INTO working_memory VALUES ('working-live', NULL, NULL);
+        INSERT INTO working_memory VALUES ('working-expired', '2000-01-01', NULL);
+        INSERT INTO memory_embeddings VALUES ('working-live', '[0]');
+        INSERT INTO vec_working VALUES (999);
+        INSERT INTO episodic_memory VALUES ('episode-1', X'00');
+        INSERT INTO episodic_memory VALUES ('episode-2', NULL);
+        """,
+    )
+    try:
+        coverage = VectorCoverageAdapter(conn).inspect().metrics
+    finally:
+        conn.close()
+
+    assert coverage["working"] == {
+        "status": "backfill_available",
+        "active_source_rows": 1,
+       "fallback_embedding_rows": 1,
+        "vec_working_rows": 1,
+        "missing_vec_working_rows": 1,
+        "orphan_vec_working_rows": 1,
+    }
+    assert coverage["episodic"] == {
+        "status": "partial",
+        "source_rows": 2,
+        "binary_vector_rows": 1,
+        "vec_episode_rows": 0,
+    }
+    assert coverage["legacy"] == {"status": "compatibility_store"}
+    assert coverage["canonical"] == {"status": "not_configured"}
+    assert coverage["triples"] == {"status": "not_configured"}
+
+
+def test_vector_coverage_ignores_a_normal_table_named_vec_working(tmp_path):
+    conn = _readonly_fixture(
+        tmp_path,
+        """
+        CREATE TABLE working_memory (id TEXT PRIMARY KEY);
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        CREATE TABLE vec_working (rowid INTEGER PRIMARY KEY);
+        INSERT INTO working_memory VALUES ('working-live');
+        INSERT INTO memory_embeddings VALUES ('working-live', '[private embedding_json]');
+        INSERT INTO vec_working VALUES (999);
+        """,
+    )
+    try:
+        working = VectorCoverageAdapter(conn).inspect().metrics["working"]
+    finally:
+        conn.close()
+
+    assert working == {
+        "status": "fallback_only",
+        "active_source_rows": 1,
+        "fallback_embedding_rows": 1,
+        "vec_working_rows": 0,
+        "missing_vec_working_rows": 0,
+        "orphan_vec_working_rows": 0,
+    }
+    assert "private embedding_json" not in json.dumps(working)
+
+
+def test_vector_coverage_does_not_claim_working_coverage_after_confirmed_vec0_read_error(tmp_path):
+    conn = _queryable_vec0_fixture(
+        tmp_path,
+        """
+        CREATE TABLE working_memory (id TEXT PRIMARY KEY);
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        CREATE TABLE vec_working (rowid INTEGER PRIMARY KEY);
+        INSERT INTO working_memory VALUES ('working-live');
+        INSERT INTO memory_embeddings VALUES ('working-live', '[0]');
+        """,
+        factory=_VecWorkingCapabilityErrorConnection,
+        verify_capability=False,
+    )
+    try:
+        working = VectorCoverageAdapter(conn).inspect().metrics["working"]
+    finally:
+        conn.close()
+
+    assert working == {"status": STATUS_UNKNOWN, "error_class": "operational_error"}
+    assert "private content" not in json.dumps(working)
+
+
+def test_vector_coverage_does_not_claim_episodic_coverage_after_confirmed_vec0_count_error(tmp_path):
+    conn = _queryable_vec0_fixture(
+        tmp_path,
+        """
+        CREATE TABLE episodic_memory (id TEXT PRIMARY KEY, binary_vector BLOB);
+        CREATE TABLE vec_episodes (rowid INTEGER PRIMARY KEY);
+        INSERT INTO episodic_memory VALUES ('episode-1', X'00');
+        """,
+        factory=_VecEpisodesCountErrorConnection,
+        vector_table="vec_episodes",
+    )
+    try:
+        episodic = VectorCoverageAdapter(conn).inspect().metrics["episodic"]
+    finally:
+        conn.close()
+
+    assert episodic == {"status": STATUS_UNKNOWN, "error_class": "operational_error"}
+    assert "private embedding" not in json.dumps(episodic)
+
+
+def test_vector_coverage_excludes_expired_iso_timestamp_on_the_current_day(tmp_path):
+    conn = _queryable_vec0_fixture(
+        tmp_path,
+        """
+        CREATE TABLE working_memory (
+          id TEXT PRIMARY KEY, valid_until TEXT, superseded_by TEXT
+        );
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        CREATE TABLE vec_working (rowid INTEGER PRIMARY KEY);
+        INSERT INTO working_memory VALUES (
+          'expired-now', strftime('%Y-%m-%dT%H:%M:%S', 'now', '-1 minute'), NULL
+        );
+        INSERT INTO working_memory VALUES (
+          'still-active', strftime('%Y-%m-%dT%H:%M:%S', 'now', '+1 minute'), NULL
+        );
+        INSERT INTO memory_embeddings VALUES ('still-active', '[0]');
+        """,
+    )
+    try:
+        working = VectorCoverageAdapter(conn).inspect().metrics["working"]
+    finally:
+        conn.close()
+
+    assert working["active_source_rows"] == 1
+    assert working["fallback_embedding_rows"] == 1
+    assert working["missing_vec_working_rows"] == 1
+    assert working["status"] == "backfill_available"
+
+
+def test_vector_coverage_treats_unloadable_vec0_as_degraded_not_corrupt(tmp_path):
+    db_path = tmp_path / "vec-unloadable.db"
+    writable = sqlite3.connect(db_path)
+    writable.executescript(
+        """
+        CREATE TABLE working_memory (id TEXT PRIMARY KEY);
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        CREATE TABLE vec_working (id INTEGER PRIMARY KEY);
+        INSERT INTO working_memory VALUES ('working-live');
+        INSERT INTO memory_embeddings VALUES ('working-live', '[0]');
+        PRAGMA writable_schema = ON;
+        UPDATE sqlite_master SET sql =
+          'CREATE VIRTUAL TABLE vec_working USING vec0(embedding float[3])'
+          WHERE name = 'vec_working';
+        PRAGMA writable_schema = OFF;
+        """
+    )
+    writable.commit()
+    writable.close()
+
+    readonly = open_readonly_doctor_db(db_path)
+    try:
+        coverage = VectorCoverageAdapter(readonly).inspect().metrics
+    finally:
+        readonly.close()
+
+    assert coverage["working"]["status"] == "unavailable"
+    assert coverage["working"]["vec0_status"] == STATUS_PRESENT_BUT_UNLOADABLE
+    assert coverage["working"]["error_class"] == "operational_error"
+    assert set(coverage["working"]) == {"status", "vec0_status", "error_class"}

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -168,12 +168,20 @@ def test_runtime_diagnostics_marks_sqlite_vec_available_only_after_loading(monke
     )
 
 
-def test_runtime_metadata_is_retained_in_safe_doctor_artifacts(monkeypatch):
+@pytest.mark.parametrize(
+    ("raw_python_path", "safe_python_executable"),
+    [
+        ("/home/doctor-user/.venvs/mnemosyne/bin/python3.13", "python3.13"),
+        (r"C:\\Users\\doctor-user\\venvs\\mnemosyne\\python.exe", "python.exe"),
+        (r"\\\\server\\share\\venvs\\mnemosyne\\python.exe", "python.exe"),
+    ],
+)
+def test_runtime_metadata_is_retained_in_safe_doctor_artifacts(
+    monkeypatch, raw_python_path, safe_python_executable
+):
     """Metadata checks use enum statuses while preserving their values as details."""
 
-    raw_python_path = "/home/doctor-user/.venvs/mnemosyne/bin/python3.13"
     raw_model_path = "/home/doctor-user/.cache/mnemosyne/models/bge-small-en-v1.5"
-    safe_python_executable = "python3.13"
     metadata = {
         "python_version": "3.13.5",
         "platform": "Linux-6.18.34-rpt-rpi-2712-aarch64-with-glibc2.40",

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -3,6 +3,8 @@
 import builtins
 import json
 import sqlite3
+import sys
+import types
 from typing import cast
 
 import pytest
@@ -138,6 +140,51 @@ def test_doctor_runtime_dependency_failure_is_safe_and_unknown(tmp_path, monkeyp
     }
     assert raw_secret not in payload
     assert "dependency capability failed" not in payload
+
+
+def test_runtime_diagnostics_marks_sqlite_vec_available_only_after_loading(monkeypatch):
+    """The diagnostic must test the extension load, not only SQLite's toggle."""
+
+    from mnemosyne import runtime_diagnostics
+    from mnemosyne.core import beam
+
+    calls: list[sqlite3.Connection] = []
+    fake_sqlite_vec = types.SimpleNamespace(load=lambda conn: calls.append(conn))
+    monkeypatch.setattr(beam, "_SQLITE_VEC_AVAILABLE", True)
+    monkeypatch.setitem(sys.modules, "sqlite_vec", fake_sqlite_vec)
+
+    result = runtime_diagnostics.collect_runtime_diagnostics()
+
+    assert len(calls) == 1
+    assert any(
+        check == {
+            "category": "core",
+            "check": "sqlite_vec_available",
+            "status": "YES",
+            "detail": "",
+        }
+        for check in result["checks"]
+    )
+
+
+def test_safe_preview_caps_raw_text_before_regex_redaction(monkeypatch):
+    """Unbounded input must not be handed to Doctor's regex redactors."""
+
+    from mnemosyne import doctor
+
+    captured: list[str] = []
+
+    class CapturePattern:
+        def sub(self, _replacement, text):
+            captured.append(text)
+            return text
+
+    monkeypatch.setattr(doctor, "_PREVIEW_SECRET_ASSIGNMENT", CapturePattern())
+
+    preview = doctor.safe_preview("x" * 100, max_length=10)
+
+    assert captured == ["x" * 40]
+    assert preview == "x" * 9 + "…"
 
 
 def test_doctor_runtime_adapter_does_not_import_or_call_diagnose(tmp_path, monkeypatch):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -171,12 +171,20 @@ def test_runtime_diagnostics_marks_sqlite_vec_available_only_after_loading(monke
 def test_runtime_metadata_is_retained_in_safe_doctor_artifacts(monkeypatch):
     """Metadata checks use enum statuses while preserving their values as details."""
 
+    raw_python_path = "/home/doctor-user/.venvs/mnemosyne/bin/python3.13"
+    raw_model_path = "/home/doctor-user/.cache/mnemosyne/models/bge-small-en-v1.5"
+    safe_python_executable = "python3.13"
     metadata = {
         "python_version": "3.13.5",
         "platform": "Linux-6.18.34-rpt-rpi-2712-aarch64-with-glibc2.40",
-        "python_executable": "/usr/bin/python3",
+        "python_executable": raw_python_path,
         "mnemosyne_version": "1.2.3",
-        "embeddings_model": "BAAI/bge-small-en-v1.5",
+        "embeddings_model": f"model cache: {raw_model_path}",
+    }
+    safe_metadata = {
+        **metadata,
+        "python_executable": safe_python_executable,
+        "embeddings_model": "model cache: <redacted-path>",
     }
     monkeypatch.setattr(
         "mnemosyne.runtime_diagnostics.collect_runtime_diagnostics",
@@ -190,16 +198,42 @@ def test_runtime_metadata_is_retained_in_safe_doctor_artifacts(monkeypatch):
     )
 
     runtime = RuntimeDiagnosticsAdapter().inspect().metrics
-    payload = DoctorReport(bank_name="default", runtime_diagnostics=runtime).to_dict()
+    assert runtime["checks"] == [
+        {
+            "check": check,
+            "status": "OK",
+            "detail": safe_metadata[check],
+        }
+        for check in metadata
+    ]
+
+    # The canonical payload boundary must also protect a future runtime source
+    # that bypasses the adapter and hands Doctor an absolute executable path.
+    payload = doctor_report_payload(
+        DoctorReport(
+            bank_name="default",
+            runtime_diagnostics={
+                "status": "ok",
+                "checks": [
+                    {"check": check, "status": "OK", "detail": detail}
+                    for check, detail in metadata.items()
+                ],
+            },
+        )
+    )
     json_artifact = render_doctor_json(payload)
     markdown_artifact = render_doctor_markdown(payload)
 
-    assert runtime["checks"] == [
-        {"check": check, "status": "OK", "detail": detail}
-        for check, detail in metadata.items()
-    ]
     assert "## Runtime" in markdown_artifact
-    for detail in metadata.values():
+    assert raw_python_path not in json_artifact
+    assert raw_python_path not in markdown_artifact
+    assert raw_model_path not in json_artifact
+    assert raw_model_path not in markdown_artifact
+    assert safe_python_executable in json_artifact
+    assert safe_python_executable in markdown_artifact
+    assert "<redacted-path>" in json_artifact
+    assert "<redacted-path>" in markdown_artifact
+    for detail in safe_metadata.values():
         assert detail in json_artifact
         assert detail in markdown_artifact
 

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -1,0 +1,413 @@
+"""CLI and renderer coverage for the read-only doctor report."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+
+import pytest
+
+from mnemosyne.doctor import write_doctor_artifacts_atomically
+
+
+ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_SECRET = "doctor-cli-fixture-secret-9f7c"  # nosec - redaction regression fixture
+FIXTURE_ORDINARY_MEMORY = "Release coordinator confirms the blue-orchard rehearsal is Friday."
+
+
+def _create_fixture_db(path: Path) -> int:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE working_memory (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            source TEXT,
+            timestamp TEXT,
+            session_id TEXT,
+            importance REAL,
+            valid_until TEXT,
+            superseded_by TEXT
+        );
+        CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+        """
+    )
+    conn.execute(
+        "INSERT INTO working_memory (id, content) VALUES (?, ?)",
+        ("safe-id", f"password={FIXTURE_SECRET}"),
+    )
+    conn.execute(
+        "INSERT INTO working_memory (id, content, source) VALUES (?, ?, ?)",
+        ("ordinary-id", FIXTURE_ORDINARY_MEMORY, "heartbeat"),
+    )
+    conn.execute(
+        "INSERT INTO memory_embeddings VALUES (?, ?)", ("safe-id", "[0.1, 0.2]"))
+    conn.commit()
+    count = conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0]
+    conn.close()
+    return count
+
+
+def _run_cli(args: list[str], tmp_path: Path, *, data_dir: Path | None = None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["MNEMOSYNE_DATA_DIR"] = str(data_dir or (tmp_path / "data"))
+    env["MNEMOSYNE_NO_EMBEDDINGS"] = "1"
+    return subprocess.run(
+        [sys.executable, "-m", "mnemosyne.cli", *args],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def _tree_snapshot(path: Path) -> tuple[bool, tuple[str, ...]]:
+    if not path.exists():
+        return False, ()
+    return True, tuple(sorted(item.relative_to(path).as_posix() for item in path.rglob("*")))
+
+
+def test_doctor_cli_writes_safe_both_reports_without_mutating_db(tmp_path):
+    db_path = tmp_path / "fixture.db"
+    expected_count = _create_fixture_db(db_path)
+    before_hash = hashlib.sha256(db_path.read_bytes()).hexdigest()
+    json_path = tmp_path / "doctor.json"
+    markdown_path = tmp_path / "doctor.md"
+
+    result = _run_cli(
+        [
+            "doctor",
+            "--db", str(db_path),
+            "--format", "both",
+            "--json-out", str(json_path),
+            "--markdown-out", str(markdown_path),
+            "--scan-limit", "10",
+            "--sample-limit", "2",
+            "--include-candidates",
+        ],
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json_path.exists()
+    assert markdown_path.exists()
+    payload = json.loads(json_path.read_text())
+    markdown = markdown_path.read_text()
+    assert payload["bank_name"] == "default"
+    assert payload["execution"] == {"dry_run": True, "query_only": True, "read_only": True}
+    candidates = payload["hygiene_summary"]["candidates"]
+    assert len(candidates) == 2
+    assert all(
+        set(candidate) == {
+            "candidate_class",
+            "noise_score",
+            "reason_count",
+            "secret_flag_count",
+            "suggested_action",
+            "table",
+        }
+        for candidate in candidates
+    )
+    assert "# Mnemosyne Doctor Report" in markdown
+    assert "Read-only / query_only / dry-run" in markdown
+    assert "## SQLite" in markdown
+    assert "## References" in markdown
+    assert "## Vector tiers" in markdown
+    assert "## Hygiene" in markdown
+    assert "Review the findings and explicit candidates before any future repair." in markdown
+    assert FIXTURE_SECRET not in json_path.read_text()
+    assert FIXTURE_SECRET not in markdown
+    assert FIXTURE_ORDINARY_MEMORY not in json_path.read_text()
+    assert "blue-orchard rehearsal" not in json_path.read_text()
+    assert FIXTURE_ORDINARY_MEMORY not in markdown
+    assert "blue-orchard rehearsal" not in markdown
+    assert "[0.1, 0.2]" not in json_path.read_text()
+    assert "[0.1, 0.2]" not in markdown
+    assert hashlib.sha256(db_path.read_bytes()).hexdigest() == before_hash
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == expected_count
+    finally:
+        conn.close()
+
+
+def test_doctor_cli_writes_content_free_markdown_candidates_without_json_artifact(tmp_path):
+    db_path = tmp_path / "fixture.db"
+    expected_count = _create_fixture_db(db_path)
+    before_hash = hashlib.sha256(db_path.read_bytes()).hexdigest()
+    markdown_path = tmp_path / "doctor.md"
+    json_path = tmp_path / "doctor.json"
+
+    result = _run_cli(
+        [
+            "doctor",
+            "--db", str(db_path),
+            "--format", "markdown",
+            "--markdown-out", str(markdown_path),
+            "--scan-limit", "10",
+            "--sample-limit", "2",
+            "--include-candidates",
+        ],
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert markdown_path.exists()
+    assert not json_path.exists()
+    markdown = markdown_path.read_text()
+    assert "# Mnemosyne Doctor Report" in markdown
+    assert "Read-only / query_only / dry-run" in markdown
+    assert FIXTURE_SECRET not in markdown
+    assert FIXTURE_ORDINARY_MEMORY not in markdown
+    assert "blue-orchard rehearsal" not in markdown
+    assert hashlib.sha256(db_path.read_bytes()).hexdigest() == before_hash
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == expected_count
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (["--db", "one.db", "--bank", "work"], "cannot be used together"),
+        (["--db", "one.db", "--scan-limit", "0"], "--scan-limit must be a positive integer"),
+        (["--db", "one.db", "--sample-limit", "-1"], "--sample-limit must be a non-negative integer"),
+        (["--db", "one.db", "--format", "html"], "--format must be one of"),
+        (["--db", "one.db", "--format", "json", "--markdown-out", "doctor.md"], "--markdown-out requires --format markdown or both"),
+    ],
+)
+def test_doctor_cli_rejects_conflicts_and_invalid_limits(tmp_path, args, expected):
+    result = _run_cli(["doctor", *args], tmp_path)
+
+    assert result.returncode == 2
+    assert expected in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_doctor_cli_resolves_named_bank_without_initializing_memory(tmp_path):
+    data_dir = tmp_path / "data"
+    db_path = data_dir / "banks" / "work" / "mnemosyne.db"
+    db_path.parent.mkdir(parents=True)
+    _create_fixture_db(db_path)
+    json_path = tmp_path / "bank.json"
+
+    result = _run_cli(
+        ["doctor", "--bank", "work", "--format", "json", "--json-out", str(json_path)],
+        tmp_path,
+        data_dir=data_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(json_path.read_text())["bank_name"] == "work"
+
+
+def test_doctor_cli_db_and_bank_resolution_leave_data_tree_unchanged(tmp_path):
+    """Doctor must not materialize DATA_DIR/banks while resolving its target."""
+
+    db_path = tmp_path / "fixture.db"
+    _create_fixture_db(db_path)
+    fresh_data_dir = tmp_path / "fresh-data"
+    before_fresh = _tree_snapshot(fresh_data_dir)
+    before_fresh_root = _tree_snapshot(tmp_path)
+
+    by_db = _run_cli(
+        ["doctor", "--db", str(db_path), "--format", "json"], tmp_path, data_dir=fresh_data_dir
+    )
+
+    assert by_db.returncode == 0, by_db.stderr
+    assert _tree_snapshot(fresh_data_dir) == before_fresh
+    assert _tree_snapshot(tmp_path) == before_fresh_root
+
+    missing_db = _run_cli(
+        ["doctor", "--db", str(fresh_data_dir / "missing.db"), "--format", "json"],
+        tmp_path,
+        data_dir=fresh_data_dir,
+    )
+
+    assert missing_db.returncode == 1
+    assert "Database not found" in missing_db.stderr
+    assert _tree_snapshot(fresh_data_dir) == before_fresh
+    assert _tree_snapshot(tmp_path) == before_fresh_root
+
+    missing_bank = _run_cli(
+        ["doctor", "--bank", "missing", "--format", "json"], tmp_path, data_dir=fresh_data_dir
+    )
+
+    assert missing_bank.returncode == 1
+    assert "does not exist" in missing_bank.stderr
+    assert _tree_snapshot(fresh_data_dir) == before_fresh
+    assert _tree_snapshot(tmp_path) == before_fresh_root
+
+    existing_data_dir = tmp_path / "existing-data"
+    bank_db = existing_data_dir / "banks" / "work" / "mnemosyne.db"
+    bank_db.parent.mkdir(parents=True)
+    _create_fixture_db(bank_db)
+    before_existing = _tree_snapshot(existing_data_dir)
+    before_existing_root = _tree_snapshot(tmp_path)
+
+    existing_bank = _run_cli(
+        ["doctor", "--bank", "work", "--format", "json"], tmp_path, data_dir=existing_data_dir
+    )
+
+    assert existing_bank.returncode == 0, existing_bank.stderr
+    assert _tree_snapshot(existing_data_dir) == before_existing
+    assert _tree_snapshot(tmp_path) == before_existing_root
+
+
+def test_doctor_cli_rejects_conflicting_or_database_overwriting_output_paths(tmp_path):
+    db_path = tmp_path / "fixture.db"
+    _create_fixture_db(db_path)
+    shared_path = tmp_path / "shared.report"
+
+    conflict = _run_cli(
+        [
+            "doctor",
+            "--db", str(db_path),
+            "--json-out", str(shared_path),
+            "--markdown-out", str(shared_path),
+        ],
+        tmp_path,
+    )
+    overwrite = _run_cli(
+        ["doctor", "--db", str(db_path), "--format", "json", "--json-out", str(db_path)],
+        tmp_path,
+    )
+
+    assert conflict.returncode == 2
+    assert "output paths must be different" in conflict.stderr
+    assert overwrite.returncode == 2
+    assert "must not overwrite the inspected database" in overwrite.stderr
+
+
+@pytest.mark.parametrize("output_format", ["json", "markdown", "both"])
+def test_doctor_cli_rejects_hardlinked_database_output_targets(tmp_path, output_format):
+    db_path = tmp_path / "fixture.db"
+    _create_fixture_db(db_path)
+    before_bytes = db_path.read_bytes()
+    before_hash = hashlib.sha256(before_bytes).hexdigest()
+
+    json_path = tmp_path / "database-hardlink.json"
+    markdown_path = tmp_path / "database-hardlink.md"
+    output_args = []
+    output_paths = []
+    if output_format in {"json", "both"}:
+        os.link(db_path, json_path)
+        output_args.extend(["--json-out", str(json_path)])
+        output_paths.append(json_path)
+    if output_format in {"markdown", "both"}:
+        os.link(db_path, markdown_path)
+        output_args.extend(["--markdown-out", str(markdown_path)])
+        output_paths.append(markdown_path)
+    before_stat = db_path.stat()
+
+    result = _run_cli(
+        ["doctor", "--db", str(db_path), "--format", output_format, *output_args], tmp_path
+    )
+
+    assert result.returncode == 2
+    assert "must not overwrite the inspected database" in result.stderr
+    after_stat = db_path.stat()
+    assert hashlib.sha256(db_path.read_bytes()).hexdigest() == before_hash
+    assert (after_stat.st_dev, after_stat.st_ino, after_stat.st_nlink) == (
+        before_stat.st_dev,
+        before_stat.st_ino,
+        before_stat.st_nlink,
+    )
+    for output_path in output_paths:
+        assert os.path.samefile(output_path, db_path)
+        assert output_path.read_bytes() == before_bytes
+    assert not list(tmp_path.glob(".doctor-*"))
+
+
+def test_atomic_both_output_write_rolls_back_first_target_if_second_replace_fails(tmp_path, monkeypatch):
+    json_path = tmp_path / "doctor.json"
+    markdown_path = tmp_path / "doctor.md"
+    json_path.write_text('{"previous": true}\n')
+    markdown_path.write_text("# previous\n")
+    real_replace = os.replace
+
+    def fail_markdown_replace(source, destination):
+        if Path(destination) == markdown_path:
+            raise OSError("simulated second target failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr("mnemosyne.doctor.os.replace", fail_markdown_replace)
+
+    with pytest.raises(OSError, match="simulated second target failure"):
+        write_doctor_artifacts_atomically(
+            json_path=json_path,
+            json_text='{"safe": true}\n',
+            markdown_path=markdown_path,
+            markdown_text="# safe\n",
+        )
+
+    assert json_path.read_text() == '{"previous": true}\n'
+    assert markdown_path.read_text() == "# previous\n"
+    assert not list(tmp_path.glob(".doctor-*"))
+
+
+def test_atomic_both_output_write_cleans_temps_when_staging_fsync_fails(tmp_path, monkeypatch):
+    json_path = tmp_path / "doctor.json"
+    markdown_path = tmp_path / "doctor.md"
+    json_path.write_text('{"previous": true}\n')
+    markdown_path.write_text("# previous\n")
+
+    def fail_fsync(_descriptor):
+        raise OSError("simulated staging fsync failure")
+
+    monkeypatch.setattr("mnemosyne.doctor.os.fsync", fail_fsync)
+
+    with pytest.raises(OSError, match="simulated staging fsync failure"):
+        write_doctor_artifacts_atomically(
+            json_path=json_path,
+            json_text='{"safe": true}\n',
+            markdown_path=markdown_path,
+            markdown_text="# safe\n",
+        )
+
+    assert json_path.read_text() == '{"previous": true}\n'
+    assert markdown_path.read_text() == "# previous\n"
+    assert not list(tmp_path.glob(".doctor-*"))
+
+
+def test_atomic_both_output_write_cleans_restore_temp_when_rollback_replace_fails(tmp_path, monkeypatch):
+    json_path = tmp_path / "doctor.json"
+    markdown_path = tmp_path / "doctor.md"
+    json_path.write_text('{"previous": true}\n')
+    markdown_path.write_text("# previous\n")
+    real_replace = os.replace
+
+    def fail_second_and_restore(source, destination):
+        source_path = Path(source)
+        destination_path = Path(destination)
+        if destination_path == markdown_path:
+            raise OSError("simulated second target failure")
+        if destination_path == json_path and "-restore-" in source_path.name:
+            raise OSError("simulated rollback restore failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr("mnemosyne.doctor.os.replace", fail_second_and_restore)
+
+    with pytest.raises(OSError, match="simulated second target failure"):
+        write_doctor_artifacts_atomically(
+            json_path=json_path,
+            json_text='{"safe": true}\n',
+            markdown_path=markdown_path,
+            markdown_text="# safe\n",
+        )
+
+    # The failed second target was never replaced; the first cannot be restored
+    # only because this test injects failure in its rollback replacement.
+    assert json_path.read_text() == '{"safe": true}\n'
+    assert markdown_path.read_text() == "# previous\n"
+    assert not list(tmp_path.glob(".doctor-*"))

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -12,7 +12,8 @@ import sys
 
 import pytest
 
-from mnemosyne.doctor import write_doctor_artifacts_atomically
+from mnemosyne import cli, doctor
+from mnemosyne.doctor import write_doctor_artifact_atomically, write_doctor_artifacts_atomically
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -416,4 +417,81 @@ def test_atomic_both_output_write_cleans_restore_temp_when_rollback_replace_fail
     # only because this test injects failure in its rollback replacement.
     assert json_path.read_text() == '{"safe": true}\n'
     assert markdown_path.read_text() == "# previous\n"
+    assert not list(tmp_path.glob(".doctor-*"))
+
+
+@pytest.mark.parametrize(
+    ("output_name", "failure"),
+    [("doctor.json", "replace"), ("doctor.md", "fsync")],
+)
+def test_atomic_single_output_write_preserves_target_and_cleans_temps(tmp_path, monkeypatch, output_name, failure):
+    target = tmp_path / output_name
+    previous = "previous artifact\n"
+    target.write_text(previous)
+
+    if failure == "replace":
+        real_replace = os.replace
+
+        def fail_replace(source, destination):
+            if Path(destination) == target:
+                raise OSError("simulated single-target replace failure")
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(doctor.os, "replace", fail_replace)
+        error = "simulated single-target replace failure"
+    else:
+
+        def fail_fsync(_descriptor):
+            raise OSError("simulated single-target fsync failure")
+
+        monkeypatch.setattr(doctor.os, "fsync", fail_fsync)
+        error = "simulated single-target fsync failure"
+
+    with pytest.raises(OSError, match=error):
+        write_doctor_artifact_atomically(path=target, text="safe artifact\n")
+
+    assert target.read_text() == previous
+    assert not list(tmp_path.glob(".doctor-*"))
+
+
+@pytest.mark.parametrize(
+    ("output_format", "output_flag", "output_name", "failure"),
+    [
+        ("json", "--json-out", "doctor.json", "replace"),
+        ("markdown", "--markdown-out", "doctor.md", "fsync"),
+    ],
+)
+def test_doctor_cli_single_output_failure_preserves_target_and_cleans_temps(
+    tmp_path, monkeypatch, capsys, output_format, output_flag, output_name, failure
+):
+    db_path = tmp_path / "fixture.db"
+    _create_fixture_db(db_path)
+    target = tmp_path / output_name
+    previous = "previous artifact\n"
+    target.write_text(previous)
+
+    if failure == "replace":
+        real_replace = os.replace
+
+        def fail_replace(source, destination):
+            if Path(destination) == target:
+                raise OSError("simulated CLI single-target replace failure")
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(doctor.os, "replace", fail_replace)
+        error = "simulated CLI single-target replace failure"
+    else:
+
+        def fail_fsync(_descriptor):
+            raise OSError("simulated CLI single-target fsync failure")
+
+        monkeypatch.setattr(doctor.os, "fsync", fail_fsync)
+        error = "simulated CLI single-target fsync failure"
+
+    with pytest.raises(SystemExit) as raised:
+        cli.cmd_doctor(["--db", str(db_path), "--format", output_format, output_flag, str(target)])
+
+    assert raised.value.code == 1
+    assert error in capsys.readouterr().err
+    assert target.read_text() == previous
     assert not list(tmp_path.glob(".doctor-*"))

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -129,6 +129,10 @@ def test_doctor_cli_writes_safe_both_reports_without_mutating_db(tmp_path):
     assert "blue-orchard rehearsal" not in json_path.read_text()
     assert FIXTURE_ORDINARY_MEMORY not in markdown
     assert "blue-orchard rehearsal" not in markdown
+    assert "safe-id" not in json_path.read_text()
+    assert "ordinary-id" not in json_path.read_text()
+    assert "safe-id" not in markdown
+    assert "ordinary-id" not in markdown
     assert "[0.1, 0.2]" not in json_path.read_text()
     assert "[0.1, 0.2]" not in markdown
     assert hashlib.sha256(db_path.read_bytes()).hexdigest() == before_hash
@@ -168,6 +172,8 @@ def test_doctor_cli_writes_content_free_markdown_candidates_without_json_artifac
     assert FIXTURE_SECRET not in markdown
     assert FIXTURE_ORDINARY_MEMORY not in markdown
     assert "blue-orchard rehearsal" not in markdown
+    assert "safe-id" not in markdown
+    assert "ordinary-id" not in markdown
     assert hashlib.sha256(db_path.read_bytes()).hexdigest() == before_hash
     conn = sqlite3.connect(db_path)
     try:

--- a/tests/test_embedding_prefixes.py
+++ b/tests/test_embedding_prefixes.py
@@ -81,6 +81,12 @@ def test_fastembed_path_applies_prefixes(monkeypatch):
             return [np.ones(768, dtype=np.float32) for _ in texts]
     monkeypatch.delenv("MNEMOSYNE_EMBEDDING_API_URL", raising=False)   # force non-API path
     monkeypatch.delenv("MNEMOSYNE_EMBEDDINGS_VIA_API", raising=False)
+    # CI globally disables local model loading to avoid downloads. This test
+    # installs a fake already-loaded model, so it must explicitly exercise the
+    # local branch rather than inherit that suite-level opt-out.
+    monkeypatch.delenv("MNEMOSYNE_NO_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_SKIP_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDINGS_OFF", raising=False)
     monkeypatch.setenv("MNEMOSYNE_EMBEDDING_QUERY_PREFIX", QUERY_PREFIX)
     monkeypatch.setenv("MNEMOSYNE_EMBEDDING_DOC_PREFIX", DOC_PREFIX)
     fake = FakeFastembedModel()

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -17,17 +17,27 @@ import pytest
 
 from mnemosyne.cli import cmd_hygiene
 from mnemosyne.core.beam import BeamMemory, init_beam
+from mnemosyne.core.filters import SECRET_LABELED_PATTERNS
 from mnemosyne.core.hygiene import (
     AuditReport,
     CleanResult,
     NoiseCandidate,
     audit_noise,
     clean_noise,
+    doctor_hygiene_summary,
     hygiene_status,
     noise_summary,
     restore_archived,
     _score_noise,
     _suggest_action,
+)
+from mnemosyne.doctor import (
+    DoctorReport,
+    HygieneSummaryAdapter,
+    STATUS_OK,
+    build_doctor_report,
+    open_readonly_doctor_db,
+    safe_preview,
 )
 
 
@@ -163,6 +173,193 @@ class TestSuggestAction:
 # ---------------------------------------------------------------------------
 
 class TestAuditNoise:
+    @pytest.mark.parametrize(
+        ("label", "secret", "sensitive_prefix"),
+        [
+            ("api_key_prefix", "sk-" + "a" * 20, "sk-"),
+            ("aws_access_key", "AKIA" + "A" * 16, "AKIA"),
+            ("github_token", "ghp_" + "a" * 36, "ghp_"),
+            ("slack_token", "xoxr-" + "a" * 20, "xoxr-"),
+            ("google_api_key", "AIza" + "a" * 35, "AIza"),
+            ("jwt_token", "eyJaaa.eyJbbb.ccc", "eyJ"),
+            ("secret_assignment", "passwd=supersecretvalue123", "supersecret"),
+            ("secret_assignment", "pwd=supersecretvalue123", "supersecret"),
+            ("secret_assignment", "access_key=supersecretvalue123", "supersecret"),
+            (
+                "private_key_block",
+                "-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAA",
+                "MIIJK",
+            ),
+            (
+                "connection_string_with_credentials",
+                "postgres://alice:***@localhost/db",
+                "postgres://alice:",
+            ),
+            ("env_secret_assignment", "DB_PASS=supersecretvalue123", "supersecret"),
+        ],
+    )
+    def test_safe_preview_redacts_all_canonical_hygiene_secrets_before_truncating(
+        self, label, secret, sensitive_prefix
+    ):
+        prefix = " " * 110 if label == "env_secret_assignment" else "x" * 110 + " "
+        preview = safe_preview(prefix + secret, max_length=120)
+        payload = json.dumps(
+            DoctorReport(
+                bank_name="test",
+                hygiene_summary={"candidates": [{"preview": preview}]},
+            ).to_dict()
+        )
+
+        assert label in {name for name, _pattern in SECRET_LABELED_PATTERNS}
+        assert secret not in payload
+        assert sensitive_prefix not in payload
+        assert "<redact" in payload
+
+    def test_safe_preview_redacts_a_secret_before_truncating(self):
+        # If truncation happened first, the secret value would partially survive.
+        raw_secret = "redaction-before-truncation-secret"  # nosec - regression fixture
+        preview = safe_preview("x" * 90 + f" password={raw_secret}" + " trailing", max_length=120)
+
+        assert len(preview) <= 120
+        assert raw_secret not in preview
+        assert "password=<redacted>" in preview
+
+    def test_doctor_hygiene_redacts_cross_boundary_values_before_truncating(self, tmp_path):
+        db_path = tmp_path / "cross-boundary-hygiene.db"
+        email = "crossboundary-email-" + "a" * 85 + "@example.test"
+        secret = "crossboundary-secret-" + "b" * 80  # nosec - regression fixture
+        content = "x" * 110 + f" {email} password={secret}"
+        writable = sqlite3.connect(db_path)
+        writable.execute(
+            """
+            CREATE TABLE working_memory (
+                id TEXT PRIMARY KEY, content TEXT, source TEXT, timestamp TEXT,
+                session_id TEXT, importance REAL, metadata_json TEXT
+            )
+            """
+        )
+        writable.execute(
+            "INSERT INTO working_memory VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("candidate", content, "test", "2026-01-01", "s", 0.5, "{}"),
+        )
+        writable.commit()
+        writable.close()
+
+        readonly = open_readonly_doctor_db(db_path)
+        try:
+            summary = doctor_hygiene_summary(
+                db_path, conn=readonly, min_score=0.0, candidate_limit=1
+            )
+        finally:
+            readonly.close()
+
+        payload = json.dumps(summary)
+        assert summary["candidates"][0]["preview"] == "x" * 110 + " <redacte…"
+        assert len(summary["candidates"][0]["preview"]) <= 120
+        for sensitive in (email, secret, "crossboundary-email", "crossboundary-secret"):
+            assert sensitive not in payload
+
+    def test_noise_summary_uses_supplied_readonly_connector_without_db_changes(self, tmp_path):
+        db_path = tmp_path / "readonly-hygiene.db"
+        fixture_secret = "fixture-hygiene-secret-123456"  # nosec - redaction fixture
+        writable = sqlite3.connect(db_path)
+        writable.execute(
+            """
+            CREATE TABLE working_memory (
+                id TEXT PRIMARY KEY, content TEXT, source TEXT, timestamp TEXT,
+                session_id TEXT, importance REAL, metadata_json TEXT
+            )
+            """
+        )
+        writable.execute(
+            "INSERT INTO working_memory VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("candidate", f"password = {fixture_secret}", "test", "2026-01-01", "s", 0.5, "{}"),
+        )
+        writable.commit()
+        writable.close()
+
+        readonly = open_readonly_doctor_db(db_path)
+        try:
+            summary = doctor_hygiene_summary(
+                db_path, conn=readonly, min_score=0.0, candidate_limit=1
+            )
+            with pytest.raises(sqlite3.OperationalError):
+                readonly.execute("INSERT INTO working_memory (id) VALUES ('forbidden')")
+        finally:
+            readonly.close()
+
+        verify = sqlite3.connect(db_path)
+        try:
+            assert verify.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == 1
+            assert verify.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name = 'hygiene_audit_log'"
+            ).fetchone()[0] == 0
+        finally:
+            verify.close()
+        assert summary["status"] == "ok"
+        assert summary["with_secrets"] == 1
+        assert fixture_secret not in json.dumps(summary)
+        assert summary["candidates"][0]["preview"] == "password=<redacted>"
+
+    def test_hygiene_adapter_whitelists_bounded_safe_data(self, monkeypatch, tmp_path):
+        db_path = tmp_path / "doctor.db"
+        sqlite3.connect(db_path).close()
+        raw_secret = "adapter-private-secret"  # nosec - regression fixture
+
+        def unsafe_summary(*_args, **_kwargs):
+            return {
+                "status": "ok",
+                "total_scanned": 1,
+                "total_candidates": 1,
+                "with_secrets": 1,
+                "candidates": [{
+                    "id": "candidate",
+                    "table": "working_memory",
+                    "noise_score": 0.9,
+                    "reasons": ["secret_detected"],
+                    "secret_flags": ["secret_assignment"],
+                    "suggested_action": "flag",
+                    "preview": f"password={raw_secret}",
+                    "content": raw_secret,
+                    "body": raw_secret,
+                    "embedding_json": raw_secret,
+                    "metadata": {"private": raw_secret},
+                }],
+            }
+
+        monkeypatch.setattr("mnemosyne.core.hygiene.doctor_hygiene_summary", unsafe_summary)
+        conn = open_readonly_doctor_db(db_path)
+        try:
+            summary = HygieneSummaryAdapter(conn, db_path, candidate_limit=1).inspect().metrics
+        finally:
+            conn.close()
+
+        payload = json.dumps(summary)
+        assert raw_secret not in payload
+        assert "password=<redacted>" in payload
+        for forbidden in ("content", "body", "embedding_json", "metadata"):
+            assert forbidden not in summary["candidates"][0]
+
+    def test_build_doctor_report_never_constructs_mnemosyne(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "doctor.db"
+        writable = sqlite3.connect(db_path)
+        writable.execute(
+            "CREATE TABLE working_memory (id TEXT, content TEXT, source TEXT, timestamp TEXT, "
+            "session_id TEXT, importance REAL, metadata_json TEXT)"
+        )
+        writable.commit()
+        writable.close()
+
+        class ForbiddenMnemosyne:
+            def __init__(self, *_args, **_kwargs):
+                raise AssertionError("Doctor must not construct Mnemosyne")
+
+        monkeypatch.setattr("mnemosyne.core.memory.Mnemosyne", ForbiddenMnemosyne)
+        report = build_doctor_report("work", db_path, scan_limit=1, candidate_limit=1)
+
+        assert report.bank_name == "work"
+        assert report.hygiene_summary["status"] == STATUS_OK
+
     def test_audit_finds_noise(self, temp_db):
         db_path, beam = temp_db
         _insert_row(beam, "working_memory", "noise1", "$ pip install foo\nCollecting foo", source="terminal")
@@ -539,3 +736,20 @@ class TestRestoreArchived:
         assert "_original_importance" not in meta  # cleaned up on restore
         assert meta.get("original") == "data"
         conn.close()
+
+
+def test_hygiene_suite_does_not_leak_config_into_subagent_provider(tmp_path, monkeypatch):
+    """A provider after hygiene must use its own safe temporary config.
+
+    Hygiene/Doctor paths initialize the process-wide MnemosyneConfig singleton.
+    This regression exercises the subsequent provider path in the same pytest
+    process: the autouse cleanup must discard that singleton before a subagent
+    provider resolves its temporary data-directory configuration.
+    """
+    from hermes_memory_provider import MnemosyneMemoryProvider
+
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+    provider = MnemosyneMemoryProvider()
+    provider.initialize("hygiene-followup", agent_context="subagent")
+
+    assert provider._beam is None

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -300,6 +300,7 @@ class TestAuditNoise:
         assert summary["with_secrets"] == 1
         assert fixture_secret not in json.dumps(summary)
         assert summary["candidates"][0]["preview"] == "password=<redacted>"
+        assert "id" not in summary["candidates"][0]
 
     def test_hygiene_adapter_whitelists_bounded_safe_data(self, monkeypatch, tmp_path):
         db_path = tmp_path / "doctor.db"
@@ -337,7 +338,7 @@ class TestAuditNoise:
         payload = json.dumps(summary)
         assert raw_secret not in payload
         assert "password=<redacted>" in payload
-        for forbidden in ("content", "body", "embedding_json", "metadata"):
+        for forbidden in ("id", "content", "body", "embedding_json", "metadata"):
             assert forbidden not in summary["candidates"][0]
 
     def test_build_doctor_report_never_constructs_mnemosyne(self, tmp_path, monkeypatch):
@@ -746,9 +747,25 @@ def test_hygiene_suite_does_not_leak_config_into_subagent_provider(tmp_path, mon
     process: the autouse cleanup must discard that singleton before a subagent
     provider resolves its temporary data-directory configuration.
     """
+    from conftest import _close_cached_connections
     from hermes_memory_provider import MnemosyneMemoryProvider
+    from mnemosyne.core.config import MnemosyneConfig
 
-    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+    stale_data_dir = tmp_path / "stale-data"
+    test_data_dir = tmp_path / "provider-data"
+    stale_data_dir.mkdir()
+    test_data_dir.mkdir()
+    # The stale config enables subagent initialization. The replacement config
+    # must win after the fixture boundary resets the process-global singleton.
+    (stale_data_dir / "config.yaml").write_text("skip_contexts: ''\n", encoding="utf-8")
+    (test_data_dir / "config.yaml").write_text("skip_contexts: subagent\n", encoding="utf-8")
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(stale_data_dir))
+    stale_config = MnemosyneConfig.get_instance()
+    assert stale_config.config_path == stale_data_dir / "config.yaml"
+
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(test_data_dir))
+    _close_cached_connections()
+    assert MnemosyneConfig._instance is None
     provider = MnemosyneMemoryProvider()
     provider.initialize("hygiene-followup", agent_context="subagent")
 

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -175,6 +175,24 @@ def test_dry_run_is_read_only_and_creates_no_backup(tmp_path):
     assert _hash(db_path) == before
 
 
+def test_repair_fails_closed_before_dry_run_on_non_linux(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    report_path = tmp_path / "missing-report.json"
+    monkeypatch.setattr(repair.sys, "platform", "darwin")
+
+    with pytest.raises(RepairError, match="supported only on Linux"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+        )
+
+    assert not report_path.exists()
+
+
 def test_manifest_bank_fingerprint_and_parse_fail_closed_before_backup_or_write(tmp_path):
     db_path = tmp_path / "memory.db"
     _create_db(db_path)

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,0 +1,904 @@
+"""Security regression coverage for narrow Doctor-gated repair operations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+
+import pytest
+
+import mnemosyne.repair as repair
+from mnemosyne.doctor import build_doctor_report, doctor_report_payload
+from mnemosyne.repair import RepairError, run_repair
+
+
+ROOT = Path(__file__).resolve().parent.parent
+RAW_SECRET = "repair-output-private-secret-79d1"  # nosec - redaction fixture
+RAW_CONTENT = "Only the hidden cobalt-archive content may contain this phrase."
+RAW_EMBEDDING = "[0.125, 0.875]"
+RAW_BLOB_HEX = "DEADBEEF"
+
+
+def _create_db(path: Path, *, with_vector_cache: bool = False) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE working_memory (
+            id TEXT PRIMARY KEY,
+            content TEXT,
+            private_blob BLOB,
+            valid_until TEXT,
+            superseded_by TEXT
+        );
+        CREATE TABLE memory_embeddings (
+            memory_id TEXT PRIMARY KEY,
+            embedding_json TEXT
+        );
+        """
+    )
+    if with_vector_cache:
+        # This is intentionally a normal SQLite table. Stock SQLite cannot load
+        # vec0, so the successful backfill test uses the controlled adapter
+        # below rather than presenting this fixture as real vec0 integration.
+        conn.execute("CREATE TABLE vec_working (rowid INTEGER PRIMARY KEY, embedding TEXT)")
+    conn.commit()
+    conn.close()
+
+
+def _insert_memory(
+    path: Path,
+    memory_id: str,
+    *,
+    valid_until: str | None = None,
+    superseded_by: str | None = None,
+    content: str = "safe fixture content",
+    embedding: str | None = None,
+) -> int:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "INSERT INTO working_memory (id, content, private_blob, valid_until, superseded_by) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (memory_id, content, bytes.fromhex(RAW_BLOB_HEX), valid_until, superseded_by),
+    )
+    if embedding is not None:
+        conn.execute("INSERT INTO memory_embeddings VALUES (?, ?)", (memory_id, embedding))
+    rowid = conn.execute("SELECT rowid FROM working_memory WHERE id = ?", (memory_id,)).fetchone()[0]
+    conn.commit()
+    conn.close()
+    return int(rowid)
+
+
+def _write_manifest(db_path: Path, tmp_path: Path, *, bank_name: str = "default") -> Path:
+    report_path = tmp_path / f"{bank_name}-doctor.json"
+    report = build_doctor_report(bank_name, db_path)
+    report_path.write_text(
+        json.dumps(doctor_report_payload(report, include_candidates=True), sort_keys=True), encoding="utf-8"
+    )
+    return report_path
+
+
+def _hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class _ControlledQueryableVecConnection(sqlite3.Connection):
+    """Test-only complete vec0 adapter-contract connection.
+
+    Stock SQLite cannot create vec0. The adapter supplies the two catalog
+    surfaces required by the production guard (DDL plus ``table_list`` type),
+    while the fixture continues to exercise the real rowid/embedding query and
+    transactional insert path. It is deliberately an isolated adapter-contract
+    test, not a claim that a normal SQLite table is a vec0 integration.
+    """
+
+    def execute(self, sql, parameters=()):
+        if sql == "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'vec_working'":
+            return super().execute(
+                "SELECT ? AS sql",
+                ("CREATE VIRTUAL TABLE vec_working USING vec0(embedding float[2])",),
+            )
+        if sql == "PRAGMA table_list":
+            return super().execute(
+                "SELECT 'main' AS schema, 'vec_working' AS name, 'virtual' AS type, "
+                "2 AS ncol, 0 AS wr, 0 AS strict"
+            )
+        return super().execute(sql, parameters)
+
+
+class _UnloadableVecConnection(_ControlledQueryableVecConnection):
+    """Expose confirmed vec0 DDL but fail its live capability probe."""
+
+    def execute(self, sql, parameters=()):
+        if sql == 'SELECT rowid, embedding FROM "vec_working" LIMIT 0':
+            raise sqlite3.OperationalError("no such module: vec0")
+        return super().execute(sql, parameters)
+
+
+def _controlled_writable_connection(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path, factory=_ControlledQueryableVecConnection, timeout=5)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _unloadable_writable_connection(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path, factory=_UnloadableVecConnection, timeout=5)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _run_cli(args: list[str], tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["MNEMOSYNE_DATA_DIR"] = str(tmp_path / "data")
+    env["MNEMOSYNE_NO_EMBEDDINGS"] = "1"
+    return subprocess.run(
+        [sys.executable, "-m", "mnemosyne.cli", *args],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def test_dry_run_is_read_only_and_creates_no_backup(tmp_path):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    report_path = _write_manifest(db_path, tmp_path)
+    before = _hash(db_path)
+    requested_backup = tmp_path / "should-not-exist.sqlite"
+
+    result = run_repair(
+        db_path=db_path,
+        bank_name="default",
+        report_path=report_path,
+        selections=["working_memory:selected"],
+        action="expire",
+        backup_path=requested_backup,
+    )
+
+    assert result == {
+        "mode": "dry_run",
+        "action": "expire",
+        "backup": False,
+        "applied": [{"table": "working_memory", "status": "planned"}],
+        "skipped": [],
+    }
+    assert not requested_backup.exists()
+    assert _hash(db_path) == before
+
+
+def test_manifest_bank_fingerprint_and_parse_fail_closed_before_backup_or_write(tmp_path):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    report_path = _write_manifest(db_path, tmp_path)
+    requested_backup = tmp_path / "blocked.sqlite"
+
+    with pytest.raises(RepairError, match="bank does not match"):
+        run_repair(
+            db_path=db_path,
+            bank_name="other",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=requested_backup,
+        )
+    assert not requested_backup.exists()
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("ALTER TABLE working_memory ADD COLUMN changed_after_report TEXT")
+    conn.commit()
+    conn.close()
+    before_mismatch = _hash(db_path)
+    with pytest.raises(RepairError, match="fingerprint does not match"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=requested_backup,
+        )
+    assert not requested_backup.exists()
+    assert _hash(db_path) == before_mismatch
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{not JSON", encoding="utf-8")
+    with pytest.raises(RepairError, match="could not be parsed"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=malformed,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=requested_backup,
+        )
+    assert not requested_backup.exists()
+
+
+def test_apply_revalidates_manifest_fingerprint_under_lock_before_backup_or_write(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    report_path = _write_manifest(db_path, tmp_path)
+    backup = tmp_path / "must-not-exist.sqlite"
+    events: list[str] = []
+    drifted_hash: str | None = None
+    real_gate = repair._verify_report_gate
+
+    def drift_after_preflight(report, database, bank_name, *, conn=None, **kwargs):
+        nonlocal drifted_hash
+        events.append("locked" if conn is not None else "preflight")
+        result = real_gate(report, database, bank_name, conn=conn, **kwargs)
+        if conn is None:
+            drift = sqlite3.connect(database)
+            try:
+                drift.execute("ALTER TABLE working_memory ADD COLUMN changed_between_gates TEXT")
+                drift.commit()
+            finally:
+                drift.close()
+            drifted_hash = _hash(database)
+        return result
+
+    monkeypatch.setattr(repair, "_verify_report_gate", drift_after_preflight)
+
+    with pytest.raises(RepairError, match="fingerprint does not match"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=backup,
+        )
+
+    assert events == ["preflight", "locked"]
+    assert drifted_hash is not None
+    assert _hash(db_path) == drifted_hash
+    assert not backup.exists()
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("SELECT valid_until FROM working_memory WHERE id = 'selected'").fetchone()[0] is None
+    finally:
+        conn.close()
+
+
+def test_apply_creates_and_quick_checks_backup_before_mutation(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    report_path = _write_manifest(db_path, tmp_path)
+    backup = tmp_path / "verified-backup.sqlite"
+    events: list[str] = []
+    real_backup = repair._create_validated_backup
+
+    def checked_backup(source: Path, destination: Path) -> None:
+        real_backup(source, destination)
+        assert destination.is_file()
+        verify = sqlite3.connect(destination)
+        try:
+            assert verify.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+            # This proves the pre-mutation snapshot still contains the active row.
+            assert verify.execute("SELECT valid_until FROM working_memory WHERE id = 'selected'").fetchone()[0] is None
+        finally:
+            verify.close()
+        events.append("backup")
+
+    def tracked_connection(path: Path) -> sqlite3.Connection:
+        conn = sqlite3.connect(path, timeout=5)
+        conn.row_factory = sqlite3.Row
+        conn.set_trace_callback(lambda sql: events.append("update") if sql.startswith("UPDATE working_memory") else None)
+        return conn
+
+    monkeypatch.setattr(repair, "_create_validated_backup", checked_backup)
+    monkeypatch.setattr(repair, "_open_writable_repair_db", tracked_connection)
+    result = run_repair(
+        db_path=db_path,
+        bank_name="default",
+        report_path=report_path,
+        selections=["working_memory:selected"],
+        action="expire",
+        apply=True,
+        backup_path=backup,
+    )
+
+    assert result["backup"] is True
+    assert events.index("backup") < events.index("update")
+    assert backup.is_file()
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("SELECT valid_until FROM working_memory WHERE id = 'selected'").fetchone()[0] is not None
+    finally:
+        conn.close()
+
+
+def test_missing_stale_and_already_expired_rows_skip_without_backup_or_write(tmp_path):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "stale", valid_until="2000-01-01")
+    _insert_memory(db_path, "already-expired", valid_until="2000-01-02")
+    _insert_memory(db_path, "inactive", superseded_by="newer")
+    report_path = _write_manifest(db_path, tmp_path)
+    before = _hash(db_path)
+    backup = tmp_path / "must-not-exist.sqlite"
+
+    result = run_repair(
+        db_path=db_path,
+        bank_name="default",
+        report_path=report_path,
+        selections=[
+            "working_memory:missing",
+            "working_memory:stale",
+            "working_memory:already-expired",
+            "working_memory:inactive",
+        ],
+        action="expire",
+        apply=True,
+        backup_path=backup,
+    )
+
+    assert result["backup"] is False
+    assert result["applied"] == []
+    assert len(result["skipped"]) == 4
+    assert {item["reason"] for item in result["skipped"]} == {"missing", "already_inactive"}
+    assert not backup.exists()
+    assert _hash(db_path) == before
+
+
+def test_controlled_vec_backfill_only_selected_row_and_is_idempotent(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path, with_vector_cache=True)
+    selected_rowid = _insert_memory(db_path, "selected", embedding="[3, 4]")
+    other_rowid = _insert_memory(db_path, "not-selected", embedding="[5, 12]")
+    report_path = _write_manifest(db_path, tmp_path)
+    statements: list[str] = []
+    backup_events: list[str] = []
+    real_backup = repair._create_validated_backup
+
+    def traced_controlled_connection(path: Path) -> sqlite3.Connection:
+        conn = _controlled_writable_connection(path)
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    def checked_backup(source_fd: int, destination: Path) -> None:
+        # The exact controlled vec0 insert has been attempted and rolled back
+        # before the first backup is allowed to exist.
+        savepoint = statements.index("SAVEPOINT repair_vec_write_preflight")
+        rollback = statements.index("ROLLBACK TO repair_vec_write_preflight")
+        assert any(statement.startswith("INSERT INTO vec_working") for statement in statements[savepoint:rollback])
+        assert "RELEASE repair_vec_write_preflight" in statements
+        backup_events.append("after_preflight")
+        real_backup(source_fd, destination)
+
+    monkeypatch.setattr(repair, "_open_writable_repair_db", traced_controlled_connection)
+    monkeypatch.setattr(repair, "_create_validated_backup", checked_backup)
+
+    first_backup = tmp_path / "first.sqlite"
+    first = run_repair(
+        db_path=db_path,
+        bank_name="default",
+        report_path=report_path,
+        selections=["working_memory:selected"],
+        action="backfill-vec-working",
+        apply=True,
+        backup_path=first_backup,
+    )
+
+    assert first["backup"] is True
+    assert first["applied"] == [{"table": "working_memory", "status": "applied"}]
+    assert backup_events == ["after_preflight"]
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT rowid, embedding FROM vec_working ORDER BY rowid").fetchall()
+    finally:
+        conn.close()
+    assert [row[0] for row in rows] == [selected_rowid]
+    assert other_rowid != selected_rowid
+    assert json.loads(rows[0][1]) == pytest.approx([0.6, 0.8])
+
+    second_backup = tmp_path / "second.sqlite"
+    second = run_repair(
+        db_path=db_path,
+        bank_name="default",
+        report_path=report_path,
+        selections=["working_memory:selected"],
+        action="backfill-vec-working",
+        apply=True,
+        backup_path=second_backup,
+    )
+    assert second["backup"] is False
+    assert second["applied"] == []
+    assert second["skipped"] == [
+        {"table": "working_memory", "status": "skipped", "reason": "already_present"}
+    ]
+    assert not second_backup.exists()
+
+
+def test_unloadable_vec_backfill_skips_without_backup_or_mutation_and_stays_content_safe(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path, with_vector_cache=True)
+    selected_id = f"id-{RAW_SECRET}"
+    _insert_memory(
+        db_path,
+        selected_id,
+        content=RAW_CONTENT,
+        embedding=RAW_EMBEDDING,
+    )
+    report_path = _write_manifest(db_path, tmp_path)
+    backup = tmp_path / "must-not-exist.sqlite"
+    before = _hash(db_path)
+    monkeypatch.setattr(repair, "_open_writable_repair_db", _unloadable_writable_connection)
+
+    result = run_repair(
+        db_path=db_path,
+        bank_name="default",
+        report_path=report_path,
+        selections=[f"working_memory:{selected_id}"],
+        action="backfill-vec-working",
+        apply=True,
+        backup_path=backup,
+    )
+
+    assert result == {
+        "mode": "apply",
+        "action": "backfill-vec-working",
+        "backup": False,
+        "applied": [],
+        "skipped": [{"table": "working_memory", "status": "skipped", "reason": "unloadable"}],
+    }
+    assert _hash(db_path) == before
+    assert not backup.exists()
+    output = repair.render_repair_json(result)
+    for raw in (RAW_SECRET, RAW_CONTENT, RAW_EMBEDDING, RAW_BLOB_HEX, selected_id):
+        assert raw not in output
+
+
+def test_expiry_changes_only_selected_valid_until_and_never_deletes(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected", content="selected content")
+    _insert_memory(db_path, "untouched", content="untouched content")
+    report_path = _write_manifest(db_path, tmp_path)
+    statements: list[str] = []
+
+    def traced_connection(path: Path) -> sqlite3.Connection:
+        conn = sqlite3.connect(path, timeout=5)
+        conn.row_factory = sqlite3.Row
+        conn.set_trace_callback(statements.append)
+        return conn
+
+    monkeypatch.setattr(repair, "_open_writable_repair_db", traced_connection)
+    result = run_repair(
+        db_path=db_path,
+        bank_name="default",
+        report_path=report_path,
+        selections=["working_memory:selected"],
+        action="expire",
+        apply=True,
+        backup_path=tmp_path / "expiry.sqlite",
+    )
+
+    assert result["applied"] == [{"table": "working_memory", "status": "applied"}]
+    assert not any("DELETE" in statement.upper() for statement in statements)
+    conn = sqlite3.connect(db_path)
+    try:
+        selected = conn.execute(
+            "SELECT content, valid_until FROM working_memory WHERE id = 'selected'"
+        ).fetchone()
+        untouched = conn.execute(
+            "SELECT content, valid_until FROM working_memory WHERE id = 'untouched'"
+        ).fetchone()
+        assert conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == 2
+    finally:
+        conn.close()
+    assert selected[0] == "selected content"
+    assert selected[1] is not None
+    assert untouched == ("untouched content", None)
+
+
+def test_apply_binds_connection_to_authorized_inode_during_a_to_b_to_a_swap(tmp_path, monkeypatch):
+    """The writable connection must not follow the public name after binding."""
+
+    db_path = tmp_path / "memory.db"
+    replacement = tmp_path / "replacement.db"
+    _create_db(db_path)
+    _create_db(replacement)
+    _insert_memory(db_path, "selected", content="authorized")
+    _insert_memory(replacement, "selected", content="attacker replacement")
+    report_path = _write_manifest(db_path, tmp_path)
+    backup = tmp_path / "authorized-backup.sqlite"
+    replacement_before = _hash(replacement)
+    original_open = repair._open_writable_repair_db
+
+    def open_during_a_to_b_to_a_swap(private_database: Path) -> sqlite3.Connection:
+        parked = tmp_path / "authorized-parked.db"
+        # The public path points at B exactly while the repair opens its write
+        # connection, then returns to A before any old pathname re-stat could
+        # notice.  The private hardlink must still keep the connection on A.
+        os.replace(db_path, parked)
+        os.replace(replacement, db_path)
+        try:
+            return original_open(private_database)
+        finally:
+            os.replace(db_path, replacement)
+            os.replace(parked, db_path)
+
+    monkeypatch.setattr(repair, "_open_writable_repair_db", open_during_a_to_b_to_a_swap)
+    result = run_repair(
+        db_path=db_path,
+        bank_name="default",
+        report_path=report_path,
+        selections=["working_memory:selected"],
+        action="expire",
+        apply=True,
+        backup_path=backup,
+    )
+
+    assert result["applied"] == [{"table": "working_memory", "status": "applied"}]
+    assert backup.is_file()
+    assert _hash(replacement) == replacement_before
+    authorized = sqlite3.connect(db_path)
+    attacker = sqlite3.connect(replacement)
+    try:
+        assert authorized.execute("SELECT valid_until FROM working_memory WHERE id = 'selected'").fetchone()[0] is not None
+        assert attacker.execute("SELECT valid_until FROM working_memory WHERE id = 'selected'").fetchone()[0] is None
+    finally:
+        authorized.close()
+        attacker.close()
+    assert not list(tmp_path.glob(".mnemosyne-repair-*"))
+
+
+def test_wal_database_is_rejected_before_backup_or_mutation(tmp_path):
+    """A private hardlink must not silently omit another pathname's WAL."""
+
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("PRAGMA journal_mode = WAL").fetchone()[0].lower() == "wal"
+    finally:
+        conn.close()
+    report_path = _write_manifest(db_path, tmp_path)
+    backup = tmp_path / "must-not-exist.sqlite"
+
+    with pytest.raises(RepairError, match="sidecars prevent"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=backup,
+        )
+
+    assert not backup.exists()
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("SELECT valid_until FROM working_memory WHERE id = 'selected'").fetchone()[0] is None
+    finally:
+        conn.close()
+    assert not list(tmp_path.glob(".mnemosyne-repair-*"))
+
+
+def test_existing_rollback_journal_fails_closed_before_binding_backup_or_mutation(tmp_path):
+    """The original rollback journal cannot be replayed through a private link."""
+
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    report_path = _write_manifest(db_path, tmp_path)
+    journal = db_path.with_name(db_path.name + "-journal")
+    journal.write_bytes(b"controlled nonempty hot-ish rollback journal")
+    before = _hash(db_path)
+    journal_before = _hash(journal)
+    backup = tmp_path / "must-not-exist.sqlite"
+
+    with pytest.raises(RepairError, match="sidecars prevent"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=backup,
+        )
+
+    assert _hash(db_path) == before
+    assert _hash(journal) == journal_before
+    assert not backup.exists()
+    assert not list(tmp_path.glob(".mnemosyne-repair-*"))
+
+
+def test_sidecar_created_after_preflight_is_rejected_before_inode_binding(tmp_path, monkeypatch):
+    """A sidecar arriving during Doctor preflight cannot cross the bind gate."""
+
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    report_path = _write_manifest(db_path, tmp_path)
+    journal = db_path.with_name(db_path.name + "-journal")
+    journal_bytes = b"sidecar created after the initial preflight check"
+    before = _hash(db_path)
+    backup = tmp_path / "must-not-exist.sqlite"
+    fd_before = len(os.listdir("/proc/self/fd"))
+    real_gate = repair._verify_report_gate
+
+    def create_sidecar_after_preflight(*args, conn=None, **kwargs):
+        result = real_gate(*args, conn=conn, **kwargs)
+        if conn is None:
+            journal.write_bytes(journal_bytes)
+        return result
+
+    monkeypatch.setattr(repair, "_verify_report_gate", create_sidecar_after_preflight)
+
+    with pytest.raises(RepairError, match="sidecars prevent"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=backup,
+        )
+
+    assert _hash(db_path) == before
+    assert journal.read_bytes() == journal_bytes
+    assert not backup.exists()
+    assert not list(tmp_path.glob(".mnemosyne-repair-*"))
+    assert len(os.listdir("/proc/self/fd")) == fd_before
+
+
+def test_backup_parent_swap_cannot_redirect_fd_anchored_backup(tmp_path, monkeypatch):
+    """The requested backup parent may be renamed only after its FD is retained."""
+
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    report_path = _write_manifest(db_path, tmp_path)
+    backup_parent = tmp_path / "backup-parent"
+    backup_parent.mkdir()
+    attacker_parent = tmp_path / "attacker-parent"
+    attacker_parent.mkdir()
+    parked_parent = tmp_path / "parked-backup-parent"
+    backup = backup_parent / "backup.sqlite"
+    fd_before = len(os.listdir("/proc/self/fd"))
+    real_backup = repair._create_validated_backup
+
+    def swap_parent_after_reservation(source_fd: int, destination) -> None:
+        # Reservation must already hold the original parent directory FD and
+        # final file FD. Any later string-path use would write to attacker_parent.
+        os.replace(backup_parent, parked_parent)
+        os.replace(attacker_parent, backup_parent)
+        real_backup(source_fd, destination)
+
+    monkeypatch.setattr(repair, "_create_validated_backup", swap_parent_after_reservation)
+    result = run_repair(
+        db_path=db_path,
+        bank_name="default",
+        report_path=report_path,
+        selections=["working_memory:selected"],
+        action="expire",
+        apply=True,
+        backup_path=backup,
+    )
+
+    assert result["backup"] is True
+    assert not backup.exists()
+    retained_backup = parked_parent / "backup.sqlite"
+    assert retained_backup.is_file()
+    verify = sqlite3.connect(retained_backup)
+    source = sqlite3.connect(db_path)
+    try:
+        assert verify.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+        assert verify.execute("SELECT valid_until FROM working_memory WHERE id = 'selected'").fetchone()[0] is None
+        assert source.execute("SELECT valid_until FROM working_memory WHERE id = 'selected'").fetchone()[0] is not None
+    finally:
+        verify.close()
+        source.close()
+    assert not list(tmp_path.glob(".mnemosyne-repair-*"))
+    assert not list(backup_parent.iterdir())
+    assert len(os.listdir("/proc/self/fd")) == fd_before
+
+
+def test_working_memory_trigger_fails_closed_before_backup_or_selected_update(tmp_path):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    _insert_memory(db_path, "untouched")
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TRIGGER working_memory_expiry_side_effect
+            AFTER UPDATE OF valid_until ON working_memory
+            BEGIN
+                UPDATE working_memory
+                SET valid_until = CURRENT_TIMESTAMP
+                WHERE id = 'untouched';
+            END;
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    report_path = _write_manifest(db_path, tmp_path)
+    manifest = json.loads(report_path.read_text(encoding="utf-8"))
+    assert any(
+        trigger["name"] == "working_memory_expiry_side_effect" and trigger["table_name"] == "working_memory"
+        for trigger in manifest["schema_fingerprint"]["triggers"]
+    )
+    backup = tmp_path / "must-not-exist.sqlite"
+
+    with pytest.raises(RepairError, match="triggers prevent"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=backup,
+        )
+
+    assert not backup.exists()
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("SELECT valid_until FROM working_memory WHERE id = 'selected'").fetchone()[0] is None
+        assert conn.execute("SELECT valid_until FROM working_memory WHERE id = 'untouched'").fetchone()[0] is None
+        assert conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == 2
+    finally:
+        conn.close()
+    assert not list(tmp_path.glob(".mnemosyne-repair-*"))
+
+
+def test_rejects_unknown_selection_action_and_database_or_hardlink_backup_targets(tmp_path):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    report_path = _write_manifest(db_path, tmp_path)
+    before = _hash(db_path)
+
+    with pytest.raises(RepairError, match="working_memory:ID") as unknown_selection:
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=[f"memories:{RAW_SECRET}"],
+            action="expire",
+        )
+    assert RAW_SECRET not in str(unknown_selection.value)
+    with pytest.raises(RepairError, match="--action"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="delete-all",
+        )
+    with pytest.raises(RepairError, match="must not be the inspected database"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=db_path,
+        )
+
+    hardlink = tmp_path / "database-hardlink.sqlite"
+    os.link(db_path, hardlink)
+    with pytest.raises(RepairError, match="must be a new file"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=hardlink,
+        )
+    symlink = tmp_path / "database-symlink.sqlite"
+    symlink.symlink_to(db_path)
+    with pytest.raises(RepairError, match="must not use a symlink"):
+        run_repair(
+            db_path=db_path,
+            bank_name="default",
+            report_path=report_path,
+            selections=["working_memory:selected"],
+            action="expire",
+            apply=True,
+            backup_path=symlink,
+        )
+    assert _hash(db_path) == before
+
+
+def test_cli_output_and_errors_never_echo_raw_memory_or_embedding_data(tmp_path):
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    selected_id = f"id-{RAW_SECRET}"
+    _insert_memory(
+        db_path,
+        selected_id,
+        content=RAW_CONTENT,
+        embedding=RAW_EMBEDDING,
+    )
+    report_path = _write_manifest(db_path, tmp_path)
+
+    result = _run_cli(
+        [
+            "repair",
+            "--db",
+            str(db_path),
+            "--report",
+            str(report_path),
+            "--select",
+            f"working_memory:{selected_id}",
+            "--action",
+            "expire",
+        ],
+        tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "dry_run"
+    assert payload["applied"] == [{"status": "planned", "table": "working_memory"}]
+    leaked = result.stdout + result.stderr
+    for raw in (RAW_SECRET, RAW_CONTENT, RAW_EMBEDDING, RAW_BLOB_HEX, selected_id):
+        assert raw not in leaked
+
+    invalid = _run_cli(
+        [
+            "repair",
+            "--db",
+            str(db_path),
+            "--report",
+            str(report_path),
+            "--select",
+            f"unknown:{RAW_SECRET}",
+        ],
+        tmp_path,
+    )
+    assert invalid.returncode == 1
+    assert RAW_SECRET not in invalid.stdout + invalid.stderr
+
+    unknown_option = _run_cli(["repair", f"--{RAW_SECRET}"], tmp_path)
+    assert unknown_option.returncode == 2
+    assert RAW_SECRET not in unknown_option.stdout + unknown_option.stderr
+
+    invalid_bank = _run_cli(
+        [
+            "repair",
+            "--bank",
+            f"bad/{RAW_SECRET}",
+            "--report",
+            str(report_path),
+            "--select",
+            "working_memory:any",
+        ],
+        tmp_path,
+    )
+    assert invalid_bank.returncode == 2
+    assert RAW_SECRET not in invalid_bank.stdout + invalid_bank.stderr
+
+
+def test_cli_apply_requires_an_explicit_complete_selection(tmp_path):
+    result = _run_cli(["repair", "--apply", "--report", "missing.json"], tmp_path)
+    assert result.returncode == 2
+    assert "At least one complete --select" in result.stderr

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -179,7 +179,14 @@ def test_repair_fails_closed_before_dry_run_on_non_linux(tmp_path, monkeypatch):
     db_path = tmp_path / "memory.db"
     _create_db(db_path)
     report_path = tmp_path / "missing-report.json"
+    before = tuple(tmp_path.iterdir())
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("platform guard must run before filesystem work")
+
     monkeypatch.setattr(repair.sys, "platform", "darwin")
+    monkeypatch.setattr(repair, "_database_identity", fail_if_called)
+    monkeypatch.setattr(repair, "_load_manifest", fail_if_called)
 
     with pytest.raises(RepairError, match="supported only on Linux"):
         run_repair(
@@ -191,6 +198,7 @@ def test_repair_fails_closed_before_dry_run_on_non_linux(tmp_path, monkeypatch):
         )
 
     assert not report_path.exists()
+    assert tuple(tmp_path.iterdir()) == before
 
 
 def test_manifest_bank_fingerprint_and_parse_fail_closed_before_backup_or_write(tmp_path):


### PR DESCRIPTION
## Summary

Adds a safe operational Doctor/Repair v1 workflow.

- `mnemosyne doctor`: separate read-only (`mode=ro` + `query_only`) SQLite/runtime/reference/vector/hygiene diagnostics with deterministic JSON/Markdown output.
- Content-safe reports: no raw memory content, IDs, embeddings, BLOBs, metadata, or secrets; output and database hardlink/symlink protections included.
- `mnemosyne repair`: dry-run by default, explicit `working_memory:<id>` selection, report bank/schema/database-identity gates, transactional revalidation, and backup + `quick_check` before a permitted mutation.
- Repair scope is deliberately narrow: selected vec-working backfill or explicit expiry only. No deletes, DDL, reindexing, re-embedding, bulk repair, or hygiene cleanup.
- Hardened against manifest/path swaps, DB/backup hardlinks, SQLite sidecars, trigger-driven bulk writes, and vec0 capability/dimension failures.

## Validation

```text
214 passed, 10 skipped
```

Focused matrix: Doctor CLI/repair/hygiene/runtime/Beam integration.

## Out of scope

No production deployment or migration is included. A future rollout should be performed only after a released upstream version, with backup and controlled smoke checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds a safe, local-first **Doctor/Repair v1** operational workflow for Mnemosyne that strengthens integrity and privacy without changing the core memory architecture.

- Introduces **read-only** `mnemosyne doctor` diagnostics for:
  - SQLite health, runtime capability checks, schema/reference contracts, vector coverage (including `vec_working`), and hygiene/noise
  - deterministic, JSON/Markdown-friendly report rendering
- Produces **redacted** artifacts intended to prevent leakage of raw memory content, IDs, embeddings/BLOBs, metadata/secrets, and sensitive runtime details (with explicit truncation-safe preview rules).
- Adds **dry-run-by-default** `mnemosyne repair`, gated by a Doctor JSON manifest and restricted to narrow, doctor-authorized mutations:
  - `working_memory:<id>` + `backfill-vec-working` (backfills already-stored fallback embedding into live `vec_working`)
  - `working_memory:<id>` + `expire` (sets `valid_until` only on the selected active row)
- Enforces **fail-closed** validation and mutation gating:
  - manifest fingerprint + database identity checks, followed by **re-verification under the same locked connection**
  - **backup + `PRAGMA quick_check`** before any UPDATE
  - blocks unsafe modes/tricks (WAL/sidecars/journals, trigger-driven bulk writes, manifest/path swaps, inode/path hardlink redirection, vec0 capability/dimension failures)
  - explicitly excludes deletes/DDL/reindexing/re-embedding/bulk repair and hygiene cleanup
- Refactors `mnemosyne diagnose` to reuse a shared pure runtime introspection collector (`collect_runtime_diagnostics`) for consistent, maintainable diagnostics behavior.
- Removes `DATA_DIR` creation side effects at import time so `doctor`/`repair` don’t trigger legacy filesystem mkdir behavior.
- Test coverage: **214 passing / 10 skipped**.

## Architectural impact

### Tiered memory (working/episodic/BEAM)
- No behavioral changes to **episodic storage**, **BEAM contents**, consolidation state, or retrieval ranking.
- `doctor` performs bounded, read-only inspection across the tiered model surface (including `vec_working` coverage/degradation views).
- `repair` mutates **only** the SQLite working-memory surface:
  - `working_memory.valid_until` updates for selected rows (`expire`)
  - `vec_working` backfill using **already-stored** fallback embedding data (`backfill-vec-working`)
- Does not alter consolidation pipeline logic, veracity scoring rules, or sync/replication mechanics.

### Retrieval strategies & consolidation pipeline
- Strictly operational/observability oriented: no changes to recall/re-ranking, consolidation scheduling, embedding training/reindex pipeline, or benchmark methodology.

### Local-first guarantees
- `doctor` opens SQLite in **read-only, query-only** mode (`mode=ro`, `PRAGMA query_only=ON`, foreign keys enabled) and returns “unavailable/unknown” sections instead of raising.
- `repair` remains local and authorization-gated:
  - requires a validated Doctor manifest
  - performs inode-stable binding (FD/hardlink-based protections) and keeps mutations transactionally fenced with preflight checks.
- Output handling is protected against overwrite/swap attacks:
  - guards destination identities (including hardlinks/symlinks), uses atomic staging/replace, and cleans temp artifacts on failure.

### Privacy posture
- Substantially improves operator-share safety:
  - doctor/repair artifacts are redaction- and serialization-hardened to avoid leaking memory text, candidate identifiers, BLOBs/metadata/secrets, embeddings content, and sensitive runtime details.
  - hygiene/noise previewing is handled with “safe preview” ordering to prevent truncation-boundary secret leakage.

### Agent integration surfaces (Hermes, MCP, CLI)
- **CLI:** adds first-class `mnemosyne doctor` and `mnemosyne repair` commands with explicit argument validation and safe output/DB target resolution.
- **Hermes CLI routing:** adds/extends behavior coverage to ensure `hermes mnemosyne doctor` resolves the correct bank without unintended side effects (and does not apply the same guard to unrelated Hermes commands).
- **MCP:** no new MCP tools are introduced; Hermes/MCP integration remains centered on the existing `mnemosyne_diagnose` tool surface (this PR does not rewire MCP to expose `mnemosyne doctor`/`mnemosyne repair`).

## Maintainability / long-term operability

- Builds a more “contract-like” operational core:
  - modular doctor **adapters** with bounded scan/candidate work, explicit allowlists, and sanitizer/redaction boundaries
  - schema fingerprinting + deterministic payload/renderers for stable ops artifacts
  - atomic, rollback-aware artifact persistence helpers for predictable tooling behavior
- The “right call” for long-term safety is centralizing read-only diagnostics and fail-closed mutation authorization in dedicated doctor/repair modules, rather than scattering risk checks through mutation code paths—improving reliability while preserving Mnemosyne’s local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->