### PR TITLE
fix: isolate enhanced recall cache requests

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6662,6 +6662,126 @@ class BeamMemory:
 
         return final_results
 
+    def _enhanced_recall_cache_key(
+        self,
+        *,
+        original_query: str,
+        expanded_query: str,
+        top_k: int,
+        runtime: Any,
+        use_weibull: bool,
+        use_mmr: bool,
+        use_intent: bool,
+        use_synonyms: bool,
+        use_associative: bool,
+        associative_depth: int,
+        mmr_lambda: float,
+        recall_kwargs: Dict[str, Any],
+    ) -> str:
+        """Build a versioned opaque key for one effective enhanced request."""
+        def canonicalize(value: Any) -> Any:
+            if isinstance(value, datetime):
+                return _normalize_datetime_utc(value).isoformat()
+            if isinstance(value, Path):
+                return str(value.resolve())
+            if isinstance(value, dict):
+                return {str(key): canonicalize(val) for key, val in value.items()}
+            if isinstance(value, (list, tuple)):
+                return [canonicalize(item) for item in value]
+            if isinstance(value, set):
+                return sorted(canonicalize(item) for item in value)
+            if value is None or isinstance(value, (str, int, float, bool)):
+                return value
+            return str(value)
+
+        raw_weights = (
+            recall_kwargs.get("vec_weight"),
+            recall_kwargs.get("fts_weight"),
+            recall_kwargs.get("importance_weight"),
+        )
+        resolved_weights = _normalize_weights(*raw_weights)
+        if (all(weight is None for weight in raw_weights)
+                and os.environ.get("MNEMOSYNE_QUERY_INTENT", "0") == "1"
+                and classify_intent is not None and adjust_weights is not None):
+            try:
+                resolved_weights = adjust_weights(
+                    base_vec=resolved_weights[0],
+                    base_fts=resolved_weights[1],
+                    base_importance=resolved_weights[2],
+                    intent=classify_intent(expanded_query),
+                )
+            except Exception:
+                logger.debug("query intent adjustment failed while building cache key", exc_info=True)
+
+        temporal_halflife = recall_kwargs.get("temporal_halflife")
+        if temporal_halflife is None:
+            temporal_halflife = float(os.environ.get("MNEMOSYNE_TEMPORAL_HALFLIFE_HOURS", "24"))
+
+        db_namespace = str(self.db_path.resolve())
+        payload = {
+            "version": 2,
+            "db_namespace": hashlib.sha256(db_namespace.encode("utf-8")).hexdigest(),
+            "query": {"original": original_query, "expanded": expanded_query},
+            "scope": {
+                "session_id": self.session_id,
+                "cross_session": bool(runtime.cross_session),
+            },
+            "top_k": top_k,
+            "recall_kwargs": canonicalize(recall_kwargs),
+            "resolved": {
+                "weights": resolved_weights,
+                "temporal_halflife": temporal_halflife,
+                "recency_halflife": RECENCY_HALFLIFE_HOURS,
+                "veracity_weights": {
+                    "stated": STATED_WEIGHT,
+                    "inferred": INFERRED_WEIGHT,
+                    "tool": TOOL_WEIGHT,
+                    "imported": IMPORTED_WEIGHT,
+                    "unknown": UNKNOWN_WEIGHT,
+                },
+            },
+            "enhanced": {
+                "weibull": use_weibull,
+                "mmr": use_mmr,
+                "intent": use_intent,
+                "synonyms": use_synonyms,
+                "associative": use_associative,
+                "associative_depth": associative_depth,
+                "mmr_lambda": mmr_lambda,
+            },
+            # Keep every dynamic recall mode in the material.  This is
+            # intentionally conservative: a harmless extra miss is preferable
+            # to returning a result ranked by a different active pipeline.
+            "active": {
+                "weibull_module": weibull_boost is not None,
+                "mmr_module": mmr_rerank is not None,
+                "intent_modules": classify_intent is not None and adjust_weights is not None,
+                "synonym_module": expand_query is not None,
+                "associative_graph": self.episodic_graph is not None,
+                "embeddings_available": _embeddings.available(),
+                "embedding_model": getattr(_embeddings, "_DEFAULT_MODEL", None),
+                "embedding_dimension": getattr(_embeddings, "EMBEDDING_DIM", None),
+                "embedding_query_prefix": os.environ.get("MNEMOSYNE_EMBEDDING_QUERY_PREFIX", ""),
+                "beam_optimizations": _BEAM_MODE,
+                "polyphonic_recall": os.environ.get("MNEMOSYNE_POLYPHONIC_RECALL", "0") == "1",
+                "query_intent": os.environ.get("MNEMOSYNE_QUERY_INTENT", "0") == "1",
+                "fact_recall": os.environ.get("MNEMOSYNE_FACT_RECALL_ENABLED", "0") == "1",
+                "lenient_fact_match": _env_truthy("MNEMOSYNE_LENIENT_FACT_MATCH"),
+                "graph_bonus": not _env_disabled("MNEMOSYNE_GRAPH_BONUS"),
+                "fact_bonus": not _env_disabled("MNEMOSYNE_FACT_BONUS"),
+                "binary_bonus": not _env_disabled("MNEMOSYNE_BINARY_BONUS"),
+                "veracity_multiplier": not _env_disabled("MNEMOSYNE_VERACITY_MULTIPLIER"),
+                "cross_tier_dedup": not _env_disabled("MNEMOSYNE_CROSS_TIER_DEDUP"),
+                "vec_type": VEC_TYPE,
+                "recall_stopwords": sorted(_extra_recall_stopwords),
+                "episodic_recall_limit": EPISODIC_RECALL_LIMIT,
+                "tier_days": (TIER2_DAYS, TIER3_DAYS),
+                "tier_weights": (TIER1_WEIGHT, TIER2_WEIGHT, TIER3_WEIGHT),
+            },
+        }
+        material = json.dumps(canonicalize(payload), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        return "v2:" + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
     def recall_enhanced(self, query: str, top_k: int = 40, *,
                         use_cache: bool = True,
                         use_weibull: bool = True,
@@ -6717,25 +6837,43 @@ class BeamMemory:
         if use_synonyms and expand_query is not None:
             expanded_query = expand_query(query)
 
-        # 3. Query cache check (Tier 1-4). Scope cache entries by the
-        # resolved runtime snapshot, otherwise a hot config reload can expose
-        # results cached under a different session/isolation policy.
+        # 3. Query cache check.  Opaque v2 keys use QueryCache's exact-only
+        # path, so no semantic tier can reuse a different effective request.
         runtime = resolve_beam_runtime()
-        cache_key = f"{self.session_id}\x1f{int(runtime.cross_session)}\x1f{original_query}"
+        explain = bool(kwargs.get("explain", False))
+        cache_key = self._enhanced_recall_cache_key(
+            original_query=original_query,
+            expanded_query=expanded_query,
+            top_k=top_k,
+            runtime=runtime,
+            use_weibull=use_weibull,
+            use_mmr=use_mmr,
+            use_intent=use_intent,
+            use_synonyms=use_synonyms,
+            use_associative=use_associative,
+            associative_depth=associative_depth,
+            mmr_lambda=mmr_lambda,
+            recall_kwargs=kwargs,
+        )
         cached = None
-        if use_cache and QueryCache is not None:
+        if use_cache and not explain and QueryCache is not None:
             if not hasattr(self, '_query_cache'):
                 cache_db = self.db_path.parent / "query_cache.db"
                 self._query_cache = QueryCache(db_path=cache_db)
-            cached = self._query_cache.get(cache_key)
+            cached = self._query_cache.get_opaque(cache_key)
 
         if cached is not None:
-            return cached[:top_k]
+            # ``top_k`` is part of the v2 digest, so truncating here would
+            # make a hit differ from the cached pipeline result (notably when
+            # associative retrieval appends related memories after top-k).
+            return cached
 
         # 4. Run base recall with expanded query
         results = self.recall(
             expanded_query, top_k=top_k * 2, _cross_session=runtime.cross_session, **kwargs
         )
+        if explain:
+            return results
 
         # 5. Weibull re-scoring (if not already using temporal_weight)
         if use_weibull and weibull_boost is not None:
@@ -6820,8 +6958,8 @@ class BeamMemory:
                 logger.info("Regex extraction failed, skipping", exc_info=True)
 
         # 9. Cache results
-        if use_cache and hasattr(self, '_query_cache') and self._query_cache is not None:
-            self._query_cache.put(cache_key, results)
+        if use_cache and not explain and hasattr(self, '_query_cache') and self._query_cache is not None:
+            self._query_cache.put_opaque(cache_key, results)
 
         return results
 

--- a/mnemosyne/core/query_cache.py
+++ b/mnemosyne/core/query_cache.py
@@ -31,11 +31,20 @@ Usage:
 
 import json
 import math
+import re
 import time
 import threading
 from typing import List, Dict, Optional
 from pathlib import Path
 import sqlite3
+
+
+_OPAQUE_V2_KEY_RE = re.compile(r"v2:[0-9a-f]{64}")
+
+
+def _is_opaque_v2_key(key: str) -> bool:
+    """Return whether *key* is an enhanced-recall request digest."""
+    return bool(_OPAQUE_V2_KEY_RE.fullmatch(key))
 
 
 class QueryCache:
@@ -63,6 +72,11 @@ class QueryCache:
         
         # Tier 4: Expanded query cache
         self._tier4: Dict[str, List[Dict]] = {}
+
+        # Opaque v2 request keys bypass every fuzzy tier.  They are used by
+        # enhanced recall, whose full request digest is not a natural-language
+        # query and must therefore be matched byte-for-byte.
+        self._opaque: Dict[str, List[Dict]] = {}
         
         # Thread safety
         self._lock = threading.Lock()
@@ -109,8 +123,12 @@ class QueryCache:
             for row in cursor.fetchall():
                 try:
                     results = json.loads(row["results_json"])
-                    self._tier1[row["normalized"]] = results
-                    self._tier4[row["normalized"]] = results
+                    key = row["normalized"]
+                    if _is_opaque_v2_key(key):
+                        self._opaque[key] = results
+                    else:
+                        self._tier1[key] = results
+                        self._tier4[key] = results
                 except Exception:
                     pass
         except Exception:
@@ -123,6 +141,7 @@ class QueryCache:
             self._tier1.clear()
             self._tier2_3.clear()
             self._tier4.clear()
+            self._opaque.clear()
             self._insert_times.clear()
             if self._conn:
                 self._conn.execute("DELETE FROM query_cache")
@@ -163,16 +182,10 @@ class QueryCache:
         return len(words_a & words_b) / len(words_a | words_b)
     
     def get(self, query: str, embedding: List[float] = None) -> Optional[List[Dict]]:
-        """
-        Try to retrieve cached results for a query.
-        
-        Args:
-            query: The search query
-            embedding: Pre-computed embedding of the query (for Tier 2-3 comparison)
-            
-        Returns:
-            Cached results or None if cache miss
-        """
+        """Retrieve a semantic entry, or exact-match an enhanced request digest."""
+        # Only complete SHA-256 request digests bypass the semantic tiers.
+        if _is_opaque_v2_key(query):
+            return self.get_opaque(query)
         normalized = self._normalize(query)
         
         with self._lock:
@@ -245,11 +258,29 @@ class QueryCache:
             
             self.misses += 1
             return None
+
+    def get_opaque(self, key: str) -> Optional[List[Dict]]:
+        """Retrieve an opaque v2 key without normalization or fuzzy matching."""
+        if not _is_opaque_v2_key(key):
+            return self.get(key)
+        with self._lock:
+            now = time.time()
+            if key in self._insert_times and now - self._insert_times[key] > self.ttl_seconds:
+                self._opaque.pop(key, None)
+                self._insert_times.pop(key, None)
+                self.misses += 1
+                return None
+            if key in self._opaque:
+                self.hits += 1
+                return self._opaque[key]
+            self.misses += 1
+            return None
     
     def put(self, query: str, results: List[Dict], embedding: List[float] = None):
-        """
-        Store results in all applicable cache tiers.
-        """
+        """Store a semantic entry, or an enhanced request digest as opaque."""
+        if _is_opaque_v2_key(query):
+            self.put_opaque(query, results)
+            return
         normalized = self._normalize(query)
         
         with self._lock:
@@ -277,6 +308,25 @@ class QueryCache:
             
             # Evict if over max_size
             self._evict_if_needed()
+
+    def put_opaque(self, key: str, results: List[Dict]):
+        """Store an opaque v2 key without adding it to any fuzzy tier."""
+        if not _is_opaque_v2_key(key):
+            self.put(key, results)
+            return
+        with self._lock:
+            self._opaque[key] = results
+            self._insert_times[key] = time.time()
+            if self._conn:
+                try:
+                    self._conn.execute(
+                        "INSERT OR REPLACE INTO query_cache (normalized, embedding_json, results_json) VALUES (?, ?, ?)",
+                        (key, None, json.dumps(results)),
+                    )
+                    self._conn.commit()
+                except Exception:
+                    pass
+            self._evict_if_needed()
     
     def _evict_if_needed(self):
         """LRU eviction if cache exceeds max_size. Also cleans TTL-expired entries."""
@@ -290,10 +340,11 @@ class QueryCache:
             self._tier1.pop(key, None)
             self._tier2_3.pop(key, None)
             self._tier4.pop(key, None)
+            self._opaque.pop(key, None)
             self._insert_times.pop(key, None)
         
         # Then evict oldest if still over max_size
-        total = len(self._tier1)
+        total = len(self._tier1) + len(self._opaque)
         if total > self.max_size:
             sorted_keys = sorted(
                 self._insert_times.keys(),
@@ -304,6 +355,7 @@ class QueryCache:
                 self._tier1.pop(key, None)
                 self._tier2_3.pop(key, None)
                 self._tier4.pop(key, None)
+                self._opaque.pop(key, None)
                 self._insert_times.pop(key, None)
     
     def close(self):
@@ -335,7 +387,7 @@ class QueryCache:
             "tier2_hits": self.tier2_hits,
             "tier3_hits": self.tier3_hits,
             "tier4_hits": self.tier4_hits,
-            "size": len(self._tier1),
+            "size": len(self._tier1) + len(self._opaque),
             "max_size": self.max_size,
             "version": self._cache_version,
         }

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -1,0 +1,272 @@
+"""Regression coverage for enhanced-recall cache request isolation (#513)."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mnemosyne.core import beam as beam_module
+from mnemosyne.core.beam import BeamMemory
+from mnemosyne.core.query_cache import QueryCache
+
+
+@pytest.fixture
+def enhanced(monkeypatch, tmp_path: Path):
+    """A deterministic enhanced-recall instance whose base pipeline is observable."""
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "1")
+    monkeypatch.setattr(
+        beam_module, "resolve_beam_runtime", lambda: SimpleNamespace(cross_session=False)
+    )
+    memory = BeamMemory(session_id="session-a", db_path=tmp_path / "memories.db")
+    calls = []
+
+    def fake_recall(query, top_k=40, **kwargs):
+        calls.append((query, top_k, kwargs.copy()))
+        if kwargs.get("explain"):
+            return {
+                "query": query,
+                "top_k": top_k,
+                "engine": "linear",
+                "results": [{"id": "explained", "content": query, "score": 1.0}],
+                "explain": {"trace": "kept"},
+            }
+        return [{"id": f"result-{len(calls)}", "content": query, "score": 1.0}]
+
+    memory.recall = fake_recall
+    yield memory, calls
+    memory.conn.close()
+    if getattr(memory, "_query_cache", None) is not None:
+        memory._query_cache.close()
+
+
+def _call(memory: BeamMemory, query: str = "private query", **kwargs):
+    return memory.recall_enhanced(
+        query,
+        use_weibull=False,
+        use_mmr=False,
+        use_intent=False,
+        use_synonyms=False,
+        **kwargs,
+    )
+
+
+def test_v2_request_digest_is_opaque_persisted_and_exact_hits_once(enhanced):
+    memory, calls = enhanced
+
+    first = _call(memory, "private query", top_k=3)
+    second = _call(memory, "private query", top_k=3)
+
+    assert first == second
+    assert len(calls) == 1
+    assert memory._query_cache is not None
+    rows = memory._query_cache._conn.execute("SELECT normalized FROM query_cache").fetchall()
+    assert len(rows) == 1
+    key = rows[0][0]
+    assert key.startswith("v2:")
+    assert len(key) == len("v2:") + 64
+    assert all(character in "0123456789abcdef" for character in key[3:])
+    assert "private query" not in key
+    assert "session-a" not in key
+    assert str(memory.db_path) not in key
+
+
+def test_v2_prefixed_natural_language_uses_normalization_after_reload(tmp_path: Path):
+    db_path = tmp_path / "query-cache.db"
+    cache = QueryCache(db_path=db_path)
+    natural_query = "v2: hello world"
+    equivalent_query = "WORLD v2: HELLO"
+    legacy_query = "v2: zebra"
+    legacy_equivalent = "zebra v2:"
+    natural_results = [{"id": "natural", "content": natural_query, "score": 1.0}]
+    legacy_results = [{"id": "legacy", "content": legacy_query, "score": 1.0}]
+
+    cache.put(natural_query, natural_results, embedding=[1.0])
+    cache.put(legacy_query, legacy_results, embedding=[1.0])
+
+    assert cache.get(equivalent_query, embedding=[1.0]) == natural_results
+    assert cache.get(legacy_equivalent, embedding=[1.0]) == legacy_results
+    assert cache._opaque == {}
+    assert cache._normalize(natural_query) in cache._tier1
+    assert cache._normalize(legacy_query) in cache._tier1
+    cache.close()
+
+    reloaded = QueryCache(db_path=db_path)
+    try:
+        assert reloaded.get(equivalent_query, embedding=[1.0]) == natural_results
+        assert reloaded.get(legacy_equivalent, embedding=[1.0]) == legacy_results
+        assert reloaded._opaque == {}
+        assert reloaded._normalize(natural_query) in reloaded._tier1
+        assert reloaded._normalize(legacy_query) in reloaded._tier1
+    finally:
+        reloaded.close()
+
+
+def test_effective_request_variants_do_not_cross_hit(enhanced):
+    memory, calls = enhanced
+    base = {
+        "top_k": 3,
+        "source": "email",
+        "channel_id": "channel-a",
+        "author_id": "author-a",
+        "author_type": "agent",
+        "veracity": "stated",
+        "memory_type": "fact",
+        "topic": "security",
+        "from_date": "2026-01-01",
+        "to_date": "2026-01-31",
+        "temporal_weight": 0.3,
+        "query_time": datetime(2026, 1, 15, tzinfo=timezone.utc),
+        "temporal_halflife": 12.0,
+        "vec_weight": 0.2,
+        "fts_weight": 0.7,
+        "importance_weight": 0.1,
+        "use_associative": True,
+        "associative_depth": 2,
+        "mmr_lambda": 0.4,
+    }
+    _call(memory, **base)
+    assert len(calls) == 1
+
+    variants = [
+        {"top_k": 4},
+        {"source": "slack"},
+        {"channel_id": "channel-b"},
+        {"author_id": "author-b"},
+        {"author_type": "human"},
+        {"veracity": "inferred"},
+        {"memory_type": "preference"},
+        {"topic": "operations"},
+        {"from_date": "2026-01-02"},
+        {"to_date": "2026-02-01"},
+        {"temporal_weight": 0.4},
+        {"query_time": datetime(2026, 1, 16, tzinfo=timezone.utc)},
+        {"temporal_halflife": 24.0},
+        {"vec_weight": 0.3},
+        {"use_associative": False},
+        {"associative_depth": 3},
+        {"mmr_lambda": 0.8},
+    ]
+    for change in variants:
+        _call(memory, **(base | change))
+
+    assert len(calls) == 1 + len(variants)
+
+
+def test_pipeline_flags_and_process_ranking_configuration_change_digest(enhanced, monkeypatch):
+    memory, _ = enhanced
+    runtime = SimpleNamespace(cross_session=False)
+    common = dict(
+        original_query="private query",
+        expanded_query="private query",
+        top_k=3,
+        runtime=runtime,
+        use_weibull=False,
+        use_mmr=False,
+        use_intent=False,
+        use_synonyms=False,
+        use_associative=False,
+        associative_depth=1,
+        mmr_lambda=0.7,
+        recall_kwargs={},
+    )
+    baseline = memory._enhanced_recall_cache_key(**common)
+
+    assert memory._enhanced_recall_cache_key(**(common | {"use_mmr": True})) != baseline
+    assert memory._enhanced_recall_cache_key(**(common | {"use_weibull": True})) != baseline
+    assert memory._enhanced_recall_cache_key(**(common | {"use_intent": True})) != baseline
+    assert memory._enhanced_recall_cache_key(**(common | {"use_synonyms": True})) != baseline
+    assert memory._enhanced_recall_cache_key(**(common | {"use_associative": True})) != baseline
+
+    monkeypatch.setattr(beam_module, "TIER2_DAYS", beam_module.TIER2_DAYS + 1)
+    assert memory._enhanced_recall_cache_key(**common) != baseline
+
+    monkeypatch.undo()
+    monkeypatch.setenv("MNEMOSYNE_CROSS_TIER_DEDUP", "0")
+    assert memory._enhanced_recall_cache_key(**common) != baseline
+
+    monkeypatch.undo()
+    monkeypatch.setattr(beam_module, "weibull_boost", None)
+    assert memory._enhanced_recall_cache_key(**common) != baseline
+
+
+def test_sessions_cross_session_and_sibling_databases_are_isolated(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "1")
+    runtime = SimpleNamespace(cross_session=False)
+    monkeypatch.setattr(beam_module, "resolve_beam_runtime", lambda: runtime)
+    db_a = tmp_path / "a.db"
+    session_a = BeamMemory(session_id="session-a", db_path=db_a)
+    session_b = BeamMemory(session_id="session-b", db_path=db_a)
+    sibling = BeamMemory(session_id="session-a", db_path=tmp_path / "b.db")
+    calls = {"a": 0, "b": 0, "sibling": 0}
+
+    def fake(label):
+        def recall(query, top_k=40, **kwargs):
+            calls[label] += 1
+            return [{"id": label, "content": label, "score": 1.0}]
+        return recall
+
+    session_a.recall = fake("a")
+    session_b.recall = fake("b")
+    sibling.recall = fake("sibling")
+    try:
+        _call(session_a)
+        _call(session_a)
+        _call(session_b)
+        _call(sibling)
+        assert calls == {"a": 1, "b": 1, "sibling": 1}
+
+        runtime.cross_session = True
+        _call(session_a)
+        assert calls["a"] == 2
+    finally:
+        for memory in (session_a, session_b, sibling):
+            memory.conn.close()
+            if getattr(memory, "_query_cache", None) is not None:
+                memory._query_cache.close()
+
+
+def test_bypass_and_explain_never_read_or_write_the_cache(enhanced):
+    memory, calls = enhanced
+
+    cached = _call(memory, "bypass query")
+    bypassed = _call(memory, "bypass query", use_cache=False)
+    assert len(calls) == 2
+    assert bypassed[0]["id"] != cached[0]["id"]
+    assert _call(memory, "bypass query") == cached
+    assert len(calls) == 2
+
+    normal = _call(memory, "explain query")
+    explained = _call(memory, "explain query", explain=True)
+    assert explained["engine"] == "linear"
+    assert explained["explain"] == {"trace": "kept"}
+    assert len(calls) == 4
+    assert _call(memory, "explain query") == normal
+    assert len(calls) == 4
+
+
+def test_legacy_entries_and_every_opaque_access_path_are_exact_only(enhanced):
+    memory, calls = enhanced
+    cache = QueryCache(max_size=20)
+    legacy_key = "session-a\x1f0\x1fprivate query"
+    cache.put(legacy_key, [{"id": "legacy", "content": "legacy", "score": 1.0}], embedding=[1.0])
+    memory._query_cache = cache
+
+    assert _call(memory)[0]["id"] != "legacy"
+    assert len(calls) == 1
+
+    opaque = "v2:" + hashlib.sha256(b"request-a").hexdigest()
+    different = "v2:" + hashlib.sha256(b"request-b").hexdigest()
+    cache.put(opaque, [{"id": "opaque", "content": "opaque", "score": 1.0}])
+    cache.put("semantic source", [{"id": "semantic", "content": "semantic", "score": 1.0}], embedding=[1.0])
+
+    assert cache.get(opaque, embedding=[1.0])[0]["id"] == "opaque"
+    assert cache.get_opaque(opaque)[0]["id"] == "opaque"
+    assert cache.get(different, embedding=[1.0]) is None
+    assert cache.get_opaque(different) is None
+    assert cache.tier2_hits == 0
+    assert cache.tier3_hits == 0
+    assert cache.tier4_hits == 0


### PR DESCRIPTION
## Summary

Fixes #513 by making Enhanced Recall's persistent cache identity depend on the full effective request rather than only normalized query text.

- use a canonical, opaque `v2:` SHA-256 request key for Enhanced Recall
- isolate database namespace, scope, filters, ranking/temporal inputs, and enabled pipeline options
- route valid opaque keys through exact-only cache access, bypassing all semantic/fuzzy tiers
- preserve the legacy generic `QueryCache` behavior for ordinary strings beginning with `v2:`
- bypass cache reads and writes for `explain=True` and `use_cache=False`

## Verification

```text
uv run --extra test pytest -q tests/test_enhanced_recall_cache.py tests/test_query_cache_synonyms.py tests/test_query_intent_recall.py tests/test_config_cross_session_runtime.py
25 passed in 18.23s
```

Also checked with `git diff --check` and an independent read-only review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevents Enhanced Recall cache collisions by deriving a canonical opaque `v2:` SHA-256 key from the full effective request, including scope, filters, ranking, temporal inputs, and pipeline options.
- Adds exact-only opaque cache access that bypasses semantic/fuzzy tiers, while preserving legacy behavior for ordinary `v2:`-prefixed strings.
- Bypasses cache reads and writes for `explain=True` and `use_cache=False`.
- Adds regression coverage for request variants, pipeline configuration, session/database isolation, persistence, legacy compatibility, and bypass behavior.

## Architectural impact

This strengthens BEAM/Enhanced Recall retrieval without changing working or episodic memory tiers, consolidation, veracity, synchronization, or agent integration surfaces such as Hermes, MCP, and the CLI. It preserves local SQLite-backed caching and therefore maintains Mnemosyne’s local-first and privacy posture: no new external service, telemetry path, or plaintext query data is introduced into the opaque key.

The exact request identity is the right call for correctness and maintainability. Dedicated opaque storage, TTL handling, eviction, persistence, and statistics keep enhanced retrieval isolated from fuzzy query semantics and make future result-affecting options easier to include safely. The expanded targeted tests provide focused regression coverage, though they do not represent a broader benchmark methodology change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->