### PR TITLE
fix(polyphonic): hydrate content before diversity ranking

### DIFF
--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -82,6 +82,7 @@ class PolyphonicResult:
     combined_score: float
     voice_scores: Dict[str, float]
     metadata: Dict
+    content: str = ""
 
 
 class PolyphonicRecallEngine:
@@ -152,13 +153,14 @@ class PolyphonicRecallEngine:
         temporal_results = self._temporal_voice(query)
         
         # Combine results
-        all_results = self._combine_voices(
+        combined = self._combine_voices(
             vector_results, graph_results, fact_results, temporal_results
         )
-        
-        # Re-rank with diversity
-        reranked = self._diversity_rerank(all_results, top_k)
-        
+        self._hydrate_result_content(combined)
+
+        # Diversity re-rank
+        reranked = self._diversity_rerank(combined, top_k)
+
         # Assemble context within budget
         context = self._assemble_context(reranked, context_budget)
         
@@ -690,6 +692,38 @@ class PolyphonicRecallEngine:
         entities = re.findall(r'\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*\b', text)
         return list(set(entities))
     
+    def _hydrate_result_content(self, results: Dict[str, PolyphonicResult]) -> None:
+        """Attach source content before applying content-based diversity ranking."""
+        if not results:
+            return
+
+        if self.conn is not None:
+            conn = self.conn
+            own_conn = False
+        else:
+            conn = sqlite3.connect(str(self.db_path))
+            conn.row_factory = sqlite3.Row
+            own_conn = True
+
+        try:
+            memory_ids = tuple(results)
+            placeholders = ", ".join("?" for _ in memory_ids)
+            for table in ("working_memory", "episodic_memory"):
+                try:
+                    rows = conn.execute(
+                        f"SELECT id, content FROM {table} WHERE id IN ({placeholders})",
+                        memory_ids,
+                    ).fetchall()
+                except sqlite3.OperationalError:
+                    continue
+                for row in rows:
+                    result = results.get(row["id"])
+                    if result is not None and not result.content:
+                        result.content = row["content"] or ""
+        finally:
+            if own_conn:
+                conn.close()
+
     def _combine_voices(self, *voice_results: List[RecallResult]) -> Dict[str, PolyphonicResult]:
         """Combine results from all voices using Reciprocal Rank Fusion.
 

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -196,7 +196,7 @@ class TestE5EnginePlumbing:
         assert combined[second_id].content == "Bob fixed the billing dashboard"
         assert engine._estimate_similarity(
             combined[first_id], combined[second_id]
-        ) < 0.8
+        ) == pytest.approx(1 / 9)
 
     def test_diversity_handles_unmapped_ids_without_shared_connection(self, temp_db):
         """Standalone engines keep synthetic IDs harmless during reranking."""

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -198,6 +198,23 @@ class TestE5EnginePlumbing:
             combined[first_id], combined[second_id]
         ) < 0.8
 
+    def test_diversity_handles_unmapped_ids_without_shared_connection(self, temp_db):
+        """Standalone engines keep synthetic IDs harmless during reranking."""
+        from mnemosyne.core.polyphonic_recall import (
+            PolyphonicRecallEngine,
+            RecallResult,
+        )
+
+        engine = PolyphonicRecallEngine(db_path=temp_db)
+        combined = engine._combine_voices([
+            RecallResult("synthetic:missing", 0.8, "graph", {}),
+        ])
+        engine._hydrate_result_content(combined)
+
+        result = combined["synthetic:missing"]
+        assert result.content == ""
+        assert engine._estimate_similarity(result, result) == 0.0
+
     def test_engine_accepts_shared_connection(self, temp_db):
         """[E5 connection reuse] PolyphonicRecallEngine.__init__ must
         accept conn= so BeamMemory can share its thread-local

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -175,6 +175,29 @@ class TestE5FeatureFlag:
 
 class TestE5EnginePlumbing:
 
+    def test_diversity_hydrates_source_content(self, temp_db):
+        """Content Jaccard must use DB content, not a missing result attribute."""
+        from mnemosyne.core.polyphonic_recall import (
+            PolyphonicRecallEngine,
+            RecallResult,
+        )
+
+        beam = BeamMemory(session_id="e5-content", db_path=temp_db)
+        first_id = beam.remember("Alice deployed the auth service")
+        second_id = beam.remember("Bob fixed the billing dashboard")
+        engine = PolyphonicRecallEngine(db_path=temp_db, conn=beam.conn)
+        combined = engine._combine_voices([
+            RecallResult(first_id, 0.8, "vector", {}),
+            RecallResult(second_id, 0.7, "vector", {}),
+        ])
+
+        engine._hydrate_result_content(combined)
+        assert combined[first_id].content == "Alice deployed the auth service"
+        assert combined[second_id].content == "Bob fixed the billing dashboard"
+        assert engine._estimate_similarity(
+            combined[first_id], combined[second_id]
+        ) < 0.8
+
     def test_engine_accepts_shared_connection(self, temp_db):
         """[E5 connection reuse] PolyphonicRecallEngine.__init__ must
         accept conn= so BeamMemory can share its thread-local


### PR DESCRIPTION
## Summary

Fixes the regression introduced by #389: `PolyphonicResult` did not carry a `content` attribute, so the new content-Jaccard diversity scorer crashed and polyphonic recall returned no results.

The engine now hydrates source content in two bounded queries (working + episodic) after RRF fusion and before diversity ranking. Synthetic/unmapped results retain empty content and are handled safely.

## Verification

- Reproduced the current-main `PolyphonicResult has no attribute content` CI failure.
- Added direct regression coverage for content hydration and content-Jaccard diversity.
- Focused polyphonic/vector suite: `40 passed, 4 skipped`.
- `py_compile` and `git diff --check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes a polyphonic recall regression where `PolyphonicResult` lacked a `content` attribute, breaking the content-Jaccard diversity re-ranking and potentially yielding empty polyphonic recall output. The polyphonic recall pipeline now hydrates `PolyphonicResult.content` from Mnemosyne’s local tiered memories immediately after RRF fusion and before diversity re-ranking; synthetic/unmapped IDs remain safe via empty content.

## Architecture impact

- **Tiered memory (working/episodic/BEAM):**
  - Adds `content: str = ""` to `PolyphonicResult`.
  - Introduces `_hydrate_result_content()` which populates `result.content` by performing **local SQLite reads** from **`working_memory`** and **`episodic_memory`** (does not change BEAM storage/schema).
  - Hydration only fills content when it’s currently empty (`if result is not None and not result.content`).

- **Retrieval strategies / ranking:**
  - Preserves the multi-voice (vector/graph/fact/temporal) recall flow and **RRF fusion**, but inserts `self._hydrate_result_content(combined)` right after combining voices and **before** `_diversity_rerank()`, so content-Jaccard operates on real source text rather than missing attributes.
  - Hydration is bounded to two known tables and targets only the fused result IDs via an `IN (...)` placeholder query.

- **Local-first / privacy posture:**
  - Reads content exclusively from the local SQLite tiered stores (`working_memory`, `episodic_memory`); no external network calls or external I/O are introduced.
  - Safely tolerates schema drift/absent tables by skipping `sqlite3.OperationalError` and leaving `content` as `""` for unmapped/synthetic IDs.

- **Agent integration surfaces (Hermes, MCP, CLI):**
  - No direct contract changes to Hermes/MCP/CLI; this is an internal fix within the polyphonic recall engine that runs under the existing retrieval feature path.
  - The model shape gains internal provenance (`PolyphonicResult.content`) used for ranking, without altering request/response semantics at the integration layer.

- **Veracity / sync layer / consolidation pipeline:**
  - No changes to consolidation, veracity scoring, or sync behavior. The change is localized to the polyphonic recall re-ranking stage.

- **Maintainability / resilience:**
  - Connection reuse aligns with Mnemosyne’s thread-local SQLite pattern: `_hydrate_result_content()` uses the engine’s shared `conn` when available, otherwise creates a short-lived connection and closes it.
  - Explicit test coverage prevents future regressions in content hydration and diversity similarity behavior.

## Verification

- Adds regression tests ensuring:
  - Hydration pulls exact DB-stored content and drives content-Jaccard similarity to the expected value (`pytest.approx(1/9)`).
  - Unmapped/synthetic IDs remain harmless: hydrated `content == ""` and similarity for identical empty content inputs returns `0.0`.
- The focused polyphonic/vector suite passes with the reported skips; `py_compile` and `git diff --check` also pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->