### PR TITLE
fix(memory): restore beam initialization lifecycle

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -487,15 +487,24 @@ def _get_connection(db_path: Path = None) -> sqlite3.Connection:
     return _thread_local.conn
 
 
-def _close_beam_connection() -> None:
+def _close_beam_connection(db_path: Optional[Path] = None) -> None:
     """Close the thread-local BEAM connection and checkpoint the WAL.
 
     Thread-local connections under WAL mode can block checkpoints
     after the owning thread exits.  Explicitly closing the connection
     and running ``PRAGMA wal_checkpoint(TRUNCATE)`` prevents the
     ``database is locked`` cascade documented in #382.
+
+    When ``db_path`` is provided, leave a thread-local connection for a
+    different database alone. This lets Mnemosyne release a closed bank
+    without invalidating a newer instance that selected another bank.
     """
-    if hasattr(_thread_local, 'conn') and _thread_local.conn is not None:
+    expected_path = str(Path(db_path)) if db_path is not None else None
+    if (
+        hasattr(_thread_local, 'conn')
+        and _thread_local.conn is not None
+        and (expected_path is None or getattr(_thread_local, 'db_path', None) == expected_path)
+    ):
         try:
             _thread_local.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
         except Exception:

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -199,6 +199,19 @@ class Mnemosyne:
         self.conn = _get_connection(self.db_path)
         init_db(self.db_path)
 
+        # Phase 8: Streaming + Patterns + Plugins (lazy init)
+        self._stream = None
+        self._compressor = None
+        self._pattern_detector = None
+        self._delta_sync = None
+        self._plugin_manager = None
+
+        # Create beam with streaming emitter wired
+        self.beam = BeamMemory(session_id=session_id, db_path=self.db_path,
+                               author_id=author_id, author_type=author_type,
+                               channel_id=channel_id,
+                               event_emitter=self._stream_emit)
+
         self._closed = False
 
     def close(self) -> None:
@@ -220,19 +233,6 @@ class Mnemosyne:
             self.close()
         except Exception:
             pass
-
-        # Phase 8: Streaming + Patterns + Plugins (lazy init)
-        self._stream = None
-        self._compressor = None
-        self._pattern_detector = None
-        self._delta_sync = None
-        self._plugin_manager = None
-
-        # Create beam with streaming emitter wired
-        self.beam = BeamMemory(session_id=session_id, db_path=self.db_path,
-                               author_id=author_id, author_type=author_type,
-                               channel_id=channel_id,
-                               event_emitter=self._stream_emit)
 
     # ─── Phase 8: Streaming ─────────────────────────────────────────
 

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -27,6 +27,8 @@ logger = logging.getLogger(__name__)
 from mnemosyne.core import embeddings as _embeddings
 from mnemosyne.core.beam import BeamMemory, init_beam
 _thread_local = threading.local()
+_instance_connection_lock = threading.Lock()
+_instance_connection_refcounts: Dict[tuple, int] = {}
 
 # Default data directory
 # NOTE: On Fly.io and ephemeral VMs, only ~/.hermes is persisted.
@@ -77,15 +79,25 @@ def _get_connection(db_path = None) -> sqlite3.Connection:
     return _thread_local.conn
 
 
-def _close_connection() -> None:
+def _close_connection(db_path: Optional[Path] = None) -> None:
     """Close the thread-local connection and checkpoint the WAL.
 
     Thread-local connections under WAL mode can block checkpoints
     after the owning thread exits.  Explicitly closing the connection
     and running ``PRAGMA wal_checkpoint(TRUNCATE)`` prevents the
     ``database is locked`` cascade documented in #382.
+
+    When ``db_path`` is provided, leave a thread-local connection for a
+    different database alone.  A thread can switch banks between live
+    Mnemosyne instances, so closing an unrelated cached connection would
+    invalidate the newer instance.
     """
-    if hasattr(_thread_local, 'conn') and _thread_local.conn is not None:
+    expected_path = str(Path(db_path)) if db_path is not None else None
+    if (
+        hasattr(_thread_local, 'conn')
+        and _thread_local.conn is not None
+        and (expected_path is None or getattr(_thread_local, 'db_path', None) == expected_path)
+    ):
         try:
             _thread_local.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
         except Exception:
@@ -96,6 +108,30 @@ def _close_connection() -> None:
             pass
         _thread_local.conn = None
         _thread_local.db_path = None
+
+
+def _connection_owner_key(db_path: Path) -> tuple:
+    """Return the per-thread key for Mnemosyne-owned shared connections."""
+    return threading.get_ident(), str(Path(db_path))
+
+
+def _acquire_instance_connections(db_path: Path) -> tuple:
+    """Register one live Mnemosyne owner for the current thread and database."""
+    key = _connection_owner_key(db_path)
+    with _instance_connection_lock:
+        _instance_connection_refcounts[key] = _instance_connection_refcounts.get(key, 0) + 1
+    return key
+
+
+def _release_instance_connections(key: tuple) -> bool:
+    """Release an owner and return whether it was the last one."""
+    with _instance_connection_lock:
+        remaining = _instance_connection_refcounts.get(key, 0) - 1
+        if remaining <= 0:
+            _instance_connection_refcounts.pop(key, None)
+            return True
+        _instance_connection_refcounts[key] = remaining
+        return False
 
 
 def wal_checkpoint(db_path=None) -> dict:
@@ -177,6 +213,11 @@ class Mnemosyne:
     def __init__(self, session_id: str = "default", db_path: Path = None, bank: str = None,
                  author_id: str = None, author_type: str = None,
                  channel_id: str = None):
+        # Set lifecycle state before allocating BEAM resources so a partially
+        # constructed instance can be cleaned up safely by __del__.
+        self._closed = False
+        self._instance_connection_owner_key = None
+
         # Auto-seed config.yaml on first Mnemosyne init
         from mnemosyne.core.config import get_config
         get_config()  # triggers _seed() if config.yaml doesn't exist
@@ -196,23 +237,35 @@ class Mnemosyne:
         else:
             self.db_path = _default_db_path()
 
-        self.conn = _get_connection(self.db_path)
-        init_db(self.db_path)
+        # Mnemosyne instances in one thread share both module-level SQLite
+        # connections. Keep a small ownership count so closing one wrapper
+        # cannot close the BeamMemory connection another live wrapper needs.
+        self._instance_connection_owner_key = _acquire_instance_connections(self.db_path)
+        try:
+            self.conn = _get_connection(self.db_path)
+            init_db(self.db_path)
 
-        # Phase 8: Streaming + Patterns + Plugins (lazy init)
-        self._stream = None
-        self._compressor = None
-        self._pattern_detector = None
-        self._delta_sync = None
-        self._plugin_manager = None
+            # Phase 8: Streaming + Patterns + Plugins (lazy init)
+            self._stream = None
+            self._compressor = None
+            self._pattern_detector = None
+            self._delta_sync = None
+            self._plugin_manager = None
 
-        # Create beam with streaming emitter wired
-        self.beam = BeamMemory(session_id=session_id, db_path=self.db_path,
-                               author_id=author_id, author_type=author_type,
-                               channel_id=channel_id,
-                               event_emitter=self._stream_emit)
-
-        self._closed = False
+            # Create beam with streaming emitter wired
+            self.beam = BeamMemory(session_id=session_id, db_path=self.db_path,
+                                   author_id=author_id, author_type=author_type,
+                                   channel_id=channel_id,
+                                   event_emitter=self._stream_emit)
+        except Exception:
+            # BeamMemory can open its own thread-local connection before a
+            # later constructor step fails. Release this provisional owner and
+            # close both resources only if no live Mnemosyne shares them.
+            try:
+                self.close()
+            except Exception:
+                pass
+            raise
 
     def close(self) -> None:
         """Close the database connection and checkpoint the WAL.
@@ -223,9 +276,14 @@ class Mnemosyne:
         if self._closed:
             return
         self._closed = True
-        _close_connection()
+        owner_key = self._instance_connection_owner_key
+        self._instance_connection_owner_key = None
+        if owner_key is None or not _release_instance_connections(owner_key):
+            return
+
+        _close_connection(self.db_path)
         from mnemosyne.core.beam import _close_beam_connection
-        _close_beam_connection()
+        _close_beam_connection(self.db_path)
 
     def __del__(self):
         """Best-effort cleanup on garbage collection."""

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -952,11 +952,19 @@ class TestSleepCycle:
 
 
 class TestMnemosyneIntegration:
-    def test_constructor_wires_beam_before_close(self, temp_db):
+    def test_constructor_wires_beam_before_close(self, temp_db, monkeypatch):
         """A close lifecycle must not move BEAM initialization into __del__."""
         mem = Mnemosyne(session_id="lifecycle", db_path=temp_db)
         assert isinstance(mem.beam, BeamMemory)
         assert mem.beam._event_emitter == mem._stream_emit
+
+        delivered = []
+        monkeypatch.setattr(mem.stream, "emit", delivered.append)
+        mem.enable_streaming()
+        event = object()
+        assert mem.beam._event_emitter is not None
+        mem.beam._event_emitter(event)
+        assert delivered == [event]
 
         mem.close()
         mem.close()  # Idempotent cleanup is safe for callers and __del__.
@@ -964,6 +972,31 @@ class TestMnemosyneIntegration:
         successor = Mnemosyne(session_id="successor", db_path=temp_db)
         assert isinstance(successor.beam, BeamMemory)
         successor.close()
+
+    def test_close_keeps_shared_beam_connection_for_live_instance(self, temp_db):
+        first = Mnemosyne(session_id="first", db_path=temp_db)
+        second = Mnemosyne(session_id="second", db_path=temp_db)
+
+        first.close()
+        assert second.beam.conn.execute("SELECT 1").fetchone()[0] == 1
+        second.close()
+
+    def test_constructor_failure_releases_provisional_connection(self, temp_db, monkeypatch):
+        import mnemosyne.core.memory as memory_module
+
+        real_beam = memory_module.BeamMemory
+
+        def fail_beam(*args, **kwargs):
+            raise RuntimeError("beam construction failed")
+
+        monkeypatch.setattr(memory_module, "BeamMemory", fail_beam)
+        with pytest.raises(RuntimeError, match="beam construction failed"):
+            Mnemosyne(session_id="broken", db_path=temp_db)
+
+        monkeypatch.setattr(memory_module, "BeamMemory", real_beam)
+        recovered = Mnemosyne(session_id="recovered", db_path=temp_db)
+        assert isinstance(recovered.beam, BeamMemory)
+        recovered.close()
 
     def test_legacy_and_beam_dual_write(self, temp_db):
         mem = Mnemosyne(session_id="s2", db_path=temp_db)

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -952,6 +952,19 @@ class TestSleepCycle:
 
 
 class TestMnemosyneIntegration:
+    def test_constructor_wires_beam_before_close(self, temp_db):
+        """A close lifecycle must not move BEAM initialization into __del__."""
+        mem = Mnemosyne(session_id="lifecycle", db_path=temp_db)
+        assert isinstance(mem.beam, BeamMemory)
+        assert mem.beam._event_emitter == mem._stream_emit
+
+        mem.close()
+        mem.close()  # Idempotent cleanup is safe for callers and __del__.
+
+        successor = Mnemosyne(session_id="successor", db_path=temp_db)
+        assert isinstance(successor.beam, BeamMemory)
+        successor.close()
+
     def test_legacy_and_beam_dual_write(self, temp_db):
         mem = Mnemosyne(session_id="s2", db_path=temp_db)
         mid = mem.remember("Likes pizza", source="preference", importance=0.8)


### PR DESCRIPTION
## Summary

Restores the pre-#382 Phase 8 lazy-state and `BeamMemory` initialization to `Mnemosyne.__init__`. The WAL cleanup methods remain lifecycle-only.

The #382 insertion accidentally left this initialization under `__del__`, so normal instances had no `beam` attribute and the main CI failed.

## Verification

- Reproduced the current-main failure: `TestMnemosyneIntegration::test_legacy_and_beam_dual_write` raised `AttributeError: Mnemosyne has no attribute beam`.
- Added constructor + idempotent-close regression coverage.
- Focused affected matrix: `44 passed`.
- `py_compile` and `git diff --check` pass.

Note: the unrelated current-main polyphonic recall failure (`PolyphonicResult` has no `content`) remains outside this narrow regression fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR corrects `Mnemosyne`’s core memory lifecycle by restoring Phase 8 lazy-subsystem placeholder setup and `BeamMemory` construction back into `Mnemosyne.__init__` (where it belongs), undoing an accidental relocation under `__del__` introduced previously. That ensures `BeamMemory` is created during construction with the intended event wiring (`event_emitter=self._stream_emit`), while `close()` remains focused on WAL-cleanup and idempotent shutdown. It also adds constructor-and-close regression coverage, including safe behavior across multiple wrappers and exception paths.

- **Core architecture (tiered memory / BEAM):** Re-establishes the intended BEAM tier initialization order by performing Phase 8 streaming/patterns/plugins/delta-sync wiring scaffolding during construction and then instantiating `BeamMemory` with the correct emitter. Removes duplicated/late Phase 8 initialization logic, preventing partially-initialized BEAM state from reaching runtime.
- **Connection lifecycle / long-term correctness:** Introduces instance-scoped ownership/refcounting around thread-local SQLite and BEAM resources so multiple `Mnemosyne` wrappers in the same thread (and/or across different banks/db paths) don’t double-close shared connections. `_close_connection`/`_close_beam_connection` now support targeted `db_path`-aware cleanup to avoid invalidating a newer live instance that switched banks.
- **Retrieval / consolidation / veracity:** No changes to retrieval strategies, consolidation pipeline, or the veracity system behavior are indicated; changes are architectural/lifecycle (initialization timing, correct event plumbing, and safe shutdown).
- **Sync layer:** Phase 8’s delta-sync component is ensured to be included in the constructor-time wiring placeholders; no new sync semantics are described beyond ensuring the sync-related subsystem is initialized in the correct lifecycle phase.
- **Privacy posture & local-first guarantees:** No evidence of added remote behavior or altered data movement. The PR is strictly about local lifecycle correctness (when BEAM is constructed and how local SQLite connections are cleaned up) while preserving the local-first storage model.
- **Agent integration surfaces (Hermes, MCP, CLI):** No direct interface changes. Plugin-manager initialization is restored as part of the constructor-time Phase 8 setup, and BEAM’s config seeding behavior remains the same; this helps ensure agent-related plugin/event surfaces are available when the instance is actually constructed.
- **Maintainability:** Improves lifecycle clarity by separating construction from teardown, adding exception-safety (if BEAM construction fails after provisional ownership acquisition, `close()` is invoked to release owners), and reinforcing `close()` idempotency. Regression tests explicitly validate constructor wiring and safe repeated/second-instance shutdown behavior.
- **Verification & remaining gaps:** Tests add constructor wiring and shared-connection-close behavior; an unrelated polyphonic recall failure remains unresolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->