### PR TITLE
ci: add fatal Ruff baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,12 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: python -m pip install ruff==0.15.22
 
       - name: Check fatal Python errors
-        run: ruff check --select E9,F63,F7,F82 mnemosyne tests integrations/hermes/src hermes_memory_provider
+        run: ruff check --select E9,F63,F7,F82 mnemosyne tests integrations/hermes/src integrations/hermes/tests hermes_memory_provider
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,22 @@ jobs:
       - name: Verify docs match generated
         run: python3 scripts/verify-docs.py 2>&1
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+
+      - name: Install Ruff
+        run: python -m pip install ruff==0.15.22
+
+      - name: Check fatal Python errors
+        run: ruff check --select E9,F63,F7,F82 mnemosyne tests integrations/hermes/src hermes_memory_provider
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -2789,6 +2789,8 @@ def register_memory_provider(ctx):
 # Plugin registration (used when loaded via Hermes plugin system)
 # ---------------------------------------------------------------------------
 
+_provider: Optional[Any] = None
+
 def register(ctx):
     """Called by Hermes plugin loader to register CLI commands and tools."""
     # Register the memory provider first so Hermes discovers it
@@ -2811,6 +2813,7 @@ def register(ctx):
     from .tools import ALL_TOOL_SCHEMAS
     from functools import partial
 
+    global _provider
     _provider = MnemosyneMemoryProvider()
     for _schema in ALL_TOOL_SCHEMAS:
         _name = _schema["name"]

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -79,13 +79,6 @@ def test_get_provider_class_returns_real_class():
     assert hasattr(cls, "_sanitize_bank_name")
 
 
-def test_get_provider_class_standalone_fallback():
-    """The helper returns the provider class through the package import path."""
-    cls = _get_provider_class()
-    assert cls is not None
-    assert hasattr(cls, "_sanitize_bank_name")
-
-
 def test_standalone_load_via_spec_resolves_profile_bank(tmp_path, monkeypatch):
     """End-to-end standalone load: CLI module loaded from file path
     (no __package__) resolves the active profile bank."""

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -79,29 +79,8 @@ def test_get_provider_class_returns_real_class():
     assert hasattr(cls, "_sanitize_bank_name")
 
 
-def test_get_provider_class_standalone_fallback(monkeypatch):
-    """When the package has no parent package (standalone CLI load),
-    the helper must fall back to absolute import and succeed."""
-    # Monkey-patch the import shim to simulate the standalone case
-    import builtins
-    orig_import = builtins.__import__
-
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        # Simulate relative import failure for the mnemosyne_hermes package
-        # when loaded standalone
-        if level > 0 and name == "" and globals and globals.get("__name__") == "_clitest_standalone":
-            raise ImportError("attempted relative import with no known parent package")
-        return orig_import(name, globals, locals, fromlist, level)
-
-    # Simulate the standalone module context
-    fake_globals = {"__name__": "_clitest_standalone", "__package__": None}
-    # We can't easily simulate this without actually loading the module
-    # via spec_from_file_location, so we'll verify the fallback directly
-    # by calling the helper and checking that it returns the class even
-    # under the normal package-import path
-    del fake_globals
-    del fake_import
-    del orig_import
+def test_get_provider_class_standalone_fallback():
+    """The helper returns the provider class through the package import path."""
     cls = _get_provider_class()
     assert cls is not None
     assert hasattr(cls, "_sanitize_bank_name")

--- a/integrations/hermes/tests/test_persona_plugin_registration.py
+++ b/integrations/hermes/tests/test_persona_plugin_registration.py
@@ -1,0 +1,53 @@
+"""Regression tests for standalone-plugin persona tool registration."""
+
+import mnemosyne_hermes as plugin
+from mnemosyne_hermes import persona_adapter
+
+
+class _Context:
+    def __init__(self):
+        self.tools = {}
+
+    def register_memory_provider(self, provider):
+        self.provider = provider
+
+    def register_cli_command(self, **_kwargs):
+        pass
+
+    def register_tool(self, *, name, handler, **_kwargs):
+        self.tools[name] = handler
+
+
+class _Provider:
+    def __init__(self):
+        self._beam = object()
+
+    def handle_tool_call(self, _tool_name, _arguments):
+        return '{"status": "ok"}'
+
+
+class _PersonaAdapter:
+    received_beam = None
+
+    def __init__(self, *, beam_instance):
+        type(self).received_beam = beam_instance
+
+    def handle_tool_call(self, _tool_name, _arguments):
+        return '{"status": "ok"}'
+
+
+def test_persona_tool_uses_plugin_registered_provider_beam(monkeypatch):
+    """Persona tools share the standalone plugin provider's BeamMemory instance."""
+    provider = _Provider()
+    context = _Context()
+
+    monkeypatch.setattr(plugin, "MnemosyneMemoryProvider", lambda: provider)
+    monkeypatch.setattr(persona_adapter, "PersonaAdapter", _PersonaAdapter)
+    monkeypatch.delattr(plugin, "_provider", raising=False)
+    monkeypatch.setattr(plugin, "_persona_adapter", None)
+    _PersonaAdapter.received_beam = None
+
+    plugin.register(context)
+    context.tools["mnemosyne_persona_promote"]({"memory_id": "memory-1"})
+
+    assert _PersonaAdapter.received_beam is provider._beam

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -13,6 +13,7 @@ All imports are guarded — this module loads safely even if mcp is not installe
 
 from typing import Dict, Any, List
 import json
+import math
 import os
 import sqlite3
 from pathlib import Path
@@ -1012,10 +1013,22 @@ def _handle_hygiene_clean(arguments: Dict[str, Any]) -> Dict[str, Any]:
             for key in ("memory_id", "table_name")
         ):
             return {"error": "candidates_json must be a list of valid hygiene candidates"}
-        if any(
-            key in candidate_data
-            and (not isinstance(candidate_data[key], (int, float)) or isinstance(candidate_data[key], bool))
-            for key in ("noise_score", "importance", "content_length")
+        if candidate_data["table_name"] not in {"working_memory", "memories", "episodic_memory"}:
+            return {"error": "candidates_json must be a list of valid hygiene candidates"}
+        noise_score = candidate_data.get("noise_score", 0.0)
+        importance = candidate_data.get("importance", 0.5)
+        content_length = candidate_data.get("content_length", 0)
+        if (
+            not isinstance(noise_score, (int, float))
+            or isinstance(noise_score, bool)
+            or not math.isfinite(noise_score)
+            or not 0 <= noise_score <= 1
+            or not isinstance(importance, (int, float))
+            or isinstance(importance, bool)
+            or not math.isfinite(importance)
+            or not isinstance(content_length, int)
+            or isinstance(content_length, bool)
+            or content_length < 0
         ):
             return {"error": "candidates_json must be a list of valid hygiene candidates"}
         if any(

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -994,32 +994,60 @@ def _handle_hygiene_clean(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_hygiene_clean tool call."""
     from mnemosyne.core.hygiene import NoiseCandidate, clean_noise
 
-    bank = _resolve_bank(arguments)
-    mem = _create_instance(bank=bank)
-    db_path = mem.beam.db_path if hasattr(mem.beam, "db_path") else mem.db_path
-
     candidates_json = arguments.get("candidates_json", "[]")
     try:
         raw_candidates = json.loads(candidates_json) if isinstance(candidates_json, str) else candidates_json
     except json.JSONDecodeError:
         return {"error": "candidates_json is not valid JSON"}
 
-    candidates = [
-        NoiseCandidate(
-            memory_id=c["memory_id"],
-            table_name=c["table_name"],
-            content_preview=c.get("content_preview", ""),
-            noise_score=c.get("noise_score", 0.0),
-            noise_reasons=c.get("noise_reasons", []),
-            secret_flags=c.get("secret_flags", []),
-            importance=c.get("importance", 0.5),
-            source=c.get("source", ""),
-            timestamp=c.get("timestamp", ""),
-            suggested_action=c.get("suggested_action", "keep"),
-            content_length=c.get("content_length", 0),
+    if not isinstance(raw_candidates, list):
+        return {"error": "candidates_json must be a list of valid hygiene candidates"}
+
+    candidates = []
+    for candidate_data in raw_candidates:
+        if not isinstance(candidate_data, dict):
+            return {"error": "candidates_json must be a list of valid hygiene candidates"}
+        if not all(
+            isinstance(candidate_data.get(key), str) and candidate_data[key].strip()
+            for key in ("memory_id", "table_name")
+        ):
+            return {"error": "candidates_json must be a list of valid hygiene candidates"}
+        if any(
+            key in candidate_data
+            and (not isinstance(candidate_data[key], (int, float)) or isinstance(candidate_data[key], bool))
+            for key in ("noise_score", "importance", "content_length")
+        ):
+            return {"error": "candidates_json must be a list of valid hygiene candidates"}
+        if any(
+            key in candidate_data
+            and (not isinstance(candidate_data[key], list) or not all(isinstance(item, str) for item in candidate_data[key]))
+            for key in ("noise_reasons", "secret_flags")
+        ):
+            return {"error": "candidates_json must be a list of valid hygiene candidates"}
+        if any(
+            key in candidate_data and not isinstance(candidate_data[key], str)
+            for key in ("content_preview", "source", "timestamp", "suggested_action")
+        ):
+            return {"error": "candidates_json must be a list of valid hygiene candidates"}
+        candidates.append(
+            NoiseCandidate(
+                memory_id=candidate_data["memory_id"],
+                table_name=candidate_data["table_name"],
+                content_preview=candidate_data.get("content_preview", ""),
+                noise_score=candidate_data.get("noise_score", 0.0),
+                noise_reasons=candidate_data.get("noise_reasons", []),
+                secret_flags=candidate_data.get("secret_flags", []),
+                importance=candidate_data.get("importance", 0.5),
+                source=candidate_data.get("source", ""),
+                timestamp=candidate_data.get("timestamp", ""),
+                suggested_action=candidate_data.get("suggested_action", "keep"),
+                content_length=candidate_data.get("content_length", 0),
+            )
         )
-        for c in raw_candidates
-    ]
+
+    bank = _resolve_bank(arguments)
+    mem = _create_instance(bank=bank)
+    db_path = mem.beam.db_path if hasattr(mem.beam, "db_path") else mem.db_path
 
     action = arguments.get("action", "keep")
     confirm = arguments.get("confirm", False)

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -1021,12 +1021,12 @@ def _handle_hygiene_clean(arguments: Dict[str, Any]) -> Dict[str, Any]:
         if (
             not isinstance(noise_score, (int, float))
             or isinstance(noise_score, bool)
-            or not math.isfinite(noise_score)
             or not 0 <= noise_score <= 1
+            or (isinstance(noise_score, float) and not math.isfinite(noise_score))
             or not isinstance(importance, (int, float))
             or isinstance(importance, bool)
-            or not math.isfinite(importance)
             or not 0 <= importance <= 1
+            or (isinstance(importance, float) and not math.isfinite(importance))
             or not isinstance(content_length, int)
             or isinstance(content_length, bool)
             or content_length < 0
@@ -1042,6 +1042,8 @@ def _handle_hygiene_clean(arguments: Dict[str, Any]) -> Dict[str, Any]:
             key in candidate_data and not isinstance(candidate_data[key], str)
             for key in ("content_preview", "source", "timestamp", "suggested_action")
         ):
+            return {"error": "candidates_json must be a list of valid hygiene candidates"}
+        if candidate_data.get("suggested_action", "keep") not in {"delete", "archive", "keep", "flag"}:
             return {"error": "candidates_json must be a list of valid hygiene candidates"}
         candidates.append(
             NoiseCandidate(

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -12,6 +12,7 @@ All imports are guarded — this module loads safely even if mcp is not installe
 """
 
 from typing import Dict, Any, List
+import json
 import os
 import sqlite3
 from pathlib import Path

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -1026,6 +1026,7 @@ def _handle_hygiene_clean(arguments: Dict[str, Any]) -> Dict[str, Any]:
             or not isinstance(importance, (int, float))
             or isinstance(importance, bool)
             or not math.isfinite(importance)
+            or not 0 <= importance <= 1
             or not isinstance(content_length, int)
             or isinstance(content_length, bool)
             or content_length < 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ openclaw = ["openclaw>=0.1.0; python_version >= '3.10'"]
 sync = ["cryptography>=41.0"]
 test = ["pytest>=7.0"]
 all = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "sqlite-vec>=0.1.0", "mcp>=1.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'", "cryptography>=41.0"]
-dev = ["pytest>=7.0", "build", "twine"]
+dev = ["pytest>=7.0", "build", "twine", "ruff==0.15.22"]
 
 [project.urls]
 Homepage = "https://github.com/AxDSan/mnemosyne"

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 import subprocess
 import sys

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -457,7 +457,20 @@ class TestToolHandlers:
 
         assert result == {"error": "candidates_json is not valid JSON"}
 
-    @pytest.mark.parametrize("candidates_json", ["null", "{}", "[{}]"])
+    @pytest.mark.parametrize(
+        "candidates_json",
+        [
+            "null",
+            "{}",
+            "[{}]",
+            json.dumps([{"memory_id": "memory-1", "table_name": "unknown"}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "noise_score": float("nan")}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "noise_score": 1.1}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "importance": float("inf")}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "content_length": -1}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "content_length": 1.5}]),
+        ],
+    )
     def test_hygiene_clean_rejects_malformed_candidates(self, candidates_json, monkeypatch):
         """Malformed candidate payloads return MCP errors before opening a memory instance."""
         monkeypatch.setattr(
@@ -518,8 +531,15 @@ class TestToolHandlers:
         candidate = captured["candidates"][0]
         assert candidate.memory_id == "memory-1"
         assert candidate.table_name == "working_memory"
+        assert candidate.content_preview == "done"
+        assert candidate.noise_score == 0.9
         assert candidate.noise_reasons == ["short acknowledgement"]
+        assert candidate.secret_flags == []
+        assert candidate.importance == 0.2
+        assert candidate.source == "test"
+        assert candidate.timestamp == "2026-07-21T00:00:00Z"
         assert candidate.suggested_action == "archive"
+        assert candidate.content_length == 4
 
     def test_unknown_tool(self):
         """Unknown tool raises ValueError."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -466,10 +466,16 @@ class TestToolHandlers:
             json.dumps([{"memory_id": "memory-1", "table_name": "unknown"}]),
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "noise_score": float("nan")}]),
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "noise_score": 1.1}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "noise_score": True}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "noise_score": 10**1000}]),
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "importance": float("inf")}]),
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "importance": 1.1}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "importance": True}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "importance": 10**1000}]),
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "content_length": -1}]),
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "content_length": 1.5}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "content_length": True}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "suggested_action": "destroy"}]),
         ],
     )
     def test_hygiene_clean_rejects_malformed_candidates(self, candidates_json, monkeypatch):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -467,6 +467,7 @@ class TestToolHandlers:
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "noise_score": float("nan")}]),
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "noise_score": 1.1}]),
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "importance": float("inf")}]),
+            json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "importance": 1.1}]),
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "content_length": -1}]),
             json.dumps([{"memory_id": "memory-1", "table_name": "working_memory", "content_length": 1.5}]),
         ],

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11,6 +11,8 @@ import sys
 import pytest
 from unittest.mock import MagicMock, patch
 
+import mnemosyne.mcp_tools as mcp_tools
+
 # Test tool schemas
 from mnemosyne.mcp_tools import (
     TOOLS, get_tool_definitions, handle_tool_call, _create_instance,
@@ -446,6 +448,42 @@ class TestToolHandlers:
         with patch("mnemosyne.mcp_tools._create_instance", return_value=mock_mnemosyne):
             with pytest.raises(RuntimeError, match="DB locked"):
                 handle_tool_call("mnemosyne_remember", {"content": "test"})
+
+    def test_hygiene_clean_rejects_invalid_candidates_json(self):
+        """Invalid hygiene payloads return the documented MCP error instead of raising."""
+        result = handle_tool_call(
+            "mnemosyne_hygiene_clean", {"candidates_json": "not-json"},
+        )
+
+        assert result == {"error": "candidates_json is not valid JSON"}
+
+    def test_hygiene_clean_parses_valid_candidates_json(self, monkeypatch):
+        """Valid JSON reaches the hygiene cleaner with parsed candidates."""
+        class _Memory:
+            class beam:
+                db_path = "test.db"
+
+        class _Result:
+            def to_dict(self):
+                return {"cleaned": 0}
+
+        captured = {}
+
+        def _clean_noise(**kwargs):
+            captured.update(kwargs)
+            return _Result()
+
+        from mnemosyne.core import hygiene
+
+        monkeypatch.setattr(mcp_tools, "_create_instance", lambda **_kwargs: _Memory())
+        monkeypatch.setattr(hygiene, "clean_noise", _clean_noise)
+
+        result = handle_tool_call(
+            "mnemosyne_hygiene_clean", {"candidates_json": "[]"},
+        )
+
+        assert result["status"] == "dry_run"
+        assert captured["candidates"] == []
 
     def test_unknown_tool(self):
         """Unknown tool raises ValueError."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -457,15 +457,29 @@ class TestToolHandlers:
 
         assert result == {"error": "candidates_json is not valid JSON"}
 
+    @pytest.mark.parametrize("candidates_json", ["null", "{}", "[{}]"])
+    def test_hygiene_clean_rejects_malformed_candidates(self, candidates_json, monkeypatch):
+        """Malformed candidate payloads return MCP errors before opening a memory instance."""
+        monkeypatch.setattr(
+            mcp_tools,
+            "_create_instance",
+            lambda **_kwargs: pytest.fail("malformed payload must not initialize memory"),
+        )
+        result = handle_tool_call(
+            "mnemosyne_hygiene_clean", {"candidates_json": candidates_json},
+        )
+
+        assert result == {"error": "candidates_json must be a list of valid hygiene candidates"}
+
     def test_hygiene_clean_parses_valid_candidates_json(self, monkeypatch):
-        """Valid JSON reaches the hygiene cleaner with parsed candidates."""
+        """Valid JSON reaches the hygiene cleaner with mapped candidate fields."""
         class _Memory:
             class beam:
                 db_path = "test.db"
 
         class _Result:
             def to_dict(self):
-                return {"cleaned": 0}
+                return {"cleaned": 1}
 
         captured = {}
 
@@ -478,12 +492,34 @@ class TestToolHandlers:
         monkeypatch.setattr(mcp_tools, "_create_instance", lambda **_kwargs: _Memory())
         monkeypatch.setattr(hygiene, "clean_noise", _clean_noise)
 
+        candidates_json = json.dumps([{
+            "memory_id": "memory-1",
+            "table_name": "working_memory",
+            "content_preview": "done",
+            "noise_score": 0.9,
+            "noise_reasons": ["short acknowledgement"],
+            "secret_flags": [],
+            "importance": 0.2,
+            "source": "test",
+            "timestamp": "2026-07-21T00:00:00Z",
+            "suggested_action": "archive",
+            "content_length": 4,
+        }])
         result = handle_tool_call(
-            "mnemosyne_hygiene_clean", {"candidates_json": "[]"},
+            "mnemosyne_hygiene_clean",
+            {"candidates_json": candidates_json, "action": "archive", "confirm": True},
         )
 
-        assert result["status"] == "dry_run"
-        assert captured["candidates"] == []
+        assert result == {"status": "applied", "result": {"cleaned": 1}, "bank": "default"}
+        assert captured["db_path"] == "test.db"
+        assert captured["action"] == "archive"
+        assert captured["confirm"] is True
+        assert captured["dry_run"] is False
+        candidate = captured["candidates"][0]
+        assert candidate.memory_id == "memory-1"
+        assert candidate.table_name == "working_memory"
+        assert candidate.noise_reasons == ["short acknowledgement"]
+        assert candidate.suggested_action == "archive"
 
     def test_unknown_tool(self):
         """Unknown tool raises ValueError."""


### PR DESCRIPTION
## Summary
- add a small pinned Ruff CI job for fatal Python errors only (`E9,F63,F7,F82`)
- fix the current baseline findings: missing `json` in the MCP hygiene handler, standalone-plugin persona handler losing its provider Beam, and missing `builtins` test import
- add MCP and standalone-plugin regressions

## Scope
No formatting pass, broad rule family, type-checker, or unrelated cleanup. Ruff runs once on Python 3.11 and is pinned to `0.15.22` in CI and the `dev` extra.

## Validation
- `uvx ruff check --select E9,F63,F7,F82 mnemosyne tests integrations/hermes/src hermes_memory_provider`
- `PYTHONPATH=.:integrations/hermes/src uv run --no-sync --with pytest --with pyyaml --with numpy --with httpx pytest tests/test_mcp_server.py integrations/hermes/tests/test_persona_plugin_registration.py -q` → `34 passed, 1 skipped`
- focused LLM import regression → passed
- workflow YAML parsed; `git diff --check` clean
- independent Claude review: pass-with-followups; path and full baseline verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds a narrowly scoped Ruff CI `lint` job on Python 3.11 (ruff pinned to `0.15.22`) that only gates fatal Python errors (`E9,F63,F7,F82`), with Ruff pinned in the `dev` extra as well.
- Hardens the MCP hygiene-clean tool (`mnemosyne_hygiene_clean`) by importing `json` and strictly parsing/validating `candidates_json` into `NoiseCandidate` objects, returning precise structured errors for invalid JSON/shape, unsupported `table_name` values, non-finite/incorrect numeric types (including rejecting booleans), and malformed list/string fields—reducing the risk of hygiene actions running on tainted input.
- Fixes a Hermes standalone-plugin persona integration issue by preserving plugin-registered provider state: Hermes now stores the active provider instance in a module-level `_provider`, and persona handlers lazily bind to the provider’s underlying BEAM (`_beam`) so persona tool calls don’t “lose” the intended MemoryProvider/BEAM connection.
- Adds regression tests covering MCP hygiene-clean input handling (including ensuring instance creation does not occur on malformed inputs) and Hermes persona tool propagation of the provider’s BEAM instance; plus small test import/monkeypatching reliability tweaks.

## Architectural / core-memory impact

This PR does **not** change Mnemosyne’s core memory architecture or pipelines (no changes to tiering behavior beyond enforcing allowed hygiene target tables, no changes to retrieval strategies, consolidation, veracity, or sync). It focuses on safer integration seams:
- MCP hygiene-clean validation enforces expected candidate structure and allowed target tables (working/episodic/BEAM-related table names), instead of accepting loosely-typed input.
- Hermes persona tooling now correctly reuses the plugin-registered provider’s active BEAM instance for downstream persona operations.

## Privacy posture and local-first guarantees

No new persistence model, networking, or external I/O is introduced. The MCP hygiene-clean change is robustness-focused: it prevents hygiene operations from acting on malformed or adversarially structured `candidates_json`, which supports safer local-first behavior by reducing unintended side effects from invalid inputs.

## Agent integration surfaces and long-term maintainability

- **MCP:** stricter input validation and clearer structured error responses make cross-agent hygiene operations more reliable and easier to debug.
- **Hermes / standalone-plugin persona:** ensures persona tool handlers operate on the correct provider state (the active provider’s `_beam`), preventing subtle cross-component state drift.
- **CI/maintainability:** conservative, pinned Ruff gating on fatal runtime error classes improves durability without expanding rule families or introducing broad stylistic churn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->