### PR TITLE
fix(beam): make embedding dim-mismatch message explicitly self-healing

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -562,6 +562,32 @@ def _existing_vec_dim(conn: sqlite3.Connection) -> Optional[int]:
     return None
 
 
+def _dim_mismatch_message(existing_dim: int, configured_dim: int) -> str:
+    """Build the embedding-dimension-mismatch message.
+
+    Extracted as a pure function so the wording -- explicitly NOT corruption plus
+    the exact self-heal commands -- is unit-testable without a sqlite-vec
+    database. The phrasing matters: 'dimension mismatch' is otherwise misread as
+    'database corrupt', and users (and agent frameworks) abandon the store
+    instead of reindexing.
+    """
+    return (
+        f"Embedding dimension mismatch — NOT database corruption: your memories "
+        f"are intact, only the vector index is affected (recall falls back to "
+        f"keyword search until this is fixed). This database stores "
+        f"{existing_dim}-dim vectors but this process is configured for "
+        f"{configured_dim}-dim (MNEMOSYNE_EMBEDDING_DIM / "
+        f"MNEMOSYNE_EMBEDDING_MODEL); sqlite-vec tables were left untouched. To "
+        f"self-heal, choose ONE:\n"
+        f"  * Keep the existing {existing_dim}-dim vectors: relaunch with "
+        f"MNEMOSYNE_EMBEDDING_DIM={existing_dim} (and the matching model).\n"
+        f"  * Re-embed all memories at {configured_dim}-dim: run "
+        f"`MNEMOSYNE_EMBEDDING_DIM={configured_dim} mnemosyne reindex` (it backs "
+        f"up first).\n"
+        f"Run `mnemosyne doctor` to re-check."
+    )
+
+
 def init_beam(db_path: Path = None):
     """Initialize BEAM schema."""
     conn = _get_connection(db_path)
@@ -772,17 +798,7 @@ def init_beam(db_path: Path = None):
         existing_dim = _existing_vec_dim(conn)
         if existing_dim is not None and existing_dim != EMBEDDING_DIM:
             vec_dim_mismatch = True
-            logger.error(
-                "Embedding dimension mismatch: this database stores %d-dimensional "
-                "vectors, but the process is configured for %d "
-                "(MNEMOSYNE_EMBEDDING_DIM / embedding model). Not creating "
-                "sqlite-vec tables at the wrong dimension. Set "
-                "MNEMOSYNE_EMBEDDING_DIM / MNEMOSYNE_EMBEDDING_MODEL to match the "
-                "stored data, or run `mnemosyne reindex` to rebuild all vectors at "
-                "the configured dimension.",
-                existing_dim,
-                EMBEDDING_DIM,
-            )
+            logger.error(_dim_mismatch_message(existing_dim, EMBEDDING_DIM))
         else:
             try:
                 cursor.execute(f"""

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -88,3 +88,19 @@ def test_init_beam_creates_vec_tables_when_dim_matches(tmp_path, monkeypatch):
         "SELECT sql FROM sqlite_master WHERE name = 'vec_working'"
     ).fetchone()
     assert working is not None and "[768]" in working[0]
+
+
+def test_dim_mismatch_message_is_self_healing():
+    """The mismatch message must say it is NOT corruption and give the exact
+    self-heal commands, so it is not misread as 'the database is corrupt'.
+
+    The original failure mode: users (and agent frameworks) read 'dimension
+    mismatch' as corruption and abandon the store instead of reindexing. The
+    message is a pure function so it can be unit-tested without sqlite-vec.
+    """
+    msg = beam._dim_mismatch_message(existing_dim=768, configured_dim=384)
+    low = msg.lower()
+    assert "not database corruption" in low, msg
+    assert "mnemosyne reindex" in low, msg
+    assert "mnemosyne_embedding_dim=" in low, msg
+    assert "768" in msg and "384" in msg, msg


### PR DESCRIPTION
Closes #518.

## What
Rewrites the `init_beam` embedding-dimension-mismatch log message to be explicit and self-healing, so it is not misread as "database corrupt" (see #518 for the failure mode and observed impact).

## Why
The guard is correct — it leaves all memories and existing `vec0` tables untouched — but the old message ("dimension mismatch ... run `mnemosyne reindex`") gets misread as corruption, and users/agents abandon the store instead of reindexing. The new message states plainly that it is **not** corruption and gives both recovery paths with the exact commands.

## How
- Extract the message into a pure `_dim_mismatch_message(existing_dim, configured_dim)` helper (unit-testable without sqlite-vec).
- `init_beam` calls `logger.error(_dim_mismatch_message(existing_dim, EMBEDDING_DIM))`.
- Add `test_dim_mismatch_message_is_self_healing`.

## Behavior
Unchanged: same ERROR level, same trigger condition (`existing_dim != EMBEDDING_DIM`), `vec0` tables still left untouched. Pure refactor of the message text plus a new test — no change to `_get_embedding_dim` or the dim-resolution logic.

## Verification
`pytest tests/test_vec_dim_guard.py tests/test_embeddings_multilingual.py` → 15 passed, 3 skipped (sqlite-vec-gated). Deeper root-cause fixes (fail-loud/auto-detect dim, `doctor` dim check) are intentionally out of scope — tracked in #518.

CLA: happy to sign on review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Refactors the BEAM initialization embedding-dimension mismatch error into a pure helper (`_dim_mismatch_message(existing_dim, configured_dim)`) and updates `init_beam()` to use it.
- The logged message now explicitly states the database/memories are **not corrupt** and provides exact, local recovery commands (two self-heal paths via `MNEMOSYNE_EMBEDDING_DIM=... mnemosyne reindex` and a follow-up `mnemosyne doctor` hint), while keeping the same guard behavior: it still refuses to create mismatched `sqlite-vec` virtual tables and leaves existing `vec0`/vector structures untouched.
- Adds a unit test that locks down the self-healing message content (including both dimension values and `mnemosyne reindex` guidance).

## Architectural impact

- **Core memory architecture (tiered BEAM):** No behavioral changes to working memory, episodic storage, or the BEAM vector/FTS hybrid retrieval pipeline. The only change is operational clarity when BEAM’s `sqlite-vec` `vec0` schema dimension doesn’t match the configured embedding dimension.
- **Retrieval strategies & consolidation pipeline:** Unchanged. This PR does not modify ranking, recall logic, FTS5 behavior, vector reads/writes, or any consolidation/veracity computations.
- **Veracity system:** Unchanged; no consolidation/veracity parameters or logic were touched.
- **Local-first & privacy posture:** Preserved. Recovery is explicitly local via Mnemosyne CLI commands; no added networking, sync, or data movement is introduced.
- **Sync layer:** Unchanged (no sync code paths modified).
- **Agent integration surfaces (Hermes, MCP, CLI):** No API surface changes. The improvement is limited to clearer operator feedback during BEAM schema initialization, which benefits CLI users and any agent frameworks that surface the same startup/log error.
- **Long-term maintainability:** Improves diagnostics maintainability by isolating the error text into a testable pure function, reducing risk of future wording regressions and making the “self-heal” guidance easier to evolve safely.

## Verification

- 15 tests passed; 3 skipped due to `sqlite-vec` gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->