### PR TITLE
fix: make backup restore atomic and recoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Atomic SQLite backup and restore.** Disaster-recovery snapshots now preserve
+  committed WAL, FTS5, and sqlite-vec state as validated binary SQLite archives,
+  publish metadata atomically, restore in place for active connections, and
+  roll back interrupted or failed cutovers.
+
 - **Hermes provider safety defaults after config bridging.** New auto-seeded
   configs now preserve user-only autosave and skip `cron`, `flush`, `subagent`,
   `background`, and `skill_loop` contexts. Existing 3.12.1/3.12.2 auto-seeded

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.13.0"
+__version__ = "3.14.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -566,10 +566,27 @@ def cmd_backup(args):
 def cmd_restore(args):
     """Restore database from a backup file."""
     if not args:
-        _usage("Usage: mnemosyne restore <backup_file.db.gz>")
+        _usage("Usage: mnemosyne restore <backup_file.db.gz> [--target <database.db>]")
+    backup_path = None
+    target_path = None
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--target":
+            if target_path is not None or i + 1 >= len(args):
+                _usage("Usage: mnemosyne restore <backup_file.db.gz> [--target <database.db>]")
+            target_path = Path(args[i + 1])
+            i += 2
+        elif arg.startswith("-") or backup_path is not None:
+            _usage("Usage: mnemosyne restore <backup_file.db.gz> [--target <database.db>]")
+        else:
+            backup_path = Path(arg)
+            i += 1
+    if backup_path is None:
+        _usage("Usage: mnemosyne restore <backup_file.db.gz> [--target <database.db>]")
     from mnemosyne.dr.recovery import restore_backup
     try:
-        result = restore_backup(Path(args[0]))
+        result = restore_backup(backup_path, target_path)
         status = "valid" if result["integrity_check"] else "corrupt"
         print(f"Restored from: {result['backup_used']}")
         print(f"  Database:     {result['database_path']}")

--- a/mnemosyne/dr/recovery.py
+++ b/mnemosyne/dr/recovery.py
@@ -5,15 +5,153 @@ Comprehensive backup, restore, and integrity verification for Mnemosyne.
 """
 
 import gzip
-import io
 import os
 import json
 import hashlib
 import shutil
 import sqlite3
+import tempfile
+import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
+
+
+BACKUP_FORMAT = "sqlite-binary-gzip-v1"
+
+
+def _load_sqlite_vec(conn: sqlite3.Connection) -> None:
+    """Load sqlite-vec when installed so vec0 databases can be inspected."""
+    try:
+        import sqlite_vec
+
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+    except (ImportError, sqlite3.OperationalError):
+        # sqlite-vec is optional.  Databases without vec0 tables remain usable;
+        # databases that need the extension will fail the subsequent check.
+        pass
+
+
+def _fsync_file(path: Path) -> None:
+    with path.open("rb") as handle:
+        os.fsync(handle.fileno())
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist directory entries on POSIX; best effort on other platforms."""
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _readonly_sqlite_uri(path: Path) -> str:
+    """Build a read-only SQLite URI without treating path delimiters as query text."""
+    return f"{path.resolve().as_uri()}?mode=ro"
+
+
+def _online_snapshot(source: Path, destination: Path) -> None:
+    """Create a self-contained SQLite snapshot, including committed WAL frames."""
+    source = source.resolve()
+    src = sqlite3.connect(_readonly_sqlite_uri(source), uri=True)
+    dst = sqlite3.connect(str(destination))
+    try:
+        _load_sqlite_vec(src)
+        _load_sqlite_vec(dst)
+        src.backup(dst)
+        # A restored file must not depend on a sidecar left beside the source.
+        dst.execute("PRAGMA journal_mode=DELETE")
+        dst.commit()
+    finally:
+        dst.close()
+        src.close()
+    _fsync_file(destination)
+
+
+def _restore_snapshot(source: Path, destination: Path) -> None:
+    """Restore a validated snapshot through SQLite without replacing its inode.
+
+    Existing SQLite connections remain attached to the restored database.  The
+    online-backup API owns the destination write transaction, so a failed copy
+    is rolled back by SQLite instead of exposing a partially replaced file.
+    """
+    source = source.resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    src = sqlite3.connect(_readonly_sqlite_uri(source), uri=True)
+    dst = sqlite3.connect(str(destination))
+    try:
+        _load_sqlite_vec(src)
+        _load_sqlite_vec(dst)
+        src.backup(dst)
+    finally:
+        dst.close()
+        src.close()
+    if destination.exists():
+        _fsync_file(destination)
+    wal = Path(str(destination) + "-wal")
+    if wal.exists():
+        _fsync_file(wal)
+    _fsync_directory(destination.parent)
+
+
+def _atomic_json(path: Path, payload: Dict) -> None:
+    fd, raw_tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp = Path(raw_tmp)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        _fsync_directory(path.parent)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _read_backup_metadata(backup_path: Path, *, verify_archive: bool = True) -> Dict:
+    """Load and validate the metadata that commits a v1 backup pair."""
+    meta_path = backup_path.with_suffix(".gz.json")
+    if not meta_path.exists():
+        raise ValueError("Backup metadata is required for sqlite-binary-gzip-v1")
+    try:
+        metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("Backup metadata is unreadable or invalid") from exc
+    if metadata.get("format") != BACKUP_FORMAT:
+        raise ValueError("Backup metadata format is missing or unsupported")
+    if metadata.get("compressed") is not True:
+        raise ValueError("Backup metadata does not describe a compressed payload")
+    for field in ("backup_checksum", "db_checksum"):
+        value = metadata.get(field)
+        if not isinstance(value, str) or len(value) != 64:
+            raise ValueError(f"Backup metadata field {field} is missing or invalid")
+    if verify_archive:
+        if not backup_path.exists():
+            raise FileNotFoundError(f"Backup not found: {backup_path}")
+        if metadata.get("backup_size") != backup_path.stat().st_size:
+            raise ValueError("Backup size does not match metadata")
+        if _sha256(backup_path) != metadata["backup_checksum"]:
+            raise ValueError("Backup checksum does not match metadata")
+    return metadata
+
+
+def _remove_sidecars(path: Path) -> None:
+    for suffix in ("-wal", "-shm"):
+        Path(str(path) + suffix).unlink(missing_ok=True)
 
 
 def get_default_paths():
@@ -43,7 +181,7 @@ def get_default_paths():
     return data_dir, backup_dir, db_path
 
 
-def create_backup(db_path: Path = None, backup_dir: Path = None) -> Dict:
+def create_backup(db_path: Optional[Path] = None, backup_dir: Optional[Path] = None) -> Dict:
     """
     Create a compressed backup of the database.
     
@@ -56,66 +194,63 @@ def create_backup(db_path: Path = None, backup_dir: Path = None) -> Dict:
     
     if not db_path.exists():
         raise FileNotFoundError(f"Database not found: {db_path}")
+    source_file_size = db_path.stat().st_size
     
     backup_dir.mkdir(parents=True, exist_ok=True)
     
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    backup_name = f"mnemosyne_backup_{timestamp}.db.gz"
+    backup_name = f"mnemosyne_backup_{timestamp}_{uuid.uuid4().hex[:8]}.db.gz"
     backup_path = backup_dir / backup_name
-    
-    # Use sqlite3 online backup API instead of shutil.copyfileobj.
-    # sqlite3.backup() is lock-aware (acquires read-lock), includes
-    # uncommitted WAL frames, and is atomic — it won't produce a torn
-    # file if a checkpoint runs partway through. The old copyfileobj
-    # approach only copied the .db file, missed .db-wal frames, and
-    # could produce corrupted backups under concurrent write load.
-    src = sqlite3.connect(str(db_path))
-    # Load sqlite-vec on BOTH connections involved in the backup.
-    # Without this, src.backup(dst) fails with "no such module: vec0"
-    # when copying vec0 virtual tables, AND dst.iterdump() (used to
-    # serialize the in-memory backup to gzipped SQL) fails the same
-    # way when introspecting the destination's vec0 schema.
-    # Mirrors the graceful-fallback pattern in core/beam.py.
-    def _load_sqlite_vec(conn):
+
+    snapshot_fd, snapshot_raw = tempfile.mkstemp(
+        prefix=".mnemosyne-snapshot-", suffix=".db", dir=backup_dir
+    )
+    os.close(snapshot_fd)
+    snapshot_path = Path(snapshot_raw)
+    gzip_fd, gzip_raw = tempfile.mkstemp(
+        prefix=f".{backup_name}.", suffix=".tmp", dir=backup_dir
+    )
+    os.close(gzip_fd)
+    gzip_tmp = Path(gzip_raw)
+
+    try:
+        _online_snapshot(db_path, snapshot_path)
+        if not verify_integrity(snapshot_path):
+            raise RuntimeError("SQLite snapshot failed integrity verification")
+
+        with snapshot_path.open("rb") as f_in, gzip.open(gzip_tmp, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out, length=1024 * 1024)
+        _fsync_file(gzip_tmp)
+
+        db_checksum = _sha256(snapshot_path)
+        backup_checksum = _sha256(gzip_tmp)
+        snapshot_size = snapshot_path.stat().st_size
+        metadata = {
+            "timestamp": timestamp,
+            "original_size": snapshot_size,
+            "source_file_size": source_file_size,
+            "backup_size": gzip_tmp.stat().st_size,
+            "db_checksum": db_checksum,
+            "backup_checksum": backup_checksum,
+            "compressed": True,
+            "format": BACKUP_FORMAT,
+        }
+        meta_path = backup_path.with_suffix('.gz.json')
         try:
-            import sqlite_vec
-            conn.enable_load_extension(True)
-            sqlite_vec.load(conn)
-        except (ImportError, sqlite3.OperationalError):
-            pass  # optional extra; absence just means no vec0 tables
-    _load_sqlite_vec(src)
-    dst = sqlite3.connect(":memory:")
-    _load_sqlite_vec(dst)
-    src.backup(dst)
-    src.close()
-
-    # Serialize the in-memory backup → gzip → disk
-    buf = io.BytesIO()
-    for line in dst.iterdump():
-        buf.write((line + "\n").encode("utf-8"))
-    dst.close()
-
-    with gzip.open(backup_path, "wb") as f_out:
-        f_out.write(buf.getvalue())
-    
-    # Calculate checksums
-    db_checksum = hashlib.sha256(db_path.read_bytes()).hexdigest()[:16]
-    backup_checksum = hashlib.sha256(backup_path.read_bytes()).hexdigest()[:16]
-    
-    # Create metadata
-    metadata = {
-        "timestamp": timestamp,
-        "original_size": db_path.stat().st_size,
-        "backup_size": backup_path.stat().st_size,
-        "db_checksum": db_checksum,
-        "backup_checksum": backup_checksum,
-        "compressed": True
-    }
-    
-    # Save metadata
-    meta_path = backup_path.with_suffix('.gz.json')
-    with open(meta_path, 'w') as f:
-        json.dump(metadata, f, indent=2)
+            _atomic_json(meta_path, metadata)
+            # The archive is the commit marker. Metadata is durable first, so
+            # readers can never observe a listed/restorable v1 archive without
+            # its validation record.
+            os.replace(gzip_tmp, backup_path)
+            _fsync_directory(backup_dir)
+        except BaseException:
+            meta_path.unlink(missing_ok=True)
+            backup_path.unlink(missing_ok=True)
+            _fsync_directory(backup_dir)
+            raise
+    finally:
+        snapshot_path.unlink(missing_ok=True)
+        gzip_tmp.unlink(missing_ok=True)
     
     return {
         "backup_path": str(backup_path),
@@ -124,7 +259,7 @@ def create_backup(db_path: Path = None, backup_dir: Path = None) -> Dict:
     }
 
 
-def restore_backup(backup_path: Path, db_path: Path = None) -> Dict:
+def restore_backup(backup_path: Path, db_path: Optional[Path] = None) -> Dict:
     """
     Restore database from a compressed backup.
     
@@ -140,28 +275,110 @@ def restore_backup(backup_path: Path, db_path: Path = None) -> Dict:
     
     if not backup_path.exists():
         raise FileNotFoundError(f"Backup not found: {backup_path}")
+
+    meta_path = backup_path.with_suffix(".gz.json")
+    metadata = None
+    if meta_path.exists():
+        try:
+            raw_metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError("Backup metadata is unreadable or invalid") from exc
+        if raw_metadata.get("format") == BACKUP_FORMAT:
+            metadata = _read_backup_metadata(backup_path)
     
-    # Create emergency backup of current DB
-    if db_path.exists():
-        emergency_path = db_path.with_suffix('.emergency_backup.db')
-        shutil.copy2(db_path, emergency_path)
-    
-    # Decompress and restore using sqlite3 backup API
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with gzip.open(backup_path, "rb") as f_in:
-        sql_dump = f_in.read().decode("utf-8")
+    payload_fd, payload_raw = tempfile.mkstemp(
+        prefix=f".{db_path.name}.restore-payload-", suffix=".tmp", dir=db_path.parent
+    )
+    os.close(payload_fd)
+    payload = Path(payload_raw)
+    candidate: Optional[Path] = None
 
-    # Rebuild DB in-memory, then backup to target file
-    mem_db = sqlite3.connect(":memory:")
-    mem_db.executescript(sql_dump)
-    target_db = sqlite3.connect(str(db_path))
-    mem_db.backup(target_db)
-    mem_db.close()
-    target_db.close()
-    
-    # Verify restored database
-    is_valid = verify_integrity(db_path)
+    try:
+        with gzip.open(backup_path, "rb") as f_in, payload.open("wb") as f_out:
+            shutil.copyfileobj(f_in, f_out, length=1024 * 1024)
+            f_out.flush()
+            os.fsync(f_out.fileno())
+
+        with payload.open("rb") as handle:
+            header = handle.read(16)
+
+        if header == b"SQLite format 3\x00":
+            if metadata is None:
+                metadata = _read_backup_metadata(backup_path)
+            candidate = payload
+        else:
+            # Backward-compatible best effort for pre-v1 SQL-dump backups.
+            # Complex FTS shadow dumps may fail, but the live target remains
+            # untouched because replay happens in a temporary candidate.
+            sql_dump = payload.read_text(encoding="utf-8")
+            candidate_fd, candidate_raw = tempfile.mkstemp(
+                prefix=f".{db_path.name}.restore-db-", suffix=".tmp", dir=db_path.parent
+            )
+            os.close(candidate_fd)
+            candidate = Path(candidate_raw)
+            conn = sqlite3.connect(str(candidate))
+            try:
+                _load_sqlite_vec(conn)
+                conn.executescript(sql_dump)
+                conn.commit()
+                conn.execute("PRAGMA journal_mode=DELETE")
+            finally:
+                conn.close()
+
+        if not verify_integrity(candidate):
+            raise RuntimeError("Restored candidate failed SQLite integrity verification")
+
+        if metadata is not None:
+            if header != b"SQLite format 3\x00":
+                raise ValueError("Backup payload does not match sqlite-binary metadata")
+            if _sha256(candidate) != metadata["db_checksum"]:
+                raise ValueError("Restored database checksum does not match metadata")
+
+        # Preserve the previous target with the same WAL-aware mechanism.
+        emergency_path: Optional[Path] = None
+        if db_path.exists():
+            emergency_path = db_path.with_suffix(".emergency_backup.db")
+            emergency_fd, emergency_raw = tempfile.mkstemp(
+                prefix=f".{emergency_path.name}.", suffix=".tmp", dir=db_path.parent
+            )
+            os.close(emergency_fd)
+            emergency_tmp = Path(emergency_raw)
+            try:
+                _online_snapshot(db_path, emergency_tmp)
+                if not verify_integrity(emergency_tmp):
+                    raise RuntimeError("Emergency backup failed integrity verification")
+                os.replace(emergency_tmp, emergency_path)
+                _fsync_directory(db_path.parent)
+            finally:
+                emergency_tmp.unlink(missing_ok=True)
+
+        had_target = db_path.exists()
+        try:
+            _restore_snapshot(candidate, db_path)
+            is_valid = verify_integrity(db_path)
+            if not is_valid:
+                raise RuntimeError("Restored target failed final integrity verification")
+        except BaseException as restore_error:
+            try:
+                if had_target and emergency_path is not None:
+                    _restore_snapshot(emergency_path, db_path)
+                    if not verify_integrity(db_path):
+                        raise RuntimeError("Rolled-back target failed integrity verification")
+                elif not had_target:
+                    db_path.unlink(missing_ok=True)
+                    _remove_sidecars(db_path)
+                    _fsync_directory(db_path.parent)
+            except BaseException as rollback_error:
+                raise RuntimeError(
+                    f"Restore failed and automatic rollback also failed: {rollback_error}"
+                ) from restore_error
+            raise
+    finally:
+        payload.unlink(missing_ok=True)
+        if candidate is not None:
+            candidate.unlink(missing_ok=True)
     
     return {
         "restored": True,
@@ -204,7 +421,7 @@ def emergency_restore(backup_dir: Path = None, db_path: Path = None) -> Dict:
     raise RuntimeError("All backups failed integrity check")
 
 
-def verify_integrity(db_path: Path = None) -> bool:
+def verify_integrity(db_path: Optional[Path] = None) -> bool:
     """
     Verify SQLite database integrity.
     
@@ -220,18 +437,84 @@ def verify_integrity(db_path: Path = None) -> bool:
         return False
     
     try:
-        conn = sqlite3.connect(str(db_path))
-        cursor = conn.cursor()
-        
-        # Run PRAGMA integrity_check
-        cursor.execute("PRAGMA integrity_check")
-        result = cursor.fetchone()
-        
-        conn.close()
-        
-        return result[0] == "ok"
+        with sqlite3.connect(str(db_path)) as conn:
+            _load_sqlite_vec(conn)
+            cursor = conn.cursor()
+            quick = cursor.execute("PRAGMA quick_check").fetchone()
+            integrity = cursor.execute("PRAGMA integrity_check").fetchone()
+            foreign_keys = cursor.execute("PRAGMA foreign_key_check").fetchall()
+            if quick[0] != "ok" or integrity[0] != "ok" or foreign_keys:
+                return False
+
+            fts_tables = cursor.execute(
+                "SELECT name, sql FROM sqlite_master "
+                "WHERE type = 'table' AND lower(sql) LIKE '%using fts5%'"
+            ).fetchall()
+            for table_name, table_sql in fts_tables:
+                quoted = table_name.replace('"', '""')
+                cursor.execute(
+                    f'INSERT INTO "{quoted}"("{quoted}") VALUES (\'integrity-check\')'
+                )
+                sql_lower = (table_sql or "").lower().replace(" ", "")
+                if "content='" in sql_lower or 'content="' in sql_lower:
+                    if "content=''" not in sql_lower and 'content=""' not in sql_lower:
+                        cursor.execute(
+                            f'INSERT INTO "{quoted}"("{quoted}", rank) '
+                            "VALUES ('integrity-check', 1)"
+                        )
+
+            for vec_table, source_table in (
+                ("vec_episodes", "episodic_memory"),
+                ("vec_working", "working_memory"),
+            ):
+                exists = cursor.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                    (vec_table,),
+                ).fetchone()
+                if not exists:
+                    continue
+                cursor.execute(f'SELECT COUNT(*) FROM "{vec_table}"').fetchone()
+                orphan = cursor.execute(
+                    f'SELECT COUNT(*) FROM "{vec_table}" v '
+                    f'LEFT JOIN "{source_table}" s ON s.rowid = v.rowid '
+                    "WHERE s.rowid IS NULL"
+                ).fetchone()[0]
+                if orphan:
+                    raise ValueError(f"orphaned rows in {vec_table}")
+
+            conn.rollback()
+            return True
     except Exception:
         return False
+
+
+def _read_backup_listing_metadata(backup_path: Path) -> Dict:
+    """Validate current backups and recognize pre-v1 SQL-dump archives."""
+    meta_path = backup_path.with_suffix(".gz.json")
+    try:
+        raw = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("Backup metadata is unreadable or invalid") from exc
+    if raw.get("format") == BACKUP_FORMAT:
+        return _read_backup_metadata(backup_path)
+    if raw.get("format") is not None or raw.get("compressed") is not True:
+        raise ValueError("Unsupported backup metadata format")
+
+    expected = str(raw.get("backup_checksum") or "")
+    actual = _sha256(backup_path)
+    if expected and actual[: len(expected)] != expected:
+        raise ValueError("Legacy backup checksum does not match metadata")
+    try:
+        with gzip.open(backup_path, "rb") as handle:
+            prefix = handle.read(64 * 1024).decode("utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValueError("Legacy backup payload is unreadable") from exc
+    if "BEGIN TRANSACTION" not in prefix:
+        raise ValueError("Legacy backup payload is not a SQLite SQL dump")
+
+    metadata = dict(raw)
+    metadata["format"] = "legacy-sql-dump-gzip"
+    return metadata
 
 
 def list_backups(backup_dir: Path = None) -> List[Dict]:
@@ -246,19 +529,17 @@ def list_backups(backup_dir: Path = None) -> List[Dict]:
     
     backups = []
     for backup_file in sorted(backup_dir.glob("mnemosyne_backup_*.db.gz"), reverse=True):
-        meta_file = backup_file.with_suffix('.gz.json')
-        
+        try:
+            metadata = _read_backup_listing_metadata(backup_file)
+        except (OSError, ValueError):
+            continue
         info = {
             "file": str(backup_file),
             "name": backup_file.name,
             "size": backup_file.stat().st_size,
-            "modified": datetime.fromtimestamp(backup_file.stat().st_mtime).isoformat()
+            "modified": datetime.fromtimestamp(backup_file.stat().st_mtime).isoformat(),
+            "metadata": metadata,
         }
-        
-        if meta_file.exists():
-            with open(meta_file) as f:
-                info["metadata"] = json.load(f)
-        
         backups.append(info)
     
     return backups
@@ -312,7 +593,7 @@ def health_check() -> Dict:
     db_valid = verify_integrity(db_path) if db_exists else False
     
     # Check backups
-    backups = list(backup_dir.glob("mnemosyne_backup_*.db.gz")) if backup_dir.exists() else []
+    backups = list_backups(backup_dir) if backup_dir.exists() else []
     
     return {
         "database": {
@@ -323,7 +604,7 @@ def health_check() -> Dict:
         },
         "backups": {
             "total": len(backups),
-            "latest": str(backups[-1]) if backups else None,
+            "latest": backups[0]["file"] if backups else None,
             "directory": str(backup_dir)
         },
         "status": "healthy" if db_valid else "unhealthy"

--- a/tests/test_dr_recovery_roundtrip.py
+++ b/tests/test_dr_recovery_roundtrip.py
@@ -1,0 +1,567 @@
+"""Regression tests for atomic, SQLite-native disaster recovery.
+
+These tests intentionally exercise FTS5, sqlite-vec, WAL frames, corrupt input,
+and pre-existing restore targets.  A backup is only useful when it can be
+restored without replaying virtual-table shadow DDL.
+"""
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from mnemosyne.dr import recovery
+from mnemosyne import cli
+
+
+SQLITE_HEADER = b"SQLite format 3\x00"
+
+
+def _load_vec(conn: sqlite3.Connection) -> None:
+    sqlite_vec = pytest.importorskip("sqlite_vec")
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+
+
+def _open(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    _load_vec(conn)
+    return conn
+
+
+def _build_feature_db(path: Path, *, keep_wal_open: bool = False):
+    """Create a small DB with ordinary, FTS5 and vec0 tables.
+
+    When ``keep_wal_open`` is true, the last committed row exists only in WAL
+    while the returned connection remains open.
+    """
+    conn = _open(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA wal_autocheckpoint=0")
+    conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, content TEXT NOT NULL)")
+    conn.execute("CREATE VIRTUAL TABLE items_fts USING fts5(content, content='items', content_rowid='id')")
+    conn.execute("CREATE VIRTUAL TABLE vec_items USING vec0(embedding float[4] distance_metric=cosine)")
+    conn.execute("CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN INSERT INTO items_fts(rowid, content) VALUES (new.id, new.content); END")
+    conn.execute("INSERT INTO items(content) VALUES ('pierwszy rekord')")
+    conn.execute("INSERT INTO vec_items(rowid, embedding) VALUES (1, '[1, 0, 0, 0]')")
+    conn.commit()
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    conn.execute("INSERT INTO items(content) VALUES ('rekord tylko w wal')")
+    conn.execute("INSERT INTO vec_items(rowid, embedding) VALUES (2, '[0, 1, 0, 0]')")
+    conn.commit()
+    if keep_wal_open:
+        return conn
+    conn.close()
+    return None
+
+
+def _decompress(backup: Path, target: Path) -> None:
+    with gzip.open(backup, "rb") as src, target.open("wb") as dst:
+        while True:
+            chunk = src.read(1024 * 1024)
+            if not chunk:
+                break
+            dst.write(chunk)
+
+
+def _logical_state(path: Path) -> dict:
+    conn = _open(path)
+    try:
+        return {
+            "quick": conn.execute("PRAGMA quick_check").fetchone()[0],
+            "integrity": conn.execute("PRAGMA integrity_check").fetchone()[0],
+            "fk": conn.execute("PRAGMA foreign_key_check").fetchall(),
+            "items": conn.execute("SELECT id, content FROM items ORDER BY id").fetchall(),
+            "fts": conn.execute("SELECT rowid FROM items_fts WHERE items_fts MATCH 'rekord' ORDER BY rowid").fetchall(),
+            "vec_count": conn.execute("SELECT COUNT(*) FROM vec_items").fetchone()[0],
+        }
+    finally:
+        conn.close()
+
+
+def test_backup_is_gzipped_binary_sqlite_and_preserves_wal_fts_vec(tmp_path):
+    source = tmp_path / "source.db"
+    writer = _build_feature_db(source, keep_wal_open=True)
+    assert writer is not None
+    try:
+        result = recovery.create_backup(source, tmp_path / "backups")
+    finally:
+        writer.close()
+
+    backup = Path(result["backup_path"])
+    unpacked = tmp_path / "unpacked.db"
+    _decompress(backup, unpacked)
+
+    assert unpacked.read_bytes().startswith(SQLITE_HEADER)
+    state = _logical_state(unpacked)
+    assert state == {
+        "quick": "ok",
+        "integrity": "ok",
+        "fk": [],
+        "items": [(1, "pierwszy rekord"), (2, "rekord tylko w wal")],
+        "fts": [(1,), (2,)],
+        "vec_count": 2,
+    }
+    assert result["format"] == "sqlite-binary-gzip-v1"
+    assert len(result["db_checksum"]) == 64
+    assert hashlib.sha256(unpacked.read_bytes()).hexdigest() == result["db_checksum"]
+
+
+def test_backup_restore_roundtrip_preserves_fts_vec_and_wal(tmp_path):
+    source = tmp_path / "source.db"
+    writer = _build_feature_db(source, keep_wal_open=True)
+    assert writer is not None
+    try:
+        result = recovery.create_backup(source, tmp_path / "backups")
+    finally:
+        writer.close()
+
+    restored = tmp_path / "restored" / "mnemosyne.db"
+    outcome = recovery.restore_backup(Path(result["backup_path"]), restored)
+
+    assert outcome["integrity_check"] is True
+    assert _logical_state(restored) == _logical_state(source)
+
+
+def test_backup_and_restore_preserve_paths_with_uri_delimiters(tmp_path):
+    source = tmp_path / "source?#.db"
+    _build_feature_db(source)
+
+    backup = Path(recovery.create_backup(source, tmp_path / "backups")["backup_path"])
+    restored = tmp_path / "restore?#" / "target?#.db"
+    outcome = recovery.restore_backup(backup, restored)
+
+    assert outcome["integrity_check"] is True
+    assert _logical_state(restored) == _logical_state(source)
+
+
+def test_legacy_sql_dump_backup_remains_discoverable(tmp_path, monkeypatch):
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    backup = backup_dir / "mnemosyne_backup_20260701_120000.db.gz"
+    sql = "BEGIN TRANSACTION;\nCREATE TABLE marker(value TEXT);\nCOMMIT;\n"
+    with gzip.open(backup, "wb") as handle:
+        handle.write(sql.encode("utf-8"))
+    metadata = {
+        "timestamp": "20260701_120000",
+        "original_size": len(sql),
+        "backup_size": backup.stat().st_size,
+        "backup_checksum": hashlib.sha256(backup.read_bytes()).hexdigest()[:16],
+        "compressed": True,
+    }
+    backup.with_suffix(".gz.json").write_text(json.dumps(metadata))
+
+    listed = recovery.list_backups(backup_dir)
+    assert len(listed) == 1
+    assert listed[0]["metadata"]["format"] == "legacy-sql-dump-gzip"
+
+    database = tmp_path / "mnemosyne.db"
+    sqlite3.connect(database).close()
+    monkeypatch.setattr(
+        recovery,
+        "get_default_paths",
+        lambda: (tmp_path, backup_dir, database),
+    )
+    assert recovery.health_check()["backups"]["total"] == 1
+
+
+def test_corrupt_backup_never_replaces_existing_target(tmp_path):
+    target = tmp_path / "target.db"
+    conn = sqlite3.connect(target)
+    conn.execute("CREATE TABLE marker(value TEXT NOT NULL)")
+    conn.execute("INSERT INTO marker VALUES ('original')")
+    conn.commit()
+    conn.close()
+    before = hashlib.sha256(target.read_bytes()).hexdigest()
+
+    corrupt = tmp_path / "broken.db.gz"
+    with gzip.GzipFile(filename=str(corrupt), mode="wb") as f:
+        f.write(b"not a sqlite database")
+
+    with pytest.raises((sqlite3.DatabaseError, ValueError, RuntimeError)):
+        recovery.restore_backup(corrupt, target)
+
+    assert hashlib.sha256(target.read_bytes()).hexdigest() == before
+    conn = sqlite3.connect(target)
+    try:
+        assert conn.execute("SELECT value FROM marker").fetchone()[0] == "original"
+    finally:
+        conn.close()
+
+
+def test_emergency_backup_includes_existing_targets_wal(tmp_path):
+    source = tmp_path / "source.db"
+    _build_feature_db(source)
+    result = recovery.create_backup(source, tmp_path / "backups")
+
+    target = tmp_path / "target.db"
+    conn = sqlite3.connect(target)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA wal_autocheckpoint=0")
+    conn.execute("CREATE TABLE marker(value TEXT NOT NULL)")
+    conn.commit()
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    conn.execute("INSERT INTO marker VALUES ('committed only in wal')")
+    conn.commit()
+    try:
+        recovery.restore_backup(Path(result["backup_path"]), target)
+    finally:
+        conn.close()
+
+    emergency = target.with_suffix(".emergency_backup.db")
+    assert emergency.exists()
+    check = sqlite3.connect(emergency)
+    try:
+        assert check.execute("SELECT value FROM marker").fetchone()[0] == "committed only in wal"
+    finally:
+        check.close()
+
+
+def test_restore_keeps_active_connections_on_the_restored_database(tmp_path):
+    source = tmp_path / "source.db"
+    _build_feature_db(source)
+    result = recovery.create_backup(source, tmp_path / "backups")
+
+    target = tmp_path / "target.db"
+    active = sqlite3.connect(target)
+    active.execute("PRAGMA journal_mode=WAL")
+    active.execute("CREATE TABLE old_marker(value TEXT)")
+    active.commit()
+    try:
+        recovery.restore_backup(Path(result["backup_path"]), target)
+        active.execute("CREATE TABLE post_restore(value TEXT)")
+        active.execute("INSERT INTO post_restore VALUES ('visible')")
+        active.commit()
+
+        fresh = _open(target)
+        try:
+            assert fresh.execute("SELECT COUNT(*) FROM items").fetchone()[0] == 2
+            assert fresh.execute("SELECT value FROM post_restore").fetchone()[0] == "visible"
+        finally:
+            fresh.close()
+    finally:
+        active.close()
+
+
+def test_verify_integrity_rejects_external_content_fts_mismatch(tmp_path):
+    db = tmp_path / "fts-mismatch.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, content TEXT NOT NULL)")
+    conn.execute(
+        "CREATE VIRTUAL TABLE items_fts USING "
+        "fts5(content, content='items', content_rowid='id')"
+    )
+    conn.executemany("INSERT INTO items(content) VALUES (?)", [("alpha",), ("beta",)])
+    conn.execute("INSERT INTO items_fts(items_fts) VALUES ('rebuild')")
+    conn.commit()
+    conn.execute(
+        "INSERT INTO items_fts(items_fts, rowid, content) "
+        "VALUES ('delete', 2, 'beta')"
+    )
+    conn.commit()
+    assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    conn.close()
+
+    assert recovery.verify_integrity(db) is False
+
+
+def test_verify_integrity_rejects_orphaned_mnemosyne_vec_row(tmp_path):
+    db = tmp_path / "vec-orphan.db"
+    conn = _open(db)
+    conn.execute("CREATE TABLE episodic_memory(id TEXT)")
+    conn.execute("CREATE VIRTUAL TABLE vec_episodes USING vec0(embedding float[4])")
+    conn.execute("INSERT INTO vec_episodes(rowid, embedding) VALUES (1, '[1,0,0,0]')")
+    conn.commit()
+    assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    conn.close()
+
+    assert recovery.verify_integrity(db) is False
+
+
+def test_two_backups_created_in_same_second_do_not_overwrite(tmp_path, monkeypatch):
+    source = tmp_path / "source.db"
+    conn = sqlite3.connect(source)
+    conn.execute("CREATE TABLE marker(value TEXT)")
+    conn.commit()
+    conn.close()
+
+    class FrozenDateTime:
+        @classmethod
+        def now(cls):
+            from datetime import datetime
+            return datetime(2026, 7, 14, 12, 0, 0)
+
+    monkeypatch.setattr(recovery, "datetime", FrozenDateTime)
+    first = recovery.create_backup(source, tmp_path / "backups")
+    second = recovery.create_backup(source, tmp_path / "backups")
+
+    assert first["backup_path"] != second["backup_path"]
+    assert Path(first["backup_path"]).exists()
+    assert Path(second["backup_path"]).exists()
+
+
+def test_metadata_matches_binary_snapshot_not_live_db_file(tmp_path):
+    source = tmp_path / "source.db"
+    writer = _build_feature_db(source, keep_wal_open=True)
+    assert writer is not None
+    try:
+        result = recovery.create_backup(source, tmp_path / "backups")
+    finally:
+        writer.close()
+
+    backup = Path(result["backup_path"])
+    metadata = json.loads(Path(result["metadata_path"]).read_text())
+    unpacked = tmp_path / "snapshot.db"
+    _decompress(backup, unpacked)
+
+    assert metadata["db_checksum"] == hashlib.sha256(unpacked.read_bytes()).hexdigest()
+    assert metadata["backup_checksum"] == hashlib.sha256(backup.read_bytes()).hexdigest()
+    assert metadata["format"] == "sqlite-binary-gzip-v1"
+
+
+def test_restore_cli_accepts_explicit_target(tmp_path, monkeypatch, capsys):
+    backup = tmp_path / "backup.db.gz"
+    backup.write_bytes(b"placeholder")
+    target = tmp_path / "isolated" / "mnemosyne.db"
+    restore = Mock(return_value={
+        "backup_used": str(backup),
+        "database_path": str(target),
+        "integrity_check": True,
+    })
+    monkeypatch.setattr(recovery, "restore_backup", restore)
+
+    cli.cmd_restore([str(backup), "--target", str(target)])
+
+    restore.assert_called_once_with(backup, target)
+    assert str(target) in capsys.readouterr().out
+
+
+def test_restore_transfer_failure_rolls_back_existing_target(tmp_path, monkeypatch):
+    source = tmp_path / "source.db"
+    _build_feature_db(source)
+    result = recovery.create_backup(source, tmp_path / "backups")
+
+    target = tmp_path / "target.db"
+    conn = sqlite3.connect(target)
+    conn.execute("CREATE TABLE marker(value TEXT)")
+    conn.execute("INSERT INTO marker VALUES ('do not replace')")
+    conn.commit()
+    conn.close()
+    real_restore = recovery._restore_snapshot
+    target_attempts = 0
+
+    def fail_first_target_restore(source_path, destination_path):
+        nonlocal target_attempts
+        if Path(destination_path) == target:
+            target_attempts += 1
+            if target_attempts == 1:
+                raise OSError("simulated SQLite restore failure")
+        return real_restore(Path(source_path), Path(destination_path))
+
+    monkeypatch.setattr(recovery, "_restore_snapshot", fail_first_target_restore)
+    with pytest.raises(OSError, match="simulated SQLite restore failure"):
+        recovery.restore_backup(Path(result["backup_path"]), target)
+
+    check = sqlite3.connect(target)
+    try:
+        assert check.execute("SELECT value FROM marker").fetchone()[0] == "do not replace"
+    finally:
+        check.close()
+    assert target_attempts == 2
+
+
+def test_failed_final_verification_rolls_back_existing_target(tmp_path, monkeypatch):
+    source = tmp_path / "source.db"
+    _build_feature_db(source)
+    result = recovery.create_backup(source, tmp_path / "backups")
+
+    target = tmp_path / "target.db"
+    conn = sqlite3.connect(target)
+    conn.execute("CREATE TABLE marker(value TEXT)")
+    conn.execute("INSERT INTO marker VALUES ('rollback me')")
+    conn.commit()
+    conn.close()
+
+    real_verify = recovery.verify_integrity
+    target_checks = 0
+
+    def fail_first_target_check(path=None):
+        nonlocal target_checks
+        assert path is not None
+        if Path(path) == target:
+            target_checks += 1
+            if target_checks == 1:
+                return False
+        return real_verify(path)
+
+    monkeypatch.setattr(recovery, "verify_integrity", fail_first_target_check)
+    with pytest.raises(RuntimeError, match="final integrity verification"):
+        recovery.restore_backup(Path(result["backup_path"]), target)
+
+    check = sqlite3.connect(target)
+    try:
+        assert check.execute("SELECT value FROM marker").fetchone()[0] == "rollback me"
+    finally:
+        check.close()
+    assert target_checks >= 2
+
+
+def test_keyboard_interrupt_during_final_verification_rolls_back_existing_target(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "source.db"
+    _build_feature_db(source)
+    result = recovery.create_backup(source, tmp_path / "backups")
+    target = tmp_path / "target.db"
+    conn = sqlite3.connect(target)
+    conn.execute("CREATE TABLE marker(value TEXT)")
+    conn.execute("INSERT INTO marker VALUES ('original')")
+    conn.commit()
+    conn.close()
+    real_verify = recovery.verify_integrity
+    target_checks = 0
+
+    def interrupt_first_target_check(path=None):
+        nonlocal target_checks
+        assert path is not None
+        if Path(path) == target:
+            target_checks += 1
+            if target_checks == 1:
+                raise KeyboardInterrupt("final verification interrupted")
+        return real_verify(path)
+
+    monkeypatch.setattr(recovery, "verify_integrity", interrupt_first_target_check)
+    with pytest.raises(KeyboardInterrupt, match="final verification interrupted"):
+        recovery.restore_backup(Path(result["backup_path"]), target)
+
+    check = sqlite3.connect(target)
+    try:
+        assert check.execute("SELECT value FROM marker").fetchone()[0] == "original"
+    finally:
+        check.close()
+    assert target_checks >= 2
+
+
+def test_system_exit_during_final_verification_removes_new_target(tmp_path, monkeypatch):
+    source = tmp_path / "source.db"
+    _build_feature_db(source)
+    result = recovery.create_backup(source, tmp_path / "backups")
+    target = tmp_path / "new-target.db"
+    real_verify = recovery.verify_integrity
+
+    def interrupt_target_check(path=None):
+        assert path is not None
+        if Path(path) == target:
+            raise SystemExit("final verification interrupted")
+        return real_verify(path)
+
+    monkeypatch.setattr(recovery, "verify_integrity", interrupt_target_check)
+    with pytest.raises(SystemExit, match="final verification interrupted"):
+        recovery.restore_backup(Path(result["backup_path"]), target)
+
+    assert not target.exists()
+    assert not Path(f"{target}-wal").exists()
+    assert not Path(f"{target}-shm").exists()
+
+
+def test_backup_metadata_survives_source_disappearing_after_archive_publication(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "source.db"
+    conn = sqlite3.connect(source)
+    conn.execute("CREATE TABLE marker(value TEXT)")
+    conn.commit()
+    conn.close()
+    source_size = source.stat().st_size
+    real_replace = recovery.os.replace
+
+    def remove_source_after_archive_publish(src, dst):
+        real_replace(src, dst)
+        if Path(dst).suffix == ".gz":
+            source.unlink()
+
+    monkeypatch.setattr(recovery.os, "replace", remove_source_after_archive_publish)
+    result = recovery.create_backup(source, tmp_path / "backups")
+
+    assert result["source_file_size"] == source_size
+    assert Path(result["backup_path"]).exists()
+    assert Path(result["metadata_path"]).exists()
+
+
+def test_metadata_interrupt_removes_published_backup_pair(tmp_path, monkeypatch):
+    source = tmp_path / "source.db"
+    conn = sqlite3.connect(source)
+    conn.execute("CREATE TABLE marker(value TEXT)")
+    conn.commit()
+    conn.close()
+    backup_dir = tmp_path / "backups"
+
+    def interrupt(_path, _metadata):
+        raise KeyboardInterrupt("metadata interrupted")
+
+    monkeypatch.setattr(recovery, "_atomic_json", interrupt)
+    with pytest.raises(KeyboardInterrupt, match="metadata interrupted"):
+        recovery.create_backup(source, backup_dir)
+
+    assert list(backup_dir.glob("*.db.gz")) == []
+    assert list(backup_dir.glob("*.json")) == []
+
+
+def test_archive_is_the_last_publication_marker(tmp_path, monkeypatch):
+    source = tmp_path / "source.db"
+    _build_feature_db(source)
+    backup_dir = tmp_path / "backups"
+    real_replace = recovery.os.replace
+    observed_window = False
+
+    def inspect_before_archive_publish(src, dst):
+        nonlocal observed_window
+        destination = Path(dst)
+        if destination.name.endswith(".db.gz"):
+            observed_window = True
+            metadata = destination.with_suffix(".gz.json")
+            assert metadata.exists()
+            assert recovery.list_backups(backup_dir) == []
+            with pytest.raises(FileNotFoundError):
+                recovery.restore_backup(destination, tmp_path / "must-not-exist.db")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(recovery.os, "replace", inspect_before_archive_publish)
+    result = recovery.create_backup(source, backup_dir)
+
+    assert observed_window is True
+    assert len(recovery.list_backups(backup_dir)) == 1
+    assert Path(result["backup_path"]).exists()
+    assert Path(result["metadata_path"]).exists()
+
+
+def test_binary_backup_without_metadata_is_hidden_and_restore_fails_closed(tmp_path):
+    source = tmp_path / "source.db"
+    _build_feature_db(source)
+    backup_dir = tmp_path / "backups"
+    result = recovery.create_backup(source, backup_dir)
+    Path(result["metadata_path"]).unlink()
+
+    assert recovery.list_backups(backup_dir) == []
+    with pytest.raises(ValueError, match="metadata"):
+        recovery.restore_backup(Path(result["backup_path"]), tmp_path / "target.db")
+
+
+def test_backup_with_invalid_checksum_is_hidden_and_restore_fails_closed(tmp_path):
+    source = tmp_path / "source.db"
+    _build_feature_db(source)
+    backup_dir = tmp_path / "backups"
+    result = recovery.create_backup(source, backup_dir)
+    metadata_path = Path(result["metadata_path"])
+    metadata = json.loads(metadata_path.read_text())
+    metadata["backup_checksum"] = "0" * 64
+    metadata_path.write_text(json.dumps(metadata))
+
+    assert recovery.list_backups(backup_dir) == []
+    with pytest.raises(ValueError, match="checksum"):
+        recovery.restore_backup(Path(result["backup_path"]), tmp_path / "target.db")

--- a/tests/test_recovery_paths.py
+++ b/tests/test_recovery_paths.py
@@ -53,13 +53,10 @@ def test_get_default_paths_data_dir_takes_precedence_over_hermes_home(monkeypatc
 
 
 def test_create_backup_succeeds_with_sqlite_vec_tables(tmp_path):
-    """Regression: create_backup() must load sqlite-vec on the source AND
-    destination connections, otherwise sqlite3.Connection.backup() and
-    Connection.iterdump() both fail with ``no such module: vec0`` on
-    databases that use vec0 virtual tables.
+    """The binary snapshot must remain queryable with sqlite-vec loaded.
 
-    Pre-fix: this test fails with ``sqlite3.OperationalError: no such
-    module: vec0`` raised from inside the backup serialization path.
+    A SQL dump is not a valid recovery format for vec0/FTS shadow tables;
+    decompress the native SQLite file and exercise the virtual table instead.
     """
     pytest.importorskip("sqlite_vec")
 
@@ -85,12 +82,20 @@ def test_create_backup_succeeds_with_sqlite_vec_tables(tmp_path):
     # raised sqlite3.OperationalError: no such module: vec0.
     result = recovery.create_backup(db_path=db_path, backup_dir=backup_dir)
 
-    # Assert: backup file exists, is non-empty, gzipped, and the gz
-    # contents contain the vec0 table definition.
+    # Assert: backup file exists, is non-empty and decompresses to a native
+    # SQLite database whose vec0 table can be queried.
     assert Path(result["backup_path"]).exists()
     assert result["backup_size"] > 0
     import gzip
-    with gzip.open(result["backup_path"], "rt") as f:
-        dump = f.read()
-    assert "vec_items" in dump
-    assert "CREATE VIRTUAL TABLE" in dump
+    restored = tmp_path / "snapshot.db"
+    with gzip.open(result["backup_path"], "rb") as source, restored.open("wb") as target:
+        target.write(source.read())
+    assert restored.read_bytes().startswith(b"SQLite format 3\x00")
+    check = sqlite3.connect(str(restored))
+    check.enable_load_extension(True)
+    sqlite_vec.load(check)
+    try:
+        assert check.execute("SELECT COUNT(*) FROM vec_items").fetchone()[0] == 0
+        assert check.execute("SELECT COUNT(*) FROM meta").fetchone()[0] == 2
+    finally:
+        check.close()


### PR DESCRIPTION
## Summary
- create WAL-aware binary SQLite backup snapshots with validation metadata and checksums
- publish archives atomically and restore in place with fail-closed rollback
- preserve legacy SQL-dump backup discovery and use URI-safe database paths

## Validation
- disaster-recovery suites: 26 passed
- related CLI error/usage suites: 13 passed
- expanded DR/CLI gate: 39 passed
- independent review: PASS

Related to #69.

## Status
Draft for maintainer review; not intended for merge yet.