### PR TITLE
feat(mcp): auto-load .env configuration and add --env-file option

### DIFF
--- a/mnemosyne/mcp_server.py
+++ b/mnemosyne/mcp_server.py
@@ -311,6 +311,8 @@ def _load_dotenv(env_file_path: Optional[str] = None) -> Optional[str]:
                 break
             except Exception as exc:
                 logger.warning("Failed to parse env file %s: %s", p, exc)
+                if env_file_path and p == Path(env_file_path).expanduser():
+                    return None
     return loaded_path
 
 

--- a/mnemosyne/mcp_server.py
+++ b/mnemosyne/mcp_server.py
@@ -30,6 +30,7 @@ import os
 import json
 import asyncio
 import logging
+from pathlib import Path
 from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -263,11 +264,62 @@ async def _run_sse(port: int = 8080, host: str = "127.0.0.1") -> None:
 # CLI Entry Point
 # ---------------------------------------------------------------------------
 
+def _load_dotenv(env_file_path: Optional[str] = None) -> Optional[str]:
+    """Auto-load .env file into os.environ for MCP server execution.
+
+    Search order:
+    1. Explicit env_file_path passed via --env-file
+    2. $HERMES_HOME/.env or ~/.hermes/.env
+    3. $MNEMOSYNE_HOME/.env or ~/.mnemosyne/.env
+    4. ./.env (current working directory)
+
+    Returns the path of the loaded .env file, or None if no file was loaded.
+    """
+    candidates = []
+    if env_file_path:
+        candidates.append(Path(env_file_path).expanduser())
+
+    hermes_home = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+    candidates.append(Path(hermes_home) / ".env")
+
+    mnemosyne_home = os.environ.get("MNEMOSYNE_HOME", os.path.expanduser("~/.mnemosyne"))
+    candidates.append(Path(mnemosyne_home) / ".env")
+
+    try:
+        candidates.append(Path.cwd() / ".env")
+    except Exception:
+        pass
+
+    loaded_path = None
+    for p in candidates:
+        if p.is_file():
+            try:
+                for line in p.read_text(encoding="utf-8").splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if line.startswith("export "):
+                        line = line[7:].strip()
+                    if "=" in line:
+                        k, v = line.split("=", 1)
+                        k = k.strip()
+                        v = v.strip().strip("'\"")
+                        if k and k not in os.environ:
+                            os.environ[k] = v
+                loaded_path = str(p)
+                logger.info("Loaded MCP environment from %s", loaded_path)
+                break
+            except Exception as exc:
+                logger.warning("Failed to parse env file %s: %s", p, exc)
+    return loaded_path
+
+
 def run_mcp_server(
     transport: str = "stdio",
     port: int = 8080,
     bank: Optional[str] = None,
     host: str = "127.0.0.1",
+    env_file: Optional[str] = None,
 ) -> None:
     """
     Run the Mnemosyne MCP server.
@@ -278,7 +330,10 @@ def run_mcp_server(
         bank: Default bank for operations (optional)
         host: Bind address for SSE transport (default: 127.0.0.1 -- loopback
             only). Non-loopback hosts require MNEMOSYNE_MCP_TOKEN.
+        env_file: Path to optional .env file to load before starting.
     """
+    _load_dotenv(env_file)
+
     if bank:
         os.environ["MNEMOSYNE_MCP_BANK"] = bank
 
@@ -323,9 +378,24 @@ def main(argv: Optional[list[str]] = None) -> None:
         default=None,
         help="Default memory bank"
     )
+    parser.add_argument(
+        "--env-file",
+        type=str,
+        default=None,
+        help="Path to .env file to load before starting server"
+    )
     args = parser.parse_args(argv)
 
-    run_mcp_server(transport=args.transport, port=args.port, bank=args.bank, host=args.host)
+    kwargs = {
+        "transport": args.transport,
+        "port": args.port,
+        "bank": args.bank,
+        "host": args.host,
+    }
+    if args.env_file is not None:
+        kwargs["env_file"] = args.env_file
+
+    run_mcp_server(**kwargs)
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_env_loader.py
+++ b/tests/test_mcp_env_loader.py
@@ -1,0 +1,63 @@
+"""
+Test auto .env loader functionality in mnemosyne/mcp_server.py.
+"""
+
+import os
+import pytest
+from mnemosyne import mcp_server
+
+
+@pytest.fixture(autouse=True)
+def restore_env():
+    """Ensure os.environ state is restored after each test."""
+    old_env = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(old_env)
+
+
+def test_load_dotenv_explicit_path(tmp_path, monkeypatch):
+    """Test loading an explicit .env file via --env-file / env_file_path."""
+    env_file = tmp_path / "custom.env"
+    env_file.write_text(
+        "export TEST_MCP_VAR_1=hello\n"
+        "TEST_MCP_VAR_2='world'\n"
+        "# comment line\n"
+        "TEST_MCP_VAR_3=\"quotes\"\n",
+        encoding="utf-8"
+    )
+    monkeypatch.delenv("TEST_MCP_VAR_1", raising=False)
+    monkeypatch.delenv("TEST_MCP_VAR_2", raising=False)
+    monkeypatch.delenv("TEST_MCP_VAR_3", raising=False)
+
+    loaded = mcp_server._load_dotenv(str(env_file))
+    assert loaded == str(env_file)
+    assert os.environ.get("TEST_MCP_VAR_1") == "hello"
+    assert os.environ.get("TEST_MCP_VAR_2") == "world"
+    assert os.environ.get("TEST_MCP_VAR_3") == "quotes"
+
+
+def test_load_dotenv_hermes_home(tmp_path, monkeypatch):
+    """Test auto-discovering .env from HERMES_HOME."""
+    hermes_dir = tmp_path / "hermes_test"
+    hermes_dir.mkdir()
+    env_file = hermes_dir / ".env"
+    env_file.write_text("HERMES_MCP_AUTO_TEST=active\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_dir))
+    monkeypatch.delenv("HERMES_MCP_AUTO_TEST", raising=False)
+
+    loaded = mcp_server._load_dotenv()
+    assert loaded == str(env_file)
+    assert os.environ.get("HERMES_MCP_AUTO_TEST") == "active"
+
+
+def test_load_dotenv_does_not_override_existing_env(tmp_path, monkeypatch):
+    """Test that existing os.environ variables take precedence over .env file."""
+    env_file = tmp_path / "override.env"
+    env_file.write_text("EXISTING_VAR=from_file\n", encoding="utf-8")
+
+    monkeypatch.setenv("EXISTING_VAR", "from_process")
+
+    mcp_server._load_dotenv(str(env_file))
+    assert os.environ.get("EXISTING_VAR") == "from_process"


### PR DESCRIPTION
## Description
When running `mnemosyne mcp` as an MCP server subprocess for AI Coding Agents (such as Claude Code, Antigravity CLI, Cursor, Roo Code), the subprocess environment often lacks variables configured in `.env` files (e.g. `MNEMOSYNE_EMBEDDING_API_URL`, `MNEMOSYNE_EMBEDDING_DIM`), leading to vector dimension mismatch errors.

This PR adds an automatic `.env` file loader to `mnemosyne mcp` and introduces a `--env-file` CLI option.

## Features
- **`--env-file <path>` CLI option**: Explicitly load a specific `.env` file when launching `mnemosyne mcp`.
- **Auto-Discovery**: Automatically searches for `.env` in:
  1. Specified `--env-file` path
  2. `$HERMES_HOME/.env` / `~/.hermes/.env`
  3. `$MNEMOSYNE_HOME/.env` / `~/.mnemosyne/.env`
  4. `./.env` (Current working directory)
- Zero external dependencies: Built-in parser supporting `KEY=VAL` and `export KEY=VAL`.
- Does not overwrite variables already present in `os.environ`.

## Testing
- Added unit test suite `tests/test_mcp_env_loader.py`.
- 100% pass rate on all MCP test suites (`35 passed in 2.61s`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds dependency-free `.env` loading to `mnemosyne mcp`, introducing a new `--env-file <path>` CLI option. On startup, it searches for a `.env` file in priority order: the explicit `--env-file` path, `$HERMES_HOME/.env`, `$MNEMOSYNE_HOME/.env`, and `./.env` (cwd). It supports `KEY=VAL` and `export KEY=VAL`, ignores blank lines and `#` comments, trims surrounding quotes, and **does not override** variables already present in the process environment.

## Architectural impact

- **Memory architecture (local-first core):** No changes to Mnemosyne’s tiered memory (working/episodic/BEAM), retrieval strategies, consolidation pipeline, veracity system, or sync layer. This is strictly an MCP startup/config concern.
- **Agent integration surfaces (Hermes, MCP, CLI):**
  - Improves local agent usability by allowing Hermes/Mnemosyne-local configuration to be injected into the MCP server without requiring external tooling.
  - Ensures the CLI can pass `--env-file` through to `run_mcp_server`, keeping the integration surface consistent.
- **Privacy and local-first guarantees:**
  - Strengthens local-first operation by relying on local files only (no network fetches, no external dependencies).
  - Avoids unintended precedence changes by not overwriting existing environment variables.
  - **Security posture interaction:** for SSE, Mnemosyne’s existing “non-loopback requires `MNEMOSYNE_MCP_TOKEN`” rule remains intact; this PR only makes it easier to supply that token via local `.env`/home discovery. It does not weaken auth gating.
- **Maintainability:** The implementation is a small internal helper (`_load_dotenv`) with focused unit tests that lock in parsing and precedence behavior.

## Tests

Adds `tests/test_mcp_env_loader.py` covering explicit `.env` loading, Hermes-home `.env` auto-discovery, quoted value parsing, and “do not override existing environment variables.” All MCP tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->