### PR TITLE
fix(hermes): close persona adapter transactions

### DIFF
--- a/hermes_memory_provider/persona_adapter.py
+++ b/hermes_memory_provider/persona_adapter.py
@@ -114,8 +114,8 @@ class PersonaAdapter:
             )
             persona_id = cur.lastrowid
             conn.commit()
-        except Exception:
-            logger.exception("Persona promotion failed; rolling back transaction")
+        except Exception as exc:
+            logger.error("Persona promotion failed; rolling back transaction: %s", exc)
             conn.rollback()
             raise
         return json.dumps({
@@ -159,8 +159,8 @@ class PersonaAdapter:
                 (persona_id,),
             )
             conn.commit()
-        except Exception:
-            logger.exception("Persona demotion failed; rolling back transaction")
+        except Exception as exc:
+            logger.error("Persona demotion failed; rolling back transaction: %s", exc)
             conn.rollback()
             raise
         return json.dumps({
@@ -225,8 +225,8 @@ class PersonaAdapter:
                     "error": f"Persona id {persona_id} not found.",
                 })
             conn.commit()
-        except Exception:
-            logger.exception("Persona reinforcement failed; rolling back transaction")
+        except Exception as exc:
+            logger.error("Persona reinforcement failed; rolling back transaction: %s", exc)
             conn.rollback()
             raise
         return json.dumps({

--- a/hermes_memory_provider/persona_adapter.py
+++ b/hermes_memory_provider/persona_adapter.py
@@ -105,6 +105,7 @@ class PersonaAdapter:
             topic = "general"
         conn = self._conn()
         try:
+            conn.execute("BEGIN IMMEDIATE")
             cur = conn.execute(
                 "INSERT INTO memoria_persona (tier, topic, content, source_memory_id, promotion_reason) "
                 "VALUES (?, ?, ?, ?, ?)",
@@ -208,6 +209,7 @@ class PersonaAdapter:
     def _reinforce(self, persona_id: int = 0) -> str:
         conn = self._conn()
         try:
+            conn.execute("BEGIN IMMEDIATE")
             cur = conn.execute(
                 "UPDATE memoria_persona SET reinforcement_count = reinforcement_count + 1, "
                 "last_reinforced_at = CURRENT_TIMESTAMP WHERE id = ?",

--- a/hermes_memory_provider/persona_adapter.py
+++ b/hermes_memory_provider/persona_adapter.py
@@ -60,6 +60,7 @@ class PersonaAdapter:
             elif tool_name == "mnemosyne_persona_reinforce":
                 return self._reinforce(**args)
         except Exception as exc:
+            logger.exception("Persona tool %s failed", tool_name)
             return json.dumps({"status": "error", "error": str(exc)})
         return json.dumps({"status": "error", "error": f"Unknown tool: {tool_name}"})
 
@@ -114,6 +115,7 @@ class PersonaAdapter:
             persona_id = cur.lastrowid
             conn.commit()
         except Exception:
+            logger.exception("Persona promotion failed; rolling back transaction")
             conn.rollback()
             raise
         return json.dumps({
@@ -158,6 +160,7 @@ class PersonaAdapter:
             )
             conn.commit()
         except Exception:
+            logger.exception("Persona demotion failed; rolling back transaction")
             conn.rollback()
             raise
         return json.dumps({
@@ -223,6 +226,7 @@ class PersonaAdapter:
                 })
             conn.commit()
         except Exception:
+            logger.exception("Persona reinforcement failed; rolling back transaction")
             conn.rollback()
             raise
         return json.dumps({

--- a/hermes_memory_provider/persona_adapter.py
+++ b/hermes_memory_provider/persona_adapter.py
@@ -127,6 +127,7 @@ class PersonaAdapter:
         # We keep a record by writing into memoria_preferences as a tombstone.
         conn = self._conn()
         try:
+            # The tombstone insert and persona delete must be all-or-nothing.
             conn.execute("BEGIN IMMEDIATE")
             cur = conn.execute(
                 "SELECT topic, content, tier FROM memoria_persona WHERE id = ?",

--- a/hermes_memory_provider/persona_adapter.py
+++ b/hermes_memory_provider/persona_adapter.py
@@ -103,12 +103,18 @@ class PersonaAdapter:
             })
         if not topic:
             topic = "general"
-        cur = self._conn().execute(
-            "INSERT INTO memoria_persona (tier, topic, content, source_memory_id, promotion_reason) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (tier, topic, content, memory_id, reason),
-        )
-        persona_id = cur.lastrowid
+        conn = self._conn()
+        try:
+            cur = conn.execute(
+                "INSERT INTO memoria_persona (tier, topic, content, source_memory_id, promotion_reason) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (tier, topic, content, memory_id, reason),
+            )
+            persona_id = cur.lastrowid
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
         return json.dumps({
             "status": "ok",
             "persona_id": persona_id,
@@ -119,31 +125,39 @@ class PersonaAdapter:
     def _demote(self, persona_id: int = 0, reason: str = "") -> str:
         # Demotion = delete from persona tier (caller decides what to do next).
         # We keep a record by writing into memoria_preferences as a tombstone.
-        cur = self._conn().execute(
-            "SELECT topic, content, tier FROM memoria_persona WHERE id = ?",
-            (persona_id,),
-        ).fetchone()
-        if cur is None:
-            return json.dumps({
-                "status": "error",
-                "error": f"Persona id {persona_id} not found.",
-            })
-        topic, content, tier = cur
-        self._conn().execute(
-            "INSERT INTO memoria_preferences (preference, topic, evolution, context_snippet, source_memory_id) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (
-                f"[demoted from {tier}] {content}",
-                topic,
-                f"demoted: {reason}" if reason else "demoted",
-                "",
-                f"persona:{persona_id}",
-            ),
-        )
-        self._conn().execute(
-            "DELETE FROM memoria_persona WHERE id = ?",
-            (persona_id,),
-        )
+        conn = self._conn()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            cur = conn.execute(
+                "SELECT topic, content, tier FROM memoria_persona WHERE id = ?",
+                (persona_id,),
+            ).fetchone()
+            if cur is None:
+                conn.rollback()
+                return json.dumps({
+                    "status": "error",
+                    "error": f"Persona id {persona_id} not found.",
+                })
+            topic, content, tier = cur
+            conn.execute(
+                "INSERT INTO memoria_preferences (preference, topic, evolution, context_snippet, source_memory_id) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    f"[demoted from {tier}] {content}",
+                    topic,
+                    f"demoted: {reason}" if reason else "demoted",
+                    "",
+                    f"persona:{persona_id}",
+                ),
+            )
+            conn.execute(
+                "DELETE FROM memoria_persona WHERE id = ?",
+                (persona_id,),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
         return json.dumps({
             "status": "ok",
             "persona_id": persona_id,
@@ -191,16 +205,23 @@ class PersonaAdapter:
         return json.dumps({"status": "ok", "count": len(out), "personas": out})
 
     def _reinforce(self, persona_id: int = 0) -> str:
-        cur = self._conn().execute(
-            "UPDATE memoria_persona SET reinforcement_count = reinforcement_count + 1, "
-            "last_reinforced_at = CURRENT_TIMESTAMP WHERE id = ?",
-            (persona_id,),
-        )
-        if cur.rowcount == 0:
-            return json.dumps({
-                "status": "error",
-                "error": f"Persona id {persona_id} not found.",
-            })
+        conn = self._conn()
+        try:
+            cur = conn.execute(
+                "UPDATE memoria_persona SET reinforcement_count = reinforcement_count + 1, "
+                "last_reinforced_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (persona_id,),
+            )
+            if cur.rowcount == 0:
+                conn.rollback()
+                return json.dumps({
+                    "status": "error",
+                    "error": f"Persona id {persona_id} not found.",
+                })
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
         return json.dumps({
             "status": "ok",
             "persona_id": persona_id,

--- a/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
@@ -114,8 +114,8 @@ class PersonaAdapter:
             )
             persona_id = cur.lastrowid
             conn.commit()
-        except Exception:
-            logger.exception("Persona promotion failed; rolling back transaction")
+        except Exception as exc:
+            logger.error("Persona promotion failed; rolling back transaction: %s", exc)
             conn.rollback()
             raise
         return json.dumps({
@@ -159,8 +159,8 @@ class PersonaAdapter:
                 (persona_id,),
             )
             conn.commit()
-        except Exception:
-            logger.exception("Persona demotion failed; rolling back transaction")
+        except Exception as exc:
+            logger.error("Persona demotion failed; rolling back transaction: %s", exc)
             conn.rollback()
             raise
         return json.dumps({
@@ -225,8 +225,8 @@ class PersonaAdapter:
                     "error": f"Persona id {persona_id} not found.",
                 })
             conn.commit()
-        except Exception:
-            logger.exception("Persona reinforcement failed; rolling back transaction")
+        except Exception as exc:
+            logger.error("Persona reinforcement failed; rolling back transaction: %s", exc)
             conn.rollback()
             raise
         return json.dumps({

--- a/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
@@ -105,6 +105,7 @@ class PersonaAdapter:
             topic = "general"
         conn = self._conn()
         try:
+            conn.execute("BEGIN IMMEDIATE")
             cur = conn.execute(
                 "INSERT INTO memoria_persona (tier, topic, content, source_memory_id, promotion_reason) "
                 "VALUES (?, ?, ?, ?, ?)",
@@ -208,6 +209,7 @@ class PersonaAdapter:
     def _reinforce(self, persona_id: int = 0) -> str:
         conn = self._conn()
         try:
+            conn.execute("BEGIN IMMEDIATE")
             cur = conn.execute(
                 "UPDATE memoria_persona SET reinforcement_count = reinforcement_count + 1, "
                 "last_reinforced_at = CURRENT_TIMESTAMP WHERE id = ?",

--- a/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
@@ -60,6 +60,7 @@ class PersonaAdapter:
             elif tool_name == "mnemosyne_persona_reinforce":
                 return self._reinforce(**args)
         except Exception as exc:
+            logger.exception("Persona tool %s failed", tool_name)
             return json.dumps({"status": "error", "error": str(exc)})
         return json.dumps({"status": "error", "error": f"Unknown tool: {tool_name}"})
 
@@ -114,6 +115,7 @@ class PersonaAdapter:
             persona_id = cur.lastrowid
             conn.commit()
         except Exception:
+            logger.exception("Persona promotion failed; rolling back transaction")
             conn.rollback()
             raise
         return json.dumps({
@@ -158,6 +160,7 @@ class PersonaAdapter:
             )
             conn.commit()
         except Exception:
+            logger.exception("Persona demotion failed; rolling back transaction")
             conn.rollback()
             raise
         return json.dumps({
@@ -223,6 +226,7 @@ class PersonaAdapter:
                 })
             conn.commit()
         except Exception:
+            logger.exception("Persona reinforcement failed; rolling back transaction")
             conn.rollback()
             raise
         return json.dumps({

--- a/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
@@ -127,6 +127,7 @@ class PersonaAdapter:
         # We keep a record by writing into memoria_preferences as a tombstone.
         conn = self._conn()
         try:
+            # The tombstone insert and persona delete must be all-or-nothing.
             conn.execute("BEGIN IMMEDIATE")
             cur = conn.execute(
                 "SELECT topic, content, tier FROM memoria_persona WHERE id = ?",

--- a/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
@@ -103,12 +103,18 @@ class PersonaAdapter:
             })
         if not topic:
             topic = "general"
-        cur = self._conn().execute(
-            "INSERT INTO memoria_persona (tier, topic, content, source_memory_id, promotion_reason) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (tier, topic, content, memory_id, reason),
-        )
-        persona_id = cur.lastrowid
+        conn = self._conn()
+        try:
+            cur = conn.execute(
+                "INSERT INTO memoria_persona (tier, topic, content, source_memory_id, promotion_reason) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (tier, topic, content, memory_id, reason),
+            )
+            persona_id = cur.lastrowid
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
         return json.dumps({
             "status": "ok",
             "persona_id": persona_id,
@@ -119,31 +125,39 @@ class PersonaAdapter:
     def _demote(self, persona_id: int = 0, reason: str = "") -> str:
         # Demotion = delete from persona tier (caller decides what to do next).
         # We keep a record by writing into memoria_preferences as a tombstone.
-        cur = self._conn().execute(
-            "SELECT topic, content, tier FROM memoria_persona WHERE id = ?",
-            (persona_id,),
-        ).fetchone()
-        if cur is None:
-            return json.dumps({
-                "status": "error",
-                "error": f"Persona id {persona_id} not found.",
-            })
-        topic, content, tier = cur
-        self._conn().execute(
-            "INSERT INTO memoria_preferences (preference, topic, evolution, context_snippet, source_memory_id) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (
-                f"[demoted from {tier}] {content}",
-                topic,
-                f"demoted: {reason}" if reason else "demoted",
-                "",
-                f"persona:{persona_id}",
-            ),
-        )
-        self._conn().execute(
-            "DELETE FROM memoria_persona WHERE id = ?",
-            (persona_id,),
-        )
+        conn = self._conn()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            cur = conn.execute(
+                "SELECT topic, content, tier FROM memoria_persona WHERE id = ?",
+                (persona_id,),
+            ).fetchone()
+            if cur is None:
+                conn.rollback()
+                return json.dumps({
+                    "status": "error",
+                    "error": f"Persona id {persona_id} not found.",
+                })
+            topic, content, tier = cur
+            conn.execute(
+                "INSERT INTO memoria_preferences (preference, topic, evolution, context_snippet, source_memory_id) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    f"[demoted from {tier}] {content}",
+                    topic,
+                    f"demoted: {reason}" if reason else "demoted",
+                    "",
+                    f"persona:{persona_id}",
+                ),
+            )
+            conn.execute(
+                "DELETE FROM memoria_persona WHERE id = ?",
+                (persona_id,),
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
         return json.dumps({
             "status": "ok",
             "persona_id": persona_id,
@@ -191,16 +205,23 @@ class PersonaAdapter:
         return json.dumps({"status": "ok", "count": len(out), "personas": out})
 
     def _reinforce(self, persona_id: int = 0) -> str:
-        cur = self._conn().execute(
-            "UPDATE memoria_persona SET reinforcement_count = reinforcement_count + 1, "
-            "last_reinforced_at = CURRENT_TIMESTAMP WHERE id = ?",
-            (persona_id,),
-        )
-        if cur.rowcount == 0:
-            return json.dumps({
-                "status": "error",
-                "error": f"Persona id {persona_id} not found.",
-            })
+        conn = self._conn()
+        try:
+            cur = conn.execute(
+                "UPDATE memoria_persona SET reinforcement_count = reinforcement_count + 1, "
+                "last_reinforced_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (persona_id,),
+            )
+            if cur.rowcount == 0:
+                conn.rollback()
+                return json.dumps({
+                    "status": "error",
+                    "error": f"Persona id {persona_id} not found.",
+                })
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
         return json.dumps({
             "status": "ok",
             "persona_id": persona_id,

--- a/integrations/hermes/tests/test_task_progress_tool.py
+++ b/integrations/hermes/tests/test_task_progress_tool.py
@@ -58,6 +58,45 @@ def test_task_progress_roundtrip_and_list(tmp_path):
         _close(provider)
 
 
+def test_persona_mutations_commit_before_task_progress(tmp_path):
+    provider = _provider(tmp_path, profile="profile_a")
+    try:
+        assert provider._beam is not None
+        remembered = json.loads(provider.handle_tool_call(
+            "mnemosyne_remember",
+            {"content": "Persona transaction regression fixture.", "source": "test"},
+        ))
+        promoted = json.loads(provider.handle_tool_call(
+            "mnemosyne_persona_promote",
+            {"memory_id": remembered["memory_id"], "tier": "working"},
+        ))
+        assert promoted["status"] == "ok"
+        assert provider._beam.conn.in_transaction is False
+
+        progressed = json.loads(provider.handle_tool_call(
+            "mnemosyne_task_progress",
+            {"action": "set", "task": "persona-transaction", "state": "current"},
+        ))
+        assert progressed["status"] == "set"
+        assert provider._beam.conn.in_transaction is False
+
+        reinforced = json.loads(provider.handle_tool_call(
+            "mnemosyne_persona_reinforce",
+            {"persona_id": promoted["persona_id"]},
+        ))
+        assert reinforced["status"] == "ok"
+        assert provider._beam.conn.in_transaction is False
+
+        demoted = json.loads(provider.handle_tool_call(
+            "mnemosyne_persona_demote",
+            {"persona_id": promoted["persona_id"]},
+        ))
+        assert demoted["status"] == "ok"
+        assert provider._beam.conn.in_transaction is False
+    finally:
+        _close(provider)
+
+
 def test_task_progress_is_profile_scoped(tmp_path):
     provider = _provider(tmp_path, profile="profile_a")
     try:

--- a/tests/test_persona_adapter.py
+++ b/tests/test_persona_adapter.py
@@ -74,11 +74,31 @@ class TestPersonaPromote:
         assert result["status"] == "error"
         assert "not found" in result["error"]
 
-    def test_promote_rolls_back_when_insert_fails(self, adapter, beam_with_memories):
+    def test_promote_rolls_back_when_insert_fails(self, adapter, beam_with_memories, caplog):
         mid = _memory_id_by_content(beam_with_memories, "XYZ")
         conn = beam_with_memories.conn
         conn.execute(
             "CREATE TRIGGER fail_persona_insert BEFORE INSERT ON memoria_persona "
+            "BEGIN SELECT RAISE(ABORT, 'forced insert failure'); END"
+        )
+        conn.commit()
+
+        result = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_promote", {"memory_id": mid, "tier": "long_term"},
+        ))
+
+        assert result["status"] == "error"
+        assert conn.in_transaction is False
+        assert conn.execute("SELECT 1 FROM memoria_persona").fetchone() is None
+        assert "Persona promotion failed; rolling back transaction" in caplog.text
+        assert "Persona tool mnemosyne_persona_promote failed" in caplog.text
+
+    def test_legacy_promote_rolls_back_when_insert_fails(self, beam_with_memories):
+        adapter = LegacyPersonaAdapter(beam_instance=beam_with_memories)
+        mid = _memory_id_by_content(beam_with_memories, "XYZ")
+        conn = beam_with_memories.conn
+        conn.execute(
+            "CREATE TRIGGER fail_legacy_persona_insert BEFORE INSERT ON memoria_persona "
             "BEGIN SELECT RAISE(ABORT, 'forced insert failure'); END"
         )
         conn.commit()
@@ -184,6 +204,53 @@ class TestPersonaReinforce:
         ))
         assert result["status"] == "error"
         assert adapter._conn().in_transaction is False
+
+    def test_reinforce_rolls_back_when_update_fails(self, adapter, beam_with_memories):
+        mid = _memory_id_by_content(beam_with_memories, "XYZ")
+        promoted = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_promote", {"memory_id": mid, "tier": "long_term"},
+        ))
+        conn = beam_with_memories.conn
+        conn.execute(
+            "CREATE TRIGGER fail_persona_reinforce BEFORE UPDATE ON memoria_persona "
+            "BEGIN SELECT RAISE(ABORT, 'forced update failure'); END"
+        )
+        conn.commit()
+
+        result = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_reinforce", {"persona_id": promoted["persona_id"]},
+        ))
+
+        assert result["status"] == "error"
+        assert conn.in_transaction is False
+        assert conn.execute(
+            "SELECT reinforcement_count FROM memoria_persona WHERE id = ?",
+            (promoted["persona_id"],),
+        ).fetchone()[0] == 0
+
+    def test_legacy_reinforce_rolls_back_when_update_fails(self, beam_with_memories):
+        adapter = LegacyPersonaAdapter(beam_instance=beam_with_memories)
+        mid = _memory_id_by_content(beam_with_memories, "XYZ")
+        promoted = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_promote", {"memory_id": mid, "tier": "long_term"},
+        ))
+        conn = beam_with_memories.conn
+        conn.execute(
+            "CREATE TRIGGER fail_legacy_persona_reinforce BEFORE UPDATE ON memoria_persona "
+            "BEGIN SELECT RAISE(ABORT, 'forced update failure'); END"
+        )
+        conn.commit()
+
+        result = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_reinforce", {"persona_id": promoted["persona_id"]},
+        ))
+
+        assert result["status"] == "error"
+        assert conn.in_transaction is False
+        assert conn.execute(
+            "SELECT reinforcement_count FROM memoria_persona WHERE id = ?",
+            (promoted["persona_id"],),
+        ).fetchone()[0] == 0
 
 
 class TestPersonaDemote:

--- a/tests/test_persona_adapter.py
+++ b/tests/test_persona_adapter.py
@@ -74,6 +74,23 @@ class TestPersonaPromote:
         assert result["status"] == "error"
         assert "not found" in result["error"]
 
+    def test_promote_rolls_back_when_insert_fails(self, adapter, beam_with_memories):
+        mid = _memory_id_by_content(beam_with_memories, "XYZ")
+        conn = beam_with_memories.conn
+        conn.execute(
+            "CREATE TRIGGER fail_persona_insert BEFORE INSERT ON memoria_persona "
+            "BEGIN SELECT RAISE(ABORT, 'forced insert failure'); END"
+        )
+        conn.commit()
+
+        result = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_promote", {"memory_id": mid, "tier": "long_term"},
+        ))
+
+        assert result["status"] == "error"
+        assert conn.in_transaction is False
+        assert conn.execute("SELECT 1 FROM memoria_persona").fetchone() is None
+
 
 class TestPersonaList:
     def test_list_empty(self, adapter):
@@ -166,6 +183,7 @@ class TestPersonaReinforce:
             "mnemosyne_persona_reinforce", {"persona_id": 9999},
         ))
         assert result["status"] == "error"
+        assert adapter._conn().in_transaction is False
 
 
 class TestPersonaDemote:

--- a/tests/test_persona_adapter.py
+++ b/tests/test_persona_adapter.py
@@ -1,6 +1,7 @@
 """Tests for the L3 persona adapter (v3.10.0)."""
 
 import json
+import logging
 import tempfile
 from pathlib import Path
 
@@ -75,6 +76,7 @@ class TestPersonaPromote:
         assert "not found" in result["error"]
 
     def test_promote_rolls_back_when_insert_fails(self, adapter, beam_with_memories, caplog):
+        caplog.set_level(logging.ERROR)
         mid = _memory_id_by_content(beam_with_memories, "XYZ")
         conn = beam_with_memories.conn
         conn.execute(
@@ -93,7 +95,8 @@ class TestPersonaPromote:
         assert "Persona promotion failed; rolling back transaction" in caplog.text
         assert "Persona tool mnemosyne_persona_promote failed" in caplog.text
 
-    def test_legacy_promote_rolls_back_when_insert_fails(self, beam_with_memories):
+    def test_legacy_promote_rolls_back_when_insert_fails(self, beam_with_memories, caplog):
+        caplog.set_level(logging.ERROR)
         adapter = LegacyPersonaAdapter(beam_instance=beam_with_memories)
         mid = _memory_id_by_content(beam_with_memories, "XYZ")
         conn = beam_with_memories.conn
@@ -110,6 +113,8 @@ class TestPersonaPromote:
         assert result["status"] == "error"
         assert conn.in_transaction is False
         assert conn.execute("SELECT 1 FROM memoria_persona").fetchone() is None
+        assert "Persona promotion failed; rolling back transaction" in caplog.text
+        assert "Persona tool mnemosyne_persona_promote failed" in caplog.text
 
 
 class TestPersonaList:
@@ -205,7 +210,8 @@ class TestPersonaReinforce:
         assert result["status"] == "error"
         assert adapter._conn().in_transaction is False
 
-    def test_reinforce_rolls_back_when_update_fails(self, adapter, beam_with_memories):
+    def test_reinforce_rolls_back_when_update_fails(self, adapter, beam_with_memories, caplog):
+        caplog.set_level(logging.ERROR)
         mid = _memory_id_by_content(beam_with_memories, "XYZ")
         promoted = json.loads(adapter.handle_tool_call(
             "mnemosyne_persona_promote", {"memory_id": mid, "tier": "long_term"},
@@ -227,6 +233,8 @@ class TestPersonaReinforce:
             "SELECT reinforcement_count FROM memoria_persona WHERE id = ?",
             (promoted["persona_id"],),
         ).fetchone()[0] == 0
+        assert "Persona reinforcement failed; rolling back transaction" in caplog.text
+        assert "Persona tool mnemosyne_persona_reinforce failed" in caplog.text
 
     def test_legacy_reinforce_rolls_back_when_update_fails(self, beam_with_memories):
         adapter = LegacyPersonaAdapter(beam_instance=beam_with_memories)

--- a/tests/test_persona_adapter.py
+++ b/tests/test_persona_adapter.py
@@ -204,6 +204,32 @@ class TestPersonaDemote:
         ))
         assert result["status"] == "error"
 
+    def test_demote_rolls_back_tombstone_when_delete_fails(self, adapter, beam_with_memories):
+        mid = _memory_id_by_content(beam_with_memories, "XYZ")
+        promoted = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_promote",
+            {"memory_id": mid, "tier": "long_term"},
+        ))
+        pid = promoted["persona_id"]
+        conn = beam_with_memories.conn
+        conn.execute(
+            "CREATE TRIGGER fail_persona_delete BEFORE DELETE ON memoria_persona "
+            "BEGIN SELECT RAISE(ABORT, 'forced delete failure'); END"
+        )
+        conn.commit()
+
+        result = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_demote", {"persona_id": pid},
+        ))
+
+        assert result["status"] == "error"
+        assert conn.in_transaction is False
+        assert conn.execute("SELECT 1 FROM memoria_persona WHERE id = ?", (pid,)).fetchone()
+        assert conn.execute(
+            "SELECT 1 FROM memoria_preferences WHERE source_memory_id = ?",
+            (f"persona:{pid}",),
+        ).fetchone() is None
+
 
 class TestPersonaAdapterReadiness:
     def test_adapter_not_ready_without_beam(self, tmp_path):

--- a/tests/test_persona_adapter.py
+++ b/tests/test_persona_adapter.py
@@ -8,6 +8,7 @@ import pytest
 
 from mnemosyne.core.beam import BeamMemory
 from mnemosyne_hermes.persona_adapter import PersonaAdapter, VALID_TIERS
+from hermes_memory_provider.persona_adapter import PersonaAdapter as LegacyPersonaAdapter
 
 
 @pytest.fixture
@@ -214,6 +215,33 @@ class TestPersonaDemote:
         conn = beam_with_memories.conn
         conn.execute(
             "CREATE TRIGGER fail_persona_delete BEFORE DELETE ON memoria_persona "
+            "BEGIN SELECT RAISE(ABORT, 'forced delete failure'); END"
+        )
+        conn.commit()
+
+        result = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_demote", {"persona_id": pid},
+        ))
+
+        assert result["status"] == "error"
+        assert conn.in_transaction is False
+        assert conn.execute("SELECT 1 FROM memoria_persona WHERE id = ?", (pid,)).fetchone()
+        assert conn.execute(
+            "SELECT 1 FROM memoria_preferences WHERE source_memory_id = ?",
+            (f"persona:{pid}",),
+        ).fetchone() is None
+
+    def test_legacy_demote_rolls_back_tombstone_when_delete_fails(self, beam_with_memories):
+        adapter = LegacyPersonaAdapter(beam_instance=beam_with_memories)
+        mid = _memory_id_by_content(beam_with_memories, "XYZ")
+        promoted = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_promote",
+            {"memory_id": mid, "tier": "long_term"},
+        ))
+        pid = promoted["persona_id"]
+        conn = beam_with_memories.conn
+        conn.execute(
+            "CREATE TRIGGER fail_legacy_persona_delete BEFORE DELETE ON memoria_persona "
             "BEGIN SELECT RAISE(ABORT, 'forced delete failure'); END"
         )
         conn.commit()

--- a/tests/test_persona_adapter.py
+++ b/tests/test_persona_adapter.py
@@ -276,6 +276,33 @@ class TestPersonaDemote:
             (f"persona:{pid}",),
         ).fetchone() is None
 
+    def test_legacy_persona_mutations_leave_connection_clean(self, beam_with_memories):
+        adapter = LegacyPersonaAdapter(beam_instance=beam_with_memories)
+        mid = _memory_id_by_content(beam_with_memories, "XYZ")
+        promoted = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_promote", {"memory_id": mid, "tier": "working"},
+        ))
+        conn = beam_with_memories.conn
+        assert promoted["status"] == "ok"
+        assert conn.in_transaction is False
+
+        reinforced = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_reinforce", {"persona_id": promoted["persona_id"]},
+        ))
+        assert reinforced["status"] == "ok"
+        assert conn.in_transaction is False
+
+        beam_with_memories.canonical.remember(
+            "default", "task:progress", "legacy-persona", "current"
+        )
+        assert conn.in_transaction is False
+
+        demoted = json.loads(adapter.handle_tool_call(
+            "mnemosyne_persona_demote", {"persona_id": promoted["persona_id"]},
+        ))
+        assert demoted["status"] == "ok"
+        assert conn.in_transaction is False
+
 
 class TestPersonaAdapterReadiness:
     def test_adapter_not_ready_without_beam(self, tmp_path):


### PR DESCRIPTION
## Summary
- close the shared Beam SQLite transaction after every persona promote, reinforce, and demote mutation
- make demotion tombstone creation and persona deletion atomic
- keep the mirrored legacy and integration persona adapters in sync

Closes #489.

## Regression coverage
- `remember → persona_promote → task_progress(set)` now completes with no open transaction
- promote insert failure rolls back cleanly
- reinforce not-found leaves no open transaction
- demote delete failure rolls back the tombstone insert and preserves the persona
- legacy provider mutation and rollback paths are exercised too

## Verification
```text
PYTHONPATH=.:integrations/hermes/src uv run --no-sync --with pytest --with pyyaml --with numpy --with httpx pytest integrations/hermes/tests/test_task_progress_tool.py integrations/hermes/tests/test_canonical_tools.py tests/test_persona_adapter.py tests/test_provider_all_15_tools.py -q
58 passed
```

Also verified `git diff --check`, normalized adapter parity, a direct legacy-adapter mutation smoke, and an independent narrow Claude review with no blockers.

## AI Assistance
The investigation, implementation, and tests were prepared with AI agents and independently reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated Hermes and legacy persona adapters to make **promo, reinforce, and demote** mutations explicitly transactional using `BEGIN IMMEDIATE`, with correct `commit()`/`rollback()` behavior on success/failure.
- Ensured **shared BEAM SQLite connection hygiene**: after persona tool calls, the connection is left **not in an active transaction** so subsequent `mnemosyne_task_progress` writes can safely start their own `BEGIN IMMEDIATE`.
- Made **demotion atomic**: creation of the persona tombstone in `memoria_preferences` and deletion from `memoria_persona` now succeed or fail together.
- Improved diagnostics by logging tool-call failures via `logger.exception(...)`.
- Added regression tests covering: successful mutation → task progress, missing persona handling during reinforce/demote, forced SQLite trigger failures, rollback correctness (including “legacy adapter parity”), and verification that the connection is not left in a transaction.
- Verified by the stated suite (58 tests).

## Architectural impact

This is the right call for Mnemosyne’s local-first memory architecture: it strengthens the **persistence/transaction boundary** around persona mutations without changing the underlying tiered memory model (e.g., working/episodic/BEAM) or any higher-level logic.
- **Not changed:** retrieval strategies, consolidation/veracity systems, synchronization behavior, or benchmark methodology.
- **Privacy/local-first:** persona data remains local in the same SQLite-backed BEAM storage; the change is purely about deterministic, atomic local writes and preventing transaction leakage.
- **Integration surface (Hermes):** improves reliability for agent-facing persona tools and their interaction with `task_progress` by eliminating the deterministic `sqlite3.OperationalError: cannot start a transaction within a transaction` failure mode.
- **Maintainability:** explicitly documents and enforces atomicity/rollback expectations in code, and keeps **Hermes and legacy adapter behavior synchronized** through parity-focused tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->