### PR TITLE
fix(embeddings): sync config.yaml and env vars in embeddings module

### DIFF
--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -6,10 +6,10 @@ Falls back to keyword-only if neither is available.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import random
 import ssl
-import sys
 import time
 import urllib.error
 import urllib.request
@@ -72,8 +72,10 @@ def _get_config_safe():
     try:
         if _default_config_path().exists():
             return get_config()
-    except Exception:
-        pass
+    except Exception as exc:
+        logging.getLogger(__name__).warning(
+            "_get_config_safe: failed to load config: %s", exc
+        )
     return None
 
 def _get_api_key() -> str:
@@ -92,12 +94,6 @@ def _get_base_url() -> str:
 def _get_default_model() -> str:
     if "MNEMOSYNE_EMBEDDING_MODEL" in os.environ:
         return os.environ["MNEMOSYNE_EMBEDDING_MODEL"]
-    # In test context (pytest running), do NOT read from config.yaml:
-    # the dev machine's configured model would break tests that hardcode
-    # "BAAI/bge-small-en-v1.5" as the expected default. Tests that want
-    # a specific model must set MNEMOSYNE_EMBEDDING_MODEL via monkeypatch.
-    if "pytest" in sys.modules:
-        return "BAAI/bge-small-en-v1.5"
     cfg = _get_config_safe()
     cfg_model = cfg.get_str("embedding_model") if cfg else ""
     return cfg_model or "BAAI/bge-small-en-v1.5"
@@ -124,7 +120,6 @@ def _get_prefix(kind: str) -> str:
     prefix = os.environ.get(var, "")
     global _PREFIXES_LOGGED
     if prefix and not _PREFIXES_LOGGED:
-        import logging
         logging.getLogger(__name__).info(
             "embedding prefixes active: query=%r doc=%r",
             os.environ.get("MNEMOSYNE_EMBEDDING_QUERY_PREFIX", ""),
@@ -134,27 +129,34 @@ def _get_prefix(kind: str) -> str:
 
 
 def _is_disabled() -> bool:
-    """True when dense retrieval has been opted out via env var."""
+    """True when dense retrieval has been opted out via env var.
+
+    Any presence of the env var (even empty string) disables embeddings,
+    matching the original semantics before the truthy-only change.
+    """
     for var in ("MNEMOSYNE_NO_EMBEDDINGS", "MNEMOSYNE_SKIP_EMBEDDINGS", "MNEMOSYNE_EMBEDDINGS_OFF"):
-        v = os.environ.get(var, "").strip().lower()
-        if v in ("1", "true", "yes", "on"):
+        if bool(os.environ.get(var)):
             return True
     return False
 
 
 def _is_api_model(model_name: str) -> bool:
     """Check if the model should use the OpenAI-compatible API."""
-    if model_name.startswith("openai/") or "text-embedding" in model_name or model_name.startswith("text-embedding"):
+    if model_name.startswith("openai/") or model_name.startswith("text-embedding"):
         return True
     if "MNEMOSYNE_EMBEDDINGS_VIA_API" in os.environ:
         return os.environ["MNEMOSYNE_EMBEDDINGS_VIA_API"].strip().lower() in ("1", "true", "yes", "on")
     if "MNEMOSYNE_EMBEDDING_API_URL" in os.environ:
         base_url = os.environ["MNEMOSYNE_EMBEDDING_API_URL"]
         return bool(base_url and "openrouter.ai" not in base_url)
-    if "pytest" in sys.modules and "MNEMOSYNE_EMBEDDINGS_VIA_API" not in os.environ and "MNEMOSYNE_EMBEDDING_API_URL" not in os.environ:
-        return False
     cfg = _get_config_safe()
-    return cfg.get_bool("embeddings_via_api") if cfg else False
+    if cfg:
+        if cfg.get_bool("embeddings_via_api"):
+            return True
+        api_url = cfg.get_str("embedding_api_url", "")
+        if api_url and "openrouter.ai" not in api_url:
+            return True
+    return False
 
 
 def _get_embedding_dim(model_name: str) -> int:
@@ -215,11 +217,6 @@ def _get_embedding_dim(model_name: str) -> int:
     # 3. For custom/unknown models, check central config or default to 384
     cfg = _get_config_safe()
     cfg_dim = cfg.get_int("embedding_dim") if cfg else 0
-    if "pytest" in sys.modules and "MNEMOSYNE_EMBEDDING_DIM" not in os.environ:
-        if model_name == "custom-model":
-            return cfg_dim if cfg_dim > 0 else 384
-        return 384
-
     return cfg_dim if cfg_dim > 0 else 384
 
 
@@ -388,6 +385,8 @@ def available() -> bool:
 
 def available_api() -> bool:
     """Check if API-based embeddings are available."""
+    if _is_disabled():
+        return False
     return bool(_get_api_key())
 
 

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -64,24 +64,31 @@ _FASTEMBED_CACHE_DIR = os.environ.get(
 # --- OpenAI-compatible API ---
 # Mnemosyne embedding config is independent of general OpenRouter/OpenAI settings.
 # Embedding models may use local llama.cpp, OpenAI, Anthropic, or any other provider.
+def _get_config_safe():
+    """Access get_config() without side-effect creation of config.yaml if it does not exist on disk."""
+    from mnemosyne.core.config import _default_config_path, get_config, MnemosyneConfig
+    if MnemosyneConfig._instance is not None or _default_config_path().exists():
+        return get_config()
+    return None
+
 def _get_api_key() -> str:
-    env_key = os.environ.get("MNEMOSYNE_EMBEDDING_API_KEY", os.environ.get("OPENAI_API_KEY", ""))
+    env_key = os.environ.get("MNEMOSYNE_EMBEDDING_API_KEY") or os.environ.get("OPENAI_API_KEY", "")
     if env_key:
         return env_key
-    from mnemosyne.core.config import get_config
-    return get_config().get_str("embedding_api_key", "")
+    cfg = _get_config_safe()
+    return cfg.get_str("embedding_api_key", "") if cfg else ""
 
 def _get_base_url() -> str:
     if "MNEMOSYNE_EMBEDDING_API_URL" in os.environ:
         return os.environ["MNEMOSYNE_EMBEDDING_API_URL"]
-    from mnemosyne.core.config import get_config
-    return get_config().get_str("embedding_api_url", "https://openrouter.ai/api/v1") or "https://openrouter.ai/api/v1"
+    cfg = _get_config_safe()
+    return cfg.get_str("embedding_api_url", "https://openrouter.ai/api/v1") if cfg else "https://openrouter.ai/api/v1"
 
 def _get_default_model() -> str:
     if "MNEMOSYNE_EMBEDDING_MODEL" in os.environ:
         return os.environ["MNEMOSYNE_EMBEDDING_MODEL"]
-    from mnemosyne.core.config import get_config
-    cfg_model = get_config().get_str("embedding_model")
+    cfg = _get_config_safe()
+    cfg_model = cfg.get_str("embedding_model") if cfg else ""
     if "pytest" in sys.modules and cfg_model and cfg_model.startswith(("gemini/", "openai/", "qwen/", "anthropic/")):
         return "BAAI/bge-small-en-v1.5"
     return cfg_model or "BAAI/bge-small-en-v1.5"
@@ -121,15 +128,15 @@ def _is_disabled() -> bool:
     """True when dense retrieval has been opted out via env var or config.yaml."""
     for var in ("MNEMOSYNE_NO_EMBEDDINGS", "MNEMOSYNE_SKIP_EMBEDDINGS", "MNEMOSYNE_EMBEDDINGS_OFF"):
         if var in os.environ:
-            if bool(os.environ[var]):
-                return True
-    from mnemosyne.core.config import get_config
-    cfg = get_config()
-    return bool(
-        cfg.get_bool("no_embeddings")
-        or cfg.get_bool("skip_embeddings")
-        or cfg.get_bool("embeddings_off")
-    )
+            return os.environ[var].strip().lower() in ("1", "true", "yes", "on")
+    cfg = _get_config_safe()
+    if cfg:
+        return bool(
+            cfg.get_bool("no_embeddings")
+            or cfg.get_bool("skip_embeddings")
+            or cfg.get_bool("embeddings_off")
+        )
+    return False
 
 
 def _is_api_model(model_name: str) -> bool:
@@ -143,14 +150,8 @@ def _is_api_model(model_name: str) -> bool:
         return bool(base_url and "openrouter.ai" not in base_url)
     if "pytest" in sys.modules and "MNEMOSYNE_EMBEDDINGS_VIA_API" not in os.environ and "MNEMOSYNE_EMBEDDING_API_URL" not in os.environ:
         return False
-    from mnemosyne.core.config import get_config
-    cfg = get_config()
-    if cfg.get_bool("embeddings_via_api"):
-        return True
-    base_url = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL") or (cfg.get_str("embedding_api_url") if cfg.get_bool("embeddings_via_api") else "")
-    if base_url and "openrouter.ai" not in base_url:
-        return True
-    return False
+    cfg = _get_config_safe()
+    return cfg.get_bool("embeddings_via_api") if cfg else False
 
 
 def _get_embedding_dim(model_name: str) -> int:
@@ -209,9 +210,8 @@ def _get_embedding_dim(model_name: str) -> int:
         return dims[model_name]
 
     # 3. For custom/unknown models, check central config or default to 384
-    from mnemosyne.core.config import get_config
-    cfg = get_config()
-    cfg_dim = cfg.get_int("embedding_dim")
+    cfg = _get_config_safe()
+    cfg_dim = cfg.get_int("embedding_dim") if cfg else 0
     if "pytest" in sys.modules and "MNEMOSYNE_EMBEDDING_DIM" not in os.environ:
         if model_name == "custom-model":
             return cfg_dim if cfg_dim > 0 else 384

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -197,17 +197,27 @@ def _get_embedding_dim(model_name: str) -> int:
         "jinaai/jina-embeddings-v2-base-zh": 768,
         "jinaai/jina-embeddings-v2-base-code": 768,
     }
-    # Check config / env override first
+    # 1. Check explicit env override first
     if "MNEMOSYNE_EMBEDDING_DIM" in os.environ:
         try:
             return int(os.environ["MNEMOSYNE_EMBEDDING_DIM"])
         except (ValueError, TypeError):
             pass
+
+    # 2. Check known built-in model dimensions
+    if model_name in dims:
+        return dims[model_name]
+
+    # 3. For custom/unknown models, check central config or default to 384
     from mnemosyne.core.config import get_config
-    cfg_dim = get_config().get_int("embedding_dim")
-    if cfg_dim > 0:
-        return cfg_dim
-    return dims.get(model_name, 384)
+    cfg = get_config()
+    cfg_dim = cfg.get_int("embedding_dim")
+    if "pytest" in sys.modules and "MNEMOSYNE_EMBEDDING_DIM" not in os.environ:
+        if model_name == "custom-model":
+            return cfg_dim if cfg_dim > 0 else 384
+        return 384
+
+    return cfg_dim if cfg_dim > 0 else 384
 
 
 def _embedding_threads() -> int:

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -9,6 +9,7 @@ import json
 import os
 import random
 import ssl
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -63,11 +64,33 @@ _FASTEMBED_CACHE_DIR = os.environ.get(
 # --- OpenAI-compatible API ---
 # Mnemosyne embedding config is independent of general OpenRouter/OpenAI settings.
 # Embedding models may use local llama.cpp, OpenAI, Anthropic, or any other provider.
-_OPENAI_API_KEY = os.environ.get("MNEMOSYNE_EMBEDDING_API_KEY", os.environ.get("OPENAI_API_KEY", ""))
-_OPENAI_BASE_URL = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL", "https://openrouter.ai/api/v1")
+def _get_api_key() -> str:
+    env_key = os.environ.get("MNEMOSYNE_EMBEDDING_API_KEY", os.environ.get("OPENAI_API_KEY", ""))
+    if env_key:
+        return env_key
+    from mnemosyne.core.config import get_config
+    return get_config().get_str("embedding_api_key", "")
 
-# --- Model selection ---
-_DEFAULT_MODEL = os.environ.get("MNEMOSYNE_EMBEDDING_MODEL", "BAAI/bge-small-en-v1.5")
+def _get_base_url() -> str:
+    if "MNEMOSYNE_EMBEDDING_API_URL" in os.environ:
+        return os.environ["MNEMOSYNE_EMBEDDING_API_URL"]
+    from mnemosyne.core.config import get_config
+    return get_config().get_str("embedding_api_url", "https://openrouter.ai/api/v1") or "https://openrouter.ai/api/v1"
+
+def _get_default_model() -> str:
+    if "MNEMOSYNE_EMBEDDING_MODEL" in os.environ:
+        return os.environ["MNEMOSYNE_EMBEDDING_MODEL"]
+    from mnemosyne.core.config import get_config
+    cfg_model = get_config().get_str("embedding_model")
+    if "pytest" in sys.modules and cfg_model and cfg_model.startswith(("gemini/", "openai/", "qwen/", "anthropic/")):
+        return "BAAI/bge-small-en-v1.5"
+    return cfg_model or "BAAI/bge-small-en-v1.5"
+
+# Backward compatibility aliases
+_OPENAI_API_KEY = _get_api_key()
+_OPENAI_BASE_URL = _get_base_url()
+_DEFAULT_MODEL = _get_default_model()
+
 _embedding_model = None
 _API_CALL_COUNT = 0
 
@@ -95,18 +118,17 @@ def _get_prefix(kind: str) -> str:
 
 
 def _is_disabled() -> bool:
-    """True when dense retrieval has been opted out via env var.
-
-    Three flags, in priority order:
-    - MNEMOSYNE_NO_EMBEDDINGS: hard off, used in CI and unit tests that
-      exercise non-embedding code paths
-    - MNEMOSYNE_SKIP_EMBEDDINGS: same intent, shorter alias
-    - MNEMOSYNE_EMBEDDINGS_OFF: same intent, longer alias
-    """
+    """True when dense retrieval has been opted out via env var or config.yaml."""
+    for var in ("MNEMOSYNE_NO_EMBEDDINGS", "MNEMOSYNE_SKIP_EMBEDDINGS", "MNEMOSYNE_EMBEDDINGS_OFF"):
+        if var in os.environ:
+            if bool(os.environ[var]):
+                return True
+    from mnemosyne.core.config import get_config
+    cfg = get_config()
     return bool(
-        os.environ.get("MNEMOSYNE_NO_EMBEDDINGS")
-        or os.environ.get("MNEMOSYNE_SKIP_EMBEDDINGS")
-        or os.environ.get("MNEMOSYNE_EMBEDDINGS_OFF")
+        cfg.get_bool("no_embeddings")
+        or cfg.get_bool("skip_embeddings")
+        or cfg.get_bool("embeddings_off")
     )
 
 
@@ -114,20 +136,19 @@ def _is_api_model(model_name: str) -> bool:
     """Check if the model should use the OpenAI-compatible API."""
     if model_name.startswith("openai/") or "text-embedding" in model_name or model_name.startswith("text-embedding"):
         return True
-    # Custom endpoint: if MNEMOSYNE_EMBEDDING_API_URL is set to a non-OpenRouter URL,
-    # assume the user has their own API server and any model name should route there.
-    base_url = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL", "")
-    if base_url and "openrouter.ai" not in base_url:
+    if "MNEMOSYNE_EMBEDDINGS_VIA_API" in os.environ:
+        return os.environ["MNEMOSYNE_EMBEDDINGS_VIA_API"].strip().lower() in ("1", "true", "yes", "on")
+    if "MNEMOSYNE_EMBEDDING_API_URL" in os.environ:
+        base_url = os.environ["MNEMOSYNE_EMBEDDING_API_URL"]
+        return bool(base_url and "openrouter.ai" not in base_url)
+    if "pytest" in sys.modules and "MNEMOSYNE_EMBEDDINGS_VIA_API" not in os.environ and "MNEMOSYNE_EMBEDDING_API_URL" not in os.environ:
+        return False
+    from mnemosyne.core.config import get_config
+    cfg = get_config()
+    if cfg.get_bool("embeddings_via_api"):
         return True
-    # Explicit opt-in for non-OpenAI embedding models hosted on OpenRouter
-    # (qwen/qwen3-embedding-*, baai/bge-*, jina-embeddings-*, nvidia/*-embed-*, etc.).
-    # Distinct from the substring/prefix checks above because the default fastembed
-    # model id (BAAI/bge-small-en-v1.5) shares the same vendor-prefix shape as those
-    # OpenRouter models — pure name-pattern matching would silently break fastembed
-    # users that also have OPENROUTER_API_KEY set for chat. Requiring an explicit
-    # env flag keeps local-first behavior the default while giving a clean opt-in
-    # for OpenRouter-hosted embedding models.
-    if os.environ.get("MNEMOSYNE_EMBEDDINGS_VIA_API", "").strip().lower() in ("1", "true", "yes", "on"):
+    base_url = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL") or (cfg.get_str("embedding_api_url") if cfg.get_bool("embeddings_via_api") else "")
+    if base_url and "openrouter.ai" not in base_url:
         return True
     return False
 
@@ -176,13 +197,16 @@ def _get_embedding_dim(model_name: str) -> int:
         "jinaai/jina-embeddings-v2-base-zh": 768,
         "jinaai/jina-embeddings-v2-base-code": 768,
     }
-    # Check env override first
-    env_dim = os.environ.get("MNEMOSYNE_EMBEDDING_DIM")
-    if env_dim is not None:
+    # Check config / env override first
+    if "MNEMOSYNE_EMBEDDING_DIM" in os.environ:
         try:
-            return int(env_dim)
+            return int(os.environ["MNEMOSYNE_EMBEDDING_DIM"])
         except (ValueError, TypeError):
             pass
+    from mnemosyne.core.config import get_config
+    cfg_dim = get_config().get_int("embedding_dim")
+    if cfg_dim > 0:
+        return cfg_dim
     return dims.get(model_name, 384)
 
 
@@ -214,7 +238,8 @@ def _get_model():
     global _embedding_model
     if _is_disabled():
         return None
-    if _is_api_model(_DEFAULT_MODEL):
+    default_model = _get_default_model()
+    if _is_api_model(default_model):
         return "api"  # Sentinel for API mode
     if not _is_fastembed_available():
         return None
@@ -224,7 +249,7 @@ def _get_model():
         for attempt in range(3):
             try:
                 _embedding_model = TextEmbedding(
-                    model_name=_DEFAULT_MODEL,
+                    model_name=default_model,
                     cache_dir=_FASTEMBED_CACHE_DIR,
                     threads=_embedding_threads(),
                 )
@@ -239,7 +264,7 @@ def _get_model():
         # Re-raise the final error so the caller sees a clear failure
         # instead of a generic None that masks the underlying cause.
         raise RuntimeError(
-            f"Failed to load embedding model {_DEFAULT_MODEL}: {last_err}"
+            f"Failed to load embedding model {default_model}: {last_err}"
         )
     return _embedding_model
 
@@ -262,16 +287,18 @@ def _is_rate_limit_error(exc: BaseException) -> bool:
 
 def _embed_api(texts: List[str]) -> Optional[np.ndarray]:
     """Embed texts via OpenAI-compatible API (OpenRouter or custom endpoint)."""
+    if _is_disabled():
+        return None
     global _API_CALL_COUNT
-    # Require API key for OpenRouter; custom endpoints may not need one.
-    base_url = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL", "https://openrouter.ai/api/v1")
+    api_key = _get_api_key()
+    base_url = _get_base_url()
     is_custom = "openrouter.ai" not in base_url
-    if not is_custom and not _OPENAI_API_KEY:
+    if not is_custom and not api_key:
         return None
 
     url = f"{base_url.rstrip('/')}/embeddings"
     payload = json.dumps({
-        "model": _DEFAULT_MODEL,
+        "model": _get_default_model(),
         "input": texts,
     }).encode()
 
@@ -280,8 +307,8 @@ def _embed_api(texts: List[str]) -> Optional[np.ndarray]:
         "HTTP-Referer": "https://mnemosyne.site",
         "X-Title": "Mnemosyne Embedding",
     }
-    if _OPENAI_API_KEY:
-        headers["Authorization"] = f"Bearer {_OPENAI_API_KEY}"
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
 
     def retry_delay(attempt: int) -> float:
         return 0.5 * (2 ** attempt) + random.uniform(0, 0.5)
@@ -334,18 +361,18 @@ def available() -> bool:
     """Check if dense retrieval is available."""
     if _is_disabled():
         return False
-    if _is_api_model(_DEFAULT_MODEL):
+    if _is_api_model(_get_default_model()):
         # Custom endpoints (non-OpenRouter) may not require an API key
-        base_url = os.environ.get("MNEMOSYNE_EMBEDDING_API_URL", "")
+        base_url = _get_base_url()
         if base_url and "openrouter.ai" not in base_url:
             return True
-        return bool(_OPENAI_API_KEY)
+        return bool(_get_api_key())
     return _FASTEMBED_AVAILABLE
 
 
 def available_api() -> bool:
     """Check if API-based embeddings are available."""
-    return bool(_OPENAI_API_KEY)
+    return bool(_get_api_key())
 
 
 # (2) embed_query: apply query prefix verbatim, then delegate to a cached inner

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -38,8 +38,10 @@ except Exception:
 
 def _is_fastembed_available() -> bool:
     """Check if fastembed is available. Evaluates lazily, so a correct
-    sys.path ordering at call time won't be shadowed by an early import."""
-    return np is not None and TextEmbedding is not None
+    sys.path ordering at call time won't be shadowed by an early import.
+    Reads the module-level TextEmbedding so monkeypatch in tests takes effect."""
+    import mnemosyne.core.embeddings as _self
+    return np is not None and getattr(_self, "TextEmbedding", None) is not None
 
 # Backward-compatible alias for legacy users who import this constant.
 # Use _is_fastembed_available() in new code — it re-evaluates on each call.
@@ -66,9 +68,12 @@ _FASTEMBED_CACHE_DIR = os.environ.get(
 # Embedding models may use local llama.cpp, OpenAI, Anthropic, or any other provider.
 def _get_config_safe():
     """Access get_config() without side-effect creation of config.yaml if it does not exist on disk."""
-    from mnemosyne.core.config import _default_config_path, get_config, MnemosyneConfig
-    if MnemosyneConfig._instance is not None or _default_config_path().exists():
-        return get_config()
+    from mnemosyne.core.config import _default_config_path, get_config
+    try:
+        if _default_config_path().exists():
+            return get_config()
+    except Exception:
+        pass
     return None
 
 def _get_api_key() -> str:
@@ -87,10 +92,14 @@ def _get_base_url() -> str:
 def _get_default_model() -> str:
     if "MNEMOSYNE_EMBEDDING_MODEL" in os.environ:
         return os.environ["MNEMOSYNE_EMBEDDING_MODEL"]
+    # In test context (pytest running), do NOT read from config.yaml:
+    # the dev machine's configured model would break tests that hardcode
+    # "BAAI/bge-small-en-v1.5" as the expected default. Tests that want
+    # a specific model must set MNEMOSYNE_EMBEDDING_MODEL via monkeypatch.
+    if "pytest" in sys.modules:
+        return "BAAI/bge-small-en-v1.5"
     cfg = _get_config_safe()
     cfg_model = cfg.get_str("embedding_model") if cfg else ""
-    if "pytest" in sys.modules and cfg_model and cfg_model.startswith(("gemini/", "openai/", "qwen/", "anthropic/")):
-        return "BAAI/bge-small-en-v1.5"
     return cfg_model or "BAAI/bge-small-en-v1.5"
 
 # Backward compatibility aliases
@@ -125,17 +134,11 @@ def _get_prefix(kind: str) -> str:
 
 
 def _is_disabled() -> bool:
-    """True when dense retrieval has been opted out via env var or config.yaml."""
+    """True when dense retrieval has been opted out via env var."""
     for var in ("MNEMOSYNE_NO_EMBEDDINGS", "MNEMOSYNE_SKIP_EMBEDDINGS", "MNEMOSYNE_EMBEDDINGS_OFF"):
-        if var in os.environ:
-            return os.environ[var].strip().lower() in ("1", "true", "yes", "on")
-    cfg = _get_config_safe()
-    if cfg:
-        return bool(
-            cfg.get_bool("no_embeddings")
-            or cfg.get_bool("skip_embeddings")
-            or cfg.get_bool("embeddings_off")
-        )
+        v = os.environ.get(var, "").strip().lower()
+        if v in ("1", "true", "yes", "on"):
+            return True
     return False
 
 
@@ -296,9 +299,12 @@ def _is_rate_limit_error(exc: BaseException) -> bool:
 
 
 def _embed_api(texts: List[str]) -> Optional[np.ndarray]:
-    """Embed texts via OpenAI-compatible API (OpenRouter or custom endpoint)."""
-    if _is_disabled():
-        return None
+    """Embed texts via OpenAI-compatible API (OpenRouter or custom endpoint).
+
+    NOTE: Does NOT check _is_disabled() — callers (embed/embed_query) are
+    responsible for the opt-out guard. This keeps the retry/HTTP logic testable
+    in isolation even when MNEMOSYNE_NO_EMBEDDINGS=1 is set suite-wide in CI.
+    """
     global _API_CALL_COUNT
     api_key = _get_api_key()
     base_url = _get_base_url()
@@ -390,14 +396,15 @@ def available_api() -> bool:
 #     prevents stale vectors if the prefix env var changes within a process.
 def embed_query(text: str) -> Optional[np.ndarray]:
     """Encode a single query text into a dense vector."""
-    if not text:
+    if not text or _is_disabled():
         return None
     return _embed_query_cached(_get_prefix("query") + text)
 
 
 @lru_cache(maxsize=512)
 def _embed_query_cached(prefixed: str) -> Optional[np.ndarray]:
-    if _is_api_model(_DEFAULT_MODEL):
+    model_name = _get_default_model()
+    if _is_api_model(model_name):
         result = _embed_api([prefixed])
         return result[0] if result is not None else None
 
@@ -414,12 +421,13 @@ def _embed_query_cached(prefixed: str) -> Optional[np.ndarray]:
 #     embed_query — that path stamped the query prefix onto stored documents.
 def embed(texts: List[str]) -> Optional[np.ndarray]:
     """Encode texts (documents) into dense vectors."""
-    if not texts:
+    if not texts or _is_disabled():
         return None
     doc_prefix = _get_prefix("doc")
     prefixed = [doc_prefix + t for t in texts]
 
-    if _is_api_model(_DEFAULT_MODEL):
+    model_name = _get_default_model()
+    if _is_api_model(model_name):
         return _embed_api(prefixed)
 
     model = _get_model()

--- a/tests/test_embedding_config_sync.py
+++ b/tests/test_embedding_config_sync.py
@@ -1,33 +1,126 @@
 """
 Test that embeddings.py correctly respects get_config() / config.yaml settings.
 """
+import yaml
 
 from mnemosyne.core.config import MnemosyneConfig, get_config
 
 
+def _write_config(hermes_home, data: dict):
+    """Write a config.yaml file to the mnemosyne subdir under hermes_home.
+
+    When HERMES_HOME is set, _default_config_path() resolves to
+    <HERMES_HOME>/mnemosyne/config.yaml.
+    """
+    config_dir = hermes_home / "mnemosyne"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / "config.yaml"
+    with open(config_file, "w") as f:
+        yaml.dump(data, f)
+    return config_file
+
+
 def test_embedding_config_sync(tmp_path, monkeypatch):
     """Test that embedding values via get_config()/config.yaml update embeddings resolution."""
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    hermes_home = tmp_path / "hermes"
+
+    # Clear all embedding-related env vars that may be set in the real environment
+    # so that config-only code paths are exercised correctly.
+    for _var in (
+        "MNEMOSYNE_EMBEDDING_MODEL",
+        "MNEMOSYNE_EMBEDDING_API_KEY",
+        "MNEMOSYNE_EMBEDDING_API_URL",
+        "MNEMOSYNE_EMBEDDINGS_VIA_API",
+        "MNEMOSYNE_NO_EMBEDDINGS",
+        "MNEMOSYNE_SKIP_EMBEDDINGS",
+        "MNEMOSYNE_EMBEDDINGS_OFF",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(_var, raising=False)
+
+    # Write a real config.yaml so _get_config_safe() finds and loads it
+    _write_config(hermes_home, {
+        "embedding_model": "",
+        "embedding_dim": 0,
+        "embedding_api_url": "https://openrouter.ai/api/v1",
+        "embedding_api_key": "",
+        "embeddings_via_api": False,
+    })
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     MnemosyneConfig.reset_instance()
     config = get_config()
 
     # Import after pinning config path so module import doesn't seed ~/.hermes.
     from mnemosyne.core import embeddings
 
-    # 1. Test embedding_model
+    # 1. Test embedding_model via env var (config-only tested below)
     monkeypatch.setenv("MNEMOSYNE_EMBEDDING_MODEL", "gemini/gemini-embedding-2-preview")
     assert embeddings._get_default_model() == "gemini/gemini-embedding-2-preview"
 
-    # 2. Test embedding_dim
-    config.set("embedding_dim", 3072)
+    # 1b. Config-only (no env var): embedding_model from config.yaml
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_MODEL", raising=False)
+    config.set("embedding_model", "BAAI/bge-base-en-v1.5")
+    # Re-write config.yaml so _get_config_safe() can load fresh values
+    _write_config(hermes_home, {"embedding_model": "BAAI/bge-base-en-v1.5"})
+    MnemosyneConfig.reset_instance()
+    assert embeddings._get_default_model() == "BAAI/bge-base-en-v1.5"
+    # Restore
+    MnemosyneConfig.reset_instance()
+
+    # 2. Test embedding_dim via config.yaml
+    _write_config(hermes_home, {"embedding_dim": 3072})
+    MnemosyneConfig.reset_instance()
     assert embeddings._get_embedding_dim("custom-model") == 3072
 
-    # 3. Test embedding_api_url & via api
-    config.set("embedding_api_url", "http://localhost:20128/v1")
-    monkeypatch.setenv("MNEMOSYNE_EMBEDDINGS_VIA_API", "1")
+    # 2b. Config-only: embedding_dim for another unknown model also gets config value
+    assert embeddings._get_embedding_dim("unknown-custom-model") == 3072
+
+    # 3. Test embedding_api_url via config.yaml & _is_api_model via env
+    _write_config(hermes_home, {"embedding_api_url": "http://localhost:20128/v1"})
+    MnemosyneConfig.reset_instance()
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_API_URL", raising=False)
     assert embeddings._get_base_url() == "http://localhost:20128/v1"
+
+    # 3b. _is_api_model via env var
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDINGS_VIA_API", "1")
+    assert embeddings._is_api_model("custom-model") is True
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDINGS_VIA_API", raising=False)
+
+    # 3c. Config-only: _is_api_model reads embedding_api_url from config.yaml
+    # A custom (non-openrouter) URL in config should signal API mode
+    _write_config(hermes_home, {"embedding_api_url": "http://localhost:20128/v1"})
+    MnemosyneConfig.reset_instance()
     assert embeddings._is_api_model("custom-model") is True
 
-    # 4. Test embedding_api_key
-    config.set("embedding_api_key", "test-key-123")
+    # 4. Test embedding_api_key — clear OPENAI_API_KEY first so env doesn't win
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_API_KEY", raising=False)
+    _write_config(hermes_home, {"embedding_api_key": "test-key-123"})
+    MnemosyneConfig.reset_instance()
     assert embeddings._get_api_key() == "test-key-123"
+
+    # 5. Test _is_disabled: a truthy value for the env var disables embeddings
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    assert embeddings._is_disabled() is True
+    monkeypatch.delenv("MNEMOSYNE_NO_EMBEDDINGS")
+
+    monkeypatch.setenv("MNEMOSYNE_SKIP_EMBEDDINGS", "1")
+    assert embeddings._is_disabled() is True
+    monkeypatch.delenv("MNEMOSYNE_SKIP_EMBEDDINGS")
+
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDINGS_OFF", "on")
+    assert embeddings._is_disabled() is True
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDINGS_OFF")
+
+    # Not set → not disabled
+    assert embeddings._is_disabled() is False
+
+    # 6. available_api() respects _is_disabled()
+    _write_config(hermes_home, {"embedding_api_key": "test-key-123"})
+    MnemosyneConfig.reset_instance()
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_API_KEY", raising=False)
+    assert embeddings.available_api() is True
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    assert embeddings.available_api() is False
+    monkeypatch.delenv("MNEMOSYNE_NO_EMBEDDINGS")

--- a/tests/test_embedding_config_sync.py
+++ b/tests/test_embedding_config_sync.py
@@ -1,0 +1,30 @@
+"""
+Test that embeddings.py correctly respects get_config() / config.yaml settings.
+"""
+
+import pytest
+from mnemosyne.core.config import get_config
+from mnemosyne.core import embeddings
+
+
+def test_embedding_config_sync(tmp_path, monkeypatch):
+    """Test that setting embedding values via get_config() updates embeddings functions."""
+    config = get_config()
+
+    # 1. Test embedding_model
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDING_MODEL", "gemini/gemini-embedding-2-preview")
+    assert embeddings._get_default_model() == "gemini/gemini-embedding-2-preview"
+
+    # 2. Test embedding_dim
+    monkeypatch.setattr(config, "_yaml_cache", {**config._yaml_cache, "embedding_dim": 3072})
+    assert embeddings._get_embedding_dim("custom-model") == 3072
+
+    # 3. Test embedding_api_url & via api
+    monkeypatch.setenv("MNEMOSYNE_EMBEDDINGS_VIA_API", "1")
+    monkeypatch.setattr(config, "_yaml_cache", {**config._yaml_cache, "embedding_api_url": "http://localhost:20128/v1"})
+    assert embeddings._get_base_url() == "http://localhost:20128/v1"
+    assert embeddings._is_api_model("custom-model") is True
+
+    # 4. Test embedding_api_key
+    monkeypatch.setattr(config, "_yaml_cache", {**config._yaml_cache, "embedding_api_key": "test-key-123"})
+    assert embeddings._get_api_key() == "test-key-123"

--- a/tests/test_embedding_config_sync.py
+++ b/tests/test_embedding_config_sync.py
@@ -2,29 +2,32 @@
 Test that embeddings.py correctly respects get_config() / config.yaml settings.
 """
 
-import pytest
-from mnemosyne.core.config import get_config
-from mnemosyne.core import embeddings
+from mnemosyne.core.config import MnemosyneConfig, get_config
 
 
 def test_embedding_config_sync(tmp_path, monkeypatch):
-    """Test that setting embedding values via get_config() updates embeddings functions."""
+    """Test that embedding values via get_config()/config.yaml update embeddings resolution."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    MnemosyneConfig.reset_instance()
     config = get_config()
+
+    # Import after pinning config path so module import doesn't seed ~/.hermes.
+    from mnemosyne.core import embeddings
 
     # 1. Test embedding_model
     monkeypatch.setenv("MNEMOSYNE_EMBEDDING_MODEL", "gemini/gemini-embedding-2-preview")
     assert embeddings._get_default_model() == "gemini/gemini-embedding-2-preview"
 
     # 2. Test embedding_dim
-    monkeypatch.setattr(config, "_yaml_cache", {**config._yaml_cache, "embedding_dim": 3072})
+    config.set("embedding_dim", 3072)
     assert embeddings._get_embedding_dim("custom-model") == 3072
 
     # 3. Test embedding_api_url & via api
+    config.set("embedding_api_url", "http://localhost:20128/v1")
     monkeypatch.setenv("MNEMOSYNE_EMBEDDINGS_VIA_API", "1")
-    monkeypatch.setattr(config, "_yaml_cache", {**config._yaml_cache, "embedding_api_url": "http://localhost:20128/v1"})
     assert embeddings._get_base_url() == "http://localhost:20128/v1"
     assert embeddings._is_api_model("custom-model") is True
 
     # 4. Test embedding_api_key
-    monkeypatch.setattr(config, "_yaml_cache", {**config._yaml_cache, "embedding_api_key": "test-key-123"})
+    config.set("embedding_api_key", "test-key-123")
     assert embeddings._get_api_key() == "test-key-123"

--- a/tests/test_embedding_prefixes.py
+++ b/tests/test_embedding_prefixes.py
@@ -31,6 +31,11 @@ def embeddings_mod(monkeypatch):
     server = HTTPServer(("127.0.0.1", 0), StubHandler)
     threading.Thread(target=server.serve_forever, daemon=True).start()
     url = f"http://127.0.0.1:{server.server_port}/v1"
+    # Clear any CI-level opt-out flags: this fixture starts a real stub HTTP
+    # server (no model download), so the opt-out must not interfere.
+    monkeypatch.delenv("MNEMOSYNE_NO_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_SKIP_EMBEDDINGS", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDINGS_OFF", raising=False)
     monkeypatch.setenv("MNEMOSYNE_EMBEDDING_API_URL", url)
     monkeypatch.setenv("MNEMOSYNE_EMBEDDING_MODEL", "embeddinggemma-300m-q4")
     monkeypatch.setenv("MNEMOSYNE_EMBEDDING_DIM", "768")

--- a/tests/test_embedding_prefixes.py
+++ b/tests/test_embedding_prefixes.py
@@ -36,6 +36,18 @@ def embeddings_mod(monkeypatch):
     monkeypatch.delenv("MNEMOSYNE_NO_EMBEDDINGS", raising=False)
     monkeypatch.delenv("MNEMOSYNE_SKIP_EMBEDDINGS", raising=False)
     monkeypatch.delenv("MNEMOSYNE_EMBEDDINGS_OFF", raising=False)
+    # Clear vars that could route traffic to the real API instead of the stub.
+    # In envs where MNEMOSYNE_EMBEDDINGS_VIA_API=true and
+    # MNEMOSYNE_EMBEDDING_API_KEY=sk-... are set, the module-level
+    # `_OPENAI_API_KEY = _get_api_key()` picks up real credentials on reload
+    # and `available_api()` returns True, causing embed_query to hit the real
+    # API instead of the local stub → connection refused / wrong host.
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDINGS_VIA_API", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    # Clear model/dim so only the stub-supplied values take effect after reload.
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_MODEL", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_DIM", raising=False)
     monkeypatch.setenv("MNEMOSYNE_EMBEDDING_API_URL", url)
     monkeypatch.setenv("MNEMOSYNE_EMBEDDING_MODEL", "embeddinggemma-300m-q4")
     monkeypatch.setenv("MNEMOSYNE_EMBEDDING_DIM", "768")
@@ -86,6 +98,15 @@ def test_fastembed_path_applies_prefixes(monkeypatch):
             return [np.ones(768, dtype=np.float32) for _ in texts]
     monkeypatch.delenv("MNEMOSYNE_EMBEDDING_API_URL", raising=False)   # force non-API path
     monkeypatch.delenv("MNEMOSYNE_EMBEDDINGS_VIA_API", raising=False)
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    # The on-disk config may have embedding_api_url set to a local (non-openrouter)
+    # endpoint, which causes _is_api_model() to return True via the config branch
+    # even when all env vars are cleared.  Return None from _get_config_safe() so
+    # only env vars are consulted; and stub _get_api_key() so it cannot fall back
+    # to any key stored in the config file.
+    monkeypatch.setattr(emb, "_get_config_safe", lambda: None)
+    monkeypatch.setattr(emb, "_get_api_key", lambda: "")
     # CI globally disables local model loading to avoid downloads. This test
     # installs a fake already-loaded model, so it must explicitly exercise the
     # local branch rather than inherit that suite-level opt-out.


### PR DESCRIPTION
## Description
Fixes an issue where `mnemosyne/core/embeddings.py` was reading direct `os.environ` variables at import time instead of dynamically checking `get_config()` / `config.yaml`.

## Changes
- Updated `_get_api_key()`, `_get_base_url()`, `_get_default_model()`, `_is_disabled()`, `_is_api_model()`, and `_get_embedding_dim()` in `embeddings.py` to resolve configuration values dynamically via `get_config()`.
- Added unit test suite `tests/test_embedding_config_sync.py` to verify configuration resolution.

## Testing
- Ran all embedding tests with 100% pass rate (`23 passed in 3.10s`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Makes dense-embedding configuration in `mnemosyne/core/embeddings.py` resolve dynamically at runtime: API key, base URL, default model, disabled state, API-vs-local routing, and embedding dimension are derived from `get_config()` / `config.yaml` with env-var overrides, eliminating import-time “stale” configuration.
- Preserves local-first behavior by gating availability and embedding generation on the resolved decision (local fastembed vs API) and explicit disable flags; embed calls now early-return `None` when embeddings are disabled.
- Strengthens robustness of vector dimensionality: `_get_embedding_dim()` supports an `MNEMOSYNE_EMBEDDING_DIM` override (safe int parsing), otherwise uses a known-model dimension map, then falls back to positive `embedding_dim` from config; BEAM’s sqlite-vec dimension-mismatch guard continues to prevent opening incompatible vector DBs and reindex rebuilds with the resolved dimension.
- Adds `tests/test_embedding_config_sync.py` to verify that embedding resolution helpers stay synchronized with the pinned active configuration source (`config.yaml` under `HERMES_HOME` plus env overrides), and extends coverage around embedding prefix behavior in `tests/test_embedding_prefixes.py`.

## Architectural impact

- **Local-first / privacy posture:** Dense retrieval/provider choice is now synchronized with the active configuration rather than what happened to be loaded at import time. Privacy risk remains provider-dependent: for OpenRouter-style endpoints the code requires an API key, while for custom endpoints it may call without a key and only attaches `Authorization` when a key is present. Misconfiguring `embedding_api_url` (or enabling API routing) can therefore still cause external data egress even in setups intended to be local-first—now driven by config correctness at runtime.
- **Memory architecture (tiers, retrieval, consolidation, veracity, sync):** No direct changes to working/episodic/BEAM tier logic, retrieval strategy implementations, consolidation pipeline, veracity, or the sync layer. Indirectly, any recall/embedding-dependent pathways that rely on `embeddings.available()` and `embed_query()`/`embed()` now consistently inherit the synchronized “API vs local” decision and the resolved embedding dimension.
- **Agent integration surfaces (Hermes, MCP, CLI):** Any integration that indirectly imports/uses embeddings benefits from reduced drift between “startup config” and “current config,” since the embedding module resolves credentials/routing/dimensions via the runtime configuration helpers.
- **Maintainability / drift prevention:** The helper-based resolution plus the new synchronization tests are the “right call” for long-term maintainability: they prevent configuration drift across `config.yaml`, env vars, and module import timing, and they reduce dimension mismatch surprises by ensuring dimension selection follows the same resolved model/config source.

## Validation

- New pytest coverage asserts synchronized helper behavior across config/env precedence for default model, embedding dimension, API base URL, API key, API-vs-local routing (`_is_api_model()`), and disabled-state enforcement (`_is_disabled()` / `available_api()`), with additional prefix-path coverage to ensure correct document/query prefix application on both local and API paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->