### PR TITLE
fix: preserve profile isolation on invalid config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Hermes provider guardrails.** Effective runtime settings are normalized and
+  inspectable, empty `sync_roles` remains an explicit opt-out, invalid values
+  fail closed without discarding the last valid configuration, and provider
+  config reads preserve the documented precedence.
+
 - **Hermes provider safety defaults after config bridging.** New auto-seeded
   configs now preserve user-only autosave and skip `cron`, `flush`, `subagent`,
   `background`, and `skill_loop` contexts. Existing 3.12.1/3.12.2 auto-seeded

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -41,7 +41,7 @@ from mnemosyne.batch_tool import (
     dry_run_batch,
     validate_batch_operations,
 )
-from mnemosyne.hermes_config import read_hermes_config_key
+from mnemosyne.hermes_config import parse_strict_bool, parse_sync_roles, read_hermes_config_key
 from mnemosyne.integrations.hermes_persona_prompt import HermesPersonaPromptMixin
 
 logger = logging.getLogger(__name__)
@@ -260,6 +260,7 @@ def _prefetch_topic_signal(row: Dict[str, Any]) -> float:
         float(row.get("keyword_score") or 0.0),
         float(row.get("fts_score") or 0.0),
         float(row.get("dense_score") or 0.0),
+        float(row.get("topic_signal") or 0.0),
     )
     # Fact/entity matches are explicit relevance signals even when recall() did
     # not fill keyword/FTS scores for that path.
@@ -1309,8 +1310,11 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         self._sync_roles: Set[str] = {"user"}
         _sync_env = os.environ.get("MNEMOSYNE_SYNC_ROLES")
         if _sync_env is not None:
-            _parsed_roles = {r.strip().lower() for r in _sync_env.split(",") if r.strip()}
-            self._sync_roles = _parsed_roles & self._VALID_SYNC_ROLES
+            self._sync_roles, _sync_warnings = parse_sync_roles(
+                _sync_env, current=self._sync_roles, valid_roles=self._VALID_SYNC_ROLES
+            )
+            for warning in _sync_warnings:
+                logger.warning("Mnemosyne: %s", warning)
         self._skip_contexts = {"cron", "flush", "subagent", "background", "skill_loop"}  # Agent contexts to skip
         # Allow override via MNEMOSYNE_SKIP_CONTEXTS env var.
         # Set to empty string to skip nothing (enable all contexts).
@@ -1495,10 +1499,11 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         if profile_isolation is None:
             profile_isolation = self._read_config_key("profile_isolation")
         if profile_isolation is not None:
-            if isinstance(profile_isolation, str):
-                self._profile_isolation_enabled = profile_isolation.lower() in ("true", "1", "yes", "on")
+            parsed_isolation, isolation_warning = parse_strict_bool(profile_isolation)
+            if isolation_warning:
+                logger.warning("Mnemosyne: %s", isolation_warning)
             else:
-                self._profile_isolation_enabled = bool(profile_isolation)
+                self._profile_isolation_enabled = parsed_isolation
 
         shared_surface_path = kwargs.get("shared_surface_path")
         if shared_surface_path is None:
@@ -1524,24 +1529,11 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         if _sync_raw is None:
             _sync_raw = self._read_config_key("sync_roles")
         if _sync_raw is not None:
-            if isinstance(_sync_raw, str):
-                _parsed_roles = {r.strip().lower() for r in _sync_raw.split(",") if r.strip()}
-            elif isinstance(_sync_raw, (list, tuple, set)):
-                _parsed_roles = {str(r).strip().lower() for r in _sync_raw if str(r).strip()}
-            else:
-                logger.warning("Mnemosyne: invalid sync_roles type %s (%r); keeping %s",
-                               type(_sync_raw).__name__, _sync_raw, sorted(self._sync_roles))
-                _sync_raw = None
-            if _sync_raw is not None:
-                _unknown = _parsed_roles - self._VALID_SYNC_ROLES
-                if _unknown:
-                    logger.warning("Mnemosyne: unknown sync_roles ignored: %s", sorted(_unknown))
-                _valid = _parsed_roles & self._VALID_SYNC_ROLES
-                if _parsed_roles and not _valid:
-                    logger.warning("Mnemosyne: no valid sync_roles in %r; keeping %s",
-                                   _parsed_roles, sorted(self._sync_roles))
-                else:
-                    self._sync_roles = _valid
+            self._sync_roles, _sync_warnings = parse_sync_roles(
+                _sync_raw, current=self._sync_roles, valid_roles=self._VALID_SYNC_ROLES
+            )
+            for warning in _sync_warnings:
+                logger.warning("Mnemosyne: %s", warning)
 
         shared_surface_read = kwargs.get("shared_surface_read")
         if shared_surface_read is None:
@@ -1564,6 +1556,20 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 self._default_scope = scope_str
             else:
                 logger.warning("Mnemosyne: invalid default_scope=%r, must be 'session' or 'global'", default_scope)
+
+    def effective_config(self) -> Dict[str, Any]:
+        """Return normalized provider settings used by the current process."""
+        return {
+            "auto_sleep": self._auto_sleep_enabled,
+            "default_scope": self._default_scope,
+            "profile_isolation": self._profile_isolation_enabled,
+            "reflect": {
+                "disabled_for_cron": self._reflect_disabled_for_cron,
+                "max_calls_per_session": self._reflect_max_calls_per_session,
+            },
+            "skip_contexts": sorted(self._skip_contexts),
+            "sync_roles": sorted(self._sync_roles),
+        }
 
 
     def _should_filter(self, content: str) -> bool:
@@ -1596,7 +1602,16 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             return val
 
         # 2. Mnemosyne config singleton (auto-reloads on file change)
-        val = get_config().get(key)
+        core_key = "auto_sleep_enabled" if key == "auto_sleep" else key
+        val = get_config().get(core_key)
+        if (
+            key == "skip_contexts"
+            and val in (None, "", [], (), set())
+            and "MNEMOSYNE_SKIP_CONTEXTS" not in os.environ
+        ):
+            # Historical auto-seeded core config used an empty value, which
+            # must not erase the provider's safe skip-context defaults.
+            return None
         if val is not None:
             return val
 
@@ -3394,6 +3409,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # the thread keeps running in the background if it overruns, but the
         # main shutdown path is freed after the join timeout.
         if not self._beam:
+            return
+        if not self._auto_sleep_enabled:
+            logger.info("Mnemosyne session-end sleep skipped: auto_sleep disabled")
             return
         try:
             skip = self._reserve_reflection_budget("session_end")

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -24,7 +24,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 from datetime import datetime, timedelta
 
 # Mnemosyne core is installed via pip (mnemosyne-memory>=3.11.1 dependency),
@@ -69,7 +69,7 @@ except Exception as _batch_tool_import_exc:  # pragma: no cover - broken install
         return {"status": "error", "error": "mnemosyne_batch is unavailable; upgrade mnemosyne-memory"}
 
 try:
-    from mnemosyne.hermes_config import read_hermes_config_key
+    from mnemosyne.hermes_config import parse_strict_bool, parse_sync_roles, read_hermes_config_key
 except Exception as _hermes_config_import_exc:  # pragma: no cover - broken install diagnostic path
     logging.getLogger(__name__).warning(
         "Hermes config helper unavailable (%s); memory.mnemosyne config keys will use defaults until mnemosyne-memory is upgraded.",
@@ -78,6 +78,24 @@ except Exception as _hermes_config_import_exc:  # pragma: no cover - broken inst
 
     def read_hermes_config_key(_hermes_home: Optional[str], _key: str) -> Any:
         return None
+
+    def parse_strict_bool(value: Any) -> Tuple[bool | None, str | None]:
+        if isinstance(value, bool):
+            return value, None
+        if isinstance(value, int) and value in (0, 1):
+            return bool(value), None
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "on"}:
+                return True, None
+            if normalized in {"false", "0", "no", "off"}:
+                return False, None
+        return None, f"invalid boolean value {value!r}; keeping the current effective value"
+
+    def parse_sync_roles(
+        _value: Any, *, current: Any, valid_roles: Any = ("user", "assistant")
+    ) -> Tuple[Set[str], List[str]]:
+        return set(current), ["sync_roles parser unavailable; keeping current roles"]
 
 try:
     from mnemosyne.integrations.hermes_persona_prompt import HermesPersonaPromptMixin
@@ -101,7 +119,7 @@ except Exception as _persona_import_exc:  # pragma: no cover - graceful import f
         def _with_persona_block(self, base: str) -> str:
             return base
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 logger = logging.getLogger(__name__)
 
@@ -321,6 +339,7 @@ def _prefetch_topic_signal(row: Dict[str, Any]) -> float:
         float(row.get("keyword_score") or 0.0),
         float(row.get("fts_score") or 0.0),
         float(row.get("dense_score") or 0.0),
+        float(row.get("topic_signal") or 0.0),
     )
     if row.get("fact_match") or row.get("entity_match"):
         signal = max(signal, 0.20)
@@ -546,8 +565,11 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         self._sync_roles: Set[str] = {"user"}
         _sync_env = os.environ.get("MNEMOSYNE_SYNC_ROLES")
         if _sync_env is not None:
-            _parsed_roles = {r.strip().lower() for r in _sync_env.split(",") if r.strip()}
-            self._sync_roles = _parsed_roles & self._VALID_SYNC_ROLES
+            self._sync_roles, _sync_warnings = parse_sync_roles(
+                _sync_env, current=self._sync_roles, valid_roles=self._VALID_SYNC_ROLES
+            )
+            for warning in _sync_warnings:
+                logger.warning("Mnemosyne: %s", warning)
         self._skip_contexts = {"cron", "flush", "subagent", "background", "skill_loop"}  # Agent contexts to skip
         # Allow override via MNEMOSYNE_SKIP_CONTEXTS env var.
         # Set to empty string to skip nothing (enable all contexts).
@@ -727,10 +749,11 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         if profile_isolation is None:
             profile_isolation = self._read_config_key("profile_isolation")
         if profile_isolation is not None:
-            if isinstance(profile_isolation, str):
-                self._profile_isolation_enabled = profile_isolation.lower() in ("true", "1", "yes", "on")
+            parsed_isolation, isolation_warning = parse_strict_bool(profile_isolation)
+            if isolation_warning:
+                logger.warning("Mnemosyne: %s", isolation_warning)
             else:
-                self._profile_isolation_enabled = bool(profile_isolation)
+                self._profile_isolation_enabled = parsed_isolation
 
         shared_surface_path = kwargs.get("shared_surface_path")
         if shared_surface_path is None:
@@ -745,13 +768,11 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         if _sync_raw is None:
             _sync_raw = self._read_config_key("sync_roles")
         if _sync_raw is not None:
-            if isinstance(_sync_raw, str):
-                parsed = {r.strip().lower() for r in _sync_raw.split(",") if r.strip()}
-            elif isinstance(_sync_raw, (list, tuple, set)):
-                parsed = {str(r).strip().lower() for r in _sync_raw if str(r).strip()}
-            else:
-                parsed = set()
-            self._sync_roles = parsed & self._VALID_SYNC_ROLES
+            self._sync_roles, _sync_warnings = parse_sync_roles(
+                _sync_raw, current=self._sync_roles, valid_roles=self._VALID_SYNC_ROLES
+            )
+            for warning in _sync_warnings:
+                logger.warning("Mnemosyne: %s", warning)
 
         # skip_contexts: kwargs > config.yaml > env var (already set in __init__)
         _skip_raw = kwargs.get("skip_contexts")
@@ -786,6 +807,20 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             else:
                 logger.warning("Mnemosyne: invalid default_scope=%r, must be 'session' or 'global'", default_scope)
 
+    def effective_config(self) -> Dict[str, Any]:
+        """Return normalized provider settings used by the current process."""
+        return {
+            "auto_sleep": self._auto_sleep_enabled,
+            "default_scope": self._default_scope,
+            "profile_isolation": self._profile_isolation_enabled,
+            "reflect": {
+                "disabled_for_cron": self._reflect_disabled_for_cron,
+                "max_calls_per_session": self._reflect_max_calls_per_session,
+            },
+            "skip_contexts": sorted(self._skip_contexts),
+            "sync_roles": sorted(self._sync_roles),
+        }
+
     def _should_filter(self, content: str) -> bool:
         """Check if content matches any ignore pattern. Returns True if it should be skipped."""
         if not self._ignore_patterns:
@@ -800,8 +835,22 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         return False
 
     def _read_config_key(self, key: str) -> Any:
-        """Read a single key from memory.mnemosyne in config.yaml."""
-        return read_hermes_config_key(getattr(self, "_hermes_home", None), key)
+        """Read Hermes config first, then the hot-reloaded Mnemosyne config."""
+        val = read_hermes_config_key(getattr(self, "_hermes_home", None), key)
+        if val is not None:
+            return val
+
+        from mnemosyne.core.config import get_config
+
+        core_key = "auto_sleep_enabled" if key == "auto_sleep" else key
+        val = get_config().get(core_key)
+        if (
+            key == "skip_contexts"
+            and val in (None, "", [], (), set())
+            and "MNEMOSYNE_SKIP_CONTEXTS" not in os.environ
+        ):
+            return None
+        return val
 
 
     def _configured_tool_schemas(self) -> List[Dict[str, Any]]:
@@ -2435,6 +2484,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # main shutdown path is freed after the join timeout.
         if not self._beam:
             return
+        if not self._auto_sleep_enabled:
+            logger.info("Mnemosyne session-end sleep skipped: auto_sleep disabled")
+            return
         try:
             skip = self._reserve_reflection_budget("session_end")
             if skip is not None:
@@ -2578,8 +2630,12 @@ def register_memory_provider(ctx):
 # Plugin registration (used when loaded via Hermes plugin system)
 # ---------------------------------------------------------------------------
 
+_provider: Optional[Any] = None
+
+
 def register(ctx):
     """Called by Hermes plugin loader to register CLI commands and tools."""
+    global _provider
     # Register the memory provider first so Hermes discovers it
     register_memory_provider(ctx)
 

--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -73,17 +73,22 @@ def register_cli(subparser):
 
 
 def _profile_isolation_enabled(hermes_home: str) -> bool:
-    """True when ``memory.mnemosyne.profile_isolation`` is set in config.yaml."""
+    """Read profile isolation strictly; invalid values must not select a bank."""
     try:
         import yaml
+        from mnemosyne.hermes_config import parse_strict_bool
+
         with open(os.path.join(hermes_home, "config.yaml")) as f:
             cfg = yaml.safe_load(f) or {}
         val = (cfg.get("memory", {}) or {}).get("mnemosyne", {}).get("profile_isolation", False)
+        parsed, warning = parse_strict_bool(val)
+        if warning:
+            raise ValueError(warning)
+        return bool(parsed)
+    except ValueError:
+        raise
     except Exception:
         return False
-    if isinstance(val, str):
-        return val.strip().lower() in ("true", "1", "yes", "on")
-    return bool(val)
 
 
 def _get_provider_class():
@@ -139,6 +144,8 @@ def _resolve_cli_bank(args, cmd):
             return None
         bank = sanitize(basename)
         return bank if bank != "default" else None
+    except ValueError:
+        raise
     except Exception:
         return None
 
@@ -165,7 +172,11 @@ def mnemosyne_command(args):
     except Exception:
         pass
 
-    bank = _resolve_cli_bank(args, cmd)
+    try:
+        bank = _resolve_cli_bank(args, cmd)
+    except ValueError as exc:
+        print(f"Error: invalid profile_isolation configuration: {exc}", file=sys.stderr)
+        return 2
 
     # Reject unknown named banks BEFORE touching the filesystem. Mnemosyne(bank=)
     # would otherwise lazily create an empty bank directory + DB on first access

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -14,7 +14,9 @@ import importlib.util
 import types
 from pathlib import Path
 
-from mnemosyne_hermes.cli import _resolve_cli_bank, _get_provider_class
+import pytest
+
+from mnemosyne_hermes.cli import _profile_isolation_enabled, _resolve_cli_bank, _get_provider_class
 import mnemosyne_hermes as _mnh
 
 
@@ -46,6 +48,18 @@ def test_default_bank_when_isolation_disabled(tmp_path, monkeypatch):
     _write_config(home, "false")
     monkeypatch.setenv("HERMES_HOME", str(home))
     assert _resolve_cli_bank(_args(bank=None), "stats") is None
+
+
+
+def test_invalid_profile_isolation_aborts_bank_resolution(tmp_path, monkeypatch):
+    home = tmp_path / "profiles" / "zedd"
+    _write_config(home, "definitely-not-a-bool")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with pytest.raises(ValueError, match="invalid boolean"):
+        _profile_isolation_enabled(str(home))
+    with pytest.raises(ValueError, match="invalid boolean"):
+        _resolve_cli_bank(_args(bank=None), "stats")
 
 
 def test_default_bank_when_no_config(tmp_path, monkeypatch):

--- a/integrations/hermes/tests/test_effective_provider_config.py
+++ b/integrations/hermes/tests/test_effective_provider_config.py
@@ -1,0 +1,75 @@
+"""Regression tests for the packaged Hermes provider's effective config."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from mnemosyne.core import config as core_config
+from mnemosyne_hermes import MnemosyneMemoryProvider
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.delenv("MNEMOSYNE_SYNC_ROLES", raising=False)
+    instance = MnemosyneMemoryProvider()
+    monkeypatch.setattr(instance, "_read_config_key", lambda _key: None)
+    return instance
+
+
+def test_serialized_yaml_list_string_no_longer_disables_capture(provider):
+    provider._apply_provider_config({"sync_roles": "['user']"})
+    assert provider._sync_roles == {"user"}
+
+
+def test_explicit_empty_list_disables_capture(provider):
+    provider._apply_provider_config({"sync_roles": []})
+    assert provider._sync_roles == set()
+
+
+def test_unknown_only_keeps_safe_default_and_logs(provider, caplog):
+    with caplog.at_level(logging.WARNING):
+        provider._apply_provider_config({"sync_roles": "['users']"})
+    assert provider._sync_roles == {"user"}
+    assert "no valid" in caplog.text
+
+
+def test_effective_config_reports_applied_guardrails(provider):
+    provider._apply_provider_config({
+        "auto_sleep": False,
+        "sync_roles": [],
+        "default_scope": "session",
+        "reflect": {"disabled_for_cron": True, "max_calls_per_session": 0},
+    })
+    assert provider.effective_config() == {
+        "auto_sleep": False,
+        "default_scope": "session",
+        "profile_isolation": False,
+        "reflect": {"disabled_for_cron": True, "max_calls_per_session": 0},
+        "skip_contexts": ["background", "cron", "flush", "skill_loop", "subagent"],
+        "sync_roles": [],
+    }
+
+
+
+def test_invalid_profile_isolation_preserves_existing_boundary(provider, caplog):
+    provider._apply_provider_config({"profile_isolation": "true"})
+    assert provider._profile_isolation_enabled is True
+
+    with caplog.at_level(logging.WARNING):
+        provider._apply_provider_config({"profile_isolation": "definitely-not-a-bool"})
+
+    assert provider._profile_isolation_enabled is True
+    assert "invalid boolean" in caplog.text
+
+
+def test_fresh_core_config_preserves_user_only_capture_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("MNEMOSYNE_SYNC_ROLES", raising=False)
+    monkeypatch.setattr(core_config.MnemosyneConfig, "_instance", None)
+    instance = MnemosyneMemoryProvider()
+    instance._hermes_home = str(tmp_path)
+
+    instance._apply_provider_config({})
+
+    assert instance.effective_config()["sync_roles"] == ["user"]

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.13.0"
+__version__ = "3.14.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/hermes_config.py
+++ b/mnemosyne/hermes_config.py
@@ -2,9 +2,80 @@
 
 from __future__ import annotations
 
+import ast
+import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable, Set, Tuple, List
+
+
+def parse_sync_roles(
+    value: Any,
+    *,
+    current: Iterable[str],
+    valid_roles: Iterable[str] = ("user", "assistant"),
+) -> Tuple[Set[str], List[str]]:
+    """Parse Hermes ``sync_roles`` without silently disabling capture.
+
+    Native lists/tuples/sets and comma-separated strings are canonical.  JSON
+    or Python-literal list strings are accepted for compatibility with older
+    config writers that serialized ``['user']`` as a scalar.  An explicit
+    empty list/string disables capture; invalid or unknown-only non-empty
+    values preserve the currently effective roles and return warnings.
+    """
+    effective = {str(role).strip().lower() for role in current if str(role).strip()}
+    allowed = {str(role).strip().lower() for role in valid_roles if str(role).strip()}
+    warnings: List[str] = []
+
+    raw_roles: Any
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            raw_roles = []
+        elif stripped.startswith("[") and stripped.endswith("]"):
+            try:
+                raw_roles = json.loads(stripped)
+            except (json.JSONDecodeError, TypeError):
+                try:
+                    raw_roles = ast.literal_eval(stripped)
+                except (ValueError, SyntaxError):
+                    warnings.append(f"invalid serialized sync_roles value: {value!r}")
+                    return effective, warnings
+            if not isinstance(raw_roles, (list, tuple, set)):
+                warnings.append(f"serialized sync_roles must be a list: {value!r}")
+                return effective, warnings
+        else:
+            raw_roles = stripped.split(",")
+    elif isinstance(value, (list, tuple, set)):
+        raw_roles = value
+    else:
+        warnings.append(f"invalid sync_roles type {type(value).__name__}: {value!r}")
+        return effective, warnings
+
+    parsed = {str(role).strip().lower() for role in raw_roles if str(role).strip()}
+    unknown = parsed - allowed
+    if unknown:
+        warnings.append(f"unknown sync_roles ignored: {sorted(unknown)!r}")
+    valid = parsed & allowed
+    if parsed and not valid:
+        warnings.append(f"no valid sync_roles in {sorted(parsed)!r}; keeping {sorted(effective)!r}")
+        return effective, warnings
+    return valid, warnings
+
+
+def parse_strict_bool(value: Any) -> Tuple[bool | None, str | None]:
+    """Parse documented boolean forms without weakening active guardrails."""
+    if isinstance(value, bool):
+        return value, None
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value), None
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True, None
+        if normalized in {"false", "0", "no", "off"}:
+            return False, None
+    return None, f"invalid boolean value {value!r}; keeping the current effective value"
 
 
 def read_hermes_config_key(hermes_home: str | None, key: str) -> Any:

--- a/tests/test_hermes_config_sync_roles.py
+++ b/tests/test_hermes_config_sync_roles.py
@@ -1,0 +1,44 @@
+"""Typed sync-role parsing shared by both Hermes provider surfaces."""
+from __future__ import annotations
+
+import pytest
+
+from mnemosyne.hermes_config import parse_sync_roles
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (["user"], {"user"}),
+        (("USER", "assistant"), {"user", "assistant"}),
+        ("user,assistant", {"user", "assistant"}),
+        ("['user']", {"user"}),
+        ('["user", "assistant"]', {"user", "assistant"}),
+        ([], set()),
+        ("", set()),
+    ],
+)
+def test_parse_sync_roles_supported_shapes(raw, expected):
+    parsed, warnings = parse_sync_roles(raw, current={"user"})
+    assert parsed == expected
+    assert warnings == []
+
+
+def test_nonempty_unknown_only_value_preserves_current_and_warns():
+    parsed, warnings = parse_sync_roles("['users', 'tool']", current={"user"})
+    assert parsed == {"user"}
+    assert warnings
+    assert "no valid" in warnings[-1]
+
+
+def test_mixed_valid_and_unknown_value_applies_valid_subset_and_warns():
+    parsed, warnings = parse_sync_roles(["user", "system"], current={"assistant"})
+    assert parsed == {"user"}
+    assert any("unknown" in warning for warning in warnings)
+
+
+@pytest.mark.parametrize("raw", [True, False, 42, 3.14, {"user": True}, None])
+def test_invalid_type_preserves_current(raw):
+    parsed, warnings = parse_sync_roles(raw, current={"user"})
+    assert parsed == {"user"}
+    assert warnings

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -97,6 +97,18 @@ def _provider_for_config(module, hermes_home: Path):
     return provider
 
 
+def test_invalid_profile_isolation_preserves_boundary_in_both_provider_surfaces(
+    provider_modules, tmp_path, caplog
+):
+    for name, module in provider_modules.items():
+        provider = _provider_for_config(module, tmp_path / name)
+        provider._read_config_key = lambda _key: None
+        provider._apply_provider_config({"profile_isolation": True})
+        assert provider._profile_isolation_enabled is True
+        provider._apply_provider_config({"profile_isolation": "definitely-not-a-bool"})
+        assert provider._profile_isolation_enabled is True
+
+
 def _json_stable(value):
     return json.loads(json.dumps(value, sort_keys=True))
 


### PR DESCRIPTION
## Summary
- parse profile_isolation strictly across both provider surfaces
- preserve an already-effective isolation boundary on invalid values
- make CLI bank routing abort before selecting a bank for invalid isolation config
- normalize and validate provider configuration guardrails

## Validation
- isolated Hermes provider integration gate: 82 passed
- focused CLI/provider guardrail gate: 76 passed
- compile and diff checks passed

Related to #327 and #362; this does not implement gateway identity mapping.

## Status
Draft for maintainer review; not intended for merge yet.