### PR TITLE
fix(hermes): retry provider init after transient SQLite lock failure

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -210,6 +210,11 @@ def _format_prefetch_content(content: str, limit: int) -> str:
     return f"{cut}..."
 
 
+# Minimum spacing between lazy re-attempts of a transiently-failed init
+# (see _maybe_retry_init). One minute keeps retry cost negligible while
+# recovering within a turn or two of a lock storm passing.
+_INIT_RETRY_INTERVAL_S = 60.0
+
 _PREFETCH_TOP_K = 5
 _PREFETCH_MIN_FRAGMENT_CHARS = 8
 _PREFETCH_FRAGMENT_STOPWORDS = frozenset({
@@ -545,6 +550,12 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # `_beam is None AND _init_error is not None` means a real failure that
         # users and operators need to see.
         self._init_error: Optional[BaseException] = None
+        # Lazy re-init after a TRANSIENT init failure (a SQLite lock held at
+        # the exact moment this session initialized). Holds the (session_id,
+        # kwargs) of the failed initialize() call plus the earliest monotonic
+        # time to try again; None means nothing to retry.
+        self._retry_init_args: Optional[tuple] = None
+        self._retry_init_at: float = 0.0
         self._session_id = "hermes_default"
         self._hermes_home = ""
         self._platform = "cli"
@@ -679,6 +690,29 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         if len(msg) > 200:
             msg = msg[:200] + "..."
         return f"{type(self._init_error).__name__}: {msg}"
+
+    @staticmethod
+    def _is_transient_init_error(exc: BaseException) -> bool:
+        # The two SQLite signatures observed taking down live sessions
+        # (2026-07-09 and 2026-07-19 lock storms). Both clear on their own
+        # once the holding writer finishes, so a later retry can succeed.
+        msg = str(exc).lower()
+        return "database is locked" in msg or "disk i/o error" in msg
+
+    def _maybe_retry_init(self) -> None:
+        # Re-attempt a transiently-failed init from the per-turn surfaces.
+        # Observed live 2026-07-19: a ~2-minute lock storm at session start
+        # left an agent memory-less for hours while the DB was healthy again
+        # minutes later; a restart was the only recovery path.
+        if self._beam is not None or self._retry_init_args is None:
+            return
+        if time.monotonic() < self._retry_init_at:
+            return
+        session_id, kwargs = self._retry_init_args
+        logger.info(
+            "Mnemosyne retrying init after transient failure: %s", self._init_error
+        )
+        self.initialize(session_id, **kwargs)
 
     @property
     def name(self) -> str:
@@ -1007,6 +1041,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         self._beam = None
         self._surface_beam = None
         self._init_error = None
+        # A fresh initialize() supersedes any pending transient-failure retry;
+        # the except path below re-stashes if THIS attempt also fails.
+        self._retry_init_args = None
 
         self._agent_context = kwargs.get("agent_context", "primary")
         self._platform = kwargs.get("platform", "cli")
@@ -1091,6 +1128,16 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             logger.warning("Mnemosyne init failed: %s", e)
             self._beam = None
             self._init_error = e
+            # A transient SQLite failure (writer holding the lock at the exact
+            # moment this session initialized) must not disable memory for the
+            # session's whole lifetime. Stash the init args so the per-turn
+            # surfaces can re-attempt via _maybe_retry_init() once the
+            # contention passes. Non-transient failures (corrupt DB, missing
+            # extras, permissions, schema mismatch) keep the fail-once C27
+            # behavior: retrying those every minute would just spam the log.
+            if self._is_transient_init_error(e):
+                self._retry_init_args = (session_id, dict(kwargs))
+                self._retry_init_at = time.monotonic() + _INIT_RETRY_INTERVAL_S
 
         # C13: activate AFTER the BeamMemory init result is known. If
         # init succeeded (_beam is set) the provider is the live memory
@@ -1114,6 +1161,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             self._init_audit_log()
 
     def system_prompt_block(self) -> str:
+        self._maybe_retry_init()
         if self._beam:
             # Merge resolution (PR #106 + C27): keep PR #106's description
             # update that adds "identity" to the recognized memory kinds
@@ -1147,11 +1195,18 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # still returns "" because that is the documented contract for
         # cron/subagent/skill_loop sessions.
         if self._init_error is not None:
+            hint = (
+                "Init failed on transient database contention and will be retried "
+                "automatically; memory may recover later this session."
+                if self._retry_init_args is not None
+                else "Memory operations will fail this session. Resolve the underlying "
+                "issue (check ~/.hermes/logs/agent.log for the WARNING) and restart "
+                "Hermes to retry."
+            )
             return (
                 "# Mnemosyne Memory\n"
                 f"⚠️ UNAVAILABLE: {self._init_error_reason()}\n"
-                "Memory operations will fail this session. Resolve the underlying issue "
-                "(check ~/.hermes/logs/agent.log for the WARNING) and restart Hermes to retry."
+                f"{hint}"
             )
         return ""
 
@@ -1160,6 +1215,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         
         Only includes memories above a relevance threshold to prevent context pollution
         from low-quality matches. Scoped to the user's author_id when available."""
+        self._maybe_retry_init()
         if not self._beam or self._agent_context in self._skip_contexts:
             return ""
         try:
@@ -1277,6 +1333,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Persist the turn to Mnemosyne episodic memory."""
+        self._maybe_retry_init()
         if not self._beam or self._agent_context in self._skip_contexts:
             return
         started = time.perf_counter()
@@ -1422,6 +1479,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             return json.dumps({"error": str(exc)})
         if tool_name == "mnemosyne_sleep" and self._reflect_disabled_for_cron and (self._agent_context or "").strip().lower() == "cron":
             return json.dumps(self._reflection_skip_response("reflect_disabled_for_cron", "tool"))
+        self._maybe_retry_init()
         if not self._beam:
             # C27: structured response carries the actual failure reason
             # instead of a generic "not initialized" string. Status field

--- a/integrations/hermes/tests/test_init_retry.py
+++ b/integrations/hermes/tests/test_init_retry.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import sqlite3
+
+import mnemosyne_hermes
+from mnemosyne_hermes import MnemosyneMemoryProvider
+
+
+class _OkBeam:
+    """Minimal stand-in for BeamMemory: accepts the init kwargs and the
+    attributes initialize() sets on success."""
+
+    author_id = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def _locked_beam_class(calls):
+    """A BeamMemory class whose first `calls['fail']` constructions raise the
+    transient SQLite lock error, then succeed."""
+
+    class _Beam(_OkBeam):
+        def __init__(self, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] <= calls["fail"]:
+                raise sqlite3.OperationalError("database is locked")
+
+    return _Beam
+
+
+def test_transient_init_failure_stashes_retry_and_says_so(monkeypatch):
+    calls = {"n": 0, "fail": 99}
+    monkeypatch.setattr(mnemosyne_hermes, "_get_beam_class", lambda: _locked_beam_class(calls))
+
+    provider = MnemosyneMemoryProvider()
+    provider.initialize("sess")
+
+    assert provider._beam is None
+    assert provider._init_error is not None
+    assert provider._retry_init_args is not None
+
+    block = provider.system_prompt_block()
+    assert "UNAVAILABLE" in block
+    assert "retried automatically" in block
+    # The old "restart Hermes" guidance must not appear while a retry is pending.
+    assert "restart Hermes" not in block
+
+
+def test_non_transient_init_failure_keeps_fail_once(monkeypatch):
+    class _CorruptBeam:
+        def __init__(self, *args, **kwargs):
+            raise sqlite3.DatabaseError("file is not a database")
+
+    monkeypatch.setattr(mnemosyne_hermes, "_get_beam_class", lambda: _CorruptBeam)
+
+    provider = MnemosyneMemoryProvider()
+    provider.initialize("sess")
+
+    assert provider._beam is None
+    assert provider._retry_init_args is None
+
+    block = provider.system_prompt_block()
+    assert "UNAVAILABLE" in block
+    assert "restart Hermes" in block
+
+
+def test_retry_recovers_once_the_lock_clears(monkeypatch):
+    calls = {"n": 0, "fail": 1}
+    monkeypatch.setattr(mnemosyne_hermes, "_get_beam_class", lambda: _locked_beam_class(calls))
+
+    provider = MnemosyneMemoryProvider()
+    provider.initialize("sess")
+    assert provider._beam is None
+
+    # Interval elapsed -> the next per-turn surface call re-runs initialize().
+    provider._retry_init_at = 0.0
+    block = provider.system_prompt_block()
+
+    assert provider._beam is not None
+    assert provider._init_error is None
+    assert provider._retry_init_args is None
+    assert "UNAVAILABLE" not in block
+
+
+def test_retry_waits_for_the_interval(monkeypatch):
+    calls = {"n": 0, "fail": 99}
+    monkeypatch.setattr(mnemosyne_hermes, "_get_beam_class", lambda: _locked_beam_class(calls))
+
+    provider = MnemosyneMemoryProvider()
+    provider.initialize("sess")
+    attempts_after_init = calls["n"]
+
+    # _retry_init_at is ~60s in the future; surface calls must not retry yet.
+    provider.system_prompt_block()
+    provider.prefetch("query")
+    assert calls["n"] == attempts_after_init
+
+
+def test_fresh_initialize_supersedes_pending_retry(monkeypatch):
+    calls = {"n": 0, "fail": 1}
+    monkeypatch.setattr(mnemosyne_hermes, "_get_beam_class", lambda: _locked_beam_class(calls))
+
+    provider = MnemosyneMemoryProvider()
+    provider.initialize("sess")
+    assert provider._retry_init_args is not None
+
+    # A real re-init (e.g. session reset) that succeeds clears the stash.
+    provider.initialize("sess2")
+    assert provider._beam is not None
+    assert provider._retry_init_args is None


### PR DESCRIPTION
## Summary

`initialize()` runs once per session. When it fails, the provider sets `_beam = None` and `_init_error`, and every memory surface is dead for the session's whole lifetime. C27 made that state visible, but nothing retries it. For transient SQLite failures (`database is locked`, `disk I/O error`) that is the wrong lifetime: both clear on their own once the holding writer finishes, so a session that happened to start during a brief lock storm loses memory until an operator restarts the host process.

Observed in a production deployment on 2026-07-19: a ~2-minute lock storm overlapped a session reset. Init failed, an external write-lock probe showed the DB healthy again 3 minutes later, and the agent ran memory-less for 22 hours until a manual restart.

## Fix

- On a transient init failure, stash the `initialize()` args and re-attempt lazily from the per-turn surfaces (`system_prompt_block`, `prefetch`, `sync_turn`, `handle_tool_call`), at most once every 60 seconds. `initialize()` already supports re-entry (it resets provider state up front), so the retry is a plain re-call.
- Non-transient failures (corrupt DB, missing extras, permissions, schema mismatch) keep the existing fail-once behavior; retrying those every minute would only spam the log.
- The C27 UNAVAILABLE banner now says a retry is pending instead of telling the operator a restart is the only recovery. A successful `initialize()` (e.g. a session reset) supersedes any pending retry.

## Verification

- `tests/test_init_retry.py` (new): transient failure stashes the retry and updates the banner; non-transient failure keeps fail-once; retry recovers once the lock clears; retry respects the 60s spacing; a fresh successful init clears the stash. 5 new tests + adjacent `test_system_prompt.py` pass.
- Reproduced end-to-end against a real DB: hold `BEGIN EXCLUSIVE` from a second connection, `initialize()` fails and stashes, release the lock, the next surface call recovers with `_beam` live and `_init_error` cleared, no restart.

Follow-up to the lock-hygiene work in #432/#439, which fixed writers holding the lock; this handles the reader of last resort, the session that initializes while such a writer is still running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds bounded, per-instance retry handling for transient Hermes/Mnemosyne initialization failures such as SQLite locks and disk I/O errors.
- Retries lazily from user-visible memory entrypoints at most once every 60 seconds, while preserving fail-once behavior for non-transient errors.
- Improves the `UNAVAILABLE` status message and clears pending retry state after successful initialization.
- Adds focused tests for retry scheduling, recovery, retry spacing, failure classification, and state cleanup.

## Architectural impact

- **Core memory architecture:** This is a reliability improvement at the Hermes provider boundary only. It does not change working, episodic, or BEAM memory tiers, retrieval, consolidation, veracity, or sync behavior.
- **Local-first and privacy:** Preserves the local SQLite-backed design and does not introduce network calls, remote fallbacks, new data collection, or changes to privacy boundaries. Keeping recovery local is the right call for local-first guarantees.
- **Agent integration surfaces:** Directly improves Hermes per-turn surfaces (`system_prompt_block`, `prefetch`, `sync_turn`, and `handle_tool_call`) without changing MCP or CLI interfaces.
- **Maintainability:** Encapsulates retry classification, scheduling, and recovery in small provider helpers with explicit state and bounded timing. The accompanying tests protect transient versus permanent failure semantics and same-session recovery.
- **Other systems:** No changes to tiering, retrieval strategies, consolidation pipelines, veracity, sync-layer architecture, or benchmark methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->