### PR TITLE
docs: align Hermes memory setup with current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,13 +391,13 @@ See [docs/hermes-integration.md](docs/hermes-integration.md) for the full setup 
 
 | Category | Tools |
 |----------|-------|
-| **Core memory** (9) | `remember`, `recall`, `sleep`, `stats`, `get`, `update`, `forget`, `invalidate`, `validate` |
-| **Knowledge graph** (4) | `triple_add`, `triple_query`, `graph_query`, `graph_link` |
-| **Multi-agent surface** (4) | `shared_remember`, `shared_recall`, `shared_forget`, `shared_stats` |
-| **Working notes** (3) | `scratchpad_write`, `scratchpad_read`, `scratchpad_clear` |
-| **Ops** (3) | `export`, `import`, `diagnose` |
+| **Core memory** | `remember`, `recall`, `sleep`, `stats`, `get`, `update`, `forget`, `invalidate`, `validate` |
+| **Knowledge graph** | `triple_add`, `triple_query`, `graph_query`, `graph_link` |
+| **Multi-agent surface** | `shared_remember`, `shared_recall`, `shared_forget`, `shared_stats` |
+| **Working notes** | `scratchpad_write`, `scratchpad_read`, `scratchpad_clear` |
+| **Ops** | `export`, `import`, `diagnose` |
 
-All 23 tools surface through the `mnemosyne-hermes` package, which wraps the `mnemosyne-memory` core library. The plugin manifest at `integrations/hermes/` is also discoverable by Hermes' plugin system.
+The provider tool inventory evolves with the installed package versions. Verify the active provider with `hermes memory status` and inspect the available tools with `hermes tools list`. The plugin manifest at `integrations/hermes/` is also discoverable by Hermes' plugin system.
 
 **Updating:** `pip install --upgrade mnemosyne-hermes && hermes gateway restart` or `git pull && pip install --upgrade integrations/hermes && hermes gateway restart` (source).
 

--- a/README.md
+++ b/README.md
@@ -146,25 +146,25 @@ Full reports: [docs/beam-benchmark.md](docs/beam-benchmark.md)
 
 ## CLI Usage
 
+If Mnemosyne is installed in an isolated venv, activate that venv or invoke its `bin/mnemosyne` executable before running these commands.
+
 ```bash
 # MCP server (works with any MCP client)
 mnemosyne mcp                          # stdio (default)
 mnemosyne mcp --transport sse --port 8080  # SSE (web clients)
 
 # Direct memory ops
-mnemosyne remember "User likes dark mode"
+mnemosyne store "User likes dark mode"
 mnemosyne recall "preferences"
 mnemosyne stats
 mnemosyne sleep                         # Run consolidation
 
 # Export / import
-mnemosyne export --output backup.json
-mnemosyne import --input backup.json
+mnemosyne export backup.json
+mnemosyne import backup.json
 
 # Sync (bidirectional memory sync between instances)
-mnemosyne sync --remote https://my-vps:8765
-mnemosyne sync --remote https://my-vps:8765 --encrypt
-mnemosyne sync serve --port 8765 --api-key "sk-..."
+mnemosyne sync --db-path /path/to/mnemosyne.db --remote https://my-vps:8765
 ```
 
 ---
@@ -374,7 +374,6 @@ python -m pip install mnemosyne-hermes
 mkdir -p ~/.hermes/plugins/mnemosyne
 ln -sfn "$(~/.hermes/hermes-agent/venv/bin/python -c 'import pathlib, mnemosyne_hermes; print(pathlib.Path(mnemosyne_hermes.__file__).resolve().parent)')"/* ~/.hermes/plugins/mnemosyne/
 hermes config set memory.provider mnemosyne
-hermes memory setup
 ```
 
 After installing, verify the provider in the active Hermes profile and start a new session or restart the gateway:
@@ -399,7 +398,15 @@ See [docs/hermes-integration.md](docs/hermes-integration.md) for the full setup 
 
 The provider tool inventory evolves with the installed package versions. Verify the active provider with `hermes memory status` and inspect the available tools with `hermes tools list`. The plugin manifest at `integrations/hermes/` is also discoverable by Hermes' plugin system.
 
-**Updating:** `pip install --upgrade mnemosyne-hermes && hermes gateway restart` or `git pull && pip install --upgrade integrations/hermes && hermes gateway restart` (source).
+**Updating:** For the persistent side-venv wrapper path, use the side venv rather than a bare `pip`:
+
+```bash
+export HERMES_HOME=/opt/data  # Replace with the active Hermes home
+"$HERMES_HOME/.mnemosyne/venv/bin/python" -m pip install --upgrade 'mnemosyne-memory[embeddings]' mnemosyne-hermes
+hermes gateway restart
+```
+
+For a direct or source install, use `pip install --upgrade mnemosyne-hermes && hermes gateway restart` or `git pull && pip install --upgrade integrations/hermes && hermes gateway restart` (source).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ See [docs/hermes-integration.md](docs/hermes-integration.md) for the full setup 
 | **Working notes** | `mnemosyne_scratchpad_write`, `mnemosyne_scratchpad_read`, `mnemosyne_scratchpad_clear` |
 | **Ops** | `mnemosyne_export`, `mnemosyne_import`, `mnemosyne_diagnose` |
 
-The provider tool inventory evolves with the installed package versions. Verify the active provider with `hermes memory status` and inspect the available tools with `hermes tools list`. The plugin manifest at `integrations/hermes/` is also discoverable by Hermes' plugin system.
+The provider tool inventory evolves with the installed package versions. Verify the active provider with `hermes memory status` and inspect the available tools with `hermes tools list`. The installer or wrapper registers the plugin manifest under `$HERMES_HOME/plugins/mnemosyne`, where Hermes discovers it.
 
 **Updating:** For the persistent side-venv wrapper path, use the side venv rather than a bare `pip`:
 

--- a/README.md
+++ b/README.md
@@ -391,11 +391,11 @@ See [docs/hermes-integration.md](docs/hermes-integration.md) for the full setup 
 
 | Category | Tools |
 |----------|-------|
-| **Core memory** | `remember`, `recall`, `sleep`, `stats`, `get`, `update`, `forget`, `invalidate`, `validate` |
-| **Knowledge graph** | `triple_add`, `triple_query`, `graph_query`, `graph_link` |
-| **Multi-agent surface** | `shared_remember`, `shared_recall`, `shared_forget`, `shared_stats` |
-| **Working notes** | `scratchpad_write`, `scratchpad_read`, `scratchpad_clear` |
-| **Ops** | `export`, `import`, `diagnose` |
+| **Core memory** | `mnemosyne_remember`, `mnemosyne_recall`, `mnemosyne_sleep`, `mnemosyne_stats`, `mnemosyne_get`, `mnemosyne_update`, `mnemosyne_forget`, `mnemosyne_invalidate`, `mnemosyne_validate` |
+| **Knowledge graph** | `mnemosyne_triple_add`, `mnemosyne_triple_query`, `mnemosyne_graph_query`, `mnemosyne_graph_link` |
+| **Multi-agent surface** | `mnemosyne_shared_remember`, `mnemosyne_shared_recall`, `mnemosyne_shared_forget`, `mnemosyne_shared_stats` |
+| **Working notes** | `mnemosyne_scratchpad_write`, `mnemosyne_scratchpad_read`, `mnemosyne_scratchpad_clear` |
+| **Ops** | `mnemosyne_export`, `mnemosyne_import`, `mnemosyne_diagnose` |
 
 The provider tool inventory evolves with the installed package versions. Verify the active provider with `hermes memory status` and inspect the available tools with `hermes tools list`. The plugin manifest at `integrations/hermes/` is also discoverable by Hermes' plugin system.
 

--- a/README.md
+++ b/README.md
@@ -348,9 +348,9 @@ See [docs/configuration.md#custom-embedding-models](docs/configuration.md#custom
 
 ---
 
-## Hermes Plugin (23 tools)
+## Hermes Plugin
 
-When used with Hermes Agent, Mnemosyne exposes **23 tools** for full memory lifecycle management -- 3 lifecycle hooks (`pre_llm_call`, `on_session_start`, `post_tool_call`) for automatic context injection, plus MCP support.
+When used with Hermes Agent, Mnemosyne exposes provider tools for the memory lifecycle, lifecycle hooks for automatic context injection, and MCP support.
 
 > **For the full Hermes setup guide, see [docs/hermes-integration.md](docs/hermes-integration.md).** That is the canonical, most up-to-date reference.
 
@@ -377,15 +377,13 @@ hermes config set memory.provider mnemosyne
 hermes memory setup
 ```
 
-Then disable Hermes' built-in MEMORY.md/USER.md system so Mnemosyne is the sole memory provider. Do NOT use `hermes tools disable memory` -- that also kills all 23 Mnemosyne-registered tools.
+After installing, verify the provider in the active Hermes profile and start a new session or restart the gateway:
 
-Edit `~/.hermes/config.yaml`:
-
-```yaml
-memory:
-  memory_enabled: false
-user_profile_enabled: false
+```bash
+hermes memory status
 ```
+
+Do **not** use `hermes tools disable memory`: that disables the memory toolset, including provider tools. In current Hermes versions, built-in memory and an external provider are separate mechanisms; `hermes memory off` disables the external provider only. Keep existing built-in memory as a rollback/reference point during a transition and confirm the active provider with `hermes memory status`.
 
 See [docs/hermes-integration.md](docs/hermes-integration.md) for the full setup guide.
 

--- a/README.md
+++ b/README.md
@@ -386,17 +386,15 @@ Do **not** use `hermes tools disable memory`: that disables the memory toolset, 
 
 See [docs/hermes-integration.md](docs/hermes-integration.md) for the full setup guide.
 
-### Tool categories
+### Tool discovery
 
-| Category | Tools |
-|----------|-------|
-| **Core memory** | `mnemosyne_remember`, `mnemosyne_recall`, `mnemosyne_sleep`, `mnemosyne_stats`, `mnemosyne_get`, `mnemosyne_update`, `mnemosyne_forget`, `mnemosyne_invalidate`, `mnemosyne_validate` |
-| **Knowledge graph** | `mnemosyne_triple_add`, `mnemosyne_triple_query`, `mnemosyne_graph_query`, `mnemosyne_graph_link` |
-| **Multi-agent surface** | `mnemosyne_shared_remember`, `mnemosyne_shared_recall`, `mnemosyne_shared_forget`, `mnemosyne_shared_stats` |
-| **Working notes** | `mnemosyne_scratchpad_write`, `mnemosyne_scratchpad_read`, `mnemosyne_scratchpad_clear` |
-| **Ops** | `mnemosyne_export`, `mnemosyne_import`, `mnemosyne_diagnose` |
+The provider tool inventory is version-specific. Confirm the active provider with `hermes memory status`, then inspect the runtime tool surface:
 
-The provider tool inventory evolves with the installed package versions. Verify the active provider with `hermes memory status` and inspect the available tools with `hermes tools list`. The installer or wrapper registers the plugin manifest under `$HERMES_HOME/plugins/mnemosyne`, where Hermes discovers it.
+```bash
+hermes tools list | grep mnemosyne_
+```
+
+Mnemosyne exposes memory, knowledge-graph, multi-agent-surface, working-note, and operational tools. Treat the runtime list as authoritative. The installer or wrapper registers the plugin manifest under `$HERMES_HOME/plugins/mnemosyne`, where Hermes discovers it.
 
 **Updating:** For the persistent side-venv wrapper path, use the side venv rather than a bare `pip`:
 

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -46,8 +46,8 @@ pip install -e "integrations/hermes[dev]"
 > ```bash
 > # Inside the container, pointing at a side/persistent venv that has mnemosyne-hermes installed
 > export HERMES_HOME=/opt/data
-> mnemosyne-hermes install --mode wrapper --python /path/to/venv/bin/python
-> mnemosyne-hermes status
+> /path/to/venv/bin/mnemosyne-hermes install --mode wrapper --python /path/to/venv/bin/python
+> /path/to/venv/bin/mnemosyne-hermes status
 > hermes config set memory.provider mnemosyne
 > hermes gateway restart
 > ```
@@ -198,8 +198,22 @@ Mnemosyne does not currently expose a standalone REST API server.
 
 ## Uninstall
 
+### Persistent wrapper / Docker-image install
+
+```bash
+export HERMES_HOME=/opt/data  # Replace with the non-default Hermes home used at install time
+VENV=/path/to/venv             # The same side venv passed to the wrapper install
+"$VENV/bin/mnemosyne-hermes" uninstall
+hermes memory off  # Disable the external provider; built-in memory remains active
+"$VENV/bin/python" -m pip uninstall mnemosyne-hermes
+```
+
+`mnemosyne-hermes uninstall` removes the plugin registration at `$HERMES_HOME/plugins/mnemosyne`.
+
+### Activated local environment
+
 ```bash
 mnemosyne-hermes uninstall
-hermes memory off  # Disable the external provider; built-in memory remains active
+hermes memory off
 pip uninstall mnemosyne-hermes
 ```

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -75,10 +75,11 @@ hermes memory setup
 
 Do **not** use `hermes tools disable memory`: that disables the memory toolset, including provider tools. In current Hermes versions, built-in memory and an external provider are separate mechanisms; `hermes memory off` disables the external provider only. Keep existing built-in memory as a rollback/reference point during a transition.
 
-Start a new session or restart the gateway, then verify the active Hermes profile:
+Start a new session or restart the gateway, then verify the active Hermes profile. `hermes memory status` reports local provider registration/state; it is not a connectivity or end-to-end write test:
 
 ```bash
 hermes memory status
+hermes tools list
 ```
 
 ### Step 5: Verify

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -124,27 +124,15 @@ Mnemosyne hooks into the Hermes agent lifecycle:
 | `on_session_start` | Initializes session-scoped memory state |
 | `post_tool_call` | Captures tool results as memories (if configured) |
 
-### Registered Tools
+### Tool discovery
 
-Mnemosyne registers these tools in the Hermes tool registry:
+The provider tool inventory is version-specific. Confirm the active provider with `hermes memory status`, then inspect the runtime tool surface:
 
-| Tool | Description |
-|---|---|
-| `mnemosyne_remember` | Store a memory |
-| `mnemosyne_recall` | Search memories |
-| `mnemosyne_stats` | Show memory statistics |
-| `mnemosyne_triple_add` | Add a knowledge graph triple |
-| `mnemosyne_triple_query` | Query the knowledge graph |
-| `mnemosyne_sleep` | Run consolidation |
-| `mnemosyne_scratchpad_write` | Write to scratchpad |
-| `mnemosyne_scratchpad_read` | Read scratchpad |
-| `mnemosyne_scratchpad_clear` | Clear scratchpad |
-| `mnemosyne_update` | Update a memory by ID |
-| `mnemosyne_forget` | Delete a memory by ID |
-| `mnemosyne_invalidate` | Mark a memory as superseded |
-| `mnemosyne_export` | Export all memories to JSON |
-| `mnemosyne_import` | Import memories from JSON |
-| `mnemosyne_diagnose` | Run PII-safe diagnostics |
+```bash
+hermes tools list | grep mnemosyne_
+```
+
+The provider exposes memory, knowledge-graph, multi-agent-surface, working-note, and operational tools; use the runtime list rather than a fixed documentation inventory.
 
 ## CLI Commands
 
@@ -203,8 +191,9 @@ Mnemosyne does not currently expose a standalone REST API server.
 ```bash
 export HERMES_HOME=/opt/data  # Replace with the non-default Hermes home used at install time
 VENV=/path/to/venv             # The same side venv passed to the wrapper install
-"$VENV/bin/mnemosyne-hermes" uninstall
 hermes memory off  # Disable the external provider; built-in memory remains active
+hermes gateway restart  # Run from a shell outside the gateway process
+"$VENV/bin/mnemosyne-hermes" uninstall
 "$VENV/bin/python" -m pip uninstall mnemosyne-hermes
 ```
 
@@ -213,7 +202,8 @@ hermes memory off  # Disable the external provider; built-in memory remains acti
 ### Activated local environment
 
 ```bash
-mnemosyne-hermes uninstall
 hermes memory off
+hermes gateway restart  # Run from a shell outside the gateway process
+mnemosyne-hermes uninstall
 pip uninstall mnemosyne-hermes
 ```

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -90,6 +90,28 @@ hermes mnemosyne stats     # Working + episodic memory counts
 
 > If `hermes mnemosyne stats` gives "invalid choice: 'mnemosyne'", the plugin CLI registration didn't load. Use the fallback `hermes hermes-mnemosyne stats` instead, or re-run step 2 to relink the plugin.
 
+## Health checks and repair
+
+Use `mnemosyne doctor` for a bounded, read-only report on one database. It never writes to the inspected database; write its report artifacts somewhere other than that database:
+
+```bash
+mnemosyne doctor --bank default \
+  --format both \
+  --json-out mnemosyne-doctor.json \
+  --markdown-out mnemosyne-doctor.md
+```
+
+`mnemosyne repair` is intentionally narrow and report-gated, not a global cleanup command. Review the Doctor report, select only the candidate you intend to act on, and run a dry run first:
+
+```bash
+mnemosyne repair \
+  --report mnemosyne-doctor.json \
+  --select working_memory:<ID> \
+  --dry-run
+```
+
+Only add `--apply` after reviewing the report and dry-run output. Repair requires both the report and an explicit selection; do not use it as a substitute for an ownership, retention, or delete-behavior decision.
+
 ## How It Works
 
 Mnemosyne hooks into the Hermes agent lifecycle:

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -45,12 +45,14 @@ pip install -e "integrations/hermes[dev]"
 >
 > ```bash
 > # Inside the container, pointing at a side/persistent venv that has mnemosyne-hermes installed
-> mnemosyne-hermes install --hermes-home /opt/data --mode wrapper --python /path/to/venv/bin/python
-> mnemosyne-hermes status --hermes-home /opt/data
+> export HERMES_HOME=/opt/data
+> mnemosyne-hermes install --mode wrapper --python /path/to/venv/bin/python
+> mnemosyne-hermes status
+> hermes config set memory.provider mnemosyne
 > hermes gateway restart
 > ```
 >
-> The default `install` mode still creates the historical plugin symlink. Wrapper mode creates a real directory under `$HERMES_HOME/plugins/mnemosyne/` and imports `mnemosyne_hermes` from the selected Python environment. Skip Steps 2-4 below; the installer handles everything. Run `hermes memory setup` after restarting to activate.
+> The default `install` mode still creates the historical plugin symlink. Wrapper mode creates a real directory under `$HERMES_HOME/plugins/mnemosyne/` and imports `mnemosyne_hermes` from the selected Python environment. Skip the manual link and activation steps below; the installer handles plugin registration. Verify the active provider after restarting.
 
 ### Step 2: Link the plugin
 
@@ -68,7 +70,6 @@ If you installed in a custom venv (e.g. `~/.hermes-venv`), replace `~/.hermes/he
 
 ```bash
 hermes config set memory.provider mnemosyne
-hermes memory setup
 ```
 
 ### Step 4: Verify the active provider
@@ -84,16 +85,16 @@ hermes tools list
 
 ### Step 5: Verify
 
+The commands below assume `mnemosyne` is on `PATH`. For persistent wrapper mode, invoke the core CLI through the side venv (for example, `/path/to/venv/bin/mnemosyne`) or activate that venv first.
+
 ```bash
 hermes memory status       # Should show "Provider: mnemosyne"
-hermes mnemosyne stats     # Working + episodic memory counts
+mnemosyne stats            # Working + episodic memory counts
 ```
-
-> If `hermes mnemosyne stats` gives "invalid choice: 'mnemosyne'", the plugin CLI registration didn't load. Use the fallback `hermes hermes-mnemosyne stats` instead, or re-run step 2 to relink the plugin.
 
 ## Health checks and repair
 
-Use `mnemosyne doctor` for a bounded, read-only report on one database. It never writes to the inspected database; write its report artifacts somewhere other than that database:
+Use `mnemosyne doctor` for a bounded, read-only report on one bank/database. It never writes to the inspected database and rejects an output path that would overwrite it; the example writes report files to the current directory, so choose explicit output paths when needed:
 
 ```bash
 mnemosyne doctor --bank default \
@@ -148,20 +149,13 @@ Mnemosyne registers these tools in the Hermes tool registry:
 ## CLI Commands
 
 ```bash
-hermes mnemosyne stats              # Current session stats
-hermes mnemosyne stats --global     # Stats across all sessions
-hermes mnemosyne inspect "query"    # Search memories
-hermes mnemosyne sleep              # Run consolidation
-hermes mnemosyne export --output backup.json
-hermes mnemosyne import --input backup.json
-
-# Import historical Hindsight memories via PR #28's timestamp-preserving importer
-hermes mnemosyne import --from hindsight --file hindsight-export.json --bank hermes
-hermes mnemosyne import --from hindsight --input hindsight-export.json --bank hermes
-hermes mnemosyne import --from hindsight --base-url http://localhost:8888 --bank hermes
-
-hermes mnemosyne clear              # Clear scratchpad
-hermes mnemosyne version            # Show version
+mnemosyne stats                         # Show memory statistics
+mnemosyne sleep                         # Run consolidation
+mnemosyne export backup.json            # Export memories
+mnemosyne import backup.json            # Import memories
+mnemosyne import-hindsight hindsight-export.json hermes
+mnemosyne doctor --bank default --format both
+mnemosyne repair --report mnemosyne-doctor.json --select working_memory:<ID> --dry-run
 ```
 
 ## Data Location
@@ -205,7 +199,7 @@ Mnemosyne does not currently expose a standalone REST API server.
 ## Uninstall
 
 ```bash
+mnemosyne-hermes uninstall
+hermes memory off  # Disable the external provider; built-in memory remains active
 pip uninstall mnemosyne-hermes
-hermes config set memory.provider memory   # Switch back to built-in
-hermes memory setup
 ```

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -71,19 +71,15 @@ hermes config set memory.provider mnemosyne
 hermes memory setup
 ```
 
-### Step 4: Disable built-in memory
+### Step 4: Verify the active provider
 
-Disable Hermes' built-in MEMORY.md/USER.md system so Mnemosyne is the sole memory provider. Do NOT use `hermes tools disable memory` — that also kills all 23 Mnemosyne-registered tools.
+Do **not** use `hermes tools disable memory`: that disables the memory toolset, including provider tools. In current Hermes versions, built-in memory and an external provider are separate mechanisms; `hermes memory off` disables the external provider only. Keep existing built-in memory as a rollback/reference point during a transition.
 
-Edit `~/.hermes/config.yaml`:
+Start a new session or restart the gateway, then verify the active Hermes profile:
 
-```yaml
-memory:
-  memory_enabled: false
-user_profile_enabled: false
+```bash
+hermes memory status
 ```
-
-`memory_enabled: false` turns off the file-based MEMORY.md system. `user_profile_enabled: false` stops USER.md injection. Both are redundant once Mnemosyne is active.
 
 ### Step 5: Verify
 

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -222,6 +222,8 @@ Set `HERMES_HOME` to the active Hermes home before removing a Path A wrapper ins
 
 ```bash
 export HERMES_HOME=/opt/data  # Replace with the active Hermes home
+hermes memory off  # Disable the external provider; built-in memory remains active
+hermes gateway restart  # Run from a shell outside the gateway process
 "$HERMES_HOME/.mnemosyne/venv/bin/mnemosyne-hermes" uninstall
 rm -rf "$HERMES_HOME/.mnemosyne/venv"  # Only if this venv was created by Path A
 ```
@@ -229,14 +231,9 @@ rm -rf "$HERMES_HOME/.mnemosyne/venv"  # Only if this venv was created by Path A
 ### Path B or Path D: pip/source install
 
 ```bash
-python -m mnemosyne.install --uninstall
-```
-
-After either path, disable the external provider and restart:
-
-```bash
 hermes memory off
-hermes gateway restart
+hermes gateway restart  # Run from a shell outside the gateway process
+python -m mnemosyne.install --uninstall
 ```
 
 ---

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -38,6 +38,8 @@ The wrapper installer registers the provider plugin in `$HERMES_HOME/plugins`. V
 hermes memory status
 ```
 
+These status commands report local provider state only; they do not prove database access, tool execution, or a successful memory round trip. Use the stats and store/recall checks in [Post-Install: Verify Everything Works](#post-install-verify-everything-works) for functional validation.
+
 ---
 
 ## Path B: pip install + Register with Hermes
@@ -86,6 +88,8 @@ hermes memory status        # Should show: Provider: mnemosyne
 mnemosyne stats             # Working + episodic counts
 hermes tools list | grep mnemosyne
 ```
+
+`hermes memory status` reports local provider state only; it does not prove database access, tool execution, or a successful memory round trip. Confirm functional behavior with `mnemosyne stats` and the store/recall check in [Post-Install: Verify Everything Works](#post-install-verify-everything-works).
 
 ---
 

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -9,7 +9,7 @@
 
 | User has... | Use |
 |---|---|
-| Hermes Agent already installed | **Path A: One-liner deploy** (fastest, 1 command) |
+| Hermes Agent already installed | **Path A: persistent side venv + wrapper** — install, configure, then restart |
 | Hermes Agent + wants PyPI package | **Path B: pip install + register** |
 | No Hermes, just wants the library | **Path C: pip install (standalone)** |
 | Wants to contribute or develop | **Path D: Source install** |
@@ -21,8 +21,11 @@
 For a persistent Docker/image install, use a persistent side venv and the wrapper installer. It keeps the plugin directory independent from a rebuildable Hermes venv:
 
 ```bash
-# install mnemosyne-memory plus mnemosyne-hermes into a persistent venv first
-mnemosyne-hermes install --hermes-home /opt/data --mode wrapper --python /path/to/venv/bin/python
+VENV=/opt/data/.mnemosyne/venv
+python3 -m venv "$VENV"
+"$VENV/bin/python" -m pip install --upgrade pip
+"$VENV/bin/python" -m pip install 'mnemosyne-memory[embeddings]' mnemosyne-hermes
+"$VENV/bin/mnemosyne-hermes" install --hermes-home /opt/data --mode wrapper --python "$VENV/bin/python"
 hermes config set memory.provider mnemosyne
 hermes gateway restart
 ```
@@ -30,7 +33,7 @@ hermes gateway restart
 The wrapper installer registers the provider plugin. Verify the active profile rather than adding a separate `plugins.enabled` entry:
 
 ```bash
-mnemosyne-hermes status --hermes-home /opt/data
+"$VENV/bin/mnemosyne-hermes" status --hermes-home /opt/data
 hermes memory status
 ```
 

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -9,8 +9,8 @@
 
 | User has... | Use |
 |---|---|
-| Hermes Agent already installed | **Path A: persistent side venv + wrapper** — install, configure, then restart |
-| Hermes Agent + wants PyPI package | **Path B: pip install + register** |
+| Hermes Agent in a persistent Docker/image deployment | **Path A: persistent side venv + wrapper** — install, configure, then restart |
+| Hermes Agent installed locally | **Path B: pip install + register** |
 | No Hermes, just wants the library | **Path C: pip install (standalone)** |
 | Wants to contribute or develop | **Path D: Source install** |
 

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -128,7 +128,7 @@ hermes gateway restart
 
 ## Post-Install: Verify Everything Works
 
-For Path A, invoke the core CLI as `"$VENV/bin/mnemosyne"` below or activate the side venv first. Other install paths assume `mnemosyne` is on `PATH`.
+For Path A, re-export `VENV=/path/to/venv` to the same side venv passed to the wrapper install when verifying from a new shell, then invoke the core CLI as `"$VENV/bin/mnemosyne"` below. Other install paths assume `mnemosyne` is on `PATH`.
 
 Run these checks in order. Stop if any fails.
 
@@ -159,7 +159,8 @@ Expected: Working and episodic memory counts (numbers, even if 0).
 ### 4. Store and recall a test memory
 
 ```bash
-python3 -c "
+# Path A: use the persistent side venv. Other paths: replace with python3.
+"$VENV/bin/python" -c "
 from mnemosyne import remember, recall
 mid = remember('TEST: install verification', importance=0.5, source='test')
 print(f'Stored: {mid}')

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -16,45 +16,22 @@
 
 ---
 
-## Path A: One-Liner Deploy (Hermes MemoryProvider)
+## Path A: Hermes provider install
 
-The fastest way to integrate Mnemosyne as Hermes's memory backend. Creates a symlink — no pip needed, no venv needed.
-
-```bash
-curl -sSL https://raw.githubusercontent.com/AxDSan/mnemosyne/main/deploy_hermes_provider.sh | bash
-```
-
-**What this does:**
-1. Symlinks `hermes_memory_provider/` → `~/.hermes/plugins/mnemosyne/`
-2. Tells you to set `memory.provider: mnemosyne` in config
-
-**After running, configure Hermes:**
+For a persistent Docker/image install, use a persistent side venv and the wrapper installer. It keeps the plugin directory independent from a rebuildable Hermes venv:
 
 ```bash
+# install mnemosyne-memory plus mnemosyne-hermes into a persistent venv first
+mnemosyne-hermes install --hermes-home /opt/data --mode wrapper --python /path/to/venv/bin/python
 hermes config set memory.provider mnemosyne
+hermes gateway restart
 ```
 
-**Or edit `~/.hermes/config.yaml` directly:**
-
-```yaml
-memory:
-  provider: mnemosyne
-```
-
-**IMPORTANT:** Also add `mnemosyne` to `plugins.enabled` in `~/.hermes/config.yaml`:
-
-```yaml
-plugins:
-  enabled:
-    - mnemosyne
-```
-
-**Verify:**
+The wrapper installer registers the provider plugin. Verify the active profile rather than adding a separate `plugins.enabled` entry:
 
 ```bash
-hermes gateway restart
+mnemosyne-hermes status --hermes-home /opt/data
 hermes memory status
-hermes mnemosyne stats
 ```
 
 ---
@@ -163,7 +140,7 @@ Expected: `Provider: mnemosyne` with `is_available: true`
 hermes tools list | grep mnemosyne
 ```
 
-Expected: 15 tools (remember, recall, stats, sleep, triple_add, triple_query, scratchpad_write, scratchpad_read, scratchpad_clear, invalidate, export, update, forget, import, diagnose)
+Expected: Mnemosyne provider tools are listed. The exact tool surface evolves with the installed package versions, so do not use a fixed tool count as the health check.
 
 ### 3. Memory operations work
 

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -154,6 +154,14 @@ Expected: Mnemosyne provider tools are listed. The exact tool surface evolves wi
 
 ### 3. Memory operations work
 
+For Path A:
+
+```bash
+"$VENV/bin/mnemosyne" stats
+```
+
+For other install paths:
+
 ```bash
 mnemosyne stats
 ```

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -18,22 +18,23 @@
 
 ## Path A: Hermes provider install
 
-For a persistent Docker/image install, use a persistent side venv and the wrapper installer. It keeps the plugin directory independent from a rebuildable Hermes venv:
+For a persistent Docker/image install, use a persistent side venv and the wrapper installer. It keeps the plugin directory independent from a rebuildable Hermes venv. Set `HERMES_HOME` to the directory that contains the active Hermes `config.yaml`; `/opt/data` below is the Docker/image example and must be replaced for other deployments:
 
 ```bash
-VENV=/opt/data/.mnemosyne/venv
+export HERMES_HOME=/opt/data
+VENV="$HERMES_HOME/.mnemosyne/venv"
 python3 -m venv "$VENV"
 "$VENV/bin/python" -m pip install --upgrade pip
 "$VENV/bin/python" -m pip install 'mnemosyne-memory[embeddings]' mnemosyne-hermes
-"$VENV/bin/mnemosyne-hermes" install --hermes-home /opt/data --mode wrapper --python "$VENV/bin/python"
+"$VENV/bin/mnemosyne-hermes" install --mode wrapper --python "$VENV/bin/python"
 hermes config set memory.provider mnemosyne
 hermes gateway restart
 ```
 
-The wrapper installer registers the provider plugin. Verify the active profile rather than adding a separate `plugins.enabled` entry:
+The wrapper installer registers the provider plugin in `$HERMES_HOME/plugins`. Verify the active profile rather than adding a separate `plugins.enabled` entry:
 
 ```bash
-"$VENV/bin/mnemosyne-hermes" status --hermes-home /opt/data
+"$VENV/bin/mnemosyne-hermes" status
 hermes memory status
 ```
 
@@ -82,7 +83,7 @@ This creates `~/.hermes/plugins/mnemosyne/` and sets `memory.provider: mnemosyne
 ```bash
 hermes gateway restart
 hermes memory status        # Should show: Provider: mnemosyne
-hermes mnemosyne stats      # Working + episodic counts
+mnemosyne stats             # Working + episodic counts
 hermes tools list | grep mnemosyne
 ```
 
@@ -127,6 +128,8 @@ hermes gateway restart
 
 ## Post-Install: Verify Everything Works
 
+For Path A, invoke the core CLI as `"$VENV/bin/mnemosyne"` below or activate the side venv first. Other install paths assume `mnemosyne` is on `PATH`.
+
 Run these checks in order. Stop if any fails.
 
 ### 1. Provider is registered
@@ -148,7 +151,7 @@ Expected: Mnemosyne provider tools are listed. The exact tool surface evolves wi
 ### 3. Memory operations work
 
 ```bash
-hermes mnemosyne stats
+mnemosyne stats
 ```
 
 Expected: Working and episodic memory counts (numbers, even if 0).
@@ -178,7 +181,7 @@ memory:
   provider: mnemosyne
 ```
 
-The wrapper installer registers the plugin; do not add a separate `plugins.enabled` entry for that path.
+Both Path A's wrapper installer and Path B's `python -m mnemosyne.install` register the plugin; do not add a separate `plugins.enabled` entry for either of those installer paths.
 
 ### Optional environment variables
 
@@ -193,25 +196,45 @@ The wrapper installer registers the plugin; do not add a separate `plugins.enabl
 ## Updating
 
 ```bash
-# PyPI users
+# Path A: persistent side venv + wrapper
+export HERMES_HOME=/opt/data  # Replace with the active Hermes home
+"$HERMES_HOME/.mnemosyne/venv/bin/python" -m pip install --upgrade 'mnemosyne-memory[embeddings]' mnemosyne-hermes
+hermes gateway restart
+
+# Path B: direct PyPI install
 pip install --upgrade mnemosyne-memory
 hermes gateway restart
 
-# Source users
+# Path D: source install
 cd mnemosyne && git pull
-hermes gateway restart
-
-# Re-run pip install -e only if setup.py or pyproject.toml changed
 pip install -e ".[all,dev]"
+hermes gateway restart
 ```
 
 ---
 
 ## Uninstalling
 
+Set `HERMES_HOME` to the active Hermes home before removing a Path A wrapper install.
+
+### Path A: persistent side venv + wrapper
+
+```bash
+export HERMES_HOME=/opt/data  # Replace with the active Hermes home
+"$HERMES_HOME/.mnemosyne/venv/bin/mnemosyne-hermes" uninstall
+rm -rf "$HERMES_HOME/.mnemosyne/venv"  # Only if this venv was created by Path A
+```
+
+### Path B or Path D: pip/source install
+
 ```bash
 python -m mnemosyne.install --uninstall
-hermes config set memory.provider null
+```
+
+After either path, disable the external provider and restart:
+
+```bash
+hermes memory off
 hermes gateway restart
 ```
 
@@ -233,7 +256,7 @@ python -m mnemosyne.install
 
 The package isn't installed in Hermes's Python environment. Either:
 - Activate the correct venv and reinstall
-- Use Path A (symlink deploy) instead — it doesn't need pip
+- Use Path A's persistent side venv + wrapper so the package does not need to live in Hermes's rebuildable environment
 
 ### Tools not showing up
 
@@ -241,8 +264,8 @@ The package isn't installed in Hermes's Python environment. Either:
 # Check plugins are loaded
 hermes plugins list
 
-# Verify wrapper registration and the active provider
-mnemosyne-hermes status --hermes-home /opt/data
+# For Path A, after setting HERMES_HOME as shown above:
+"$HERMES_HOME/.mnemosyne/venv/bin/mnemosyne-hermes" status
 hermes memory status
 
 # Restart gateway after any config change

--- a/docs/llm-installation-guide.md
+++ b/docs/llm-installation-guide.md
@@ -176,11 +176,9 @@ In `~/.hermes/config.yaml`:
 ```yaml
 memory:
   provider: mnemosyne
-
-plugins:
-  enabled:
-    - mnemosyne
 ```
+
+The wrapper installer registers the plugin; do not add a separate `plugins.enabled` entry for that path.
 
 ### Optional environment variables
 
@@ -217,8 +215,6 @@ hermes config set memory.provider null
 hermes gateway restart
 ```
 
-To also remove the plugin from config, delete `mnemosyne` from `plugins.enabled` in `~/.hermes/config.yaml`.
-
 ---
 
 ## Troubleshooting for Agents
@@ -245,8 +241,9 @@ The package isn't installed in Hermes's Python environment. Either:
 # Check plugins are loaded
 hermes plugins list
 
-# If mnemosyne isn't listed, check config.yaml plugins.enabled
-grep -A5 "plugins:" ~/.hermes/config.yaml
+# Verify wrapper registration and the active provider
+mnemosyne-hermes status --hermes-home /opt/data
+hermes memory status
 
 # Restart gateway after any config change
 hermes gateway restart


### PR DESCRIPTION
## Summary

Corrects P0 Hermes integration guidance against current Hermes CLI behavior and current Mnemosyne main.

- removes the stale claim that `memory_enabled: false` / `user_profile_enabled: false` disable built-in memory; current Hermes reports built-in memory as always active and `hermes memory off` disables the external provider only
- removes the deleted `deploy_hermes_provider.sh` one-liner and stale `plugins.enabled` requirement
- makes persistent wrapper mode the documented Docker/image path
- replaces fixed provider tool-count checks with status/tool discovery
- documents the v3.14 Doctor → selected Repair workflow: bounded read-only reports, explicit candidate selection, dry-run first, and `--apply` only after review

## Verification

- Fresh `main` checkout at `4e5ed14`
- Verified `deploy_hermes_provider.sh` is absent
- Verified wrapper install/status in a persistent side venv
- Tested an isolated Hermes home with the old flags: `hermes memory status` still reports `Built-in: always active`
- Cross-checked Doctor/Repair options and safety contract against current `mnemosyne/cli.py`
- `git diff --check` passes

## Non-goals

No PyPI release-pair, version-matrix, config-migration, or historical compatibility changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates Hermes integration and README docs to track current Hermes CLI behavior and Mnemosyne “main” **without changing Mnemosyne’s core memory architecture or runtime logic** (BEAM tiering, retrieval, consolidation, veracity, and sync/benchmarking remain as-is).
- Improves **local-first / operator safety** by clarifying Hermes memory semantics so operators disable the intended layer only:
  - Hermes built-in memory remains active.
  - `hermes memory off` disables only the external (provider) mechanism, not Mnemosyne’s built-in memory tooling.
  - Explicit warnings distinguish `hermes memory off` from `hermes tools disable memory` (which disables the entire memory toolset, including provider tools).
  - `hermes memory status` is documented as reporting **local provider state/registration**, not end-to-end connectivity.
- Strengthens **Hermes↔Mnemosyne maintainability** by documenting a durable “persistent wrapper mode” for Docker/image deployments:
  - Uses `HERMES_HOME` and a persistent side-venv for installs, plus wrapper install/status/restart/config steps.
  - Routes locally installed Hermes users through the existing alternative integration path.
  - Removes legacy/contradictory setup references (deleted deploy script and obsolete `plugins.enabled` expectations).
- Reduces brittleness in agent integration by switching from fixed assumptions to **runtime tool discovery** (validate via Hermes status + live tool surface inspection rather than hard-coded tool counts).
- Updates the operational reliability surface for repairing knowledge with a safer workflow aligned to v3.14:
  - bounded, read-only `mnemosyne doctor`
  - report-gated, explicitly `--select`-scoped `mnemosyne repair`
  - dry-run before any reviewed `--apply`

## Architecture and design impact

- **Mnemosyne core memory & privacy/local-first:** Documentation changes are targeted at preventing misconfiguration that could mistakenly disable the wrong Hermes memory layer; they do not alter working/episodic/BEAM behavior, retrieval/consolidation/valiation logic, or the sync/encryption model.
- **Agent integration surfaces (Hermes, MCP, CLI):** Hermes documentation clarifies provider tooling, lifecycle/context injection expectations, and MCP exposure via the Hermes tool surface; CLI usage examples are refreshed to reflect current command naming and venv/isolated execution patterns.
- **Long-term maintainability:** Eliminating legacy plugin-wiring assumptions and replacing fixed tool-count checks with runtime discovery makes the integration more robust to Hermes CLI evolution.
- **Verification/repair safety:** The v3.14 Doctor → selected Repair workflow provides guardrails against broad/accidental repairs by constraining scope and requiring dry runs plus reviewed `--apply`.

## Verification

- Document verification was done against Mnemosyne commit `4e5ed14`, including wrapper installation/status behavior, isolated Hermes configuration behavior, current Doctor/Repair options, and `git diff --check`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->