### PR TITLE
fix: preserve atomic sqlite-vec batch rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Atomic batch and sqlite-vec transactions.** Deferred vector writes now
+  respect the enclosing transaction, while transaction guards reset state and
+  roll back cleanly across exceptions, cancellation, and interrupted commits.
+
 - **Hermes provider safety defaults after config bridging.** New auto-seeded
   configs now preserve user-only autosave and skip `cron`, `flush`, `subagent`,
   `background`, and `skill_loop` contexts. Existing 3.12.1/3.12.2 auto-seeded

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.13.0"
+__version__ = "3.14.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1262,11 +1262,15 @@ def _guarded_transaction(conn: sqlite3.Connection):
     try:
         yield
         conn.commit()
-    except Exception:
+    except BaseException:
         try:
             conn.rollback()
-        except sqlite3.Error:
-            pass  # rollback of a dead connection must not mask the cause
+        except BaseException:
+            logger.error(
+                "_guarded_transaction: rollback failed while preserving "
+                "the original exception",
+                exc_info=True,
+            )
         raise
 
 
@@ -1299,18 +1303,22 @@ def _deferred_commits(conn: sqlite3.Connection):
     conn._defer_commit = True
     try:
         yield
-    except Exception:
+    except BaseException:
         conn._defer_commit = False
         try:
             conn.rollback()
-        except sqlite3.Error:
-            pass
+        except BaseException:
+            logger.error(
+                "_deferred_commits: rollback failed while preserving "
+                "the original exception",
+                exc_info=True,
+            )
         raise
     else:
         conn._defer_commit = False
         try:
             conn._real_commit()
-        except sqlite3.Error as exc:
+        except BaseException as exc:
             logger.error(
                 "_deferred_commits: final commit failed: %s; "
                 "rolling back the buffered transaction",
@@ -1318,8 +1326,12 @@ def _deferred_commits(conn: sqlite3.Connection):
             )
             try:
                 conn.rollback()
-            except sqlite3.Error:
-                pass
+            except BaseException:
+                logger.error(
+                    "_deferred_commits: rollback after final commit failure "
+                    "also failed",
+                    exc_info=True,
+                )
             raise
     finally:
         # Defense in depth: clear the flag on any control-flow path.
@@ -2134,15 +2146,12 @@ def _vec_table_insert(conn: sqlite3.Connection, table: str, rowid: int, embeddin
             f"INSERT INTO {table}(rowid, embedding) VALUES (?, ?)",
             (rowid, emb_json)
         )
-    # Ensure the insert is committed even when the caller's connection
-    # has _defer_commit=True (_BeamConnection). Without this, inserts
-    # sit in the deferred transaction and disappear if the caller
-    # later rolls back or the connection is reused in a different context.
+    # Use the public commit path so an enclosing _deferred_commits() scope
+    # remains atomic. _BeamConnection.commit() commits immediately outside
+    # such a scope and deliberately becomes a no-op inside it; bypassing that
+    # contract with _real_commit() would make a later batch rollback partial.
     if commit:
-        if isinstance(conn, _BeamConnection):
-            conn._real_commit()
-        else:
-            conn.commit()
+        conn.commit()
 
 
 def _wm_rowid(conn: sqlite3.Connection, memory_id: str) -> Optional[int]:

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -119,6 +119,162 @@ def _require_vec_working(conn):
         pytest.skip("sqlite-vec vec_working table unavailable")
 
 
+def test_vec_insert_commit_respects_deferred_transaction_rollback(temp_db):
+    beam = BeamMemory(session_id="vec-deferred-rollback", db_path=temp_db)
+    _require_vec_working(beam.conn)
+    memory_id = "vec-deferred"
+    rowid = None
+
+    with pytest.raises(RuntimeError, match="rollback vec transaction"):
+        with beam_module._deferred_commits(beam.conn):
+            cursor = beam.conn.execute(
+                "INSERT INTO working_memory "
+                "(id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+                (
+                    memory_id,
+                    "must roll back with vector",
+                    "test",
+                    datetime.now().isoformat(),
+                    beam.session_id,
+                ),
+            )
+            inserted_rowid = cursor.lastrowid
+            assert inserted_rowid is not None
+            rowid = int(inserted_rowid)
+            beam_module._vec_table_insert(
+                beam.conn,
+                "vec_working",
+                rowid,
+                _unit_embedding(),
+                commit=True,
+            )
+            raise RuntimeError("rollback vec transaction")
+
+    assert rowid is not None
+    assert beam.conn.execute(
+        "SELECT COUNT(*) FROM working_memory WHERE id = ?", (memory_id,)
+    ).fetchone()[0] == 0
+    assert beam.conn.execute(
+        "SELECT COUNT(*) FROM vec_working WHERE rowid = ?", (rowid,)
+    ).fetchone()[0] == 0
+
+
+def test_guarded_transaction_rolls_back_keyboard_interrupt(temp_db):
+    beam = BeamMemory(session_id="guarded-interrupt", db_path=temp_db)
+
+    with pytest.raises(KeyboardInterrupt, match="guarded interrupted"):
+        with beam_module._guarded_transaction(beam.conn):
+            beam.conn.execute(
+                "INSERT INTO working_memory "
+                "(id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+                (
+                    "guarded-interrupt",
+                    "must roll back",
+                    "test",
+                    datetime.now().isoformat(),
+                    beam.session_id,
+                ),
+            )
+            raise KeyboardInterrupt("guarded interrupted")
+
+    assert beam.conn.in_transaction is False
+    assert beam.conn.execute(
+        "SELECT COUNT(*) FROM working_memory WHERE id = 'guarded-interrupt'"
+    ).fetchone()[0] == 0
+
+
+def test_deferred_commits_resets_flag_and_rolls_back_system_exit(temp_db):
+    beam = BeamMemory(session_id="deferred-interrupt", db_path=temp_db)
+
+    with pytest.raises(SystemExit, match="deferred interrupted"):
+        with beam_module._deferred_commits(beam.conn):
+            beam.conn.execute(
+                "INSERT INTO working_memory "
+                "(id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+                (
+                    "deferred-interrupt",
+                    "must roll back",
+                    "test",
+                    datetime.now().isoformat(),
+                    beam.session_id,
+                ),
+            )
+            beam.conn.commit()
+            assert getattr(beam.conn, "_defer_commit") is True
+            raise SystemExit("deferred interrupted")
+
+    assert getattr(beam.conn, "_defer_commit") is False
+    assert beam.conn.in_transaction is False
+    assert beam.conn.execute(
+        "SELECT COUNT(*) FROM working_memory WHERE id = 'deferred-interrupt'"
+    ).fetchone()[0] == 0
+
+
+@pytest.mark.parametrize(
+    "interruption",
+    [KeyboardInterrupt("commit interrupted"), SystemExit("commit interrupted")],
+    ids=["keyboard-interrupt", "system-exit"],
+)
+def test_deferred_commits_rolls_back_interrupted_final_commit(
+    temp_db, monkeypatch, interruption
+):
+    beam = BeamMemory(session_id="deferred-final-commit", db_path=temp_db)
+    original_real_commit = getattr(beam.conn, "_real_commit")
+
+    def interrupt_final_commit():
+        raise interruption
+
+    monkeypatch.setattr(beam.conn, "_real_commit", interrupt_final_commit)
+    with pytest.raises(type(interruption), match="commit interrupted"):
+        with beam_module._deferred_commits(beam.conn):
+            beam.conn.execute(
+                "INSERT INTO working_memory "
+                "(id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+                (
+                    "interrupted-final-commit",
+                    "must never be published",
+                    "test",
+                    datetime.now().isoformat(),
+                    beam.session_id,
+                ),
+            )
+
+    assert getattr(beam.conn, "_defer_commit") is False
+    assert beam.conn.in_transaction is False
+    monkeypatch.setattr(beam.conn, "_real_commit", original_real_commit)
+    beam.conn.commit()
+
+    fresh = sqlite3.connect(temp_db)
+    try:
+        assert fresh.execute(
+            "SELECT COUNT(*) FROM working_memory "
+            "WHERE id = 'interrupted-final-commit'"
+        ).fetchone()[0] == 0
+    finally:
+        fresh.close()
+
+
+@pytest.mark.parametrize(
+    "transaction_guard",
+    [beam_module._guarded_transaction, beam_module._deferred_commits],
+    ids=["guarded-transaction", "deferred-commits"],
+)
+def test_transaction_guard_preserves_body_interrupt_when_rollback_is_interrupted(
+    temp_db, monkeypatch, transaction_guard
+):
+    beam = BeamMemory(session_id="rollback-interrupt", db_path=temp_db)
+
+    def interrupt_rollback():
+        raise SystemExit("rollback interrupted")
+
+    monkeypatch.setattr(beam.conn, "rollback", interrupt_rollback)
+    with pytest.raises(KeyboardInterrupt, match="body interrupted"):
+        with transaction_guard(beam.conn):
+            raise KeyboardInterrupt("body interrupted")
+
+    assert getattr(beam.conn, "_defer_commit") is False
+
+
 def test_remember_update_and_forget_maintain_vec_working(temp_db, monkeypatch):
     beam = BeamMemory(session_id="vec-working-session", db_path=temp_db)
     _require_vec_working(beam.conn)


### PR DESCRIPTION
## Summary
- keep sqlite-vec writes inside deferred batch transactions
- reset deferred transaction state and roll back safely across BaseException paths
- preserve the original exception if rollback also fails

## Validation
- focused transaction/vector tests: 7 passed
- independent review: PASS

## Status
Draft for maintainer review; not intended for merge yet.