### PR TITLE
revert: unsafe #382 connection lifecycle change

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -487,27 +487,6 @@ def _get_connection(db_path: Path = None) -> sqlite3.Connection:
     return _thread_local.conn
 
 
-def _close_beam_connection() -> None:
-    """Close the thread-local BEAM connection and checkpoint the WAL.
-
-    Thread-local connections under WAL mode can block checkpoints
-    after the owning thread exits.  Explicitly closing the connection
-    and running ``PRAGMA wal_checkpoint(TRUNCATE)`` prevents the
-    ``database is locked`` cascade documented in #382.
-    """
-    if hasattr(_thread_local, 'conn') and _thread_local.conn is not None:
-        try:
-            _thread_local.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-        except Exception:
-            pass
-        try:
-            _thread_local.conn.close()
-        except Exception:
-            pass
-        _thread_local.conn = None
-        _thread_local.db_path = None
-
-
 def _detect_vec_type(conn: sqlite3.Connection) -> str:
     """
     Detect whether sqlite-vec supports int8/bit.

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -77,45 +77,6 @@ def _get_connection(db_path = None) -> sqlite3.Connection:
     return _thread_local.conn
 
 
-def _close_connection() -> None:
-    """Close the thread-local connection and checkpoint the WAL.
-
-    Thread-local connections under WAL mode can block checkpoints
-    after the owning thread exits.  Explicitly closing the connection
-    and running ``PRAGMA wal_checkpoint(TRUNCATE)`` prevents the
-    ``database is locked`` cascade documented in #382.
-    """
-    if hasattr(_thread_local, 'conn') and _thread_local.conn is not None:
-        try:
-            _thread_local.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-        except Exception:
-            pass
-        try:
-            _thread_local.conn.close()
-        except Exception:
-            pass
-        _thread_local.conn = None
-        _thread_local.db_path = None
-
-
-def wal_checkpoint(db_path=None) -> dict:
-    """Run a WAL checkpoint on the thread-local or specified connection.
-
-    Returns a dict with ``busy``, ``log``, ``checkpointed`` keys so
-    callers can monitor whether the checkpoint succeeded.
-    """
-    conn = _get_connection(db_path) if db_path else (
-        _thread_local.conn if hasattr(_thread_local, 'conn') and _thread_local.conn is not None
-        else _get_connection()
-    )
-    try:
-        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
-        return {"busy": row[0], "log": row[1], "checkpointed": row[2]}
-    except Exception as exc:
-        logger.warning("wal_checkpoint failed: %s", exc)
-        return {"busy": -1, "log": -1, "checkpointed": -1}
-
-
 def init_db(db_path: Path = None):
     """Initialize legacy database schema + BEAM schema"""
     conn = _get_connection(db_path)
@@ -198,28 +159,6 @@ class Mnemosyne:
 
         self.conn = _get_connection(self.db_path)
         init_db(self.db_path)
-
-        self._closed = False
-
-    def close(self) -> None:
-        """Close the database connection and checkpoint the WAL.
-
-        Must be called before the owning thread exits to prevent
-        WAL checkpoint blocking (#382).
-        """
-        if self._closed:
-            return
-        self._closed = True
-        _close_connection()
-        from mnemosyne.core.beam import _close_beam_connection
-        _close_beam_connection()
-
-    def __del__(self):
-        """Best-effort cleanup on garbage collection."""
-        try:
-            self.close()
-        except Exception:
-            pass
 
         # Phase 8: Streaming + Patterns + Plugins (lazy init)
         self._stream = None


### PR DESCRIPTION
## Summary

Reverts `c527c40` (#382). The change accidentally moved Mnemosyne constructor initialization under `__del__`, breaking every normal instance with a missing `beam` attribute. Follow-up attempts exposed that safe multi-DB lifecycle support needs a defined lease contract, not incremental patching.

This restores the previously stable connection behavior. The WAL cleanup design will be revisited separately with an explicit lifecycle contract and test matrix.

## Verification

- Reproduced the #382 regression before rollback.
- Focused formerly failing Beam/CLI/allowlist matrix: `43 passed`.
- `py_compile` and `git diff --check` pass.

Supersedes #470 and #472.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Reverts the lifecycle changes that caused normal `Mnemosyne` instances to lose their `beam` attribute, restoring stable core initialization and connection behavior.

## Architectural impact

- Restores the existing working, episodic, and BEAM memory architecture without changing tiering, retrieval, consolidation, veracity, or synchronization behavior.
- Removes the experimental thread-local connection shutdown and WAL checkpointing paths from BEAM and `Mnemosyne`.
- Preserves local-first operation by avoiding new remote dependencies or changes to local persistence.
- Keeps Hermes, MCP, and CLI integration surfaces behaviorally unchanged while restoring their access to properly initialized Mnemosyne instances.
- Simplifies the lifecycle implementation and avoids an implicit destructor-based contract; explicit multi-database lifecycle handling and WAL cleanup should be addressed separately with defined semantics and test coverage.

## Validation

- 43 Beam, CLI, and allowlist tests pass.
- `py_compile` succeeds.
- `git diff --check` succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->