### PR TITLE
fix(doctor): load sqlite-vec in read-only reports

### DIFF
--- a/mnemosyne/doctor.py
+++ b/mnemosyne/doctor.py
@@ -66,6 +66,11 @@ _RUNTIME_ABSOLUTE_PATH = re.compile(
     r"(?<![A-Za-z0-9_.-])(?:~[\\/]|(?:[A-Za-z]:)?[\\/])[^\s`<>\"']+"
 )
 
+
+class _SQLiteVecExtensionDisableError(RuntimeError):
+    """The connection cannot safely continue after extension loading was enabled."""
+
+
 # Adapter SQL is deliberately limited to these known contracts. Catalog
 # metadata only proves that one of these names exists; it never turns an
 # arbitrary application table into a doctor query target.
@@ -211,6 +216,29 @@ def open_readonly_doctor_db(db_path: str | Path) -> sqlite3.Connection:
     conn.execute("PRAGMA query_only=ON")
     conn.execute("PRAGMA foreign_keys=ON")
     return conn
+
+
+def _load_optional_sqlite_vec(conn: sqlite3.Connection) -> bool:
+    """Load the bundled sqlite-vec module into an already read-only connection.
+
+    The Doctor must remain usable when the optional dependency is absent or
+    incompatible with the host SQLite build.  In that case, its existing
+    ``present_but_unloadable`` capability report remains the safe fallback.
+    """
+
+    try:
+        import sqlite_vec
+
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+    except Exception:
+        return False
+    finally:
+        try:
+            conn.enable_load_extension(False)
+        except Exception as error:
+            raise _SQLiteVecExtensionDisableError from error
+    return True
 
 
 def safe_preview(value: Any, max_length: int = 120) -> str:
@@ -626,6 +654,15 @@ def build_doctor_report(
         report.hygiene_summary = dict(unavailable, candidates=[])
         return report
     try:
+        try:
+            _load_optional_sqlite_vec(conn)
+        except _SQLiteVecExtensionDisableError:
+            unavailable = {"status": "unavailable", "error_class": "sqlite_error"}
+            report.sqlite_health = dict(unavailable)
+            report.reference_contracts = dict(unavailable)
+            report.vector_coverage = dict(unavailable)
+            report.hygiene_summary = dict(unavailable, candidates=[])
+            return report
         report.schema_fingerprint = inspect_schema_fingerprint(conn, scan_limit=scan_limit)
         sqlite_health = SQLiteHealthAdapter(conn, scan_limit=scan_limit).inspect()
         reference_contracts = ReferenceContractRegistry(conn, scan_limit=scan_limit).inspect()

--- a/mnemosyne/doctor.py
+++ b/mnemosyne/doctor.py
@@ -226,18 +226,21 @@ def _load_optional_sqlite_vec(conn: sqlite3.Connection) -> bool:
     ``present_but_unloadable`` capability report remains the safe fallback.
     """
 
+    extension_loading_enabled = False
     try:
         import sqlite_vec
 
         conn.enable_load_extension(True)
+        extension_loading_enabled = True
         sqlite_vec.load(conn)
     except Exception:
         return False
     finally:
-        try:
-            conn.enable_load_extension(False)
-        except Exception as error:
-            raise _SQLiteVecExtensionDisableError from error
+        if extension_loading_enabled:
+            try:
+                conn.enable_load_extension(False)
+            except Exception as error:
+                raise _SQLiteVecExtensionDisableError from error
     return True
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -118,6 +118,129 @@ def test_open_readonly_doctor_db_rejects_schema_and_data_writes(tmp_path):
         conn.close()
 
 
+def test_optional_sqlite_vec_load_keeps_doctor_connection_write_protected(tmp_path):
+    sqlite_vec = pytest.importorskip("sqlite_vec")
+    db_path = tmp_path / "doctor.db"
+    sqlite3.connect(db_path).close()
+
+    conn = open_readonly_doctor_db(db_path)
+    try:
+        assert doctor._load_optional_sqlite_vec(conn) is True
+        with pytest.raises(sqlite3.OperationalError, match="not authorized"):
+            conn.execute("SELECT load_extension(?)", ("unused",))
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("CREATE TABLE forbidden_items (id INTEGER PRIMARY KEY)")
+    finally:
+        conn.close()
+
+
+def test_optional_sqlite_vec_load_preserves_unloadable_fallback(tmp_path, monkeypatch):
+    db_path = tmp_path / "doctor.db"
+    sqlite3.connect(db_path).close()
+    failing_sqlite_vec = types.SimpleNamespace(
+        load=lambda _conn: (_ for _ in ()).throw(sqlite3.OperationalError("unavailable"))
+    )
+    monkeypatch.setitem(sys.modules, "sqlite_vec", failing_sqlite_vec)
+
+    conn = open_readonly_doctor_db(db_path)
+    try:
+        assert doctor._load_optional_sqlite_vec(conn) is False
+    finally:
+        conn.close()
+
+
+def test_build_doctor_report_preserves_unloadable_vec0_fallback(tmp_path, monkeypatch):
+    db_path = tmp_path / "doctor.db"
+    writable = sqlite3.connect(db_path)
+    writable.execute("CREATE TABLE vec_working (id INTEGER PRIMARY KEY)")
+    writable.execute("PRAGMA writable_schema=ON")
+    writable.execute(
+        "UPDATE sqlite_master SET sql = "
+        "'CREATE VIRTUAL TABLE vec_working USING vec0(embedding float[2])' "
+        "WHERE name = 'vec_working'"
+    )
+    writable.execute("PRAGMA writable_schema=OFF")
+    writable.commit()
+    writable.close()
+    failing_sqlite_vec = types.SimpleNamespace(
+        load=lambda _conn: (_ for _ in ()).throw(sqlite3.OperationalError("unavailable"))
+    )
+    monkeypatch.setitem(sys.modules, "sqlite_vec", failing_sqlite_vec)
+
+    report = build_doctor_report("work", db_path)
+
+    assert report.sqlite_health["vec0"]["status"] == STATUS_PRESENT_BUT_UNLOADABLE
+    assert any(finding.code == "sqlite.vec0_capability" for finding in report.findings)
+
+
+def test_optional_sqlite_vec_load_disables_extensions_after_success(monkeypatch):
+    calls: list[object] = []
+    fake_sqlite_vec = types.SimpleNamespace(load=lambda _conn: calls.append("load"))
+
+    class TrackingConnection:
+        def enable_load_extension(self, enabled):
+            calls.append(enabled)
+
+    monkeypatch.setitem(sys.modules, "sqlite_vec", fake_sqlite_vec)
+
+    assert doctor._load_optional_sqlite_vec(cast(sqlite3.Connection, TrackingConnection())) is True
+    assert calls == [True, "load", False]
+
+
+def test_optional_sqlite_vec_load_fails_closed_when_disable_fails(monkeypatch):
+    calls: list[object] = []
+    fake_sqlite_vec = types.SimpleNamespace(load=lambda _conn: calls.append("load"))
+
+    class DisableFailingConnection:
+        def enable_load_extension(self, enabled):
+            calls.append(enabled)
+            if not enabled:
+                raise sqlite3.OperationalError("disable failed")
+
+    monkeypatch.setitem(sys.modules, "sqlite_vec", fake_sqlite_vec)
+
+    with pytest.raises(doctor._SQLiteVecExtensionDisableError):
+        doctor._load_optional_sqlite_vec(cast(sqlite3.Connection, DisableFailingConnection()))
+    assert calls == [True, "load", False]
+
+
+def test_build_doctor_report_fails_closed_when_extensions_cannot_be_disabled(tmp_path, monkeypatch):
+    db_path = tmp_path / "doctor.db"
+    sqlite3.connect(db_path).close()
+    monkeypatch.setattr(
+        doctor,
+        "_load_optional_sqlite_vec",
+        lambda _conn: (_ for _ in ()).throw(doctor._SQLiteVecExtensionDisableError()),
+    )
+
+    report = build_doctor_report("work", db_path)
+
+    assert report.sqlite_health["status"] == "unavailable"
+    assert report.reference_contracts["status"] == "unavailable"
+    assert report.vector_coverage["status"] == "unavailable"
+
+
+def test_build_doctor_report_uses_optional_sqlite_vec_for_real_vec0_tables(tmp_path):
+    sqlite_vec = pytest.importorskip("sqlite_vec")
+    db_path = tmp_path / "doctor.db"
+    writable = sqlite3.connect(db_path)
+    try:
+        writable.enable_load_extension(True)
+        sqlite_vec.load(writable)
+        writable.execute("CREATE VIRTUAL TABLE vec_working USING vec0(embedding float[2])")
+        writable.commit()
+    finally:
+        writable.enable_load_extension(False)
+        writable.close()
+
+    report = build_doctor_report("work", db_path)
+
+    vec_table = next(table for table in report.schema_fingerprint.tables if table.name == "vec_working")
+    assert vec_table.status == STATUS_OK
+    assert report.sqlite_health["vec0"]["status"] == "available"
+    assert not any(finding.code == "sqlite.vec0_capability" for finding in report.findings)
+
+
 def test_open_readonly_doctor_db_does_not_create_a_missing_path(tmp_path):
     db_path = tmp_path / "missing.db"
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -178,7 +178,7 @@ def test_optional_sqlite_vec_load_disables_extensions_after_success(monkeypatch)
     fake_sqlite_vec = types.SimpleNamespace(load=lambda _conn: calls.append("load"))
 
     class TrackingConnection:
-        def enable_load_extension(self, enabled):
+        def enable_load_extension(self, enabled) -> None:
             calls.append(enabled)
 
     monkeypatch.setitem(sys.modules, "sqlite_vec", fake_sqlite_vec)
@@ -192,7 +192,7 @@ def test_optional_sqlite_vec_load_fails_closed_when_disable_fails(monkeypatch):
     fake_sqlite_vec = types.SimpleNamespace(load=lambda _conn: calls.append("load"))
 
     class DisableFailingConnection:
-        def enable_load_extension(self, enabled):
+        def enable_load_extension(self, enabled) -> None:
             calls.append(enabled)
             if not enabled:
                 raise sqlite3.OperationalError("disable failed")
@@ -202,6 +202,37 @@ def test_optional_sqlite_vec_load_fails_closed_when_disable_fails(monkeypatch):
     with pytest.raises(doctor._SQLiteVecExtensionDisableError):
         doctor._load_optional_sqlite_vec(cast(sqlite3.Connection, DisableFailingConnection()))
     assert calls == [True, "load", False]
+
+
+def test_optional_sqlite_vec_load_falls_back_when_enabling_extensions_is_unsupported(monkeypatch):
+    calls: list[bool] = []
+    fake_sqlite_vec = types.SimpleNamespace(load=lambda _conn: pytest.fail("load should not run"))
+
+    class UnsupportedConnection:
+        def enable_load_extension(self, enabled) -> None:
+            calls.append(enabled)
+            raise sqlite3.OperationalError("extension loading unsupported")
+
+    monkeypatch.setitem(sys.modules, "sqlite_vec", fake_sqlite_vec)
+
+    assert doctor._load_optional_sqlite_vec(cast(sqlite3.Connection, UnsupportedConnection())) is False
+    assert calls == [True]
+
+
+def test_optional_sqlite_vec_load_fails_closed_when_load_and_disable_fail(monkeypatch):
+    fake_sqlite_vec = types.SimpleNamespace(
+        load=lambda _conn: (_ for _ in ()).throw(sqlite3.OperationalError("load failed"))
+    )
+
+    class LoadAndDisableFailingConnection:
+        def enable_load_extension(self, enabled) -> None:
+            if not enabled:
+                raise sqlite3.OperationalError("disable failed")
+
+    monkeypatch.setitem(sys.modules, "sqlite_vec", fake_sqlite_vec)
+
+    with pytest.raises(doctor._SQLiteVecExtensionDisableError):
+        doctor._load_optional_sqlite_vec(cast(sqlite3.Connection, LoadAndDisableFailingConnection()))
 
 
 def test_build_doctor_report_fails_closed_when_extensions_cannot_be_disabled(tmp_path, monkeypatch):
@@ -218,6 +249,7 @@ def test_build_doctor_report_fails_closed_when_extensions_cannot_be_disabled(tmp
     assert report.sqlite_health["status"] == "unavailable"
     assert report.reference_contracts["status"] == "unavailable"
     assert report.vector_coverage["status"] == "unavailable"
+    assert report.hygiene_summary["status"] == "unavailable"
 
 
 def test_build_doctor_report_uses_optional_sqlite_vec_for_real_vec0_tables(tmp_path):
@@ -235,7 +267,11 @@ def test_build_doctor_report_uses_optional_sqlite_vec_for_real_vec0_tables(tmp_p
 
     report = build_doctor_report("work", db_path)
 
-    vec_table = next(table for table in report.schema_fingerprint.tables if table.name == "vec_working")
+    vec_table = next(
+        (table for table in report.schema_fingerprint.tables if table.name == "vec_working"),
+        None,
+    )
+    assert vec_table is not None
     assert vec_table.status == STATUS_OK
     assert report.sqlite_health["vec0"]["status"] == "available"
     assert not any(finding.code == "sqlite.vec0_capability" for finding in report.findings)


### PR DESCRIPTION
## Summary
- load the installed optional `sqlite-vec` extension only inside Doctor’s already `mode=ro` / `query_only` connection
- retain `present_but_unloadable` when the optional load fails
- fail closed if extension loading cannot be disabled again

## Why this path
The Doctor already detects actual vec0-table capability, but it previously did so in a connection where the installed extension was never loaded. This produced a false `present_but_unloadable` warning for healthy sqlite-vec deployments.

## Non-goals / rollback
No provider, repair, schema, or data changes. If sqlite-vec is absent or fails to load, behavior remains the existing conservative warning path.

## Why not
Do not infer capability from package import/runtime diagnostics alone: the Doctor continues to query the live vec0 tables after loading.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider tests/test_doctor.py tests/test_doctor_cli.py -q` → 66 passed
- product-DB read-only smoke: vec0 `available`, no `sqlite.vec0_capability` warning
- regression coverage for extension disablement, load failure, real vec0 availability, and fail-closed disable failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates Doctor’s read-only reporting to load the installed optional `sqlite-vec` extension within its existing `mode=ro` / `query_only` connection.
- Prevents false diagnostics by keeping the existing `present_but_unloadable` fallback when `sqlite-vec` can’t be imported/loaded or when `vec0` is present but not usable in the current runtime.
- Adds “fail closed” safety: if extension loading cannot be disabled after enabling it, Doctor marks multiple report sections (`sqlite_health`, `reference_contracts`, `vector_coverage`, `hygiene_summary`) as unavailable and exits early, preserving the read-only contract.
- Adds targeted regression tests covering optional load behavior, fallback correctness, and failure-closed handling when extension enable/disable operations error.

## Architectural impact

- No changes to Mnemosyne’s core memory architecture (working/episodic/BEAM tiers), retrieval strategies, consolidation pipeline, veracity system, sync layer, schema/data model, or benchmark methodology.
- No changes to agent integration surfaces (Hermes, MCP, CLI command behavior beyond using the updated Doctor report builder).
- The right call for local-first/privacy: vector capability verification is done entirely against the local product database via Doctor’s bounded, content-safe read-only inspection (no repairs, no migrations, no data writes), and the connection is kept constrained (`mode=ro`, `query_only`) even when optional extension loading is attempted.
- Maintains long-term safety/maintainability by making extension lifecycle handling explicit and test-covered, specifically avoiding ambiguous “healthy runtime” vs “false warning” states for `vec0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->