### PR TITLE
chore(hermes): bump mnemosyne-hermes to 0.5.0

### DIFF
--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mnemosyne-hermes"
-version = "0.4.0"
+version = "0.5.0"
 description = "Mnemosyne memory provider for Hermes Agent — local-first, zero-cloud memory"
 readme = "README.md"
 license = "MIT"

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -135,7 +135,7 @@ except Exception as _persona_import_exc:  # pragma: no cover - graceful import f
         def _with_persona_block(self, base: str) -> str:
             return base
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Bumps the Hermes integration package to 0.5.0.

Changes since 0.4.0:
- write_approval gate for mnemosyne_remember and mnemosyne_batch (#456)
- forget_canonical tool support
- doctor bank routing fixes
- provider hardening and lifecycle fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Bumps the Hermes integration package and runtime version from `0.4.0` to `0.5.0`.
- The provided changes only update package metadata; they do not demonstrate changes to Mnemosyne’s core memory architecture, tiered memory, retrieval, consolidation, veracity, sync, or benchmark systems.
- No verified impact is shown for privacy posture, local-first guarantees, Hermes/MCP/CLI surfaces, or long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->