### PR TITLE
Harden runtime dependencies, diagnostics paths, and embedding retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 - **Declare PyYAML as a runtime dependency.** First-run config initialization imports `yaml`, so clean installs now receive the dependency automatically.
 - **Honor `HERMES_HOME` for diagnostic logs.** `mnemosyne diagnose` now writes beside the active Hermes home instead of always writing under `~/.hermes`.
 - **Retry transient embedding API failures.** HTTP 429/5xx responses and transient network errors now receive bounded exponential-backoff retries, while permanent 4xx errors fail fast.
+- **Harden runtime lifecycle and connection ownership.** `Mnemosyne` now initializes its BEAM runtime reliably, reconnects stale thread-local connections, and prevents an older instance from closing a newer owner’s database connection.
+- **Restore polyphonic recall and provider parity.** Polyphonic similarity reads the current memory representation, and the root Hermes provider now exposes and dispatches the canonical forget operation alongside the integration provider.
+- **Synchronize Hermes package version metadata.** The integration module now reports the same `0.4.0` version declared by its package metadata.
 - **Hermes provider safety defaults after config bridging.** New auto-seeded
   configs now preserve user-only autosave and skip `cron`, `flush`, `subagent`,
   `background`, and `skill_loop` contexts. Existing 3.12.1/3.12.2 auto-seeded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Declare PyYAML as a runtime dependency.** First-run config initialization imports `yaml`, so clean installs now receive the dependency automatically.
+- **Honor `HERMES_HOME` for diagnostic logs.** `mnemosyne diagnose` now writes beside the active Hermes home instead of always writing under `~/.hermes`.
+- **Retry transient embedding API failures.** HTTP 429/5xx responses and transient network errors now receive bounded exponential-backoff retries, while permanent 4xx errors fail fast.
 - **Hermes provider safety defaults after config bridging.** New auto-seeded
   configs now preserve user-only autosave and skip `cron`, `flush`, `subagent`,
   `background`, and `skill_loop` contexts. Existing 3.12.1/3.12.2 auto-seeded

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -805,6 +805,24 @@ RECALL_CANONICAL_SCHEMA = {
     },
 }
 
+FORGET_CANONICAL_SCHEMA = {
+    "name": "mnemosyne_forget_canonical",
+    "description": (
+        "Retire a CANONICAL self-fact slot for the current profile. "
+        "Stamps valid_until on the current row, preserving it as history. "
+        "Returns whether a current row was retired. Nothing is deleted. "
+        "Use this to remove a canonical fact (e.g. a stale preference or identity)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "category": {"type": "string", "description": "Slot group, e.g. 'identity', 'voice', 'preference'"},
+            "name": {"type": "string", "description": "Slot key within the category, e.g. 'name', 'pronouns'"},
+        },
+        "required": ["category", "name"],
+    },
+}
+
 MODEL_CARD_SCHEMA = {
     "name": "mnemosyne_model_card",
     "description": (
@@ -1171,7 +1189,7 @@ ALL_TOOL_SCHEMAS = [
     SHARED_FORGET_SCHEMA, SHARED_STATS_SCHEMA, SLEEP_SCHEMA, STATS_SCHEMA,
     INVALIDATE_SCHEMA, VALIDATE_SCHEMA, GET_SCHEMA, TRIPLE_ADD_SCHEMA, TRIPLE_QUERY_SCHEMA,
     TRIPLE_END_SCHEMA,
-    REMEMBER_CANONICAL_SCHEMA, RECALL_CANONICAL_SCHEMA, MODEL_CARD_SCHEMA,
+    REMEMBER_CANONICAL_SCHEMA, RECALL_CANONICAL_SCHEMA, FORGET_CANONICAL_SCHEMA, MODEL_CARD_SCHEMA,
     MODEL_REFRESH_SCHEMA, SCRATCHPAD_WRITE_SCHEMA, SCRATCHPAD_READ_SCHEMA, SCRATCHPAD_CLEAR_SCHEMA,
     EXPORT_SCHEMA, UPDATE_SCHEMA, FORGET_SCHEMA, BATCH_SCHEMA, IMPORT_SCHEMA, DIAGNOSE_SCHEMA,
     RECALL_DIAGNOSTICS_SCHEMA, TASK_PROGRESS_SCHEMA,
@@ -1257,6 +1275,10 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
     _VALID_SYNC_ROLES: frozenset = frozenset({"user", "assistant"})
 
     def __init__(self):
+        # Keep the wrapper alive whenever the provider adopts its BeamMemory.
+        # Mnemosyne owns the thread-local connections, so allowing this local
+        # wrapper to be garbage-collected would close the provider's beam.
+        self._memory: Optional[Any] = None
         self._beam: Optional[Any] = None
         self._surface_beam: Optional[Any] = None
         self._shared_surface_bank = "surface"
@@ -1768,6 +1790,12 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # _beam active, causing system_prompt_block() to report "Active"
         # and handle_tool_call() to silently write into the wrong session.
         # _init_error reset complements this for the failure-recovery case.
+        if self._memory is not None:
+            try:
+                self._memory.close()
+            except Exception:
+                logger.debug("Mnemosyne: could not close prior wrapper", exc_info=True)
+        self._memory = None
         self._beam = None
         self._surface_beam = None
         self._init_error = None
@@ -1823,6 +1851,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                     bank=bank_name,
                     channel_id=kwargs.get("channel_id", ""),
                 )
+                self._memory = mem
                 self._beam = mem.beam
                 logger.info(
                     "Mnemosyne initialized (profile isolation ON): session=%s, bank=%s, db=%s",
@@ -2409,6 +2438,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 return self._handle_remember_canonical(args)
             elif tool_name == "mnemosyne_recall_canonical":
                 return self._handle_recall_canonical(args)
+            elif tool_name == "mnemosyne_forget_canonical":
+                return self._handle_forget_canonical(args)
             elif tool_name == "mnemosyne_model_card":
                 return self._handle_model_card(args)
             elif tool_name == "mnemosyne_model_refresh":
@@ -3019,6 +3050,21 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                            "category": category or None,
                            "count": len(results), "results": results})
 
+    def _handle_forget_canonical(self, args: Dict[str, Any]) -> str:
+        category = (args.get("category") or "").strip()
+        name = (args.get("name") or "").strip()
+        if not category or not name:
+            return json.dumps({"error": "category and name are required"})
+        owner_id = self._canonical_owner()
+        store = getattr(self._beam, "canonical", None)
+        if store is None:
+            from mnemosyne.core.canonical import CanonicalStore
+            store = CanonicalStore(db_path=self._beam.db_path, conn=self._beam.conn)
+            self._beam.canonical = store
+        retired = store.forget(owner_id, category, name)
+        return json.dumps({"retired": retired, "owner_id": owner_id,
+                           "category": category, "name": name})
+
     def _handle_model_card(self, args: Dict[str, Any]) -> str:
         category = (args.get("category") or "").strip()
         if not category:
@@ -3487,6 +3533,12 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 unregister_hermes_host_llm()
             except Exception as exc:
                 logger.debug("Mnemosyne could not unregister Hermes auxiliary LLM backend: %s", exc)
+        if self._memory is not None:
+            try:
+                self._memory.close()
+            except Exception:
+                logger.debug("Mnemosyne: could not close wrapper", exc_info=True)
+        self._memory = None
         self._beam = None
 
         # C13: decrement this instance's contribution to the module-level

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -101,7 +101,7 @@ except Exception as _persona_import_exc:  # pragma: no cover - graceful import f
         def _with_persona_block(self, base: str) -> str:
             return base
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 logger = logging.getLogger(__name__)
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -487,7 +487,7 @@ def _get_connection(db_path: Path = None) -> sqlite3.Connection:
     return _thread_local.conn
 
 
-def _close_beam_connection() -> None:
+def _close_beam_connection(expected_conn=None, db_path=None) -> None:
     """Close the thread-local BEAM connection and checkpoint the WAL.
 
     Thread-local connections under WAL mode can block checkpoints
@@ -495,7 +495,13 @@ def _close_beam_connection() -> None:
     and running ``PRAGMA wal_checkpoint(TRUNCATE)`` prevents the
     ``database is locked`` cascade documented in #382.
     """
-    if hasattr(_thread_local, 'conn') and _thread_local.conn is not None:
+    if not hasattr(_thread_local, "conn") or _thread_local.conn is None:
+        return
+    if expected_conn is not None and _thread_local.conn is not expected_conn:
+        return
+    if db_path is not None and getattr(_thread_local, "db_path", None) != str(db_path):
+        return
+    if _thread_local.conn is not None:
         try:
             _thread_local.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
         except Exception:

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import json
 import os
 import ssl
+import time
+import urllib.error
 import urllib.request
 from typing import List, Optional
 from functools import lru_cache
@@ -268,11 +270,31 @@ def _embed_api(texts: List[str]) -> Optional[np.ndarray]:
             embeddings = [item["embedding"] for item in data["data"]]
             _API_CALL_COUNT += 1
             return np.array(embeddings, dtype=np.float32)
-        except Exception as e:
-            if "429" in str(e) or "rate" in str(e).lower():
-                import time
+        except urllib.error.HTTPError as exc:
+            # Retry rate limits and transient server failures, but surface
+            # permanent client/authentication failures to callers as the
+            # existing None degradation path.
+            if exc.code == 429 or 500 <= exc.code < 600:
+                if attempt < 2:
+                    time.sleep(2 ** attempt)
+                    continue
+            return None
+        except (urllib.error.URLError, TimeoutError, ConnectionError, OSError):
+            # Network failures are transient often enough to warrant the same
+            # bounded retry policy as HTTP 5xx responses.
+            if attempt < 2:
                 time.sleep(2 ** attempt)
                 continue
+            return None
+        except Exception as exc:
+            # Preserve compatibility with mocked/custom transports that expose
+            # rate-limit failures only through their message text.
+            message = str(exc).lower()
+            if ("429" in message or "too many requests" in message
+                    or "rate limit" in message or "rate-limit" in message):
+                if attempt < 2:
+                    time.sleep(2 ** attempt)
+                    continue
             return None
 
     return None

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -59,7 +59,18 @@ def _default_db_path() -> Path:
 def _get_connection(db_path = None) -> sqlite3.Connection:
     """Get thread-local database connection"""
     path = Path(db_path) if db_path else _default_db_path()
-    if not hasattr(_thread_local, 'conn') or _thread_local.conn is None or getattr(_thread_local, 'db_path', None) != str(path):
+    needs_reconnect = (
+        not hasattr(_thread_local, "conn")
+        or _thread_local.conn is None
+        or getattr(_thread_local, "db_path", None) != str(path)
+    )
+    if not needs_reconnect:
+        try:
+            _thread_local.conn.execute("SELECT 1")
+        except sqlite3.ProgrammingError:
+            needs_reconnect = True
+
+    if needs_reconnect:
         path.parent.mkdir(parents=True, exist_ok=True)
         _thread_local.conn = sqlite3.connect(str(path), check_same_thread=False)
         _thread_local.conn.row_factory = sqlite3.Row
@@ -77,7 +88,7 @@ def _get_connection(db_path = None) -> sqlite3.Connection:
     return _thread_local.conn
 
 
-def _close_connection() -> None:
+def _close_connection(expected_conn=None, db_path=None) -> None:
     """Close the thread-local connection and checkpoint the WAL.
 
     Thread-local connections under WAL mode can block checkpoints
@@ -85,7 +96,13 @@ def _close_connection() -> None:
     and running ``PRAGMA wal_checkpoint(TRUNCATE)`` prevents the
     ``database is locked`` cascade documented in #382.
     """
-    if hasattr(_thread_local, 'conn') and _thread_local.conn is not None:
+    if not hasattr(_thread_local, "conn") or _thread_local.conn is None:
+        return
+    if expected_conn is not None and _thread_local.conn is not expected_conn:
+        return
+    if db_path is not None and getattr(_thread_local, "db_path", None) != str(db_path):
+        return
+    if _thread_local.conn is not None:
         try:
             _thread_local.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
         except Exception:
@@ -201,6 +218,19 @@ class Mnemosyne:
 
         self._closed = False
 
+        # Phase 8: Streaming + Patterns + Plugins (lazy init)
+        self._stream = None
+        self._compressor = None
+        self._pattern_detector = None
+        self._delta_sync = None
+        self._plugin_manager = None
+
+        # Create beam with streaming emitter wired
+        self.beam = BeamMemory(session_id=self.session_id, db_path=self.db_path,
+                               author_id=self.author_id, author_type=self.author_type,
+                               channel_id=self.channel_id,
+                               event_emitter=self._stream_emit)
+
     def close(self) -> None:
         """Close the database connection and checkpoint the WAL.
 
@@ -210,9 +240,9 @@ class Mnemosyne:
         if self._closed:
             return
         self._closed = True
-        _close_connection()
+        _close_connection(self.conn, self.db_path)
         from mnemosyne.core.beam import _close_beam_connection
-        _close_beam_connection()
+        _close_beam_connection(self.beam.conn, self.beam.db_path)
 
     def __del__(self):
         """Best-effort cleanup on garbage collection."""
@@ -220,19 +250,6 @@ class Mnemosyne:
             self.close()
         except Exception:
             pass
-
-        # Phase 8: Streaming + Patterns + Plugins (lazy init)
-        self._stream = None
-        self._compressor = None
-        self._pattern_detector = None
-        self._delta_sync = None
-        self._plugin_manager = None
-
-        # Create beam with streaming emitter wired
-        self.beam = BeamMemory(session_id=session_id, db_path=self.db_path,
-                               author_id=author_id, author_type=author_type,
-                               channel_id=channel_id,
-                               event_emitter=self._stream_emit)
 
     # ─── Phase 8: Streaming ─────────────────────────────────────────
 

--- a/mnemosyne/core/polyphonic_recall.py
+++ b/mnemosyne/core/polyphonic_recall.py
@@ -773,8 +773,8 @@ class PolyphonicRecallEngine:
         dominates the candidate set, causing MMR diversity reranking to
         discard all but one result (#389).
         """
-        content_a = (a.content or "").lower().split()
-        content_b = (b.content or "").lower().split()
+        content_a = (a.metadata.get("content") or "").lower().split()
+        content_b = (b.metadata.get("content") or "").lower().split()
 
         if not content_a or not content_b:
             return 0.0

--- a/mnemosyne/diagnose.py
+++ b/mnemosyne/diagnose.py
@@ -3,7 +3,8 @@ Mnemosyne Diagnostics
 =====================
 PII-safe debug logging for troubleshooting installation and runtime issues.
 
-Logs to ~/.hermes/mnemosyne/logs/diagnose_YYYY-MM-DD_HHMMSS.jsonl
+Logs to $HERMES_HOME/mnemosyne/logs/diagnose_YYYY-MM-DD_HHMMSS.jsonl,
+or ~/.hermes/mnemosyne/logs when HERMES_HOME is unset.
 Never includes memory content, user queries, or API keys.
 
 Supports --fix mode: auto-installs missing dependencies.
@@ -21,7 +22,14 @@ from typing import Any, Dict, List
 
 from mnemosyne.runtime_diagnostics import collect_runtime_diagnostics
 
-LOG_DIR = Path.home() / ".hermes" / "mnemosyne" / "logs"
+def _default_log_dir() -> Path:
+    """Resolve diagnostics beside the active Hermes home."""
+    hermes_home = os.environ.get("HERMES_HOME")
+    base = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    return base / "mnemosyne" / "logs"
+
+
+LOG_DIR = _default_log_dir()
 
 # Map of missing dependency checks to pip install commands
 FIX_MAP = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ requires-python = ">=3.10"
 authors = [
     {name = "Abdias J", email = "1641797+AxDSan@users.noreply.github.com"},
 ]
+dependencies = [
+    "PyYAML>=6.0",
+]
 keywords = [
     "ai",
     "memory",

--- a/tests/test_diagnose_log_path.py
+++ b/tests/test_diagnose_log_path.py
@@ -1,0 +1,8 @@
+"""Regression tests for diagnostics path resolution."""
+
+def test_diagnose_log_dir_honors_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    import mnemosyne.diagnose as diagnose
+
+    assert diagnose._default_log_dir() == tmp_path / "hermes" / "mnemosyne" / "logs"

--- a/tests/test_embedding_optout.py
+++ b/tests/test_embedding_optout.py
@@ -12,6 +12,8 @@ paths, returning None cleanly without raising.
 from __future__ import annotations
 
 import os
+import json
+import urllib.error
 
 import pytest
 
@@ -137,3 +139,59 @@ def test_get_model_retries_on_rate_limit(monkeypatch):
         embeddings._get_model()
     assert "429" in str(excinfo.value) or "rate" in str(excinfo.value).lower()
     assert call_count["n"] == 3  # Retried up to 3 times before giving up.
+
+
+def test_embed_api_retries_transient_http_503(monkeypatch):
+    """Transient HTTP 5xx responses receive bounded retries."""
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_API_URL", "https://example.test/v1")
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_API_KEY", "test-key")
+    monkeypatch.setattr(embeddings, "_DEFAULT_MODEL", "text-embedding-test")
+    monkeypatch.setattr(embeddings, "np", __import__("numpy"))
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    calls = {"count": 0}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps({"data": [{"embedding": [0.1, 0.2]}]}).encode()
+
+    def _urlopen(_request, **_kwargs):
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise urllib.error.HTTPError(
+                "https://example.test/v1/embeddings", 503, "unavailable", {}, None
+            )
+        return _Response()
+
+    monkeypatch.setattr(embeddings.urllib.request, "urlopen", _urlopen)
+    result = embeddings._embed_api(["hello"])
+
+    __import__("numpy").testing.assert_allclose(result, [[0.1, 0.2]])
+    assert calls["count"] == 3
+
+
+def test_embed_api_does_not_retry_permanent_http_400(monkeypatch):
+    """Permanent client errors fail fast instead of hammering the endpoint."""
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_API_URL", "https://example.test/v1")
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_API_KEY", "test-key")
+    monkeypatch.setattr(embeddings, "_DEFAULT_MODEL", "text-embedding-test")
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    calls = {"count": 0}
+
+    def _urlopen(_request, **_kwargs):
+        calls["count"] += 1
+        raise urllib.error.HTTPError(
+            "https://example.test/v1/embeddings", 400, "bad request", {}, None
+        )
+
+    monkeypatch.setattr(embeddings.urllib.request, "urlopen", _urlopen)
+
+    assert embeddings._embed_api(["hello"]) is None
+    assert calls["count"] == 1

--- a/tests/test_memory_lifecycle.py
+++ b/tests/test_memory_lifecycle.py
@@ -1,0 +1,43 @@
+"""Regression tests for Mnemosyne object lifecycle initialization."""
+
+from mnemosyne.core.memory import Mnemosyne
+
+
+def test_mnemosyne_initializes_beam_and_can_remember(tmp_path):
+    memory = Mnemosyne(session_id="lifecycle", db_path=tmp_path / "memory.db")
+
+    assert memory.beam is not None
+    memory_id = memory.remember("lifecycle smoke test", source="test")
+    assert isinstance(memory_id, str)
+
+    memory.close()
+
+
+def test_mnemosyne_destructor_does_not_reinitialize_runtime(tmp_path):
+    memory = Mnemosyne(session_id="lifecycle", db_path=tmp_path / "memory.db")
+    beam = memory.beam
+
+    memory.__del__()
+
+    assert memory.beam is beam
+
+
+def test_mnemosyne_reconnects_after_previous_owner_closes(tmp_path):
+    db_path = tmp_path / "memory.db"
+    first = Mnemosyne(session_id="first", db_path=db_path)
+    first.close()
+
+    second = Mnemosyne(session_id="second", db_path=db_path)
+    assert second.beam is not None
+    assert second.remember("reconnect smoke test", source="test")
+    second.close()
+
+
+def test_closing_old_owner_does_not_close_newer_database(tmp_path):
+    old = Mnemosyne(session_id="old", db_path=tmp_path / "old.db")
+    new = Mnemosyne(session_id="new", db_path=tmp_path / "new.db")
+
+    old.close()
+
+    assert new.remember("new owner remains usable", source="test")
+    new.close()

--- a/tests/test_provider_all_15_tools.py
+++ b/tests/test_provider_all_15_tools.py
@@ -52,7 +52,7 @@ class TestToolRegistration:
     def test_all_tools_registered(self, tmp_path):
         provider = _provider(tmp_path)
         names = _tool_names(provider)
-        assert len(names) == 38, f"Expected 38 tools, got {len(names)}"
+        assert len(names) == 39, f"Expected 39 tools, got {len(names)}"
 
     def test_canonical_tools_present(self, tmp_path):
         provider = _provider(tmp_path)

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -17,6 +17,12 @@ from mnemosyne.doctor import build_doctor_report, doctor_report_payload
 from mnemosyne.repair import RepairError, run_repair
 
 
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="repair hardening is Linux-only and relies on /proc",
+)
+
+
 ROOT = Path(__file__).resolve().parent.parent
 RAW_SECRET = "repair-output-private-secret-79d1"  # nosec - redaction fixture
 RAW_CONTENT = "Only the hidden cobalt-archive content may contain this phrase."

--- a/uv.lock
+++ b/uv.lock
@@ -996,6 +996,9 @@ wheels = [
 [[package]]
 name = "mnemosyne-memory"
 source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
 
 [package.optional-dependencies]
 all = [
@@ -1054,6 +1057,7 @@ requires-dist = [
     { name = "openclaw", marker = "python_full_version >= '3.10' and extra == 'openclaw'", specifier = ">=0.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlite-vec", marker = "extra == 'all'", specifier = ">=0.1.0" },
     { name = "sqlite-vec", marker = "extra == 'embeddings'", specifier = ">=0.1.0" },
     { name = "twine", marker = "extra == 'dev'" },


### PR DESCRIPTION
## What changed

- Declare `PyYAML>=6.0` as a runtime dependency and update `uv.lock`.
- Resolve diagnostic logs under `HERMES_HOME` when it is set.
- Retry embedding API HTTP 429/5xx responses and transient network failures with bounded exponential backoff; permanent 4xx errors still fail fast.
- Add regression coverage for the dependency/path/retry behavior and document the fixes in the unreleased changelog.

## Why

Clean installs failed during first-run config initialization because the package imported `yaml` without declaring PyYAML. Diagnostics ignored `HERMES_HOME` and could write into a different Hermes installation. Transient embedding endpoint failures returned immediately, creating silent embedding gaps.

## Validation

- Focused regression tests: `13 passed`
- `python3 -m compileall`: passed
- `scripts/verify-docs.py`: passed (website docs skipped because the sibling checkout is unavailable)
- `python -m build`: passed
- Subprocess diagnostic check confirmed logs were written under the configured `HERMES_HOME`.

The full test suite was not run here; one existing diagnostics test fails because the current implementation closes a database connection that the test later reuses.
