### PR TITLE
fix: serialize Beam access to prevent SEGV in auto_sleep daemon

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -2265,6 +2265,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         """Initialize sync_turn telemetry for tests that construct via __new__."""
         if not hasattr(self, "_sync_turn_lock"):
             self._sync_turn_lock = threading.Lock()
+        if not hasattr(self, "_beam_access_lock"):
+            self._beam_access_lock = threading.Lock()
         if not hasattr(self, "_sync_turn_telemetry"):
             self._sync_turn_telemetry = {
                 "pending_queue_length": 0,

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1362,6 +1362,12 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         self._agent_context = "primary"
         self._turn_count = 0
         self._sync_turn_lock = threading.Lock()
+        # Serialize all Beam/SQLite access between the main thread and the
+        # auto_sleep daemon thread.  Without this, concurrent connections to
+        # the same WAL database can trigger a NULL-pointer SEGV in
+        # sqlite3_clear_bindings when a checkpoint invalidates an active
+        # statement on the other connection (#498).
+        self._beam_access_lock = threading.Lock()
         self._sync_turn_telemetry: Dict[str, Any] = {
             "pending_queue_length": 0,
             "max_queue_length": 0,
@@ -2201,7 +2207,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             # sessions) should never bypass session scoping.
             if author_id:
                 recall_kwargs["author_id"] = author_id
-            results = self._beam.recall(**recall_kwargs)
+            with self._beam_access_lock:
+                results = self._beam.recall(**recall_kwargs)
             if not results:
                 return ""
             # Filter out low-relevance results to prevent context pollution.
@@ -2304,27 +2311,28 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 in_flight,
             )
         try:
-            if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
-                user_limit = _sync_turn_user_limit()
-                uc = user_content[:user_limit] if user_limit > 0 else user_content
-                self._beam.remember(
-                    content=f"[USER] {uc}",
-                    source="conversation",
-                    importance=0.5,
-                    scope=self._default_scope,
-                    extract_entities=True,
-                )
-                self._capture_identity_signals(user_content)
-            if "assistant" in self._sync_roles and assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
-                assistant_limit = _sync_turn_assistant_limit()
-                ac = assistant_content[:assistant_limit] if assistant_limit > 0 else assistant_content
-                self._beam.remember(
-                    content=f"[ASSISTANT] {ac}",
-                    source="conversation",
-                    importance=0.15,
-                    scope=self._default_scope,
-                    extract_entities=True,
-                )
+            with self._beam_access_lock:
+                if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
+                    user_limit = _sync_turn_user_limit()
+                    uc = user_content[:user_limit] if user_limit > 0 else user_content
+                    self._beam.remember(
+                        content=f"[USER] {uc}",
+                        source="conversation",
+                        importance=0.5,
+                        scope=self._default_scope,
+                        extract_entities=True,
+                    )
+                    self._capture_identity_signals(user_content)
+                if "assistant" in self._sync_roles and assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
+                    assistant_limit = _sync_turn_assistant_limit()
+                    ac = assistant_content[:assistant_limit] if assistant_limit > 0 else assistant_content
+                    self._beam.remember(
+                        content=f"[ASSISTANT] {ac}",
+                        source="conversation",
+                        importance=0.15,
+                        scope=self._default_scope,
+                        extract_entities=True,
+                    )
             self._turn_count += 1
             if self._auto_sleep_enabled and self._turn_count % 10 == 0:
                 self._maybe_auto_sleep()
@@ -2415,6 +2423,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 # main thread's sync_turn() writes, causing episodic INSERT
                 # failures (commit rolled back by concurrent main-thread writes).
                 beam_ref = self._beam
+                beam_lock = self._beam_access_lock
                 def _sleep_isolated():
                     try:
                         BeamClass = _get_beam_class()
@@ -2425,7 +2434,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                             author_type=beam_ref.author_type,
                             channel_id=beam_ref.channel_id,
                         )
-                        sleep_beam.sleep()
+                        with beam_lock:
+                            sleep_beam.sleep()
                     except Exception as inner:
                         logger.debug("Mnemosyne auto-sleep worker failed: %s", inner)
                 sleep_thread = threading.Thread(target=_sleep_isolated, daemon=True)


### PR DESCRIPTION
## Problem

The auto_sleep daemon thread creates a separate `BeamMemory` connection and calls `sleep()`, which triggers WAL checkpointing. If the main thread's `sync_turn()` or `prefetch()` has an active statement on its own connection at the same time, `sqlite3_clear_bindings` can NULL-deref when the checkpoint invalidates the statement.

This causes a hard SEGV (signal 11) that kills the Hermes process.

## Fix

Add a provider-level `_beam_access_lock` that serializes all Beam/SQLite access between the main thread and the auto_sleep daemon thread:

- **Daemon thread**: `sleep_beam.sleep()` wrapped in lock
- **Main thread**: `sync_turn()` Beam writes wrapped in lock
- **Main thread**: `prefetch()` Beam recall wrapped in lock

This prevents concurrent WAL access between the two connections, eliminating the race condition.

## Testing

- Existing test suite passes (no behavioral change, only serialization)
- The lock is uncontended in normal operation (daemon sleeps every 10 turns, main thread operations are brief)
- Worst case: a brief delay in sync_turn/prefetch while sleep completes

Closes #498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR hardens Mnemosyne’s Hermes memory provider against a crash caused by concurrent Beam/SQLite access during auto-sleep consolidation. It introduces a provider-level `_beam_access_lock` that serializes BEAM reads (prefetch/recall) and writes (sync_turn/remember) with the daemon-thread `sleep()` path, preventing the WAL/checkpoint race that led to null-pointer failures in SQLite.

## Architectural impact

- **Tiered memory (working → episodic → BEAM):** No changes to consolidation semantics or the tiering model. The auto-sleep pipeline remains the mechanism that compresses older working memories into episodic summaries; it’s simply protected from concurrent access while SQLite/WAL is checkpointing.
- **Retrieval strategy:** Prefetch (`prefetch()`/bank recall) continues using the same hybrid recall + relevance filtering; it now acquires the lock around `self._beam.recall(...)` to avoid racing with consolidation.
- **Sync/persistence surfaces:** `sync_turn()` still performs the same role-scoped autosave behavior (including existing user/assistant gating and filtering/length truncation), but writes are executed under the same lock around `self._beam.remember(...)`.
- **Veracity system:** No changes to veracity tagging/updates; the lock only governs concurrency at the Beam/SQLite boundary.
- **Sync layer:** No changes to peer sync/checkpointing logic (event delivery/checkpoints remain untouched); this is strictly a concurrency safety fix inside the provider’s BEAM access pattern.

## Agent integration surfaces (Hermes/MCP/CLI)

Hermes (memory-context injection via pre-turn prefetch, post-turn sync via `sync_turn()`, and the auto-sleep daemon triggered on turns) gains stability when retrieval overlaps with consolidation. MCP and CLI integration points are not functionally altered; they benefit indirectly through the same underlying provider safety.

## Privacy & local-first posture

No external services or new data flows are introduced. The change is internal synchronization only, preserving Mnemosyne’s local-first design and privacy stance.

## Maintainability

Centralizing the SQLite/BEAM concurrency invariant at the provider boundary makes the “no concurrent Beam access across daemon-thread sleep vs main-thread recall/remember” rule explicit and easier to reason about going forward. Tests that construct providers via `__new__` are supported via lazy lock/telemetry initialization.

## Benchmarking

No benchmarking methodology changes or new performance claims were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->