### PR TITLE
fix: calibrate polyphonic recall admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Calibrated hybrid recall.** Dense scores now use backend-correct geometry,
+  vector-only results require calibrated top-1 confidence and margin, Polish
+  question glue no longer creates lexical relevance, full content is returned
+  unless truncation is explicitly requested, and fact FTS updates stay synchronized.
+
 - **Hermes provider safety defaults after config bridging.** New auto-seeded
   configs now preserve user-only autosave and skip `cron`, `flush`, `subagent`,
   `background`, and `skill_loop` contexts. Existing 3.12.1/3.12.2 auto-seeded

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -260,6 +260,7 @@ def _prefetch_topic_signal(row: Dict[str, Any]) -> float:
         float(row.get("keyword_score") or 0.0),
         float(row.get("fts_score") or 0.0),
         float(row.get("dense_score") or 0.0),
+        float(row.get("topic_signal") or 0.0),
     )
     # Fact/entity matches are explicit relevance signals even when recall() did
     # not fill keyword/FTS scores for that path.

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -321,6 +321,7 @@ def _prefetch_topic_signal(row: Dict[str, Any]) -> float:
         float(row.get("keyword_score") or 0.0),
         float(row.get("fts_score") or 0.0),
         float(row.get("dense_score") or 0.0),
+        float(row.get("topic_signal") or 0.0),
     )
     if row.get("fact_match") or row.get("entity_match"):
         signal = max(signal, 0.20)

--- a/integrations/hermes/tests/test_polyphonic_topic_signal.py
+++ b/integrations/hermes/tests/test_polyphonic_topic_signal.py
@@ -1,0 +1,28 @@
+"""Polyphonic-to-provider topical signal contract."""
+from __future__ import annotations
+
+from mnemosyne.core.polyphonic_recall import PolyphonicRecallEngine, RecallResult
+from mnemosyne_hermes import _prefetch_topic_signal
+
+
+def test_combine_voices_preserves_raw_per_voice_scores():
+    engine = object.__new__(PolyphonicRecallEngine)
+    combined = engine._combine_voices(
+        [RecallResult(memory_id="m1", score=0.82, voice="vector", metadata={})],
+        [RecallResult(memory_id="m1", score=0.61, voice="fact", metadata={})],
+    )
+
+    assert combined["m1"].metadata["raw_voice_scores"] == {
+        "vector": 0.82,
+        "fact": 0.61,
+    }
+
+
+def test_provider_prefetch_uses_explicit_topic_signal():
+    assert _prefetch_topic_signal({
+        "score": 0.04,
+        "keyword_score": 0.0,
+        "fts_score": 0.0,
+        "dense_score": 0.0,
+        "topic_signal": 0.73,
+    }) == 0.73

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.13.0"
+__version__ = "3.14.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -26,7 +26,7 @@ import math
 
 logger = logging.getLogger(__name__)
 from datetime import datetime, timedelta, timezone
-from typing import List, Dict, Optional, Any, Set, Union, Tuple
+from typing import List, Dict, Optional, Any, Set, Union, Tuple, Callable
 from pathlib import Path
 
 
@@ -1174,6 +1174,14 @@ def init_beam(db_path: Path = None):
             VALUES ('delete', old.rowid, old.subject, old.predicate, old.object);
         END
     """)
+    cursor.execute("""
+        CREATE TRIGGER IF NOT EXISTS facts_au AFTER UPDATE ON facts BEGIN
+            INSERT INTO fts_facts(fts_facts, rowid, subject, predicate, object)
+            VALUES ('delete', old.rowid, old.subject, old.predicate, old.object);
+            INSERT INTO fts_facts(rowid, subject, predicate, object)
+            VALUES (new.rowid, new.subject, new.predicate, new.object);
+        END
+    """)
 
     # Vector table for facts (sqlite-vec). Skipped on a dimension mismatch for the
     # same reason as vec_episodes / vec_working above (see the guard in the
@@ -1668,6 +1676,11 @@ _FACT_MATCH_STOPWORDS: Set[str] = {
     # to them" to fact-match unrelated policies via overlaps such as "not/they".
     "again", "into", "not", "please", "somewhere", "supposed", "them", "then",
     "they", "whatever",
+    # Polish conversational/question glue.  These were calibrated against the
+    # multilingual regression harness after a negative WiFi question matched
+    # unrelated memories through only "jest"/"dla".  Keep domain nouns out.
+    "czy", "dla", "dokąd", "gdzie", "ile", "jak", "jaka", "jaki", "jakie", "jaką",
+    "jest", "kiedy", "kto", "która", "które", "którego", "który", "oraz", "przy", "się",
     # Query/meta words describe the retrieval act, not the user's target.
     # Deployments can extend these with MNEMOSYNE_RECALL_EXTRA_STOPWORDS
     # instead of patching source for local corpora.
@@ -2092,9 +2105,9 @@ def _effective_vec_type(conn: sqlite3.Connection, table: str = "vec_episodes") -
     return "float32"
 
 
-def _vec_insert(conn: sqlite3.Connection, rowid: int, embedding: List[float]):
+def _vec_insert(conn: sqlite3.Connection, rowid: int, embedding: List[float], *, commit: bool = True):
     """Insert embedding into the episodic sqlite-vec table."""
-    _vec_table_insert(conn, "vec_episodes", rowid, embedding)
+    _vec_table_insert(conn, "vec_episodes", rowid, embedding, commit=commit)
 
 
 def _vec_table_insert(conn: sqlite3.Connection, table: str, rowid: int, embedding: List[float], *, commit: bool = True):
@@ -2817,6 +2830,106 @@ def _wm_vec_search(conn: sqlite3.Connection, query_embedding, k: int = 20,
                                    where_params=where_params)
 
 
+def _vec_distance_to_similarity(distance: float, vec_type: str) -> float:
+    """Convert sqlite-vec distance to a bounded cosine-like similarity.
+
+    float32 vectors are normalized on insert/query, so Euclidean distance ``d``
+    has the exact relation ``cosine = 1 - d²/2``.  Bit vectors report Hamming
+    distance.  Keep the historical bounded int8 scaling until sqlite-vec exposes
+    a stable dequantized metric contract for that backend.
+    """
+    d = max(float(distance), 0.0)
+    if vec_type == "float32":
+        similarity = 1.0 - ((d * d) / 2.0)
+    elif vec_type == "bit":
+        similarity = 1.0 - (d / max(float(EMBEDDING_DIM), 1.0))
+    else:
+        similarity = 1.0 - (d / max(2.0 * float(EMBEDDING_DIM), 1.0))
+    return max(0.0, min(1.0, similarity))
+
+
+def _cosine_distance_to_similarity(distance: float) -> float:
+    """Convert the in-memory fallback's ``1 - cosine`` distance."""
+    return max(0.0, min(1.0, 1.0 - float(distance)))
+
+
+def _admit_vector_only(
+    memory_id: str,
+    ranked: List[Dict[str, Any]],
+    *,
+    env_prefix: str,
+    label: str,
+) -> bool:
+    """Admit one strong, unambiguous semantic hit without lexical overlap.
+
+    The defaults are calibrated against the checked-in Polish multilingual-e5
+    harness: the weakest positive is 0.8126 and the strongest negative is
+    0.8006.  Only vector top-1 can pass; with multiple candidates it must also
+    have a minimum lead over the runner-up.
+    """
+    if not ranked or ranked[0].get("id") != memory_id:
+        return False
+    try:
+        min_sim = float(os.environ.get(f"{env_prefix}_MIN_SIM", "0.81"))
+        min_margin = float(os.environ.get(f"{env_prefix}_MIN_MARGIN", "0.02"))
+    except ValueError:
+        logger.warning("Invalid %s vector-only threshold; using safe defaults", label)
+        min_sim, min_margin = 0.81, 0.02
+    top_sim = float(ranked[0].get("sim") or 0.0)
+    if top_sim < min_sim:
+        return False
+    if len(ranked) > 1:
+        runner_up = float(ranked[1].get("sim") or 0.0)
+        if top_sim - runner_up < min_margin:
+            return False
+    return True
+
+
+def _admit_wm_vector_only(memory_id: str, ranked: List[Dict[str, Any]]) -> bool:
+    return _admit_vector_only(
+        memory_id,
+        ranked,
+        env_prefix="MNEMOSYNE_WM_VECTOR_ONLY",
+        label="WM",
+    )
+
+
+def _admit_ep_vector_only(memory_id: str, ranked: List[Dict[str, Any]]) -> bool:
+    return _admit_vector_only(
+        memory_id,
+        ranked,
+        env_prefix="MNEMOSYNE_EP_VECTOR_ONLY",
+        label="episodic",
+    )
+
+
+def _admit_poly_vector_only(memory_id: str, ranked: List[Dict[str, Any]]) -> bool:
+    return _admit_vector_only(
+        memory_id,
+        ranked,
+        env_prefix="MNEMOSYNE_POLY_VECTOR_ONLY",
+        label="Polyphonic",
+    )
+
+
+def _recall_content_char_limit() -> int:
+    """Return recall result content limit; ``0`` means full content."""
+    raw = os.environ.get("MNEMOSYNE_RECALL_CONTENT_CHARS", "0").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning(
+            "Invalid MNEMOSYNE_RECALL_CONTENT_CHARS=%r; disabling recall truncation",
+            raw,
+        )
+        return 0
+
+
+def _format_recall_content(content: str) -> str:
+    limit = _recall_content_char_limit()
+    return content[:limit] if limit > 0 else content
+
+
 def _wm_vec_search_sqlite(conn: sqlite3.Connection, query_embedding, k: int = 20,
                           *, where_sql: str,
                           where_params: Tuple[Any, ...] = ()) -> List[Dict]:
@@ -2868,12 +2981,7 @@ def _wm_vec_search_sqlite(conn: sqlite3.Connection, query_embedding, k: int = 20
     results = []
     for row in rows:
         distance = float(row["distance"])
-        # Keep the existing caller contract: larger sim is better and roughly
-        # cosine-like. sqlite-vec reports a distance whose raw scale differs
-        # by backend/vector type; divide by dimensionality before bounding so
-        # the vector voice remains comparable to the memory_embeddings cosine
-        # fallback instead of collapsing to ~0 on high-dimensional vectors.
-        sim = max(0.0, min(1.0, 1.0 - (max(distance, 0.0) / (2.0 * EMBEDDING_DIM))))
+        sim = _vec_distance_to_similarity(distance, vec_type)
         results.append({"id": row["id"], "sim": sim})
     return results[:k]
 
@@ -5632,6 +5740,7 @@ class BeamMemory:
 
         # ---- Working memory (vector search) ----
         wm_vec_sims = {}
+        wm_vec = []
         if embeddings_available:
             try:
                 emb_result = _get_query_embedding()
@@ -5721,7 +5830,15 @@ class BeamMemory:
             else:
                 relevance = _lexical_relevance(query_words, row["content"], query_lower)
                 row_min_relevance = single_token_relevance if broad_multi_hit_query else min_relevance
-            if relevance >= row_min_relevance or (wm_ranks and len(query_words) <= 1 and relevance > 0):
+            vec_sim = wm_vec_sims.get(row["id"], 0.0)
+            vector_only = (
+                relevance < row_min_relevance
+                and (relevance == 0.0 or len(query_words) >= 4)
+                and _admit_wm_vector_only(row["id"], wm_vec)
+            )
+            if (relevance >= row_min_relevance
+                    or (wm_ranks and len(query_words) <= 1 and relevance > 0)
+                    or vector_only):
                 decay = _recency_decay(row["timestamp"])
                 # Phase 4: configurable scoring for working memory
                 # keyword_share = (1 - importance_weight) * 0.6, recency_share = (1 - importance_weight) * 0.4
@@ -5729,7 +5846,6 @@ class BeamMemory:
                 rc_share = (1.0 - iw) * 0.4
                 base_score = relevance * kw_share + row["importance"] * iw + (relevance ** 2) * 0.08
                 # Blend vector similarity into working memory score (weighted toward keyword precision)
-                vec_sim = wm_vec_sims.get(row["id"], 0.0)
                 if vec_sim > 0:
                     base_score = base_score * 0.80 + vec_sim * 0.20
                 score = base_score * (rc_share + (1.0 - rc_share) * decay)
@@ -5754,13 +5870,14 @@ class BeamMemory:
                     _wm_vec_kept += 1
                 results.append({
                     "id": row["id"],
-                    "content": row["content"][:500],
+                    "content": _format_recall_content(row["content"]),
                     "source": row["source"],
                     "timestamp": row["timestamp"],
                     "tier": "working",
                     "score": round(score, 4),
                     "keyword_score": round(relevance, 4),
                     "dense_score": round(vec_sim, 4),
+                    "vector_only": vector_only,
                     "fts_score": round(relevance, 4) if wm_ranks else 0.0,
                     "importance": row["importance"],
                     "recall_count": row["recall_count"] or 0,
@@ -5824,7 +5941,7 @@ class BeamMemory:
                         score *= (1.0 + temporal_weight * t_boost)
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": _format_recall_content(row["content"]),
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "working",
@@ -5886,7 +6003,7 @@ class BeamMemory:
                         score *= (1.0 + temporal_weight * t_boost)
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": _format_recall_content(row["content"]),
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "episodic",
@@ -5947,7 +6064,7 @@ class BeamMemory:
                         score *= (1.0 + temporal_weight * t_boost)
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": _format_recall_content(row["content"]),
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "working",
@@ -6008,7 +6125,7 @@ class BeamMemory:
                         score *= (1.0 + temporal_weight * t_boost)
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": _format_recall_content(row["content"]),
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "episodic",
@@ -6048,20 +6165,20 @@ class BeamMemory:
 
         # ---- Episodic memory (vec + FTS5 hybrid) ----
         vec_results = {}
-        max_distance = 0.0
         if embeddings_available:
             emb_result = _get_query_embedding()
             if emb_result is not None:
                 if _vec_available(self.conn):
                     vec_rows = _vec_search(self.conn, emb_result.tolist(), k=max(top_k * 3, 20))
+                    vec_type = _effective_vec_type(self.conn, "vec_episodes")
+                    distance_to_similarity = lambda d: _vec_distance_to_similarity(d, vec_type)
                 else:
                     # Fallback: in-memory cosine similarity search
                     vec_rows = _in_memory_vec_search(self.conn, emb_result, k=max(top_k * 3, 20))
+                    distance_to_similarity = _cosine_distance_to_similarity
                 if vec_rows:
-                    max_distance = max(vr["distance"] for vr in vec_rows)
                     for vr in vec_rows:
-                        sim = max(0.0, 1.0 - (vr["distance"] / max_distance)) if max_distance > 0 else 1.0
-                        vec_results[vr["rowid"]] = sim
+                        vec_results[vr["rowid"]] = distance_to_similarity(vr["distance"])
 
         fts_results = {}
         fts_rows = _fts_search(self.conn, query, k=max(top_k * 3, 20))
@@ -6144,6 +6261,15 @@ class BeamMemory:
             _em_candidate_rows = cursor.fetchall()
         else:
             _em_candidate_rows = []
+        em_vec_ranked = sorted(
+            [
+                {"id": row["id"], "sim": vec_results[row["rowid"]]}
+                for row in _em_candidate_rows
+                if row["rowid"] in vec_results
+            ],
+            key=lambda item: item["sim"],
+            reverse=True,
+        )
         for row in _em_candidate_rows:
             rid = row["rowid"]
             sim = vec_results.get(rid, 0.0)
@@ -6170,6 +6296,13 @@ class BeamMemory:
             # lexical coverage before admitting FTS-only episodic rows, while
             # still allowing genuinely strong vector-only hits through.
             if lexical < min_relevance and sim < 0.65:
+                continue
+            if (
+                sim > 0.0
+                and fts == 0.0
+                and (lexical == 0.0 or len(query_words) >= 4)
+                and not _admit_ep_vector_only(memory_id, em_vec_ranked)
+            ):
                 continue
             if self.episodic_graph is not None and not _env_disabled("MNEMOSYNE_GRAPH_BONUS"):
                 try:
@@ -6234,7 +6367,7 @@ class BeamMemory:
                 _em_vec_kept += 1
             results.append({
                 "id": row["id"],
-                "content": row["content"][:500],
+                "content": _format_recall_content(row["content"]),
                 "source": row["source"],
                 "timestamp": row["timestamp"],
                 "tier": "episodic",
@@ -6338,7 +6471,7 @@ class BeamMemory:
                     _em_fallback_kept += 1
                     results.append({
                         "id": row["id"],
-                        "content": row["content"][:500],
+                        "content": _format_recall_content(row["content"]),
                         "source": row["source"],
                         "timestamp": row["timestamp"],
                         "tier": "episodic",
@@ -7075,7 +7208,9 @@ class BeamMemory:
         final = []
         cursor = self.conn.cursor()
         now_iso = datetime.now().isoformat()
-
+        query_lower = query.lower()
+        query_words = _recall_tokens(query_lower)
+        visible_polyphonic_results = []
         for r in polyphonic_results:
             memory_id = r.memory_id
             if memory_id.startswith("cf_"):
@@ -7091,6 +7226,49 @@ class BeamMemory:
                 source=source, topic=topic, author_id=author_id,
                 author_type=author_type, channel_id=channel_id,
                 veracity=veracity, memory_type=memory_type, now_iso=now_iso,
+            ):
+                continue
+            visible_polyphonic_results.append((r, row_dict))
+
+        poly_vector_ranked = sorted(
+            [
+                {
+                    "id": result.memory_id,
+                    "sim": float(
+                        result.metadata.get("raw_voice_scores", {}).get("vector", 0.0)
+                    ),
+                }
+                for result, _row_dict in visible_polyphonic_results
+                if float(
+                    result.metadata.get("raw_voice_scores", {}).get("vector", 0.0)
+                ) > 0.0
+            ],
+            key=lambda item: item["sim"],
+            reverse=True,
+        )
+
+        for r, row_dict in visible_polyphonic_results:
+            memory_id = r.memory_id
+
+            raw_voice_scores = dict(r.metadata.get("raw_voice_scores", {}))
+            vector_score = float(raw_voice_scores.get("vector", 0.0))
+            topical_voice_scores = {
+                name: float(value)
+                for name, value in raw_voice_scores.items()
+                if name in {"vector", "fact", "graph"}
+            }
+            has_other_voice = any(
+                name != "vector" and value > 0.0
+                for name, value in topical_voice_scores.items()
+            )
+            lexical = _lexical_relevance(
+                query_words, row_dict.get("content", ""), query_lower
+            )
+            if (
+                vector_score > 0.0
+                and not has_other_voice
+                and (lexical == 0.0 or len(query_words) >= 4)
+                and not _admit_poly_vector_only(memory_id, poly_vector_ranked)
             ):
                 continue
 
@@ -7111,6 +7289,10 @@ class BeamMemory:
 
             row_dict["score"] = score
             row_dict["voice_scores"] = dict(r.voice_scores)
+            row_dict["raw_voice_scores"] = raw_voice_scores
+            row_dict["topic_signal"] = max(
+                list(topical_voice_scores.values()) or [0.0]
+            )
             final.append(row_dict)
             # No early-break: dedup needs to see all candidates before
             # truncation, otherwise a wm row dropped from top-K by an

--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -47,15 +47,6 @@ from mnemosyne.core.veracity_consolidation import (
     compute_fact_id,
 )
 
-# Cached embedding dim for vector normalization — resolved once at import time.
-# Avoids a per-row import inside the bit-vec normalization hot path.
-try:
-    from mnemosyne.core.embeddings import EMBEDDING_DIM as _EMB_DIM
-except ImportError:
-    _EMB_DIM = 384
-_EMBEDDING_DIM_BITS = float(_EMB_DIM)
-
-
 def _env_disabled(name: str) -> bool:
     """A/B toggle helper: return True iff env var is set to a falsy
     value (`0`/`false`/`no`/`off`). Used by the per-voice ablation
@@ -65,6 +56,18 @@ def _env_disabled(name: str) -> bool:
     """
     val = os.environ.get(name, "").strip().lower()
     return val in ("0", "false", "no", "off")
+
+
+def _vector_distance_to_similarity(distance: float, vec_type: str) -> float:
+    """Use the linear recall path's sqlite-vec distance calibration."""
+    from mnemosyne.core.beam import _vec_distance_to_similarity
+
+    return _vec_distance_to_similarity(distance, vec_type)
+
+
+def _cosine_to_similarity(cosine: float) -> float:
+    """Keep absolute cosine semantics used by the linear numpy fallback."""
+    return max(0.0, min(1.0, float(cosine)))
 
 
 @dataclass
@@ -326,29 +329,13 @@ class PolyphonicRecallEngine:
                             # /review (4-source: Codex structured P2,
                             # Codex adversarial MEDIUM, Claude
                             # CRITICAL, perf HIGH) caught the pre-fix
-                            # behavior of using `1.0 - distance`
-                            # directly: bit-type Hamming distance is
-                            # an int in [0, EMBEDDING_DIM_BITS], so
-                            # the score went heavily negative
-                            # (~-383). WM cosine is in [-1, 1].
-                            # Dedup at `sim > existing.score` then
-                            # always preferred WM hits over EM
-                            # sqlite-vec hits, silently inverting the
-                            # tier-priority semantics for bit-quantized
-                            # vectors. Normalize per vec_type:
-                            #   bit:    1 - dist/EMBEDDING_DIM_BITS
-                            #   int8:   1 - dist/2  (cosine_dist in
-                            #                       [0, 2] for unit
-                            #                       vectors)
-                            #   raw f32: 1/(1+dist) (L2 → (0, 1])
+                            # behavior of using one generic formula for
+                            # incompatible sqlite-vec metrics. Delegate
+                            # to beam.py so Polyphonic and linear recall
+                            # share the exact same per-type calibration;
+                            # normalized float32 uses 1 - d²/2.
                             raw_dist = float(dist)
-                            if vec_type == "bit":
-                                # Resolved from configured model dim
-                                sim = 1.0 - (raw_dist / _EMBEDDING_DIM_BITS)
-                            elif vec_type == "int8":
-                                sim = 1.0 - (raw_dist / 2.0)
-                            else:
-                                sim = 1.0 / (1.0 + raw_dist)
+                            sim = _vector_distance_to_similarity(raw_dist, vec_type)
                             existing = by_id.get(mid)
                             if existing is None or sim > existing.score:
                                 by_id[mid] = RecallResult(
@@ -412,12 +399,9 @@ class PolyphonicRecallEngine:
                         if vec_norm == 0.0:
                             continue
                         cos_sim = float(np.dot(query_unit, vec / vec_norm))
-                        # Normalize cosine to [0, 1] so cross-path dedup
-                        # against the sqlite-vec fast path (which now
-                        # also produces [0, 1] scores) compares apples
-                        # to apples. /review (4-source) caught the
-                        # raw-cosine-vs-bit-Hamming inversion bug.
-                        sim = min(1.0, max(0.0, (cos_sim + 1.0) / 2.0))
+                        # Keep the absolute positive cosine score, matching
+                        # the linear numpy fallback and sqlite-vec calibration.
+                        sim = _cosine_to_similarity(cos_sim)
                         existing = by_id.get(memory_id)
                         if existing is None or sim > existing.score:
                             by_id[memory_id] = RecallResult(
@@ -465,9 +449,8 @@ class PolyphonicRecallEngine:
                     if vec_norm == 0.0:
                         continue
                     cos_sim = float(np.dot(query_unit, vec / vec_norm))
-                    # Normalize cosine to [0, 1] -- same rationale as EM
-                    # numpy path above (cross-path dedup parity).
-                    sim = min(1.0, max(0.0, (cos_sim + 1.0) / 2.0))
+                    # Keep parity with the episodic numpy path above.
+                    sim = _cosine_to_similarity(cos_sim)
                     existing = by_id.get(memory_id)
                     if existing is None or sim > existing.score:
                         by_id[memory_id] = RecallResult(
@@ -731,6 +714,8 @@ class PolyphonicRecallEngine:
                 combined[r.memory_id].voice_scores[r.voice] = rrf_contribution
                 combined[r.memory_id].combined_score += rrf_contribution
                 combined[r.memory_id].metadata.update(r.metadata)
+                raw_scores = combined[r.memory_id].metadata.setdefault("raw_voice_scores", {})
+                raw_scores[r.voice] = max(float(r.score), float(raw_scores.get(r.voice, 0.0)))
 
         return combined
     

--- a/tests/fixtures/polish_recall_cases.json
+++ b/tests/fixtures/polish_recall_cases.json
@@ -1,0 +1,102 @@
+{
+  "records": [
+    {
+      "key": "hydraulika",
+      "content": "Prasa hydrauliczna PH-7 ma nominalne ciśnienie robocze 180 bar. Przegląd filtra oleju odbywa się w każdy pierwszy poniedziałek miesiąca."
+    },
+    {
+      "key": "backup",
+      "content": "Backup bazy PostgreSQL jest wykonywany codziennie o 02:30 na serwer NAS Orion. Retencja kopii wynosi 30 dni."
+    },
+    {
+      "key": "brygadzista",
+      "content": "Jan Kowalski jest brygadzistą zmiany nocnej i odpowiada za linię montażową numer trzy."
+    },
+    {
+      "key": "router",
+      "content": "Router MikroTik RB5009 obsługuje sieć produkcyjną VLAN 40. Adres bramy tej sieci to 10.40.0.1."
+    },
+    {
+      "key": "faktury",
+      "content": "Faktury dostawcy Stalpol zatwierdza Anna Nowak. Termin płatności wynosi 21 dni od daty wystawienia."
+    },
+    {
+      "key": "cnc",
+      "content": "Tokarka CNC Mazak QTN-250 wymaga kalibracji osi X co 500 godzin pracy. Ostatnią kalibrację wykonano w czerwcu."
+    },
+    {
+      "key": "energia",
+      "content": "Sprężarka Atlas Copco GA37 jest wyłączana w godzinach szczytu energetycznego od 17:00 do 19:00."
+    },
+    {
+      "key": "ewakuacja",
+      "content": "Punkt zbiórki ewakuacyjnej dla hali B znajduje się przy północnej bramie obok magazynu narzędzi."
+    },
+    {
+      "key": "stal",
+      "content": "Dostawy blach S355 od firmy Metalex przyjeżdżają we wtorki i czwartki o godzinie 06:00."
+    },
+    {
+      "key": "spoiny",
+      "content": "Pomiar jakości spoin metodą ultradźwiękową wykonuje laboratorium Delta. Raport trafia do działu jakości."
+    }
+  ],
+  "queries": [
+    {"expected": "hydraulika", "query": "Jakie ciśnienie robocze ma prasa PH-7?"},
+    {"expected": "hydraulika", "query": "Kiedy odbywa się przegląd filtra oleju?"},
+    {"expected": "hydraulika", "query": "Ile barów ma prasa hydrauliczna?"},
+    {"expected": "hydraulika", "query": "Którego dnia przeglądamy filtr prasy?"},
+
+    {"expected": "backup", "query": "O której godzinie wykonywany jest backup PostgreSQL?"},
+    {"expected": "backup", "query": "Jak długo trwa retencja kopii bazy?"},
+    {"expected": "backup", "query": "Na jaki serwer trafia backup?"},
+    {"expected": "backup", "query": "Ile dni przechowujemy kopie PostgreSQL?"},
+
+    {"expected": "brygadzista", "query": "Kto jest brygadzistą zmiany nocnej?"},
+    {"expected": "brygadzista", "query": "Za którą linię odpowiada Jan Kowalski?"},
+    {"expected": "brygadzista", "query": "Kto odpowiada za linię montażową numer trzy?"},
+    {"expected": "brygadzista", "query": "Jaką funkcję pełni Jan na nocnej zmianie?"},
+
+    {"expected": "router", "query": "Jaki router obsługuje VLAN 40?"},
+    {"expected": "router", "query": "Jaki jest adres bramy sieci produkcyjnej?"},
+    {"expected": "router", "query": "Który model MikroTik działa w produkcji?"},
+    {"expected": "router", "query": "Do jakiej sieci należy adres 10.40.0.1?"},
+
+    {"expected": "faktury", "query": "Kto zatwierdza faktury Stalpol?"},
+    {"expected": "faktury", "query": "Jaki termin płatności ma dostawca Stalpol?"},
+    {"expected": "faktury", "query": "Ile dni jest na zapłatę faktury?"},
+    {"expected": "faktury", "query": "Które faktury zatwierdza Anna Nowak?"},
+
+    {"expected": "cnc", "query": "Co ile godzin kalibrujemy oś X tokarki?"},
+    {"expected": "cnc", "query": "Kiedy wykonano ostatnią kalibrację Mazaka?"},
+    {"expected": "cnc", "query": "Która tokarka wymaga kalibracji osi X?"},
+    {"expected": "cnc", "query": "Jaki model CNC ma interwał 500 godzin?"},
+
+    {"expected": "energia", "query": "Kiedy wyłączamy sprężarkę Atlas Copco?"},
+    {"expected": "energia", "query": "W jakich godzinach trwa szczyt energetyczny?"},
+    {"expected": "energia", "query": "Która sprężarka jest wyłączana od 17 do 19?"},
+    {"expected": "energia", "query": "Jaki model sprężarki ogranicza pobór energii?"},
+
+    {"expected": "ewakuacja", "query": "Gdzie jest punkt zbiórki dla hali B?"},
+    {"expected": "ewakuacja", "query": "Przy której bramie znajduje się punkt ewakuacyjny?"},
+    {"expected": "ewakuacja", "query": "Co znajduje się obok magazynu narzędzi?"},
+    {"expected": "ewakuacja", "query": "Dokąd ewakuuje się hala B?"},
+
+    {"expected": "stal", "query": "W jakie dni przyjeżdżają dostawy blach S355?"},
+    {"expected": "stal", "query": "O której godzinie przyjeżdża Metalex?"},
+    {"expected": "stal", "query": "Kto dostarcza blachy S355?"},
+    {"expected": "stal", "query": "Czy dostawy stali są we wtorki i czwartki?"},
+
+    {"expected": "spoiny", "query": "Kto wykonuje ultradźwiękowy pomiar spoin?"},
+    {"expected": "spoiny", "query": "Dokąd trafia raport z badania spoin?"},
+    {"expected": "spoiny", "query": "Jaką metodą laboratorium Delta bada jakość?"},
+    {"expected": "spoiny", "query": "Który dział otrzymuje raport ultradźwiękowy?"}
+  ],
+  "negative_queries": [
+    "Jaki kolor ma prywatny samochód prezesa?",
+    "Jakie jest hasło do sieci WiFi dla gości?",
+    "Co dziś podaje stołówka na obiad?",
+    "Kiedy marketing wymienia drukarkę kolorową?",
+    "Ile dni urlopu zostało Pawłowi?"
+  ]
+}

--- a/tests/test_polish_recall_harness.py
+++ b/tests/test_polish_recall_harness.py
@@ -1,0 +1,62 @@
+"""Deterministic Polish-language recall acceptance harness."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core import beam as beam_module
+from mnemosyne.core.beam import BeamMemory
+
+
+CASES = json.loads(
+    (Path(__file__).parent / "fixtures" / "polish_recall_cases.json").read_text()
+)
+
+
+def test_polish_recall_topk_and_abstention(tmp_path, monkeypatch):
+    if os.environ.get("MNEMOSYNE_RUN_POLISH_RECALL_HARNESS") != "1":
+        pytest.skip("set MNEMOSYNE_RUN_POLISH_RECALL_HARNESS=1 for multilingual embedding evaluation")
+    if not beam_module._embeddings.available():
+        pytest.skip("configured embedding backend is unavailable")
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    monkeypatch.setenv("MNEMOSYNE_CROSS_SESSION", "0")
+    memory = BeamMemory(session_id="polish-eval", db_path=tmp_path / "memory.db")
+
+    ids = {}
+    for record in CASES["records"]:
+        ids[record["key"]] = memory.remember(
+            record["content"], source="polish-harness", importance=0.8
+        )
+
+    top1_hits = 0
+    top3_hits = 0
+    misses = []
+    for case in CASES["queries"]:
+        results = memory.recall(case["query"], top_k=3)
+        result_ids = [row["id"] for row in results]
+        expected_id = ids[case["expected"]]
+        top1_hits += bool(result_ids and result_ids[0] == expected_id)
+        top3_hits += expected_id in result_ids
+        if expected_id not in result_ids:
+            misses.append({"query": case["query"], "returned": result_ids})
+
+    false_positives = []
+    for query in CASES["negative_queries"]:
+        results = memory.recall(query, top_k=3)
+        if results:
+            false_positives.append({"query": query, "returned": [row["id"] for row in results]})
+
+    positives = len(CASES["queries"])
+    print(json.dumps({
+        "positive_total": positives,
+        "top1_hits": top1_hits,
+        "top3_hits": top3_hits,
+        "negative_total": len(CASES["negative_queries"]),
+        "false_positives": len(false_positives),
+    }, sort_keys=True))
+    assert top3_hits == positives, {"top3_hits": top3_hits, "misses": misses}
+    assert top1_hits / positives >= 0.90, {"top1_hits": top1_hits, "total": positives}
+    assert false_positives == []

--- a/tests/test_recall_calibration_regressions.py
+++ b/tests/test_recall_calibration_regressions.py
@@ -1,0 +1,245 @@
+"""Recall calibration, full-content and FTS synchronization regressions."""
+from __future__ import annotations
+
+import math
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from mnemosyne.core import beam as beam_module
+from mnemosyne.core import polyphonic_recall as polyphonic_module
+from mnemosyne.core.beam import BeamMemory
+from mnemosyne.core.polyphonic_recall import PolyphonicResult
+
+
+@pytest.mark.parametrize(
+    ("distance", "expected"),
+    [
+        (0.0, 1.0),
+        (math.sqrt(0.5), 0.75),
+        (math.sqrt(2.0), 0.0),
+        (2.0, 0.0),
+    ],
+)
+def test_float32_l2_distance_uses_normalized_vector_geometry(distance, expected):
+    assert beam_module._vec_distance_to_similarity(distance, "float32") == pytest.approx(expected)
+
+
+def test_in_memory_cosine_distance_uses_one_minus_distance():
+    assert beam_module._cosine_distance_to_similarity(0.2) == pytest.approx(0.8)
+
+
+def test_polyphonic_float32_distance_uses_linear_recall_geometry():
+    assert polyphonic_module._vector_distance_to_similarity(
+        math.sqrt(0.5), "float32"
+    ) == pytest.approx(0.75)
+
+
+def test_polyphonic_numpy_cosine_keeps_absolute_cosine_score():
+    assert polyphonic_module._cosine_to_similarity(0.5) == pytest.approx(0.5)
+    assert polyphonic_module._cosine_to_similarity(-0.2) == pytest.approx(0.0)
+
+
+def test_polish_question_glue_is_not_a_lexical_relevance_signal():
+    assert beam_module._recall_tokens("Jakie jest hasło dla gości") == ["hasło", "gości"]
+
+
+def test_vector_only_admission_requires_calibrated_top1_and_margin(monkeypatch):
+    monkeypatch.delenv("MNEMOSYNE_WM_VECTOR_ONLY_MIN_SIM", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_WM_VECTOR_ONLY_MIN_MARGIN", raising=False)
+    ranked = [{"id": "correct", "sim": 0.82}, {"id": "runner-up", "sim": 0.79}]
+
+    assert beam_module._admit_wm_vector_only("correct", ranked) is True
+    assert beam_module._admit_wm_vector_only("runner-up", ranked) is False
+    assert beam_module._admit_wm_vector_only(
+        "ambiguous", [{"id": "ambiguous", "sim": 0.82}, {"id": "other", "sim": 0.81}]
+    ) is False
+    assert beam_module._admit_wm_vector_only(
+        "weak", [{"id": "weak", "sim": 0.80}, {"id": "other", "sim": 0.70}]
+    ) is False
+
+
+def test_vector_only_single_candidate_uses_absolute_threshold(monkeypatch):
+    monkeypatch.delenv("MNEMOSYNE_WM_VECTOR_ONLY_MIN_SIM", raising=False)
+    assert beam_module._admit_wm_vector_only("only", [{"id": "only", "sim": 0.82}]) is True
+    assert beam_module._admit_wm_vector_only("only", [{"id": "only", "sim": 0.80}]) is False
+
+
+def test_single_episodic_candidate_keeps_absolute_dense_score(tmp_path, monkeypatch):
+    memory = BeamMemory(session_id="s1", db_path=tmp_path / "memory.db")
+    now = datetime.now().isoformat()
+    cursor = memory.conn.execute(
+        "INSERT INTO episodic_memory "
+        "(id, content, source, timestamp, importance, session_id, scope, veracity) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("ep-one", "hydraulika zaworu proporcjonalnego", "test", now, 0.5, "s1", "session", "stated"),
+    )
+    rowid = cursor.lastrowid
+    memory.conn.commit()
+
+    monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam_module._embeddings,
+        "embed_query",
+        lambda _query: np.array([1.0, 0.0], dtype=np.float32),
+    )
+    monkeypatch.setattr(beam_module, "_vec_available", lambda _conn: True)
+    monkeypatch.setattr(beam_module, "_effective_vec_type", lambda _conn, table="vec_episodes": "float32")
+    monkeypatch.setattr(
+        beam_module,
+        "_vec_search",
+        lambda _conn, _embedding, k=20: [{"rowid": rowid, "distance": math.sqrt(0.4)}],
+    )
+    monkeypatch.setattr(beam_module, "_fts_search", lambda _conn, _query, k=20: [])
+
+    results = memory.recall("hydraulika", top_k=3)
+
+    episodic = next(row for row in results if row["id"] == "ep-one")
+    assert episodic["dense_score"] == pytest.approx(0.8, abs=1e-4)
+
+
+def test_episodic_vector_only_noise_below_calibrated_threshold_abstains(tmp_path, monkeypatch):
+    memory = BeamMemory(session_id="s1", db_path=tmp_path / "memory.db")
+    now = datetime.now().isoformat()
+    cursor = memory.conn.execute(
+        "INSERT INTO episodic_memory "
+        "(id, content, source, timestamp, importance, session_id, scope, veracity) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("ep-noise", "hydraulika zaworu proporcjonalnego", "test", now, 0.5, "s1", "session", "stated"),
+    )
+    rowid = cursor.lastrowid
+    memory.conn.commit()
+
+    monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam_module._embeddings,
+        "embed_query",
+        lambda _query: np.array([1.0, 0.0], dtype=np.float32),
+    )
+    monkeypatch.setattr(beam_module, "_vec_available", lambda _conn: True)
+    monkeypatch.setattr(beam_module, "_effective_vec_type", lambda _conn, table="vec_episodes": "float32")
+    monkeypatch.setattr(
+        beam_module,
+        "_vec_search",
+        lambda _conn, _embedding, k=20: [{"rowid": rowid, "distance": math.sqrt(0.4)}],
+    )
+    monkeypatch.setattr(beam_module, "_fts_search", lambda _conn, _query, k=20: [])
+
+    results = memory.recall("zzzx qqqy wwwv", top_k=3)
+
+    assert all(row["id"] != "ep-noise" for row in results)
+
+
+@pytest.mark.parametrize(("similarity", "expected_ids"), [(0.80, []), (0.82, ["wm-poly"])])
+def test_polyphonic_vector_only_uses_calibrated_abstention(
+    tmp_path, monkeypatch, similarity, expected_ids
+):
+    memory = BeamMemory(session_id="s1", db_path=tmp_path / "memory.db")
+    memory.conn.execute(
+        "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
+        "VALUES ('wm-poly', 'hydraulika zaworu proporcjonalnego', 'test', ?, 's1')",
+        (datetime.now().isoformat(),),
+    )
+    memory.conn.commit()
+
+    class FakeEngine:
+        def recall(self, **_kwargs):
+            return [PolyphonicResult(
+                memory_id="wm-poly",
+                combined_score=1.0 / 61.0,
+                voice_scores={"vector": 1.0 / 61.0},
+                metadata={"raw_voice_scores": {"vector": similarity}},
+            )]
+
+    monkeypatch.setattr(memory, "_get_polyphonic_engine", lambda: FakeEngine())
+    monkeypatch.setattr(beam_module._embeddings, "available", lambda: False)
+
+    results = memory._recall_polyphonic("zzzx qqqy wwwv", top_k=3)
+
+    assert [row["id"] for row in results] == expected_ids
+
+
+def test_polyphonic_vector_margin_ignores_filtered_foreign_session(tmp_path, monkeypatch):
+    memory = BeamMemory(session_id="s1", db_path=tmp_path / "memory.db")
+    timestamp = datetime.now().isoformat()
+    memory.conn.executemany(
+        "INSERT INTO working_memory (id, content, source, timestamp, session_id, scope) "
+        "VALUES (?, ?, 'test', ?, ?, 'session')",
+        [
+            ("wm-visible", "hydraulika zaworu", timestamp, "s1"),
+            ("wm-foreign", "sprężarka powietrza", timestamp, "s2"),
+        ],
+    )
+    memory.conn.commit()
+
+    class FakeEngine:
+        def recall(self, **_kwargs):
+            return [
+                PolyphonicResult(
+                    memory_id="wm-visible",
+                    combined_score=1.0 / 61.0,
+                    voice_scores={"vector": 1.0 / 61.0},
+                    metadata={"raw_voice_scores": {"vector": 0.82}},
+                ),
+                PolyphonicResult(
+                    memory_id="wm-foreign",
+                    combined_score=1.0 / 62.0,
+                    voice_scores={"vector": 1.0 / 62.0},
+                    metadata={"raw_voice_scores": {"vector": 0.81}},
+                ),
+            ]
+
+    monkeypatch.setenv("MNEMOSYNE_CROSS_SESSION", "0")
+    monkeypatch.setattr(beam_module, "_CROSS_SESSION", False)
+    monkeypatch.setattr(memory, "_get_polyphonic_engine", lambda: FakeEngine())
+    monkeypatch.setattr(beam_module._embeddings, "available", lambda: False)
+
+    results = memory._recall_polyphonic("zzzx qqqy wwwv", top_k=3)
+
+    assert [row["id"] for row in results] == ["wm-visible"]
+
+
+def test_recall_returns_full_content_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("MNEMOSYNE_RECALL_CONTENT_CHARS", raising=False)
+    memory = BeamMemory(session_id="s1", db_path=tmp_path / "memory.db")
+    sentinel = "KONIEC-PEŁNEJ-TREŚCI"
+    content = "hydraulika " + ("bardzo-długi-opis " * 45) + sentinel
+    memory.remember(content, source="test", importance=0.8)
+
+    results = memory.recall("hydraulika", top_k=3)
+
+    row = next(item for item in results if item["tier"] == "working")
+    assert len(row["content"]) > 500
+    assert sentinel in row["content"]
+
+
+def test_recall_content_truncation_is_explicit_opt_in(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_RECALL_CONTENT_CHARS", "20")
+    assert beam_module._format_recall_content("0123456789abcdefghijTAIL") == "0123456789abcdefghij"
+
+
+def test_facts_fts_is_synchronized_after_update(tmp_path):
+    memory = BeamMemory(session_id="s1", db_path=tmp_path / "memory.db")
+    memory.conn.execute(
+        "INSERT INTO facts(subject, predicate, object, source_msg_id, confidence, session_id) VALUES (?, ?, ?, ?, ?, ?)",
+        ("pompa", "ma", "ciśnienie", "msg-1", 1.0, "s1"),
+    )
+    memory.conn.commit()
+    rowid = memory.conn.execute("SELECT rowid FROM facts WHERE source_msg_id='msg-1'").fetchone()[0]
+    assert memory.conn.execute(
+        "SELECT rowid FROM fts_facts WHERE fts_facts MATCH 'pompa'"
+    ).fetchone()[0] == rowid
+
+    memory.conn.execute(
+        "UPDATE facts SET subject=?, object=? WHERE rowid=?",
+        ("zawór", "przepływ", rowid),
+    )
+    memory.conn.commit()
+
+    assert memory.conn.execute(
+        "SELECT rowid FROM fts_facts WHERE fts_facts MATCH 'zawór'"
+    ).fetchone()[0] == rowid
+    assert memory.conn.execute(
+        "SELECT rowid FROM fts_facts WHERE fts_facts MATCH 'pompa'"
+    ).fetchone() is None


### PR DESCRIPTION
## Summary
- align vector distance calibration between linear and polyphonic recall
- gate weak vector-only results using calibrated confidence and margin
- preserve topical signal through both Hermes provider surfaces
- exclude temporal-only scores from topical admission and provider signal

## Validation
- targeted recall/polyphonic gate: 37 passed, 1 skipped
- Polish acceptance harness: 40/40 top-1, 40/40 top-3, 0/5 false positives
- compile and diff checks passed

Related to #389; this does not close it because its diversity-rerank root cause is separate.

## Status
Draft for maintainer review; not intended for merge yet.