### PR TITLE
fix(sync): align CLI with Hermes shared session

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -672,6 +672,9 @@ def _read_secret_file(path: str, label: str) -> str:
     return value
 
 
+_DEFAULT_SYNC_SESSION_ID = "hermes_shared_surface"
+
+
 def cmd_sync_init(args):
     """Explicitly initialize or migrate a dedicated shared-surface DB."""
     import argparse
@@ -680,7 +683,7 @@ def cmd_sync_init(args):
     parser.add_argument("--db-path", required=True, help="Dedicated shared-surface DB")
     parser.add_argument(
         "--session-id",
-        default="hermes_shared_surface",
+        default=_DEFAULT_SYNC_SESSION_ID,
         help="Stable session ID used by the shared-surface Beam",
     )
     parser.add_argument(
@@ -744,6 +747,11 @@ def cmd_sync(args):
         required=True,
         help="Explicit SQLite DB to sync; use the dedicated shared-surface DB, not a private DB",
     )
+    parser.add_argument(
+        "--session-id",
+        default=_DEFAULT_SYNC_SESSION_ID,
+        help="Stable session ID used by the shared-surface Beam",
+    )
     parser.add_argument("--mode", choices=["push", "pull", "bidirectional"], default="bidirectional",
                         help="Sync direction (default: bidirectional)")
     encryption_group = parser.add_mutually_exclusive_group()
@@ -769,7 +777,7 @@ def cmd_sync(args):
     from mnemosyne.core.memory import Mnemosyne
     from mnemosyne.core.sync import SyncEngine, SyncEncryption
 
-    mem = Mnemosyne(db_path=parsed.db_path)
+    mem = Mnemosyne(db_path=parsed.db_path, session_id=parsed.session_id)
 
     encryption_source = parsed.encrypt
     if parsed.encrypt_key_file:

--- a/tests/test_sync_security.py
+++ b/tests/test_sync_security.py
@@ -132,6 +132,61 @@ def test_sync_init_requires_explicit_confirmation_for_existing_rows(tmp_path, ca
     ).fetchone()[0] == "shared-surface-v1"
 
 
+def test_sync_cli_claims_new_hermes_shared_surface_rows(tmp_path, monkeypatch, capsys):
+    from mnemosyne.cli import cmd_sync, cmd_sync_init
+    from mnemosyne.core.sync import SyncEngine
+
+    db_path = tmp_path / "hermes-shared.db"
+    cmd_sync_init(["--db-path", str(db_path)])
+    capsys.readouterr()
+
+    memory = Mnemosyne(db_path=db_path, session_id="hermes_shared_surface")
+    memory_id = memory.beam.remember(
+        "new Hermes shared memory",
+        source="surface_manual",
+        scope="global",
+    )
+
+    observed = {}
+
+    def fake_sync_with(engine, remote_url, mode="bidirectional", api_key=None, **_kwargs):
+        observed["surface_session_id"] = engine.surface_session_id
+        observed["unowned_rows"] = engine.conn.execute(
+            """SELECT COUNT(*) FROM working_memory
+               WHERE sync_surface_id IS NULL OR sync_surface_id != ?""",
+            (engine.surface_id,),
+        ).fetchone()[0]
+        return {
+            "remote": remote_url,
+            "mode": mode,
+            "push": {"accepted": 0, "duplicates": 0, "conflicts": 0},
+            "pull": None,
+            "errors": [],
+        }
+
+    monkeypatch.setattr(SyncEngine, "sync_with", fake_sync_with)
+
+    cmd_sync(
+        [
+            "--db-path",
+            str(db_path),
+            "--remote",
+            "http://127.0.0.1:8765",
+            "--mode",
+            "push",
+        ]
+    )
+
+    assert observed == {
+        "surface_session_id": "hermes_shared_surface",
+        "unowned_rows": 0,
+    }
+    assert memory.beam.conn.execute(
+        "SELECT sync_surface_id FROM working_memory WHERE id = ?",
+        (memory_id,),
+    ).fetchone()[0] == "shared-surface-v1"
+
+
 def test_packaged_deployment_commands_match_hardened_cli():
     from pathlib import Path
 


### PR DESCRIPTION
## Summary

- make `mnemosyne sync` use the same `hermes_shared_surface` session default as `sync-init`
- add an explicit `--session-id` override for non-Hermes surfaces
- add a regression test proving newly written Hermes shared rows are claimed before network sync

## Root cause

`sync-init` creates/validates the dedicated surface with session `hermes_shared_surface`, but `cmd_sync` reopened the DB with `Mnemosyne(..., session_id="default")`. New rows written by `mnemosyne_shared_remember` therefore remained unowned and the fail-closed surface guard rejected sync with `surface-only sync requires a dedicated DB with no unowned working rows`.

## Verification

- `84 passed` — `test_sync_security.py`, `test_sync_correctness.py`, `test_sync.py`
- local encrypted blind-relay E2E: `CREATE -> UPDATE -> DELETE`
- relay retained only `mne1:` ciphertext and materialized zero working rows
- integrity checks passed for both clients and relay

I have read and agree to the project CLA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Aligns `mnemosyne sync` with `sync-init` by defaulting to the `hermes_shared_surface` session.
- Adds `--session-id` for non-Hermes surfaces.
- Adds regression coverage ensuring newly written Hermes rows are claimed before synchronization.

## Architectural impact

This is the right call for the sync layer: it fixes session ownership without changing BEAM’s working, episodic, or scratchpad tiers, retrieval, consolidation, or veracity behavior. Local writes now reliably participate in shared-surface sync while preserving the local-first SQLite architecture.

Hermes integration and CLI behavior are corrected; MCP surfaces remain unaffected. No benchmark methodology changes are introduced.

## Privacy and maintainability

The change preserves encrypted, ciphertext-only relay behavior and avoids materializing relay rows, so it does not weaken the privacy posture. Explicit session selection also makes cross-surface boundaries clearer.

Centralizing the default session identifier reduces configuration drift, while the regression test protects the claim-before-sync invariant. Nothing in this change erodes the local-first design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->