### PR TITLE
fix: require instruction keyword boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
+## [3.16.0] - 2026-07-21
+
+### Fixed
+
+- **Instruction extraction inverted “whenever” into “never” (#507).** English instruction keywords now require a word boundary, preventing positive “whenever” statements from being stored as prohibitions.
+
 ## [3.15.0] - 2026-07-20
 
 ### Fixed

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.15.0"
+__version__ = "3.16.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4505,7 +4505,7 @@ class BeamMemory:
             'sequence': r'((?:first|second|third|fourth|fifth|finally|next|then|after that)[^.,;!?\n]{15,120})',
             'instruction_false_positives': ['i think you should leave', 'should behave', 'their work style'],
             'instruction_imperative': 'always|never|remember|use|keep|avoid|ensure|check|verify|run|test|build|deploy|push|pull|merge|commit|close|open|update|install|configure|set|enable|disable|add|remove|create|delete|start|stop|restart|reload|reset|try|implement|write|read|switch|move|copy|rename|send|reply|respond',
-            'instruction': r'(?:always|never|must|must not|should(?: not)?(?=\s+(?:you|we|i|one)\s+(?:IMPVERBS))|need(?:s)? to(?: not)?|required to|prefer(?: not)? to|want to(?: avoid| ensure| use| keep))\s+([^.,;!?\n]{10,200})',
+            'instruction': r'\b(?:always|never|must|must not|should(?: not)?(?=\s+(?:you|we|i|one)\s+(?:IMPVERBS))|need(?:s)? to(?: not)?|required to|prefer(?: not)? to|want to(?: avoid| ensure| use| keep))\s+([^.,;!?\n]{10,200})',
             'preference': r'(?:'
                 # First person (original) and second person
                 r'(?:I|You|you|YOU)(?: |\')?(?:like|love|prefer|hate|dislike|enjoy|use|stick with|switched to|moved to|changed to|want|need|tend to|usually|would rather|don\'t like|don\'t want|not a fan of|am okay with|am comfortable with|am used to|am happy with|am tired of|am sick of|prefer not to|try to avoid|find it easier to|find it better to|find it useful to)'

--- a/tests/test_instruction_word_boundary.py
+++ b/tests/test_instruction_word_boundary.py
@@ -1,0 +1,29 @@
+from mnemosyne.core.beam import BeamMemory
+
+
+def test_whenever_is_not_extracted_as_never(tmp_path):
+    beam = BeamMemory(session_id="instruction-boundary", db_path=tmp_path / "test.db")
+
+    counts = beam.extract_and_store_facts(
+        "Good - whenever needed we can use it. I've disabled it.", message_idx=1
+    )
+
+    instructions = beam.conn.execute(
+        "SELECT instruction, topic FROM memoria_instructions"
+    ).fetchall()
+    assert counts.get("instruction", 0) == 0
+    assert instructions == []
+
+
+def test_never_at_word_boundary_remains_an_instruction(tmp_path):
+    beam = BeamMemory(session_id="instruction-boundary", db_path=tmp_path / "test.db")
+
+    counts = beam.extract_and_store_facts(
+        "Never discard completed work without checking it.", message_idx=1
+    )
+
+    instruction = beam.conn.execute(
+        "SELECT instruction FROM memoria_instructions"
+    ).fetchone()
+    assert counts["instruction"] == 1
+    assert instruction[0] == "Never discard completed work without checking it"


### PR DESCRIPTION
## Description

Prevents the `never` instruction keyword from matching inside `whenever`, which inverted positive statements into prohibitions. The focused regression fails before the word-boundary fix and passes after it.

## Related Issue

Closes #507

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / performance
- [x] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [ ] Existing tests still pass (`pytest tests/ -v`)
- [x] New tests added for any new functionality
- [x] Manual verification (focused regression and standalone `never` instruction)

## Checklist

- [x] Version bumped in `mnemosyne/__init__.py`
- [x] `CHANGELOG.md` updated with a brief entry
- [ ] README updated if user-facing behavior changed
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed BEAM instruction keyword extraction so negation/modals like `never` only match at word boundaries, preventing embedded occurrences (e.g., `whenever`) from being inverted into prohibitions.
- Added regression tests for both the embedded-keyword false positive case and a valid standalone `Never …` instruction.
- Bumped the package version to `3.16.0` and recorded the change in `CHANGELOG.md` (including the issue reference).

## Architectural impact

- **Memory architecture (tiered/BEAM pipeline):** Scope is limited to the **instruction parsing step inside BEAM** (how instruction facts are recognized and stored). It does not change the working/episodic tiering model, nor the structure of the consolidation pipeline.
- **Retrieval strategies & consolidation:** No changes to retrieval ranking logic or consolidation behavior implied by the fix; the impact is upstream at fact-extraction time.
- **Veracity system:** No behavioral changes to veracity scoring/propagation; the fix prevents incorrect “instruction” fact creation in the first place.
- **Sync layer / local-first posture:** No new sync, networking, or persistence flows were introduced by the keyword-boundary change; this is a local parsing/regex correctness fix.
- **Agent integration surfaces (Hermes, MCP, CLI):** Hermes/MCP/CLI continue to rely on the same BEAM fact-extraction path; they benefit from improved correctness when user text contains embedded instruction substrings.

## Privacy & local-first guarantees

- Preserves local-first behavior: the change is purely in-text pattern matching at extraction time, with no added external calls, data export, or altered storage boundaries.

## Maintainability

- The word-boundary requirement plus targeted regression coverage makes this class of parsing bug much less likely to recur, and it explicitly documents the intended keyword-matching contract for future changes.

**This is the right call:** it fixes a narrow extraction boundary issue without expanding scope into retrieval/consolidation/sync, and it strengthens correctness while maintaining local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->