### PR TITLE
fix(config): honor config for cross-session recall

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -23,6 +23,8 @@ import hashlib
 import threading
 import math
 
+from mnemosyne.core.config import resolve_beam_runtime
+
 logger = logging.getLogger(__name__)
 from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Optional, Any, Set, Union, Tuple, Callable
@@ -398,34 +400,29 @@ def _warn_about_veracity_weight_overrides(force: bool = False) -> bool:
 _warn_about_veracity_weight_overrides()
 
 
-# Cross-session recall toggle. When enabled via MNEMOSYNE_CROSS_SESSION=1,
-# the session filter (session_id = ? OR scope = 'global') is replaced with
-# (1=1), making all working and episodic memories visible across sessions.
-# Default off preserves backward compatibility.
-_CROSS_SESSION = os.environ.get("MNEMOSYNE_CROSS_SESSION", "0") == "1"
-
-
+# Cross-session recall toggle. The typed config resolver keeps the documented
+# config.yaml > env > default precedence and observes hot reloads.
 def _cross_session_enabled() -> bool:
     """Return whether session scoping should be disabled for recall."""
-    return _CROSS_SESSION or os.environ.get("MNEMOSYNE_CROSS_SESSION", "0") == "1"
+    return resolve_beam_runtime().cross_session
 
 
-def _session_scope_filter(extra_col: str = "") -> str:
-    """Return a WHERE clause for session scoping.
-
-    When cross-session recall is enabled, returns (1=1) to disable filtering.
-    Otherwise returns (session_id = ? OR scope = 'global'[ OR col = ?]).
-    """
-    if _cross_session_enabled():
+def _session_scope_filter(extra_col: str = "", *, cross_session: Optional[bool] = None) -> str:
+    """Return a WHERE clause for session scoping from one runtime snapshot."""
+    if cross_session is None:
+        cross_session = _cross_session_enabled()
+    if cross_session:
         return "(1=1)"
     if extra_col:
         return f"(session_id = ? OR scope = 'global' OR {extra_col} = ?)"
     return "(session_id = ? OR scope = 'global')"
 
 
-def _session_scope_params(session_id: str, extra_value=None) -> list:
-    """Return bind params matching _session_scope_filter()."""
-    if _cross_session_enabled():
+def _session_scope_params(session_id: str, extra_value=None, *, cross_session: Optional[bool] = None) -> list:
+    """Return bind params matching a scope filter from one runtime snapshot."""
+    if cross_session is None:
+        cross_session = _cross_session_enabled()
+    if cross_session:
         return []
     if extra_value is not None:
         return [session_id, extra_value]
@@ -5413,7 +5410,8 @@ class BeamMemory:
                vec_weight: float = None,
                fts_weight: float = None,
                importance_weight: float = None,
-               explain: bool = False) -> List[Dict]:
+               explain: bool = False,
+               _cross_session: Optional[bool] = None) -> List[Dict]:
         """
         Hybrid recall across working_memory + episodic_memory.
         Uses sqlite-vec + FTS5 for episodic, FTS5 for working.
@@ -5465,6 +5463,8 @@ class BeamMemory:
             Flag unset or "0" (default): the existing linear scorer
             below runs unchanged. Zero behavior change for production.
         """
+        cross_session = _cross_session_enabled() if _cross_session is None else _cross_session
+
         # E5 feature flag -- read per call so operators can toggle
         # without rebuilding BeamMemory (critical for A/B experiments
         # in the same process). All recall filter kwargs flow through
@@ -5479,6 +5479,7 @@ class BeamMemory:
                 author_id=author_id, author_type=author_type,
                 channel_id=channel_id,
                 veracity=veracity, memory_type=memory_type,
+                cross_session=cross_session,
             )
             if explain:
                 return {
@@ -5614,13 +5615,13 @@ class BeamMemory:
         # Session scope: channel filter only when explicitly specified.
         # Author-only searches have no session/channel restriction.
         if channel_id:
-            wm_where_clauses.append(_session_scope_filter("channel_id"))
-            wm_params.extend(_session_scope_params(self.session_id, channel_id))
+            wm_where_clauses.append(_session_scope_filter("channel_id", cross_session=cross_session))
+            wm_params.extend(_session_scope_params(self.session_id, channel_id, cross_session=cross_session))
         elif author_id or author_type:
             wm_where_clauses.append("(1=1)")
         else:
-            wm_where_clauses.append(_session_scope_filter())
-            wm_params.extend(_session_scope_params(self.session_id))
+            wm_where_clauses.append(_session_scope_filter(cross_session=cross_session))
+            wm_params.extend(_session_scope_params(self.session_id, cross_session=cross_session))
         
         if from_date:
             wm_where_clauses.append("timestamp >= ?")
@@ -5872,14 +5873,14 @@ class BeamMemory:
             # Also check episodic memory for entity matches
             em_placeholders = ",".join("?" * len(entity_memory_ids))
             if channel_id:
-                em_entity_scope = _session_scope_filter("channel_id")
-                em_entity_params = [*tuple(entity_memory_ids), *_session_scope_params(self.session_id, channel_id)]
+                em_entity_scope = _session_scope_filter("channel_id", cross_session=cross_session)
+                em_entity_params = [*tuple(entity_memory_ids), *_session_scope_params(self.session_id, channel_id, cross_session=cross_session)]
             elif author_id or author_type:
                 em_entity_scope = "(1=1)"
                 em_entity_params = [*tuple(entity_memory_ids)]
             else:
-                em_entity_scope = _session_scope_filter()
-                em_entity_params = [*tuple(entity_memory_ids), *_session_scope_params(self.session_id)]
+                em_entity_scope = _session_scope_filter(cross_session=cross_session)
+                em_entity_params = [*tuple(entity_memory_ids), *_session_scope_params(self.session_id, cross_session=cross_session)]
             em_entity_params.extend([datetime.now().isoformat()])
             cursor.execute(f"""
                 SELECT id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope, author_id, author_type, channel_id, veracity, memory_type
@@ -5994,14 +5995,14 @@ class BeamMemory:
             
             # Also check episodic memory for fact matches
             if channel_id:
-                fact_em_scope = _session_scope_filter("channel_id")
-                fact_em_params = [*tuple(fact_memory_ids), *_session_scope_params(self.session_id, channel_id)]
+                fact_em_scope = _session_scope_filter("channel_id", cross_session=cross_session)
+                fact_em_params = [*tuple(fact_memory_ids), *_session_scope_params(self.session_id, channel_id, cross_session=cross_session)]
             elif author_id or author_type:
                 fact_em_scope = "(1=1)"
                 fact_em_params = [*tuple(fact_memory_ids)]
             else:
-                fact_em_scope = _session_scope_filter()
-                fact_em_params = [*tuple(fact_memory_ids), *_session_scope_params(self.session_id)]
+                fact_em_scope = _session_scope_filter(cross_session=cross_session)
+                fact_em_params = [*tuple(fact_memory_ids), *_session_scope_params(self.session_id, cross_session=cross_session)]
             fact_em_params.extend([datetime.now().isoformat()])
             cursor.execute(f"""
                 SELECT id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope, author_id, author_type, channel_id, veracity, memory_type
@@ -6117,13 +6118,13 @@ class BeamMemory:
         # Session scope: channel filter only when explicitly specified.
         # Author-only searches have no session/channel restriction.
         if channel_id:
-            em_where_clauses.append(_session_scope_filter("channel_id"))
-            em_params.extend(_session_scope_params(self.session_id, channel_id))
+            em_where_clauses.append(_session_scope_filter("channel_id", cross_session=cross_session))
+            em_params.extend(_session_scope_params(self.session_id, channel_id, cross_session=cross_session))
         elif author_id or author_type:
             em_where_clauses.append("(1=1)")
         else:
-            em_where_clauses.append(_session_scope_filter())
-            em_params.extend(_session_scope_params(self.session_id))
+            em_where_clauses.append(_session_scope_filter(cross_session=cross_session))
+            em_params.extend(_session_scope_params(self.session_id, cross_session=cross_session))
         
         if from_date:
             em_where_clauses.append("timestamp >= ?")
@@ -6560,18 +6561,18 @@ class BeamMemory:
         em_ids = [r["id"] for r in final_results if r.get("tier") == "episodic"]
         cursor = self.conn.cursor()
         if channel_id:
-            rec_scope = _session_scope_filter("channel_id")
+            rec_scope = _session_scope_filter("channel_id", cross_session=cross_session)
         elif author_id or author_type:
             rec_scope = "(1=1)"
         else:
-            rec_scope = _session_scope_filter()
+            rec_scope = _session_scope_filter(cross_session=cross_session)
         if wm_ids:
             placeholders = ",".join("?" * len(wm_ids))
             rec_params = [now_iso, *tuple(wm_ids)]
             if channel_id:
-                rec_params.extend(_session_scope_params(self.session_id, channel_id))
+                rec_params.extend(_session_scope_params(self.session_id, channel_id, cross_session=cross_session))
             elif not (author_id or author_type):
-                rec_params.extend(_session_scope_params(self.session_id))
+                rec_params.extend(_session_scope_params(self.session_id, cross_session=cross_session))
             cursor.execute(f"""
                 UPDATE working_memory
                 SET recall_count = recall_count + 1, last_recalled = ?
@@ -6581,9 +6582,9 @@ class BeamMemory:
             placeholders = ",".join("?" * len(em_ids))
             rec_params = [now_iso, *tuple(em_ids)]
             if channel_id:
-                rec_params.extend(_session_scope_params(self.session_id, channel_id))
+                rec_params.extend(_session_scope_params(self.session_id, channel_id, cross_session=cross_session))
             elif not (author_id or author_type):
-                rec_params.extend(_session_scope_params(self.session_id))
+                rec_params.extend(_session_scope_params(self.session_id, cross_session=cross_session))
             cursor.execute(f"""
                 UPDATE episodic_memory
                 SET recall_count = recall_count + 1, last_recalled = ?
@@ -6711,19 +6712,25 @@ class BeamMemory:
         if use_synonyms and expand_query is not None:
             expanded_query = expand_query(query)
 
-        # 3. Query cache check (Tier 1-4)
+        # 3. Query cache check (Tier 1-4). Scope cache entries by the
+        # resolved runtime snapshot, otherwise a hot config reload can expose
+        # results cached under a different session/isolation policy.
+        runtime = resolve_beam_runtime()
+        cache_key = f"{self.session_id}\x1f{int(runtime.cross_session)}\x1f{original_query}"
         cached = None
         if use_cache and QueryCache is not None:
             if not hasattr(self, '_query_cache'):
                 cache_db = self.db_path.parent / "query_cache.db"
                 self._query_cache = QueryCache(db_path=cache_db)
-            cached = self._query_cache.get(original_query)
+            cached = self._query_cache.get(cache_key)
 
         if cached is not None:
             return cached[:top_k]
 
         # 4. Run base recall with expanded query
-        results = self.recall(expanded_query, top_k=top_k * 2, **kwargs)
+        results = self.recall(
+            expanded_query, top_k=top_k * 2, _cross_session=runtime.cross_session, **kwargs
+        )
 
         # 5. Weibull re-scoring (if not already using temporal_weight)
         if use_weibull and weibull_boost is not None:
@@ -6809,7 +6816,7 @@ class BeamMemory:
 
         # 9. Cache results
         if use_cache and hasattr(self, '_query_cache') and self._query_cache is not None:
-            self._query_cache.put(original_query, results)
+            self._query_cache.put(cache_key, results)
 
         return results
 
@@ -7040,7 +7047,8 @@ class BeamMemory:
                            author_type: Optional[str] = None,
                            channel_id: Optional[str] = None,
                            veracity: Optional[str] = None,
-                           memory_type: Optional[str] = None) -> List[Dict]:
+                           memory_type: Optional[str] = None,
+                           cross_session: Optional[bool] = None) -> List[Dict]:
         """[E5] Polyphonic recall path.
 
         Delegates to PolyphonicRecallEngine when MNEMOSYNE_POLYPHONIC_RECALL=1.
@@ -7067,6 +7075,8 @@ class BeamMemory:
         surfaced by other voices. Known limitation, documented in
         CHANGELOG.
         """
+        if cross_session is None:
+            cross_session = _cross_session_enabled()
         engine = self._get_polyphonic_engine()
 
         query_embedding = None
@@ -7113,6 +7123,7 @@ class BeamMemory:
                 source=source, topic=topic, author_id=author_id,
                 author_type=author_type, channel_id=channel_id,
                 veracity=veracity, memory_type=memory_type, now_iso=now_iso,
+                cross_session=cross_session,
             ):
                 continue
 
@@ -7163,18 +7174,18 @@ class BeamMemory:
         # gap; rebuilding from `final` post-dedup is the right shape, so
         # add the scope guard here too.
         if channel_id:
-            rec_scope = _session_scope_filter("channel_id")
+            rec_scope = _session_scope_filter("channel_id", cross_session=cross_session)
         elif author_id or author_type:
             rec_scope = "(1=1)"
         else:
-            rec_scope = _session_scope_filter()
+            rec_scope = _session_scope_filter(cross_session=cross_session)
 
         def _rec_scope_params() -> List:
             if channel_id:
-                return _session_scope_params(self.session_id, channel_id)
+                return _session_scope_params(self.session_id, channel_id, cross_session=cross_session)
             if author_id or author_type:
                 return []
-            return _session_scope_params(self.session_id)
+            return _session_scope_params(self.session_id, cross_session=cross_session)
 
         # Update recall_count / last_recalled for engine results too --
         # the linear path updates them and downstream features (decay
@@ -7253,13 +7264,14 @@ class BeamMemory:
                                        channel_id: Optional[str],
                                        veracity: Optional[str],
                                        memory_type: Optional[str],
-                                       now_iso: str) -> bool:
+                                       now_iso: str,
+                                       cross_session: bool) -> bool:
         """Mirror the linear path's filter set for the engine path.
         Always-on filters: session scope, valid_until, superseded_by.
         Conditional filters: caller-supplied kwargs.
         """
         # Session scope filter (honors MNEMOSYNE_CROSS_SESSION).
-        if not _cross_session_enabled():
+        if not cross_session:
             row_session = row_dict.get("session_id") if "session_id" in row_dict else None
             row_scope = row_dict.get("scope") or "session"
             if row_scope != "global" and row_session is not None and row_session != self.session_id:

--- a/mnemosyne/core/config.py
+++ b/mnemosyne/core/config.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -324,6 +325,13 @@ def _default_config_path() -> Path:
     return Path.home() / ".hermes" / "mnemosyne" / "config.yaml"
 
 
+@dataclass(frozen=True)
+class BeamRuntimeConfig:
+    """Typed runtime settings consumed by Beam on each configuration lookup."""
+
+    cross_session: bool
+
+
 class MnemosyneConfig:
     """Central config reader with YAML + env var + defaults precedence.
 
@@ -613,6 +621,10 @@ class MnemosyneConfig:
             return val
         return str(val).strip().lower() in ("1", "true", "yes", "on")
 
+    def resolve_beam_runtime(self) -> BeamRuntimeConfig:
+        """Resolve Beam's hot-reloadable runtime settings with typed values."""
+        return BeamRuntimeConfig(cross_session=self.get_bool("cross_session", False))
+
     def set(self, key: str, value: Any) -> None:
         """Write a config value to config.yaml.
 
@@ -751,6 +763,11 @@ def get_bool(key: str, default: bool = False) -> bool:
 
 def get_str(key: str, default: str = "") -> str:
     return get_config().get_str(key, default)
+
+
+def resolve_beam_runtime() -> BeamRuntimeConfig:
+    """Resolve the typed, hot-reloadable Beam runtime settings."""
+    return get_config().resolve_beam_runtime()
 
 
 def reload() -> Set[str]:

--- a/tests/test_config_cross_session_runtime.py
+++ b/tests/test_config_cross_session_runtime.py
@@ -1,0 +1,89 @@
+"""Fresh-process regressions for cross-session runtime config resolution."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+HERMES_SRC = ROOT / "integrations" / "hermes" / "src"
+
+
+def _run(script: str, *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment.update(env)
+    environment.pop("PYTHONHOME", None)
+    existing_path = environment.get("PYTHONPATH", "")
+    environment["PYTHONPATH"] = os.pathsep.join([str(ROOT), str(HERMES_SRC), existing_path])
+    return subprocess.run(
+        [sys.executable, "-c", script], text=True, capture_output=True, env=environment, check=True
+    )
+
+
+@pytest.mark.parametrize(
+    ("yaml_value", "env_value", "expected"),
+    [("true", "0", "True"), ("false", "1", "False")],
+)
+def test_cross_session_direct_core_honors_yaml_over_env(tmp_path: Path, yaml_value: str, env_value: str, expected: str):
+    """Beam's real scope helpers honor config.yaml over a conflicting env var."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "config.yaml").write_text(f"cross_session: {yaml_value}\n")
+    result = _run(
+        """
+import os
+from pathlib import Path
+from mnemosyne.core.beam import BeamMemory
+
+db_path = Path(os.environ["TEST_DB"])
+writer = BeamMemory(session_id="session-a", db_path=db_path)
+reader = BeamMemory(session_id="session-b", db_path=db_path)
+writer.remember("cross session runtime sentinel", source="test", importance=0.9)
+results = reader.recall("cross session runtime sentinel", top_k=10)
+print(any("runtime sentinel" in row.get("content", "") for row in results))
+writer.conn.close()
+reader.conn.close()
+""",
+        env={
+            "MNEMOSYNE_DATA_DIR": str(data_dir),
+            "MNEMOSYNE_CROSS_SESSION": env_value,
+            "TEST_DB": str(tmp_path / "direct.db"),
+        },
+    )
+    assert result.stdout.strip() == expected
+
+
+@pytest.mark.parametrize(
+    ("yaml_value", "env_value", "expected"),
+    [("true", "0", "True"), ("false", "1", "False")],
+)
+def test_cross_session_hermes_provider_honors_yaml_over_env(tmp_path: Path, yaml_value: str, env_value: str, expected: str):
+    """Hermes initialization uses the same cross-session resolver contract."""
+    hermes_home = tmp_path / "hermes"
+    config_dir = hermes_home / "mnemosyne"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.yaml").write_text(f"cross_session: {yaml_value}\n")
+    result = _run(
+        """
+import os
+from mnemosyne_hermes import MnemosyneMemoryProvider
+
+writer = MnemosyneMemoryProvider()
+reader = MnemosyneMemoryProvider()
+home = os.environ["HERMES_HOME"]
+writer.initialize("session-a", hermes_home=home)
+reader.initialize("session-b", hermes_home=home)
+assert writer._beam is not None and reader._beam is not None
+writer._beam.remember("cross session provider sentinel", source="test", importance=0.9)
+results = reader._beam.recall("cross session provider sentinel", top_k=10)
+print(any("provider sentinel" in row.get("content", "") for row in results))
+writer._beam.conn.close()
+reader._beam.conn.close()
+""",
+        env={"HERMES_HOME": str(hermes_home), "MNEMOSYNE_CROSS_SESSION": env_value, "MNEMOSYNE_DATA_DIR": ""},
+    )
+    assert result.stdout.strip() == expected

--- a/tests/test_cross_session_hot_reload.py
+++ b/tests/test_cross_session_hot_reload.py
@@ -1,0 +1,39 @@
+"""In-process hot-reload coverage for cross-session recall."""
+
+from mnemosyne.core.beam import BeamMemory
+from mnemosyne.core.config import MnemosyneConfig, get_config
+
+
+def test_cross_session_recall_follows_config_reload(tmp_path, monkeypatch):
+    """One Beam reader observes false -> true -> false without reconstruction."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    config_path = data_dir / "config.yaml"
+    config_path.write_text("cross_session: false\n")
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("MNEMOSYNE_CROSS_SESSION", "1")
+    MnemosyneConfig.reset_instance()
+
+    writer = reader = None
+    try:
+        db_path = tmp_path / "memories.db"
+        writer = BeamMemory(session_id="writer", db_path=db_path)
+        reader = BeamMemory(session_id="reader", db_path=db_path)
+        writer.remember("reload scope sentinel", source="test", importance=0.9)
+
+        def visible():
+            return any("reload scope sentinel" in row["content"] for row in reader.recall("reload scope sentinel"))
+
+        assert not visible()
+        config_path.write_text("cross_session: true\n")
+        get_config().reload()
+        assert visible()
+        config_path.write_text("cross_session: false\n")
+        get_config().reload()
+        assert not visible()
+    finally:
+        if writer is not None:
+            writer.conn.close()
+        if reader is not None:
+            reader.conn.close()
+        MnemosyneConfig.reset_instance()

--- a/tests/test_issue_421_scope.py
+++ b/tests/test_issue_421_scope.py
@@ -5,12 +5,21 @@ import sqlite3
 from mnemosyne.core.beam import BeamMemory
 
 
+def _use_empty_config(tmp_path, monkeypatch):
+    """Keep env-fallback regressions independent of the developer's config."""
+    data_dir = tmp_path / "config-data"
+    data_dir.mkdir()
+    (data_dir / "config.yaml").write_text("")
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+
+
 def _contents(results):
     return [r.get("content", "") for r in results]
 
 
 def test_cross_session_recall_does_not_bind_session_params_when_filter_disabled(tmp_path, monkeypatch):
     """MNEMOSYNE_CROSS_SESSION=1 should not leave stale bind params behind."""
+    _use_empty_config(tmp_path, monkeypatch)
     monkeypatch.setenv("MNEMOSYNE_CROSS_SESSION", "1")
     db_path = tmp_path / "mnemosyne.db"
 
@@ -30,6 +39,7 @@ def test_cross_session_recall_does_not_bind_session_params_when_filter_disabled(
 
 def test_non_cross_session_recall_still_shows_only_session_and_global_scope(tmp_path, monkeypatch):
     """The issue #421 fix must preserve default session/global visibility."""
+    _use_empty_config(tmp_path, monkeypatch)
     monkeypatch.delenv("MNEMOSYNE_CROSS_SESSION", raising=False)
     db_path = tmp_path / "mnemosyne.db"
 


### PR DESCRIPTION
## Summary

Part 1 of #482: migrate the real Beam `cross_session` consumer from import-time environment reads to the existing typed config resolver.

- preserves the documented `config.yaml > env > default` contract
- removes the stale import-time `_CROSS_SESSION` cache; the existing config reader observes reloads
- keeps existing env-only behavior when `config.yaml` does not set the key

## Coverage

- fresh-process direct-core matrix with conflicting YAML/env values
- fresh-process Hermes-provider matrix with the same conflicts
- isolates existing #421 env-fallback tests from an ambient developer config

## Non-goals

- no YAML-to-`os.environ` bridge or process-global environment mutation
- no config migration/provenance work (#446)
- no conversion of the remaining config consumers; those follow after this pattern lands

## Tests

```text
PYTHONPATH=.:integrations/hermes/src uv run --no-sync --with pytest --with pyyaml pytest tests/test_config_cross_session_runtime.py tests/test_issue_421_scope.py tests/test_config_profiles.py integrations/hermes/tests/test_recall_diagnostics_tool.py -q
# 87 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Core architecture:** Cross-session recall is now driven by typed, hot-reloadable runtime configuration (`resolve_beam_runtime().cross_session`) instead of an import-time environment cache. `BeamMemory.recall()` resolves `cross_session` once per call and threads it through all session-scoped SQL construction (working memory and episodic memory, including channel vs. non-channel branching and the author-only isolation path). The polyphonic recall/update path propagates the same value end-to-end (`_recall_polyphonic(..., cross_session=...)` → `_polyphonic_row_passes_filters(...)`) so both selection guards and the `recall_count/last_recalled` update scoping are consistent.
- **Config precedence & local-first determinism:** The existing precedence model is preserved (**`config.yaml` > env > default**), including explicit YAML-versus-env conflicts. By removing module-level caching, BEAM behavior tracks the existing config reader/reloadable configuration during runtime, avoiding stale ambient settings.
- **Privacy/local-first posture:** No new sync, external data flows, provenance/migration, or network-facing behavior is introduced. The change is strictly a local storage visibility boundary—what rows are eligible for recall and which rows get recall bookkeeping—based on the resolved `cross_session` flag.
- **Agent integration surfaces:** Hermes-provider coverage is added to ensure the same YAML-versus-env override semantics apply when Hermes writes/loads `mnemosyne/config.yaml`, matching direct-core recall behavior.
- **Maintainability:** Centralizing runtime resolution makes precedence and reload behavior explicit, reduces duplicated implicit env handling, and removes drift between import-time state and runtime configuration. `recall_enhanced()`’s query cache key is updated to include the resolved `cross_session` value to prevent cross-session cache collisions. Subprocess-based regression tests also isolate environment-fallback behavior from ambient developer configuration.
- **Validation:** 87 tests pass; benchmark methodology is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->