### PR TITLE
ci: pin remaining GitHub Action refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Cache embedding model
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ env.MNEMOSYNE_FASTEMBED_CACHE_DIR }}
           key: fastembed-bge-small-en-v1.5-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           generate_release_notes: true
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           packages-dir: dist/
 
@@ -71,6 +71,6 @@ jobs:
           generate_release_notes: true
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           packages-dir: integrations/hermes/dist/


### PR DESCRIPTION
## Summary
- pin `actions/cache` in CI to the immutable v4.3.0 commit
- pin both PyPI publish action uses in the release workflow to the immutable v1.14.1 commit

## Verification
- `git diff --check`
- parsed both changed workflows with PyYAML
- verified every workflow `uses:` reference is a full 40-character SHA
- verified the pinned SHAs against the upstream action tags
- independent narrow Claude review: pass-with-followups; tag-to-SHA mapping verified afterwards

Keeps the diff workflow-only; file-permission hardening and `uv.lock` policy remain separate follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Pins GitHub Actions to immutable commit SHAs in CI and release workflows.
- No changes to Mnemosyne’s tiered memory, retrieval, consolidation, veracity, sync, benchmarking, or agent integration surfaces (Hermes, MCP, CLI).
- Preserves local-first behavior and privacy posture; no new external runtime dependencies or data flows are introduced.
- Improves long-term maintainability and supply-chain reproducibility by preventing mutable action tags from changing unexpectedly. This is the right call for reliable, auditable automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->