### PR TITLE
fix(embeddings): add Jina v2 base family dims (silent 384 fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
+## [3.15.0] - 2026-07-20
+
+### Fixed
+
+- **Jina v2 base embedding models silently fell back to 384 dimensions.** The
+  `jinaai/jina-embeddings-v2-base-{es,en,de,zh,code}` models output 768-dim
+  vectors, but were absent from `_get_embedding_dim`'s table and so resolved to
+  the 384 unknown-model fallback — a silent dimension mismatch that corrupts
+  vector similarity search for anyone using these popular models (notably the
+  `-es` Spanish/English bilingual model). Added explicit 768-dim entries plus a
+  regression test in `tests/test_embeddings_multilingual.py`.
+
 ## [3.14.0] - 2026-07-17
 
 ### Added

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.14.0"
+__version__ = "3.15.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -167,6 +167,14 @@ def _get_embedding_dim(model_name: str) -> int:
         # --- Jina ---
         "jina-embeddings-v5-omni-nano": 768,
         "jina-embeddings-v5-omni-small": 1024,
+        # Jina v2 base family (bilingual/monolingual, all 768-dim). Without these
+        # entries these popular models silently fall back to 384 below, which
+        # mismatches their true 768-dim output and corrupts vector search.
+        "jinaai/jina-embeddings-v2-base-es": 768,
+        "jinaai/jina-embeddings-v2-base-en": 768,
+        "jinaai/jina-embeddings-v2-base-de": 768,
+        "jinaai/jina-embeddings-v2-base-zh": 768,
+        "jinaai/jina-embeddings-v2-base-code": 768,
     }
     # Check env override first
     env_dim = os.environ.get("MNEMOSYNE_EMBEDDING_DIM")

--- a/tests/test_embeddings_multilingual.py
+++ b/tests/test_embeddings_multilingual.py
@@ -39,6 +39,24 @@ def test_get_embedding_dim_jina_models():
     assert embeddings._get_embedding_dim("jina-embeddings-v5-omni-small") == 1024
 
 
+def test_get_embedding_dim_jina_v2_base_family():
+    """Jina v2 base models are all 768-dim, not the 384 unknown-model fallback.
+
+    Regression guard: these popular bilingual/monolingual models (the ES one is
+    a common Spanish/English choice) output 768-dim vectors. If they are absent
+    from the dim table they silently resolve to 384, mismatching the real output
+    and corrupting similarity search.
+    """
+    for model in (
+        "jinaai/jina-embeddings-v2-base-es",
+        "jinaai/jina-embeddings-v2-base-en",
+        "jinaai/jina-embeddings-v2-base-de",
+        "jinaai/jina-embeddings-v2-base-zh",
+        "jinaai/jina-embeddings-v2-base-code",
+    ):
+        assert embeddings._get_embedding_dim(model) == 768, model
+
+
 def test_get_embedding_dim_env_override():
     """MNEMOSYNE_EMBEDDING_DIM env var overrides model-based detection."""
     os.environ["MNEMOSYNE_EMBEDDING_DIM"] = "768"


### PR DESCRIPTION
## The bug: Jina v2 base models silently fall back to 384 dimensions

`_get_embedding_dim(model_name)` in `mnemosyne/core/embeddings.py` maps a model
name to its embedding dimension, and returns `dims.get(model_name, 384)` for
anything it doesn't recognize. The table knows the Jina **v5-omni** models but
not the widely-used **v2 base** family:

- `jinaai/jina-embeddings-v2-base-es` (ES/EN bilingual)
- `jinaai/jina-embeddings-v2-base-en`
- `jinaai/jina-embeddings-v2-base-de`
- `jinaai/jina-embeddings-v2-base-zh`
- `jinaai/jina-embeddings-v2-base-code`

All five output **768-dim** vectors. Because they're absent from the table, a
user who selects one silently gets the **384** unknown-model fallback. That is a
dimension mismatch against the model's real output: it corrupts vector
similarity search and can trip the `vec` dimension guard downstream. The failure
is silent — no error, just wrong-sized vectors and degraded recall.

## The fix

Add explicit 768-dim entries for the five v2 base models, mirroring the existing
`# --- Jina ---` v5-omni entries. Additive and minimal:

- unknown models still fall back to 384 (unchanged)
- every existing table entry is unchanged
- `MNEMOSYNE_EMBEDDING_DIM` env override still takes precedence (unchanged)

## Test

`tests/test_embeddings_multilingual.py::test_get_embedding_dim_jina_v2_base_family`
asserts all five v2 base models resolve to 768. Existing invariants verified
locally: unknown → 384, `BAAI/bge-base-en-v1.5` → 768, `jina-embeddings-v5-omni-small`
→ 1024.

## Housekeeping (per CONTRIBUTING.md)

- Bumps `__version__` `3.14.0` → `3.15.0` (MINOR-per-iteration).
- Adds a `[3.15.0]` `### Fixed` entry to `CHANGELOG.md`.

No private data, real model config, or secrets included — only public model
identifiers and their published dimensions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Corrects `_get_embedding_dim` to map five Jina v2 base models to 768 dimensions instead of the 384-dimension fallback.
- Adds regression coverage for Spanish, English, German, Chinese, and code models.
- Bumps the version to 3.15.0 and documents the fix.

## Architectural impact

This is a targeted embedding-dimension correction with no changes to tiered memory (working, episodic, or BEAM), retrieval strategies, consolidation, veracity, synchronization, or benchmark methodology. It improves downstream vector-search correctness without changing memory architecture.

No changes affect Mnemosyne’s privacy posture, local-first guarantees, or Hermes, MCP, and CLI integration surfaces. Existing unknown-model behavior and the `MNEMOSYNE_EMBEDDING_DIM` override remain intact.

The explicit model mappings and regression test are the right call: they prevent silent vector-size mismatches while preserving existing configuration behavior and improving long-term maintainability. No aspect of the change erodes the local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->