### PR TITLE
fix: surface owner_id mismatch hint on canonical recall miss

### DIFF
--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -739,9 +739,29 @@ def _handle_recall_canonical(arguments: Dict[str, Any]) -> Dict[str, Any]:
                     "name": name, "results_count": len(results),
                     "results": results, "store": "canonical"}
         row = store.recall(owner_id, category, name)
-        return {"mode": "recall", "owner_id": owner_id, "category": category,
+        result = {"mode": "recall", "owner_id": owner_id, "category": category,
                 "name": name, "found": row is not None, "result": row,
                 "store": "canonical"}
+        if row is None:
+            # Diagnostic: check if the row exists under a different owner_id
+            try:
+                conn = store.conn if hasattr(store, "conn") else None
+                if conn is not None:
+                    cur = conn.execute(
+                        "SELECT owner_id FROM canonical_facts "
+                        "WHERE category=? AND name=? AND valid_until IS NULL LIMIT 1",
+                        (category, name),
+                    )
+                    alt = cur.fetchone()
+                    if alt:
+                        result["hint"] = (
+                            f"Row exists under owner_id '{alt[0]}' but you queried "
+                            f"with '{owner_id}'. Set MNEMOSYNE_DEFAULT_OWNER={alt[0]} "
+                            f"or check your profile/provider config."
+                        )
+            except Exception:
+                pass
+        return result
     results = store.list(owner_id, category=category or None)
     return {"mode": "list", "owner_id": owner_id, "category": category or None,
             "results_count": len(results), "results": results, "store": "canonical"}


### PR DESCRIPTION
Closes #494

When mnemosyne_recall_canonical returns found:false, check if the row exists under a different owner_id and include a diagnostic hint in the response.

Before: {found: false, result: null}
After: {found: false, result: null, hint: "Row exists under owner_id 'hermes-switch' but you queried with 'default'. Set MNEMOSYNE_DEFAULT_OWNER=hermes-switch or check your profile/provider config."}

This lets users self-diagnose multi-tenant owner_id mismatches without needing to query SQLite directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Makes canonical recall misses actionable for MCP and Hermes-connected agents by detecting when the queried canonical fact exists under a different `owner_id` (within the same `category`/`name`, with `valid_until IS NULL`) and returning a diagnostic `hint` pointing to the stored owner and configuration checks (e.g., `MNEMOSYNE_DEFAULT_OWNER` / provider-profile owner mapping).
- Preserves Mnemosyne’s core local-first architecture: the new behavior is a best-effort local SQLite lookup used only for diagnostics, with broad error isolation so normal `found: false` semantics are not degraded.
- Improves the owner-scoped canonical memory layer’s diagnosability without changing Mnemosyne’s tiered memory model (working/episodic/BEAM), retrieval/ranking behavior, consolidation pipeline, embeddings, or veracity weighting.
- Expands maintainability and integration robustness by standardizing the `_handle_recall_canonical` response contract into a structured `result` object and adding explicit guidance rather than silent misses.
- Privacy posture remains local-first; however, when a diagnostic hint is included, the response may expose the stored owner identifier to the authorized caller, increasing visibility of tenant/profile configuration metadata while still keeping the data access bounded to the same local recall context.
- No changes to sync layer, CLI behavior, or benchmark methodology; regression coverage is still important to ensure canonical data stored under non-default owners is correctly surfaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->