### PR TITLE
fix: mnemosyne_invalidate returns memory_not_found when no row matched

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -2913,13 +2913,15 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         replacement_id = args.get("replacement_id", None) or None
         if not memory_id:
             return json.dumps({"error": "memory_id is required"})
-        self._beam.invalidate(memory_id, replacement_id=replacement_id if replacement_id else None)
+        ok = self._beam.invalidate(memory_id, replacement_id=replacement_id)
         self._audit_event(
             "invalidate", memory_id=memory_id, bank="private",
             source_tool="mnemosyne_invalidate",
-            metadata={"replacement_id": replacement_id} if replacement_id else None,
+            metadata={"replacement_id": replacement_id, "invalidated": ok} if replacement_id else {"invalidated": ok},
         )
-        return json.dumps({"status": "invalidated", "memory_id": memory_id})
+        if ok:
+            return json.dumps({"status": "invalidated", "memory_id": memory_id})
+        return json.dumps({"status": "memory_not_found", "memory_id": memory_id})
 
     def _handle_validate(self, args: Dict[str, Any]) -> str:
         """Collaborative attestation: any agent can attest, update, invalidate,

--- a/tests/test_hermes_memory_provider_audit.py
+++ b/tests/test_hermes_memory_provider_audit.py
@@ -96,6 +96,22 @@ class TestAuditIntegration:
         assert events[0]["action"] == "invalidate"
         assert events[0]["memory_id"] == stored["memory_id"]
 
+    def test_invalidate_not_found_returns_status(self, tmp_path):
+        provider = _provider(tmp_path)
+        result = _call(provider, "mnemosyne_invalidate", {"memory_id": "nonexistent-id"})
+        assert result["status"] == "memory_not_found"
+        assert result["memory_id"] == "nonexistent-id"
+
+    def test_invalidate_success_returns_status(self, tmp_path):
+        provider = _provider(tmp_path)
+        stored = _call(provider, "mnemosyne_remember", {
+            "content": "will be invalidated",
+            "source": "fact",
+        })
+        result = _call(provider, "mnemosyne_invalidate", {"memory_id": stored["memory_id"]})
+        assert result["status"] == "invalidated"
+        assert result["memory_id"] == stored["memory_id"]
+
     def test_sleep_creates_audit_event(self, tmp_path):
         provider = _provider(tmp_path)
         _call(provider, "mnemosyne_remember", {


### PR DESCRIPTION
fix: mnemosyne_invalidate returns memory_not_found when no row matched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed Hermes’ `mnemosyne_invalidate` integration to return `memory_not_found` when no matching memory exists, while preserving the requested `memory_id`.
- Added audit metadata for the invalidation outcome and optional replacement memory.
- Added integration coverage for both successful and unsuccessful invalidation.

## Architectural impact

- **Agent integration:** Improves the Hermes tool contract and gives agents reliable feedback about whether a memory was actually removed.
- **Privacy and local-first behavior:** No changes to storage, data flow, synchronization, or external services; invalidation remains handled through the existing local memory provider.
- **Memory architecture:** Does not alter working, episodic, or BEAM tiers, retrieval, consolidation, veracity, or sync behavior.
- **MCP/CLI surfaces:** No direct changes.
- **Maintainability:** This is the right call: the handler now reflects the underlying BEAM operation instead of reporting success unconditionally, with focused regression tests protecting the contract.
- **Benchmark methodology:** Unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->