### PR TITLE
fix: mnemosyne_invalidate returns memory_not_found when no row matched

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -2913,13 +2913,15 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         replacement_id = args.get("replacement_id", None) or None
         if not memory_id:
             return json.dumps({"error": "memory_id is required"})
-        self._beam.invalidate(memory_id, replacement_id=replacement_id if replacement_id else None)
+        ok = self._beam.invalidate(memory_id, replacement_id=replacement_id)
         self._audit_event(
             "invalidate", memory_id=memory_id, bank="private",
             source_tool="mnemosyne_invalidate",
-            metadata={"replacement_id": replacement_id} if replacement_id else None,
+            metadata={"replacement_id": replacement_id, "invalidated": ok} if replacement_id else {"invalidated": ok},
         )
-        return json.dumps({"status": "invalidated", "memory_id": memory_id})
+        if ok:
+            return json.dumps({"status": "invalidated", "memory_id": memory_id})
+        return json.dumps({"status": "memory_not_found", "memory_id": memory_id})
 
     def _handle_validate(self, args: Dict[str, Any]) -> str:
         """Collaborative attestation: any agent can attest, update, invalidate,

--- a/tests/test_hermes_memory_provider_audit.py
+++ b/tests/test_hermes_memory_provider_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 from mnemosyne.core.beam import BeamMemory
@@ -111,7 +112,9 @@ class TestAuditIntegration:
             "content": "will be invalidated",
             "source": "fact",
         })
+        before_invalidate = datetime.now()
         result = _call(provider, "mnemosyne_invalidate", {"memory_id": stored["memory_id"]})
+        after_invalidate = datetime.now()
         assert result["status"] == "invalidated"
         assert result["memory_id"] == stored["memory_id"]
         row = provider._beam.conn.execute(
@@ -119,7 +122,10 @@ class TestAuditIntegration:
             (stored["memory_id"],),
         ).fetchone()
         assert row is not None
-        assert row[0] is not None
+        valid_until = datetime.fromisoformat(row[0])
+        assert before_invalidate <= valid_until <= after_invalidate
+        context_ids = {memory["id"] for memory in provider._beam.get_context(limit=10)}
+        assert stored["memory_id"] not in context_ids
         events = provider._audit.query(limit=10)
         assert json.loads(events[0]["metadata_json"]) == {"invalidated": True}
 
@@ -133,18 +139,24 @@ class TestAuditIntegration:
             "content": "replacement fact",
             "source": "fact",
         })
+        before_invalidate = datetime.now()
         result = _call(provider, "mnemosyne_invalidate", {
             "memory_id": original["memory_id"],
             "replacement_id": replacement["memory_id"],
         })
+        after_invalidate = datetime.now()
         assert result["status"] == "invalidated"
         row = provider._beam.conn.execute(
             "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?",
             (original["memory_id"],),
         ).fetchone()
         assert row is not None
-        assert row[0] is not None
+        valid_until = datetime.fromisoformat(row[0])
+        assert before_invalidate <= valid_until <= after_invalidate
         assert row[1] == replacement["memory_id"]
+        context_ids = {memory["id"] for memory in provider._beam.get_context(limit=10)}
+        assert original["memory_id"] not in context_ids
+        assert replacement["memory_id"] in context_ids
         events = provider._audit.query(limit=10)
         assert json.loads(events[0]["metadata_json"]) == {
             "replacement_id": replacement["memory_id"],

--- a/tests/test_hermes_memory_provider_audit.py
+++ b/tests/test_hermes_memory_provider_audit.py
@@ -96,6 +96,22 @@ class TestAuditIntegration:
         assert events[0]["action"] == "invalidate"
         assert events[0]["memory_id"] == stored["memory_id"]
 
+    def test_invalidate_not_found_returns_status(self, tmp_path):
+        provider = _provider(tmp_path)
+        result = _call(provider, "mnemosyne_invalidate", {"memory_id": "nonexistent-id"})
+        assert result["status"] == "memory_not_found"
+        assert result["memory_id"] == "nonexistent-id"
+
+    def test_invalidate_success_returns_status(self, tmp_path):
+        provider = _provider(tmp_path)
+        stored = _call(provider, "mnemosyne_remember", {
+            "content": "will be invalidated",
+            "source": "fact",
+        })
+        result = _call(provider, "mnemosyne_invalidate", {"memory_id": stored["memory_id"]})
+        assert result["status"] == "invalidated"
+        assert result["memory_id"] == stored["memory_id"]
+
     def test_sleep_creates_audit_event(self, tmp_path):
         provider = _provider(tmp_path)
         _call(provider, "mnemosyne_remember", {

--- a/tests/test_hermes_memory_provider_audit.py
+++ b/tests/test_hermes_memory_provider_audit.py
@@ -101,6 +101,9 @@ class TestAuditIntegration:
         result = _call(provider, "mnemosyne_invalidate", {"memory_id": "nonexistent-id"})
         assert result["status"] == "memory_not_found"
         assert result["memory_id"] == "nonexistent-id"
+        events = provider._audit.query(limit=10)
+        assert len(events) == 1
+        assert json.loads(events[0]["metadata_json"]) == {"invalidated": False}
 
     def test_invalidate_success_returns_status(self, tmp_path):
         provider = _provider(tmp_path)
@@ -111,6 +114,42 @@ class TestAuditIntegration:
         result = _call(provider, "mnemosyne_invalidate", {"memory_id": stored["memory_id"]})
         assert result["status"] == "invalidated"
         assert result["memory_id"] == stored["memory_id"]
+        row = provider._beam.conn.execute(
+            "SELECT valid_until FROM working_memory WHERE id = ?",
+            (stored["memory_id"],),
+        ).fetchone()
+        assert row is not None
+        assert row[0] is not None
+        events = provider._audit.query(limit=10)
+        assert json.loads(events[0]["metadata_json"]) == {"invalidated": True}
+
+    def test_invalidate_with_replacement_persists_link_and_audit_metadata(self, tmp_path):
+        provider = _provider(tmp_path)
+        original = _call(provider, "mnemosyne_remember", {
+            "content": "original fact",
+            "source": "fact",
+        })
+        replacement = _call(provider, "mnemosyne_remember", {
+            "content": "replacement fact",
+            "source": "fact",
+        })
+        result = _call(provider, "mnemosyne_invalidate", {
+            "memory_id": original["memory_id"],
+            "replacement_id": replacement["memory_id"],
+        })
+        assert result["status"] == "invalidated"
+        row = provider._beam.conn.execute(
+            "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?",
+            (original["memory_id"],),
+        ).fetchone()
+        assert row is not None
+        assert row[0] is not None
+        assert row[1] == replacement["memory_id"]
+        events = provider._audit.query(limit=10)
+        assert json.loads(events[0]["metadata_json"]) == {
+            "replacement_id": replacement["memory_id"],
+            "invalidated": True,
+        }
 
     def test_sleep_creates_audit_event(self, tmp_path):
         provider = _provider(tmp_path)


### PR DESCRIPTION
## Summary

- Return `memory_not_found` when `mnemosyne_invalidate` does not match a memory.
- Preserve the requested `memory_id` in the response.
- Record invalidation outcome metadata and optional replacement memory.
- Add integration coverage for successful and unsuccessful invalidation.

## Why

The handler previously reported success unconditionally instead of reflecting the underlying BEAM invalidation result. This gives agents reliable feedback about whether a memory was actually removed.

## Validation

- `python -m pytest tests/test_hermes_memory_provider_audit.py -q` — 14 passed

Supersedes #527 with corrected GitHub commit attribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated Hermes’ `mnemosyne_invalidate` tool handling to return a non-error outcome when the target memory doesn’t exist:
  - `status: "invalidated"` when the BEAM invalidation succeeds
  - `status: "memory_not_found"` when no memory matches, while preserving the caller-provided `memory_id`.
- The invalidation handler now always threads `replacement_id` into the underlying BEAM call (passing `None` when omitted), and records audit metadata capturing:
  - `invalidated: True/False`
  - optional `replacement_id` (only when provided).
- Added integration tests covering:
  - missing `memory_id` → `memory_not_found` + audit metadata `{"invalidated": False}`
  - existing `memory_id` → `invalidated` + `working_memory.valid_until` set within the expected time window + audit metadata `{"invalidated": True}` + removal from current context
  - invalidation with `replacement_id` → `invalidated` + `working_memory.superseded_by` set + replacement present in context while original is not, with audit metadata including both `replacement_id` and `invalidated: True`.

## Architectural impact (Mnemosyne core memory + local-first architecture)

- **BEAM / tiered memory (working tier boundary):** Tightens the semantics of the BEAM “invalidate working memory” operation. It clarifies and tests the observable outcome of invalidation (including time-bounded `working_memory.valid_until` updates) without changing retrieval behavior, episodic tier handling, or consolidation scheduling.
- **Retrieval strategies / consolidation pipeline:** No indicated changes. The update is strictly about the invalidation outcome and auditability of the working-tier mutation, not how memories are later recalled or how consolidation proceeds.
- **Veracity system:** No indicated changes. Invalidation outcome handling and audit metadata are orthogonal to veracity/consolidation logic.
- **Sync layer / maintainability:** Improves long-term maintainability and agent integration correctness by making invalidation results deterministic and machine-checkable (explicit `memory_not_found` vs `invalidated`, plus structured audit metadata). This strengthens local observability without introducing new hosted/sync dependencies or affecting local-first data ownership.

## Agent integration surfaces (Hermes)

- **Hermes tool semantics:** Makes “memory not found” an explicit, agent-consumable status for `mnemosyne_invalidate`, preserving the requested `memory_id` for downstream reasoning. Audit metadata is enriched to support reliable auditing and automated workflows around invalidation and replacement linkage.
- **MCP / CLI:** No changes indicated in this update.

Validation: `python -m pytest tests/test_hermes_memory_provider_audit.py -q` — 14 passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->