### PR TITLE
fix: enable PRAGMA foreign_keys and add FK on gists.memory_id

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -467,6 +467,7 @@ def _get_connection(db_path: Path = None) -> sqlite3.Connection:
         )
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
         # Configurable so deployments with long consolidation write windows
         # can let tool calls ride them out instead of failing with
         # "database is locked" after a hardcoded 5s.

--- a/mnemosyne/core/episodic_graph.py
+++ b/mnemosyne/core/episodic_graph.py
@@ -119,7 +119,7 @@ class EpisodicGraph:
                 location TEXT,
                 emotion TEXT,
                 time_scope TEXT,
-                memory_id TEXT,
+                memory_id TEXT REFERENCES working_memory(id) ON DELETE SET NULL,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)


### PR DESCRIPTION
Closes #408

Two changes:
1. beam.py: add PRAGMA foreign_keys=ON to the connection factory (memory.py already had it, beam.py was missing it)
2. episodic_graph.py: add REFERENCES working_memory(id) ON DELETE SET NULL to gists.memory_id

This prevents orphaned gists and embeddings from accumulating when memory rows are deleted. The ON DELETE SET NULL on gists preserves the gist text while clearing the dangling reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Enables SQLite foreign-key enforcement earlier in BEAM connection setup.
- Adds `gists.memory_id → working_memory(id) ON DELETE SET NULL`, preserving gist content while clearing deleted-memory references.
- Prevents newly created orphaned gists and improves referential integrity.

## Architectural impact

- **Tiered memory:** Strengthens the working-memory/episodic relationship without changing BEAM behavior or tiering.
- **Retrieval and consolidation:** No changes to retrieval, consolidation, veracity, embeddings, or benchmark methodology.
- **Privacy and local-first:** No erosion; this remains a local SQLite integrity improvement with no sync or external data flow.
- **Agent integrations:** No changes to Hermes, MCP, CLI, or other integration surfaces.
- **Maintainability:** This is the right call: schema-level enforcement is safer than relying on application cleanup. However, the legacy `memory_embeddings → memories` relationship and any existing orphaned data still require separate migration/cleanup work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->