### PR TITLE
fix: honor configured local LLM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Configured local LLM model is now honored.** Local consolidation uses
+  `llm_repo` and `llm_file` from `config.yaml` (or their environment-variable
+  equivalents when YAML config is unavailable), preserves zero-config operation
+  without PyYAML, and scopes cached GGUF files by repository to prevent
+  same-filename cache collisions.
+
 - **Hermes provider safety defaults after config bridging.** New auto-seeded
   configs now preserve user-only autosave and skip `cron`, `flush`, `subagent`,
   `background`, and `skill_loop` contexts. Existing 3.12.1/3.12.2 auto-seeded

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.13.0"
+__version__ = "3.14.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -12,8 +12,11 @@ Default model: openbmb/MiniCPM5-1B-GGUF (Q4_K_M, ~656MB)
 import os
 import sys
 import re
+from hashlib import sha256
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
+
+from mnemosyne.core.config import get_config
 
 # --- Config ------------------------------------------------------------------
 DEFAULT_MODEL_REPO = "openbmb/MiniCPM5-1B-GGUF"
@@ -24,13 +27,6 @@ LLM_ENABLED = os.environ.get("MNEMOSYNE_LLM_ENABLED", "true").lower() in ("1", "
 LLM_MAX_TOKENS=int(os.environ.get("MNEMOSYNE_LLM_MAX_TOKENS", "2048") or "2048")
 LLM_N_THREADS = int(os.environ.get("MNEMOSYNE_LLM_N_THREADS", "4"))
 LLM_N_CTX = int(os.environ.get("MNEMOSYNE_LLM_N_CTX", "2048"))
-
-# Override model via env
-_env_repo = os.environ.get("MNEMOSYNE_LLM_REPO")
-_env_file = os.environ.get("MNEMOSYNE_LLM_FILE")
-if _env_repo and _env_file:
-    DEFAULT_MODEL_REPO = _env_repo
-    DEFAULT_MODEL_FILE = _env_file
 
 # Remote API config
 LLM_BASE_URL = os.environ.get("MNEMOSYNE_LLM_BASE_URL", "").rstrip("/")
@@ -77,16 +73,55 @@ def _ensure_sys_path():
         sys.path.append(sp)
 
 
+def _fallback_model() -> Tuple[str, str]:
+    """Return the environment-selected or built-in model without YAML config."""
+    repo = os.environ.get("MNEMOSYNE_LLM_REPO", "").strip()
+    filename = os.environ.get("MNEMOSYNE_LLM_FILE", "").strip()
+    if repo and filename:
+        return repo, filename
+    return DEFAULT_MODEL_REPO, DEFAULT_MODEL_FILE
+
+
+def _configured_model() -> Tuple[str, str]:
+    """Return the configured local model, or the zero-config fallback.
+
+    ``MnemosyneConfig`` owns YAML > environment > hardcoded-default precedence.
+    Keeping the MiniCPM constants as the final fallback preserves standalone,
+    zero-config behavior while allowing configured installations to select a
+    different local GGUF model.
+    """
+    try:
+        config = get_config()
+    except ModuleNotFoundError as error:
+        if error.name == "yaml":
+            return _fallback_model()
+        raise
+
+    repo = config.get_str("llm_repo").strip()
+    filename = config.get_str("llm_file").strip()
+    if repo and filename:
+        return repo, filename
+    return DEFAULT_MODEL_REPO, DEFAULT_MODEL_FILE
+
+
+def _model_cache_dir(repo: str) -> Path:
+    """Return the repository-scoped cache directory for a local model."""
+    return MODEL_CACHE_DIR / sha256(repo.encode("utf-8")).hexdigest()[:16]
+
+
 def _model_path() -> Optional[Path]:
-    """Return path to the local GGUF model file, or None if not downloaded."""
-    candidate = MODEL_CACHE_DIR / DEFAULT_MODEL_FILE
+    """Return path to the configured local GGUF model file, or None."""
+    repo, filename = _configured_model()
+    candidate = _model_cache_dir(repo) / filename
     return candidate if candidate.exists() else None
 
 
 def _download_model() -> Path:
-    """Download the GGUF model from HuggingFace if not present."""
-    MODEL_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    local_path = MODEL_CACHE_DIR / DEFAULT_MODEL_FILE
+    """Download the configured local GGUF model from HuggingFace if absent."""
+    repo, filename = _configured_model()
+    cache_dir = _model_cache_dir(repo)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    local_path = cache_dir / filename
     if local_path.exists():
         return local_path
 
@@ -98,9 +133,9 @@ def _download_model() -> Path:
         )
 
     downloaded = hf_hub_download(
-        repo_id=DEFAULT_MODEL_REPO,
-        filename=DEFAULT_MODEL_FILE,
-        local_dir=str(MODEL_CACHE_DIR),
+        repo_id=repo,
+        filename=filename,
+        local_dir=str(cache_dir),
         local_dir_use_symlinks=False,
     )
     return Path(downloaded)

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import subprocess
 import sys
 import pytest
@@ -124,6 +125,183 @@ class TestRemoteLLM:
                 assert result is None
                 mock_remote.assert_called_once()
                 mock_load.assert_called_once()
+
+
+class TestConfiguredLocalModel:
+    def test_download_uses_model_selected_in_config(self, monkeypatch, tmp_path):
+        """A configured local model must override the MiniCPM zero-config fallback."""
+        configured_repo = "bartowski/Qwen_Qwen3-4B-Instruct-2507-GGUF"
+        configured_file = "Qwen_Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "llm_repo: bartowski/Qwen_Qwen3-4B-Instruct-2507-GGUF\n"
+            "llm_file: Qwen_Qwen3-4B-Instruct-2507-Q4_K_M.gguf\n"
+        )
+        from mnemosyne.core.config import MnemosyneConfig
+        config = MnemosyneConfig(config_path=config_path)
+        monkeypatch.setenv("MNEMOSYNE_LLM_REPO", "env/ignored-by-yaml")
+        monkeypatch.setenv("MNEMOSYNE_LLM_FILE", "ignored.gguf")
+        monkeypatch.setattr(local_llm, "get_config", lambda: config)
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_REPO", "fallback/example")
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_FILE", "fallback.gguf")
+        monkeypatch.setattr(local_llm, "MODEL_CACHE_DIR", tmp_path)
+
+        downloaded = tmp_path / configured_file
+        calls = []
+
+        def fake_download(**kwargs):
+            calls.append(kwargs)
+            downloaded.touch()
+            return str(downloaded)
+
+        monkeypatch.setitem(
+            sys.modules,
+            "huggingface_hub",
+            MagicMock(hf_hub_download=fake_download),
+        )
+
+        assert local_llm._download_model() == downloaded
+        assert calls[0]["repo_id"] == configured_repo
+        assert calls[0]["filename"] == configured_file
+        assert Path(calls[0]["local_dir"]).parent == tmp_path
+
+    def test_config_unavailable_keeps_zero_config_fallback(self, monkeypatch):
+        """Missing optional YAML support must not break standalone local LLM use."""
+        monkeypatch.delenv("MNEMOSYNE_LLM_REPO", raising=False)
+        monkeypatch.delenv("MNEMOSYNE_LLM_FILE", raising=False)
+        monkeypatch.setattr(
+            local_llm,
+            "get_config",
+            lambda: (_ for _ in ()).throw(ModuleNotFoundError("No module named 'yaml'", name="yaml")),
+        )
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_REPO", "fallback/example")
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_FILE", "fallback.gguf")
+
+        assert local_llm._configured_model() == ("fallback/example", "fallback.gguf")
+
+    def test_configured_repo_does_not_reuse_same_filename_from_other_repo(
+        self, monkeypatch, tmp_path
+    ):
+        """A cache entry is scoped to its repository, not only its filename."""
+        configured_repo = "org/new-model"
+        filename = "shared.gguf"
+        config = MagicMock()
+        config.get_str.side_effect = lambda key, default="": {
+            "llm_repo": configured_repo,
+            "llm_file": filename,
+        }.get(key, default)
+        monkeypatch.setattr(local_llm, "get_config", lambda: config)
+        monkeypatch.setattr(local_llm, "MODEL_CACHE_DIR", tmp_path)
+        legacy_file = tmp_path / filename
+        legacy_file.touch()
+
+        assert local_llm._model_path() is None
+
+        calls = []
+
+        def fake_download(**kwargs):
+            calls.append(kwargs)
+            target = Path(kwargs["local_dir"]) / filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.touch()
+            return str(target)
+
+        monkeypatch.setitem(
+            sys.modules,
+            "huggingface_hub",
+            MagicMock(hf_hub_download=fake_download),
+        )
+
+        assert local_llm._download_model().name == filename
+        assert calls[0]["repo_id"] == configured_repo
+        assert calls[0]["local_dir"] != str(tmp_path)
+
+    def test_environment_model_is_used_when_config_is_absent(
+        self, monkeypatch, tmp_path
+    ):
+        """A fresh config seeds local-model values from environment variables."""
+        from mnemosyne.core.config import MnemosyneConfig
+
+        configured_repo = "org/environment-model"
+        configured_file = "environment.gguf"
+        monkeypatch.setenv("MNEMOSYNE_LLM_REPO", configured_repo)
+        monkeypatch.setenv("MNEMOSYNE_LLM_FILE", configured_file)
+        config = MnemosyneConfig(config_path=tmp_path / "config.yaml")
+        monkeypatch.setattr(local_llm, "get_config", lambda: config)
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_REPO", "fallback/example")
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_FILE", "fallback.gguf")
+
+        assert local_llm._configured_model() == (configured_repo, configured_file)
+
+    def test_zero_config_without_pyyaml_keeps_fallback(self, tmp_path):
+        """No optional YAML dependency must not break standalone local LLM use."""
+        env = os.environ.copy()
+        env.update({
+            "HERMES_HOME": str(tmp_path),
+            "MNEMOSYNE_DATA_DIR": str(tmp_path / "mnemosyne"),
+            "PYTHONPATH": str(Path(__file__).parents[1]),
+        })
+        env.pop("MNEMOSYNE_LLM_REPO", None)
+        env.pop("MNEMOSYNE_LLM_FILE", None)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-S",
+                "-c",
+                "from mnemosyne.core.local_llm import _configured_model; "
+                "print(_configured_model())",
+            ],
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == (
+            "('openbmb/MiniCPM5-1B-GGUF', 'MiniCPM5-1B-Q4_K_M.gguf')"
+        )
+
+    def test_empty_yaml_does_not_inherit_environment_model(self, tmp_path):
+        """Explicitly blank YAML model settings take precedence over env values."""
+        config_dir = tmp_path / "mnemosyne"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("llm_repo: ''\nllm_file: ''\n")
+        env = os.environ.copy()
+        env.update({
+            "HERMES_HOME": str(tmp_path),
+            "MNEMOSYNE_DATA_DIR": str(config_dir),
+            "MNEMOSYNE_LLM_REPO": "org/environment-model",
+            "MNEMOSYNE_LLM_FILE": "environment.gguf",
+            "PYTHONPATH": str(Path(__file__).parents[1]),
+        })
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from mnemosyne.core.local_llm import _configured_model; "
+                "print(_configured_model())",
+            ],
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == (
+            "('openbmb/MiniCPM5-1B-GGUF', 'MiniCPM5-1B-Q4_K_M.gguf')"
+        )
+
+    def test_unrelated_missing_module_is_not_silenced(self, monkeypatch):
+        """Only an unavailable YAML parser is allowed to trigger fallback."""
+        missing = ModuleNotFoundError("No module named 'other_dependency'", name="other_dependency")
+        monkeypatch.setattr(
+            local_llm,
+            "get_config",
+            lambda: (_ for _ in ()).throw(missing),
+        )
+
+        with pytest.raises(ModuleNotFoundError, match="other_dependency"):
+            local_llm._configured_model()
 
 
 class TestSleepPromptOverride:


### PR DESCRIPTION
## Summary
- honor local LLM model selection with YAML > environment > built-in precedence
- fall back safely when PyYAML is absent
- scope model cache keys to the source repository

## Validation
- focused local-LLM configuration tests passed
- hermetic config/local gate: 123 passed
- wheel smoke, compile and diff checks passed

## Status
Draft for maintainer review; not intended for merge yet.