### PR TITLE
fix(hygiene): enforce read-only audit and status

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -1196,6 +1196,7 @@ def cmd_hygiene(args):
         hygiene_status,
         restore_archived,
     )
+    from mnemosyne.doctor import open_readonly_doctor_db
 
     if not args or args[0] in ("--help", "-h"):
         print("Usage: mnemosyne hygiene audit|status|clean|restore [options]")
@@ -1239,7 +1240,9 @@ def cmd_hygiene(args):
         if not db_path.exists():
             _fail(f"Database not found at {db_path}")
 
+        conn = None
         try:
+            conn = open_readonly_doctor_db(db_path)
             report = audit_noise(
                 db_path=db_path,
                 limit=limit,
@@ -1247,9 +1250,13 @@ def cmd_hygiene(args):
                 offset=offset,
                 scan_all=scan_all,
                 batch_size=batch_size,
+                conn=conn,
             )
         except (ValueError, sqlite3.Error) as e:
             _fail(str(e))
+        finally:
+            if conn is not None:
+                conn.close()
 
         if as_json:
             print(json.dumps(report.to_dict(), indent=2))
@@ -1286,10 +1293,15 @@ def cmd_hygiene(args):
         db_path = Path(DATA_DIR) / "mnemosyne.db"
         if not db_path.exists():
             _fail(f"Database not found at {db_path}")
+        conn = None
         try:
-            status = hygiene_status(db_path=db_path, limit=limit)
+            conn = open_readonly_doctor_db(db_path)
+            status = hygiene_status(db_path=db_path, limit=limit, conn=conn)
         except (ValueError, sqlite3.Error) as e:
             _fail(str(e))
+        finally:
+            if conn is not None:
+                conn.close()
         if as_json:
             print(json.dumps(status, indent=2))
         else:

--- a/mnemosyne/core/hygiene.py
+++ b/mnemosyne/core/hygiene.py
@@ -513,11 +513,21 @@ def doctor_hygiene_summary(
 
 
 def hygiene_status(
-    db_path: Path, *, include_noise_summary: bool = True, limit: int = 200
+    db_path: Path,
+    *,
+    include_noise_summary: bool = True,
+    limit: int = 200,
+    conn: Optional[sqlite3.Connection] = None,
 ) -> Dict[str, Any]:
-    """Return PII-safe hygiene status and optional current noise summary."""
+    """Return PII-safe hygiene status and optional current noise summary.
+
+    A caller may supply a read-only connection, which remains caller-owned and
+    is also used for the optional noise summary.
+    """
     status: Dict[str, Any] = {"status": "ok", "audit_log": {}}
-    conn = sqlite3.connect(str(db_path))
+    owns_connection = conn is None
+    if conn is None:
+        conn = sqlite3.connect(str(db_path))
     try:
         if _table_exists(conn, "hygiene_audit_log"):
             total = int(conn.execute("SELECT COUNT(*) FROM hygiene_audit_log").fetchone()[0])
@@ -537,10 +547,15 @@ def hygiene_status(
         else:
             status["audit_log"] = {"present": False, "total_entries": 0, "by_action": {}}
     finally:
-        conn.close()
+        if owns_connection:
+            conn.close()
 
     if include_noise_summary:
-        status["noise_summary"] = noise_summary(db_path=db_path, limit=limit)
+        status["noise_summary"] = noise_summary(
+            db_path=db_path,
+            limit=limit,
+            conn=None if owns_connection else conn,
+        )
     return status
 
 

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -474,6 +474,30 @@ class TestAuditNoise:
         assert status["audit_log"]["total_entries"] == 0
         assert status["audit_log"]["by_action"] == {}
 
+    def test_hygiene_status_can_skip_noise_summary_with_owned_connection(self, temp_db, monkeypatch):
+        db_path, _beam = temp_db
+        original_connect = sqlite3.connect
+        owned_connections = []
+
+        def capture_connection(*args, **kwargs):
+            connection = original_connect(*args, **kwargs)
+            owned_connections.append(connection)
+            return connection
+
+        def unexpected_noise_summary(*_args, **_kwargs):
+            raise AssertionError("noise_summary must not be called when disabled")
+
+        monkeypatch.setattr(hygiene_module.sqlite3, "connect", capture_connection)
+        monkeypatch.setattr(hygiene_module, "noise_summary", unexpected_noise_summary)
+
+        status = hygiene_status(db_path=db_path, include_noise_summary=False)
+
+        assert status["status"] == "ok"
+        assert "noise_summary" not in status
+        assert len(owned_connections) == 1
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            owned_connections[0].execute("SELECT 1")
+
     def test_hygiene_status_can_skip_noise_summary_without_closing_supplied_readonly_connection(self, temp_db):
         db_path, _beam = temp_db
         readonly = open_readonly_doctor_db(db_path)

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -539,6 +539,28 @@ class TestAuditNoise:
 
         assert status["status"] == "ok"
 
+    def test_hygiene_status_keeps_supplied_readonly_connection_open_when_noise_summary_fails(
+        self, temp_db, monkeypatch
+    ):
+        db_path, _beam = temp_db
+        readonly = open_readonly_doctor_db(db_path)
+        received_connection = None
+
+        def fail_noise_summary(*_args, **kwargs):
+            nonlocal received_connection
+            received_connection = kwargs["conn"]
+            raise sqlite3.OperationalError("noise summary failed")
+
+        monkeypatch.setattr(hygiene_module, "noise_summary", fail_noise_summary)
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="noise summary failed"):
+                hygiene_status(db_path=db_path, limit=10, conn=readonly)
+
+            assert received_connection is readonly
+            assert readonly.execute("SELECT 1").fetchone()[0] == 1
+        finally:
+            readonly.close()
+
     @pytest.mark.parametrize(
         ("command_args", "function_name"),
         [

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -474,12 +474,21 @@ class TestAuditNoise:
         assert status["audit_log"]["total_entries"] == 0
         assert status["audit_log"]["by_action"] == {}
 
-    def test_hygiene_status_can_skip_noise_summary(self, temp_db):
+    def test_hygiene_status_can_skip_noise_summary_without_closing_supplied_readonly_connection(self, temp_db):
         db_path, _beam = temp_db
+        readonly = open_readonly_doctor_db(db_path)
+        try:
+            status = hygiene_status(
+                db_path=db_path,
+                include_noise_summary=False,
+                conn=readonly,
+            )
 
-        status = hygiene_status(db_path=db_path, include_noise_summary=False)
-
-        assert "noise_summary" not in status
+            assert "noise_summary" not in status
+            assert status["status"] == "ok"
+            assert readonly.execute("SELECT 1").fetchone()[0] == 1
+        finally:
+            readonly.close()
 
     def test_hygiene_status_uses_supplied_readonly_connection(self, temp_db, monkeypatch):
         db_path, _beam = temp_db
@@ -549,6 +558,42 @@ class TestAuditNoise:
         with pytest.raises(sqlite3.ProgrammingError):
             injected_connection.execute("SELECT 1")
         assert capsys.readouterr().err == ""
+
+    @pytest.mark.parametrize(
+        ("command_args", "function_name"),
+        [
+            (["audit"], "audit_noise"),
+            (["status"], "hygiene_status"),
+        ],
+    )
+    def test_cmd_hygiene_read_commands_close_connection_after_hygiene_error(
+        self, monkeypatch, tmp_path, capsys, command_args, function_name
+    ):
+        db_path = tmp_path / "mnemosyne.db"
+        sqlite3.connect(db_path).close()
+        monkeypatch.setattr("mnemosyne.cli.DATA_DIR", str(tmp_path))
+
+        connection = None
+
+        def capture_readonly_connection(path):
+            nonlocal connection
+            connection = open_readonly_doctor_db(path)
+            return connection
+
+        def fail_after_connection(*_args, **kwargs):
+            assert kwargs["conn"] is connection
+            raise sqlite3.OperationalError("hygiene read failed")
+
+        monkeypatch.setattr("mnemosyne.doctor.open_readonly_doctor_db", capture_readonly_connection)
+        monkeypatch.setattr(hygiene_module, function_name, fail_after_connection)
+
+        with pytest.raises(SystemExit):
+            cmd_hygiene(command_args)
+
+        assert connection is not None
+        with pytest.raises(sqlite3.ProgrammingError):
+            connection.execute("SELECT 1")
+        assert "hygiene read failed" in capsys.readouterr().err
 
     @pytest.mark.parametrize("command_args", [["audit"], ["status"]])
     def test_cmd_hygiene_read_commands_report_readonly_open_errors(

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -498,6 +498,31 @@ class TestAuditNoise:
         with pytest.raises(sqlite3.ProgrammingError, match="closed"):
             owned_connections[0].execute("SELECT 1")
 
+    def test_hygiene_status_closes_owned_connection_when_audit_log_read_fails(self, temp_db, monkeypatch):
+        db_path, _beam = temp_db
+        original_connect = sqlite3.connect
+        owned_connections = []
+        read_error = sqlite3.OperationalError("audit log read failed")
+
+        def capture_connection(*args, **kwargs):
+            connection = original_connect(*args, **kwargs)
+            owned_connections.append(connection)
+            return connection
+
+        def fail_audit_log_read(*_args, **_kwargs):
+            raise read_error
+
+        monkeypatch.setattr(hygiene_module.sqlite3, "connect", capture_connection)
+        monkeypatch.setattr(hygiene_module, "_table_exists", fail_audit_log_read)
+
+        with pytest.raises(sqlite3.OperationalError, match="audit log read failed") as exc_info:
+            hygiene_status(db_path=db_path, include_noise_summary=False)
+
+        assert exc_info.value is read_error
+        assert len(owned_connections) == 1
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            owned_connections[0].execute("SELECT 1")
+
     def test_hygiene_status_can_skip_noise_summary_without_closing_supplied_readonly_connection(self, temp_db):
         db_path, _beam = temp_db
         readonly = open_readonly_doctor_db(db_path)

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+import mnemosyne.core.hygiene as hygiene_module
 from mnemosyne.cli import cmd_hygiene
 from mnemosyne.core.beam import BeamMemory, init_beam
 from mnemosyne.core.filters import SECRET_LABELED_PATTERNS
@@ -479,6 +480,77 @@ class TestAuditNoise:
         status = hygiene_status(db_path=db_path, include_noise_summary=False)
 
         assert "noise_summary" not in status
+
+    def test_hygiene_status_uses_supplied_readonly_connection(self, temp_db):
+        db_path, _beam = temp_db
+        readonly = open_readonly_doctor_db(db_path)
+        try:
+            status = hygiene_status(db_path=db_path, limit=10, conn=readonly)
+
+            assert readonly.execute("PRAGMA query_only").fetchone()[0] == 1
+            with pytest.raises(sqlite3.OperationalError):
+                readonly.execute("CREATE TABLE forbidden_hygiene_write (id INTEGER)")
+        finally:
+            readonly.close()
+
+        assert status["status"] == "ok"
+
+    @pytest.mark.parametrize(
+        ("command_args", "function_name"),
+        [
+            (["audit", "--json"], "audit_noise"),
+            (["status", "--json"], "hygiene_status"),
+        ],
+    )
+    def test_cmd_hygiene_read_commands_use_readonly_connection(
+        self, monkeypatch, tmp_path, capsys, command_args, function_name
+    ):
+        db_path = tmp_path / "mnemosyne.db"
+        writable = sqlite3.connect(db_path)
+        writable.execute(
+            """
+            CREATE TABLE working_memory (
+                id TEXT PRIMARY KEY, content TEXT, source TEXT, timestamp TEXT,
+                session_id TEXT, importance REAL, metadata_json TEXT
+            )
+            """
+        )
+        writable.commit()
+        writable.close()
+        monkeypatch.setattr("mnemosyne.cli.DATA_DIR", str(tmp_path))
+
+        original = getattr(hygiene_module, function_name)
+
+        def require_readonly_connection(*args, **kwargs):
+            conn = kwargs["conn"]
+            assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute("CREATE TABLE forbidden_cli_write (id INTEGER)")
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(hygiene_module, function_name, require_readonly_connection)
+
+        cmd_hygiene(command_args)
+
+        assert capsys.readouterr().err == ""
+
+    @pytest.mark.parametrize("command_args", [["audit"], ["status"]])
+    def test_cmd_hygiene_read_commands_report_readonly_open_errors(
+        self, monkeypatch, tmp_path, capsys, command_args
+    ):
+        db_path = tmp_path / "mnemosyne.db"
+        sqlite3.connect(db_path).close()
+        monkeypatch.setattr("mnemosyne.cli.DATA_DIR", str(tmp_path))
+
+        def fail_open(_db_path):
+            raise sqlite3.OperationalError("readonly connection failed")
+
+        monkeypatch.setattr("mnemosyne.doctor.open_readonly_doctor_db", fail_open)
+
+        with pytest.raises(SystemExit):
+            cmd_hygiene(command_args)
+
+        assert "readonly connection failed" in capsys.readouterr().err
 
     def test_noise_summary_is_pii_safe(self, temp_db):
         db_path, beam = temp_db

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -531,6 +531,7 @@ class TestAuditNoise:
 
             assert received_connection is readonly
             assert readonly.execute("PRAGMA query_only").fetchone()[0] == 1
+            readonly.execute("PRAGMA query_only = OFF")
             with pytest.raises(sqlite3.OperationalError):
                 readonly.execute("CREATE TABLE forbidden_hygiene_write (id INTEGER)")
         finally:
@@ -570,6 +571,7 @@ class TestAuditNoise:
             conn = kwargs["conn"]
             injected_connection = conn
             assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+            conn.execute("PRAGMA query_only = OFF")
             with pytest.raises(sqlite3.OperationalError):
                 conn.execute("CREATE TABLE forbidden_cli_write (id INTEGER)")
             return original(*args, **kwargs)

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -481,12 +481,22 @@ class TestAuditNoise:
 
         assert "noise_summary" not in status
 
-    def test_hygiene_status_uses_supplied_readonly_connection(self, temp_db):
+    def test_hygiene_status_uses_supplied_readonly_connection(self, temp_db, monkeypatch):
         db_path, _beam = temp_db
         readonly = open_readonly_doctor_db(db_path)
+        original_noise_summary = hygiene_module.noise_summary
+        received_connection = None
+
+        def capture_noise_summary(*args, **kwargs):
+            nonlocal received_connection
+            received_connection = kwargs["conn"]
+            return original_noise_summary(*args, **kwargs)
+
+        monkeypatch.setattr(hygiene_module, "noise_summary", capture_noise_summary)
         try:
             status = hygiene_status(db_path=db_path, limit=10, conn=readonly)
 
+            assert received_connection is readonly
             assert readonly.execute("PRAGMA query_only").fetchone()[0] == 1
             with pytest.raises(sqlite3.OperationalError):
                 readonly.execute("CREATE TABLE forbidden_hygiene_write (id INTEGER)")
@@ -520,9 +530,12 @@ class TestAuditNoise:
         monkeypatch.setattr("mnemosyne.cli.DATA_DIR", str(tmp_path))
 
         original = getattr(hygiene_module, function_name)
+        injected_connection = None
 
         def require_readonly_connection(*args, **kwargs):
+            nonlocal injected_connection
             conn = kwargs["conn"]
+            injected_connection = conn
             assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
             with pytest.raises(sqlite3.OperationalError):
                 conn.execute("CREATE TABLE forbidden_cli_write (id INTEGER)")
@@ -532,6 +545,9 @@ class TestAuditNoise:
 
         cmd_hygiene(command_args)
 
+        assert injected_connection is not None
+        with pytest.raises(sqlite3.ProgrammingError):
+            injected_connection.execute("SELECT 1")
         assert capsys.readouterr().err == ""
 
     @pytest.mark.parametrize("command_args", [["audit"], ["status"]])


### PR DESCRIPTION
## Summary

Make the read-only hygiene CLI paths enforce that property at the SQLite connection boundary.

- open `mnemosyne hygiene audit` and `mnemosyne hygiene status` through the existing `mode=ro` / `PRAGMA query_only=ON` helper
- allow `hygiene_status()` to reuse a caller-owned connection for its optional noise summary
- add regressions that prove schema writes are rejected and read-only open failures are reported

## Scope

`clean`, `restore`, scoring, schema, and documentation are intentionally unchanged.

## Verification

- `PYTHONPATH=. uv run --no-sync --extra test pytest tests/test_hygiene.py tests/test_doctor.py -q`
- `uv tool run ruff==0.15.22 check --select E9,F63,F7,F82 mnemosyne tests`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Hardens Mnemosyne’s CLI “hygiene” inspection paths (`mnemosyne hygiene audit` and `mnemosyne hygiene status`) to be **strictly read-only at the SQLite boundary** by opening the doctor/audit database with `open_readonly_doctor_db` (uses `mode=ro` + `PRAGMA query_only=ON`) and passing that connection into the hygiene routines.
- Extends `hygiene_status()` to accept an optional caller-owned `sqlite3.Connection` (`conn`) and to apply correct connection ownership/lifecycle semantics:
  - if the caller supplies `conn`, `hygiene_status()` reuses it for the optional noise summary path (and does not close it),
  - if `hygiene_status()` opens the connection itself, it closes it after reading the audit log and lets `noise_summary()` open as needed.
- Adds regressions verifying:
  - `PRAGMA query_only=ON` is in effect on supplied read-only connections,
  - **schema writes** (e.g., `CREATE TABLE ...`) are rejected,
  - CLI surfaces read-only open failures as CLI errors,
  - connection closing behavior is correct on both success and failure paths (including failures during the noise-summary step).

## Architectural Impact

- **Core memory architecture (working/episodic/BEAM), retrieval, consolidation, veracity, sync:** No changes. This PR is confined to **doctor/hygiene database access semantics** used by CLI diagnostics.
- **Privacy posture / safety:** Improves safety by making `audit`/`status` impossible to mutate local SQLite state via accidents, and by explicitly rejecting write SQL at runtime (`mode=ro` + `PRAGMA query_only=ON`). The architectural win is enforcing a **“read-only at the SQLite boundary”** contract and proving it with tests that attempt both data and schema writes.
- **Local-first guarantees:** Strengthens local-first operator workflows by removing any possibility that hygiene inspection becomes a write-capable side channel (no new write paths, no remote effects, no sync/replication changes).
- **Agent integration surfaces (Hermes, MCP, CLI):** Hermes/MCP integration surfaces are unchanged; the behavioral hardening is limited to the **CLI hygiene** command’s internal use of read-only doctor DB connections.  
- **Maintainability / long-term risk:** Makes connection ownership explicit (caller-owned vs owned connections) and covers failure modes with targeted regression tests, reducing the risk that future refactors accidentally reintroduce write-capable connections or mishandle connection lifetimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->