### PR TITLE
fix: guard working embedding parent race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
+## [3.15.0] - 2026-07-18
+
+### Fixed
+
+- **Trim-before-embedding foreign-key failure (#491).** Working-memory embedding storage now atomically checks that its parent row still exists. A row legitimately removed by trimming or concurrent deletion becomes a clean no-op instead of logging a foreign-key failure; foreign-key enforcement remains enabled and no orphan embedding is created.
+
 ## [3.14.0] - 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
-- **Trim-before-embedding foreign-key failure (#491).** Working-memory embedding storage now atomically checks that its parent row still exists. A row legitimately removed by trimming or concurrent deletion becomes a clean no-op instead of logging a foreign-key failure; foreign-key enforcement remains enabled and no orphan embedding is created.
+- **Trim-before-embedding race (#491).** Working-memory embedding storage now atomically checks that its parent row still exists. If trimming or concurrent deletion removes the parent before the fallback insert executes, both fallback and `vec_working` writes become a clean no-op instead of logging an embedding-storage failure.
 
 ## [3.14.0] - 2026-07-17
 

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.14.0"
+__version__ = "3.15.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2178,10 +2178,16 @@ def _store_working_embedding(conn: sqlite3.Connection, memory_id: str, embedding
     """
     emb_for_json = np.array(embedding, dtype=np.float32) if np is not None else embedding
     emb_json = _embeddings.serialize(emb_for_json)
-    conn.execute(
-        "INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
-        (memory_id, emb_json, _embeddings._DEFAULT_MODEL)
+    inserted = conn.execute(
+        """
+        INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model)
+        SELECT ?, ?, ?
+        WHERE EXISTS (SELECT 1 FROM working_memory WHERE id = ?)
+        """,
+        (memory_id, emb_json, _embeddings._DEFAULT_MODEL, memory_id),
     )
+    if inserted.rowcount == 0:
+        return
     try:
         _wm_vec_upsert(conn, memory_id, embedding, commit=commit_vec)
     except Exception as exc:

--- a/tests/test_working_embedding_parent_race.py
+++ b/tests/test_working_embedding_parent_race.py
@@ -1,0 +1,94 @@
+"""Regression coverage for the trim-before-embedding parent race."""
+
+import json
+import logging
+import sqlite3
+
+import mnemosyne.core.beam as beam
+
+
+def _minimal_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(
+        """
+        CREATE TABLE working_memory (
+            id TEXT PRIMARY KEY
+        );
+        CREATE TABLE memory_embeddings (
+            memory_id TEXT PRIMARY KEY
+                REFERENCES working_memory(id) ON DELETE CASCADE,
+            embedding_json TEXT NOT NULL,
+            model TEXT NOT NULL
+        );
+        """
+    )
+    return conn
+
+
+def test_embedding_store_skips_parent_removed_by_trim(monkeypatch):
+    conn = _minimal_connection()
+    vec_calls = []
+    monkeypatch.setattr(beam, "np", None)
+    monkeypatch.setattr(beam._embeddings, "serialize", json.dumps)
+    monkeypatch.setattr(
+        beam, "_wm_vec_upsert", lambda *args, **kwargs: vec_calls.append(args)
+    )
+
+    beam._store_working_embedding(conn, "trimmed", [0.1, 0.2])
+
+    assert conn.execute("SELECT count(*) FROM memory_embeddings").fetchone()[0] == 0
+    assert vec_calls == []
+    assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_embedding_store_preserves_present_parent_and_cascade(monkeypatch):
+    conn = _minimal_connection()
+    conn.execute("INSERT INTO working_memory(id) VALUES ('live')")
+    vec_calls = []
+    monkeypatch.setattr(beam, "np", None)
+    monkeypatch.setattr(beam._embeddings, "serialize", json.dumps)
+    monkeypatch.setattr(
+        beam, "_wm_vec_upsert", lambda *args, **kwargs: vec_calls.append(args)
+    )
+
+    beam._store_working_embedding(conn, "live", [0.1, 0.2])
+    beam._store_working_embedding(conn, "live", [0.3, 0.4])
+
+    row = conn.execute(
+        "SELECT embedding_json, model FROM memory_embeddings WHERE memory_id='live'"
+    ).fetchone()
+    assert json.loads(row[0]) == [0.3, 0.4]
+    assert row[1] == beam._embeddings._DEFAULT_MODEL
+    assert len(vec_calls) == 2
+
+    conn.execute("DELETE FROM working_memory WHERE id='live'")
+    assert conn.execute("SELECT count(*) FROM memory_embeddings").fetchone()[0] == 0
+    assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_remember_trim_before_embedding_is_quiet(tmp_path, monkeypatch, caplog):
+    memory = beam.BeamMemory(session_id="trim-race", db_path=tmp_path / "mnemosyne.db")
+    monkeypatch.setattr(beam, "np", None)
+    monkeypatch.setattr(beam._embeddings, "available", lambda: True)
+    monkeypatch.setattr(beam._embeddings, "embed", lambda values: [[0.1, 0.2]])
+    monkeypatch.setattr(beam._embeddings, "serialize", json.dumps)
+
+    def delete_new_parent():
+        memory.conn.execute(
+            "DELETE FROM working_memory WHERE session_id = ?", (memory.session_id,)
+        )
+        memory.conn.commit()
+
+    monkeypatch.setattr(memory, "_trim_working_memory", delete_new_parent)
+    with caplog.at_level(logging.WARNING):
+        memory_id = memory.remember("deterministic trim-before-embedding regression")
+
+    assert memory.conn.execute(
+        "SELECT count(*) FROM working_memory WHERE id = ?", (memory_id,)
+    ).fetchone()[0] == 0
+    assert memory.conn.execute(
+        "SELECT count(*) FROM memory_embeddings WHERE memory_id = ?", (memory_id,)
+    ).fetchone()[0] == 0
+    assert memory.conn.execute("PRAGMA foreign_key_check").fetchall() == []
+    assert "embedding storage failed" not in caplog.text

--- a/tests/test_working_embedding_parent_race.py
+++ b/tests/test_working_embedding_parent_race.py
@@ -60,7 +60,10 @@ def test_embedding_store_preserves_present_parent_and_cascade(monkeypatch):
     ).fetchone()
     assert json.loads(row[0]) == [0.3, 0.4]
     assert row[1] == beam._embeddings._DEFAULT_MODEL
-    assert len(vec_calls) == 2
+    assert [call[1:] for call in vec_calls] == [
+        ("live", [0.1, 0.2]),
+        ("live", [0.3, 0.4]),
+    ]
 
     conn.execute("DELETE FROM working_memory WHERE id='live'")
     assert conn.execute("SELECT count(*) FROM memory_embeddings").fetchone()[0] == 0
@@ -69,10 +72,14 @@ def test_embedding_store_preserves_present_parent_and_cascade(monkeypatch):
 
 def test_remember_trim_before_embedding_is_quiet(tmp_path, monkeypatch, caplog):
     memory = beam.BeamMemory(session_id="trim-race", db_path=tmp_path / "mnemosyne.db")
+    vec_calls = []
     monkeypatch.setattr(beam, "np", None)
     monkeypatch.setattr(beam._embeddings, "available", lambda: True)
     monkeypatch.setattr(beam._embeddings, "embed", lambda _values: [[0.1, 0.2]])
     monkeypatch.setattr(beam._embeddings, "serialize", json.dumps)
+    monkeypatch.setattr(
+        beam, "_wm_vec_upsert", lambda *args, **_kwargs: vec_calls.append(args)
+    )
 
     def delete_new_parent() -> None:
         memory.conn.execute(
@@ -91,4 +98,5 @@ def test_remember_trim_before_embedding_is_quiet(tmp_path, monkeypatch, caplog):
         "SELECT count(*) FROM memory_embeddings WHERE memory_id = ?", (memory_id,)
     ).fetchone()[0] == 0
     assert memory.conn.execute("PRAGMA foreign_key_check").fetchall() == []
+    assert vec_calls == []
     assert "embedding storage failed" not in caplog.text

--- a/tests/test_working_embedding_parent_race.py
+++ b/tests/test_working_embedding_parent_race.py
@@ -16,10 +16,10 @@ def _minimal_connection() -> sqlite3.Connection:
             id TEXT PRIMARY KEY
         );
         CREATE TABLE memory_embeddings (
-            memory_id TEXT PRIMARY KEY
-                REFERENCES working_memory(id) ON DELETE CASCADE,
+            memory_id TEXT PRIMARY KEY,
             embedding_json TEXT NOT NULL,
-            model TEXT NOT NULL
+            model TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         );
         """
     )
@@ -39,10 +39,10 @@ def test_embedding_store_skips_parent_removed_by_trim(monkeypatch):
 
     assert conn.execute("SELECT count(*) FROM memory_embeddings").fetchone()[0] == 0
     assert vec_calls == []
-    assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+    assert conn.execute("PRAGMA foreign_key_list(memory_embeddings)").fetchall() == []
 
 
-def test_embedding_store_preserves_present_parent_and_cascade(monkeypatch):
+def test_embedding_store_preserves_present_parent_and_updates(monkeypatch):
     conn = _minimal_connection()
     conn.execute("INSERT INTO working_memory(id) VALUES ('live')")
     vec_calls = []
@@ -64,10 +64,6 @@ def test_embedding_store_preserves_present_parent_and_cascade(monkeypatch):
         ("live", [0.1, 0.2]),
         ("live", [0.3, 0.4]),
     ]
-
-    conn.execute("DELETE FROM working_memory WHERE id='live'")
-    assert conn.execute("SELECT count(*) FROM memory_embeddings").fetchone()[0] == 0
-    assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
 
 
 def test_remember_trim_before_embedding_is_quiet(tmp_path, monkeypatch, caplog):

--- a/tests/test_working_embedding_parent_race.py
+++ b/tests/test_working_embedding_parent_race.py
@@ -4,7 +4,7 @@ import json
 import logging
 import sqlite3
 
-import mnemosyne.core.beam as beam
+from mnemosyne.core import beam
 
 
 def _minimal_connection() -> sqlite3.Connection:
@@ -32,7 +32,7 @@ def test_embedding_store_skips_parent_removed_by_trim(monkeypatch):
     monkeypatch.setattr(beam, "np", None)
     monkeypatch.setattr(beam._embeddings, "serialize", json.dumps)
     monkeypatch.setattr(
-        beam, "_wm_vec_upsert", lambda *args, **kwargs: vec_calls.append(args)
+        beam, "_wm_vec_upsert", lambda *args, **_kwargs: vec_calls.append(args)
     )
 
     beam._store_working_embedding(conn, "trimmed", [0.1, 0.2])
@@ -49,7 +49,7 @@ def test_embedding_store_preserves_present_parent_and_cascade(monkeypatch):
     monkeypatch.setattr(beam, "np", None)
     monkeypatch.setattr(beam._embeddings, "serialize", json.dumps)
     monkeypatch.setattr(
-        beam, "_wm_vec_upsert", lambda *args, **kwargs: vec_calls.append(args)
+        beam, "_wm_vec_upsert", lambda *args, **_kwargs: vec_calls.append(args)
     )
 
     beam._store_working_embedding(conn, "live", [0.1, 0.2])
@@ -71,10 +71,10 @@ def test_remember_trim_before_embedding_is_quiet(tmp_path, monkeypatch, caplog):
     memory = beam.BeamMemory(session_id="trim-race", db_path=tmp_path / "mnemosyne.db")
     monkeypatch.setattr(beam, "np", None)
     monkeypatch.setattr(beam._embeddings, "available", lambda: True)
-    monkeypatch.setattr(beam._embeddings, "embed", lambda values: [[0.1, 0.2]])
+    monkeypatch.setattr(beam._embeddings, "embed", lambda _values: [[0.1, 0.2]])
     monkeypatch.setattr(beam._embeddings, "serialize", json.dumps)
 
-    def delete_new_parent():
+    def delete_new_parent() -> None:
         memory.conn.execute(
             "DELETE FROM working_memory WHERE session_id = ?", (memory.session_id,)
         )


### PR DESCRIPTION
## Summary

- make the fallback `memory_embeddings` insert atomic with its `working_memory` parent-existence check
- if trimming or concurrent deletion removes the parent before that insert executes, skip both the fallback row and `vec_working` upsert
- model the production no-FK `memory_embeddings` schema in regression tests
- preserve normal insert/update behavior when the parent exists

This PR intentionally does not define cleanup semantics for a parent deleted after a successful embedding insert.

Closes #491.

## Verification

```text
pytest -q tests/test_working_embedding_parent_race.py tests/test_beam.py
87 passed, 1 skipped

ruff check tests/test_working_embedding_parent_race.py
All checks passed!

git diff --check
passed
```

Independent read-only review of the final correction: `PASS`.

## AI Assistance

The implementation, regression tests, and initial analysis were prepared with AI agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixes a race in Mnemosyne’s **working-memory (WM) embedding persistence** path by making `_store_working_embedding` **parent-guarded**: the write now only occurs if the referenced `working_memory.id` still exists, so trimming or concurrent deletion becomes a **clean no-op** instead of a **foreign-key enforcement failure**.
- Prevents **orphan `memory_embeddings`** rows and ensures the WM vector side (`vec_working` / `_wm_vec_upsert`) is **skipped when the parent is gone**, while keeping **SQLite foreign keys enabled** and preserving expected **ON DELETE CASCADE** behavior.
- Preserves Mnemosyne’s **local-first integrity** by containing the correctness fix at the **SQLite write boundary** (no new services, constraints aren’t relaxed, and no cross-layer consistency assumptions are introduced).
- Adds regression coverage for:
  - **missing-parent** insertion (no embedding row written; no FK violations),
  - **present-parent** upsert + **cascade-delete** of embeddings,
  - an end-to-end `remember()` flow where **trim happens before embedding storage** (quiet/no warning; no vector upsert call).
- Updates **changelog** and bumps version to **3.15.0** documenting the **trim-before-embedding foreign-key failure**.

## Architectural impact (core memory architecture)

This change is narrowly scoped to the **WM → embedding** bridge in the tiered memory architecture (WM embeddings backing **working retrieval**), without altering behavior of **episodic/BEAM tiers**, retrieval strategies, consolidation, veracity, or sync.

## Privacy posture / agent integration surfaces

No changes to the privacy posture or agent integration surfaces (**Hermes, MCP, CLI**).

## Long-term maintainability

The fix improves maintainability by:
- hardening an otherwise timing-sensitive DB write into an **invariant-preserving** operation, and
- adding focused tests that lock in expected behavior for the **trim-before-embedding** ordering case and concurrent deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->