### PR TITLE
fix(mcp): keep hygiene audits strictly read-only

### DIFF
--- a/mnemosyne/core/banks.py
+++ b/mnemosyne/core/banks.py
@@ -219,6 +219,29 @@ def bank_exists_read_only(name: str, data_dir: Path = None) -> bool:
     return (banks_dir / name).is_dir()
 
 
+def get_bank_db_path_read_only(name: str, data_dir: Path = None) -> Path:
+    """Resolve an existing bank database path without initializing bank state.
+
+    This is the read-only counterpart to ``BankManager.get_bank_db_path`` for
+    inspection paths. It validates bank names but never constructs a
+    ``BankManager`` (whose constructor creates ``banks/``). The default bank
+    retains its legacy location; named banks must already have both their bank
+    directory and database file on disk.
+    """
+    _validate_bank_name(name)
+    resolved: Path = data_dir or _default_data_dir()
+    if name == "default":
+        return resolved / "mnemosyne.db"
+
+    if not bank_exists_read_only(name, data_dir=resolved):
+        raise ValueError(f"Bank '{name}' does not exist")
+
+    db_path = resolved / "banks" / name / "mnemosyne.db"
+    if not db_path.is_file():
+        raise FileNotFoundError(f"Database for bank '{name}' does not exist")
+    return db_path
+
+
 # Module-level convenience functions
 def create_bank(name: str, data_dir: Path = None) -> Path:
     """Create a new memory bank."""

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -11,7 +11,7 @@ Usage:
 All imports are guarded — this module loads safely even if mcp is not installed.
 """
 
-from typing import Dict, Any, List
+from typing import TYPE_CHECKING, Dict, Any, List, TypeAlias
 import json
 import math
 import os
@@ -29,7 +29,6 @@ except ImportError:
     CallToolResult = None
     ErrorData = None
 
-from mnemosyne.core.memory import Mnemosyne
 from mnemosyne.core.beam import BeamMemory, _guarded_transaction
 
 from mnemosyne.tool_schemas import ALL_TOOL_SCHEMAS
@@ -40,6 +39,28 @@ from mnemosyne.batch_tool import (
     dry_run_batch,
     validate_batch_operations,
 )
+
+if TYPE_CHECKING:
+    from mnemosyne.core.memory import Mnemosyne
+
+    MnemosyneInstance: TypeAlias = Mnemosyne
+else:
+    # Runtime type-hint resolution must not import core.memory.
+    MnemosyneInstance: TypeAlias = Any
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily retain the historical public ``Mnemosyne`` export.
+
+    Importing ``mnemosyne.core.memory`` initializes legacy default-memory
+    state, so only an explicit compatibility access may trigger that import.
+    """
+    if name == "Mnemosyne":
+        from mnemosyne.core.memory import Mnemosyne
+
+        return Mnemosyne
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # ---------------------------------------------------------------------------
 # Tool Definitions
@@ -126,14 +147,22 @@ def _shared_db_path() -> Path:
 
 def _create_instance(session_id: str = None, author_id: str = None,
                      author_type: str = None, channel_id: str = None,
-                     bank: str = "default") -> Mnemosyne:
+                     bank: str = "default") -> MnemosyneInstance:
     """Create a fresh Mnemosyne instance for each MCP connection.
 
     Identity is resolved from:
     1. Explicit args (from tool call or constructor)
     2. Environment variables (MNEMOSYNE_AUTHOR_ID, etc.)
     3. None (backward compatible, no identity tracking)
+
+    ``MnemosyneInstance`` resolves to ``Any`` at runtime so type-hint
+    resolution remains side-effect-free, while static checkers use the
+    TYPE_CHECKING Mnemosyne alias above.
     """
+    # Importing core.memory initializes the legacy default database, so keep it
+    # on this mutation-capable construction path rather than at MCP import time.
+    from mnemosyne.core.memory import Mnemosyne
+
     auth = author_id or os.environ.get("MNEMOSYNE_AUTHOR_ID")
     auth_type = author_type or os.environ.get("MNEMOSYNE_AUTHOR_TYPE")
     chan = channel_id or os.environ.get("MNEMOSYNE_CHANNEL_ID") or session_id or "default"
@@ -190,7 +219,8 @@ def _serialize(obj):
 class _WrapperBatchAdapter:
     """Expose Mnemosyne wrapper mutations through the Beam batch interface."""
 
-    def __init__(self, mem: Mnemosyne):
+    def __init__(self, mem: MnemosyneInstance):
+        """Adapt a Mnemosyne instance without resolving its import at runtime."""
         self._mem = mem
         self.conn = mem.beam.conn
         self.wrapper_events = []
@@ -962,11 +992,12 @@ def _handle_graph_link(arguments: Dict[str, Any]) -> Dict[str, Any]:
 
 def _handle_hygiene_audit(arguments: Dict[str, Any]) -> Dict[str, Any]:
     """Handle mnemosyne_hygiene_audit tool call."""
+    from mnemosyne.core.banks import get_bank_db_path_read_only
     from mnemosyne.core.hygiene import audit_noise
+    from mnemosyne.doctor import open_readonly_doctor_db
 
     bank = _resolve_bank(arguments)
-    mem = _create_instance(bank=bank)
-    db_path = mem.beam.db_path if hasattr(mem.beam, "db_path") else mem.db_path
+    db_path = get_bank_db_path_read_only(bank)
 
     limit = arguments.get("limit", 200)
     min_score = arguments.get("min_score", 0.3)
@@ -975,15 +1006,20 @@ def _handle_hygiene_audit(arguments: Dict[str, Any]) -> Dict[str, Any]:
     scan_all = arguments.get("scan_all", False)
     batch_size = arguments.get("batch_size", 1000)
 
-    report = audit_noise(
-        db_path=db_path,
-        limit=limit,
-        tables=tables,
-        min_score=min_score,
-        offset=offset,
-        scan_all=scan_all,
-        batch_size=batch_size,
-    )
+    conn = open_readonly_doctor_db(db_path)
+    try:
+        report = audit_noise(
+            db_path=db_path,
+            limit=limit,
+            tables=tables,
+            min_score=min_score,
+            offset=offset,
+            scan_all=scan_all,
+            batch_size=batch_size,
+            conn=conn,
+        )
+    finally:
+        conn.close()
     return {
         "status": "audited",
         "report": report.to_dict(),
@@ -1143,3 +1179,34 @@ def handle_tool_call(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
 def get_tool_definitions() -> List[Dict[str, Any]]:
     """Return all tool definitions for MCP server registration."""
     return TOOLS
+
+
+# Keep the exact pre-lazy-import star-import surface.  ``Mnemosyne`` remains
+# lazy through ``__getattr__`` above, but star imports historically resolved it
+# because this module had no ``__all__`` and held the class in its globals.
+# New typing-only implementation details deliberately stay private to stars.
+__all__ = [
+    "ALL_TOOL_SCHEMAS",
+    "Any",
+    "BatchValidationError",
+    "BeamMemory",
+    "CallToolResult",
+    "Dict",
+    "ErrorData",
+    "List",
+    "Mnemosyne",
+    "Path",
+    "TOOLS",
+    "TextContent",
+    "Tool",
+    "apply_beam_batch",
+    "batch_validation_error_payload",
+    "dry_run_batch",
+    "get_tool_definitions",
+    "handle_tool_call",
+    "json",
+    "math",
+    "os",
+    "sqlite3",
+    "validate_batch_operations",
+]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,6 +6,7 @@ Run with: pytest tests/test_mcp_server.py -v
 
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 import pytest
@@ -449,6 +450,179 @@ class TestToolHandlers:
             with pytest.raises(RuntimeError, match="DB locked"):
                 handle_tool_call("mnemosyne_remember", {"content": "test"})
 
+    def test_hygiene_audit_default_uses_and_closes_exact_readonly_connection(
+        self, tmp_path, monkeypatch
+    ):
+        """Default-bank audits use one real query-only connection, never Mnemosyne."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        db_path = data_dir / "mnemosyne.db"
+        with sqlite3.connect(db_path) as writable:
+            writable.execute("CREATE TABLE audit_marker (id INTEGER)")
+
+        class _Report:
+            def to_dict(self):
+                return {"total_candidates": 0}
+
+        from mnemosyne.core import hygiene
+
+        captured = {}
+
+        def _audit_noise(**kwargs):
+            conn = kwargs["conn"]
+            captured.update(kwargs)
+            assert conn.execute("PRAGMA query_only").fetchone()[0] == 1
+            with pytest.raises(
+                sqlite3.OperationalError, match="attempt to write a readonly database"
+            ):
+                conn.execute("CREATE TABLE forbidden_write (id INTEGER)")
+            return _Report()
+
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+        monkeypatch.setattr(
+            mcp_tools,
+            "_create_instance",
+            lambda **_kwargs: pytest.fail("hygiene audit must not initialize Mnemosyne"),
+        )
+        monkeypatch.setattr(hygiene, "audit_noise", _audit_noise)
+
+        arguments = {
+            "limit": 17,
+            "tables": ["audit_marker"],
+            "min_score": 0.8,
+            "offset": 3,
+            "scan_all": True,
+            "batch_size": 11,
+        }
+        result = handle_tool_call("mnemosyne_hygiene_audit", arguments)
+
+        assert result == {
+            "status": "audited",
+            "report": {"total_candidates": 0},
+            "bank": "default",
+        }
+        assert captured == {
+            "db_path": db_path,
+            "limit": 17,
+            "tables": ["audit_marker"],
+            "min_score": 0.8,
+            "offset": 3,
+            "scan_all": True,
+            "batch_size": 11,
+            "conn": captured["conn"],
+        }
+        with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+            captured["conn"].execute("SELECT 1")
+
+    def test_hygiene_audit_closes_connection_when_audit_raises(self, tmp_path, monkeypatch):
+        """The read-only connection closes even if audit_noise raises."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        db_path = data_dir / "mnemosyne.db"
+        sqlite3.connect(db_path).close()
+
+        from mnemosyne.core import hygiene
+        from mnemosyne import doctor
+
+        captured = {}
+        real_open = doctor.open_readonly_doctor_db
+
+        def _open_readonly(path):
+            captured["conn"] = real_open(path)
+            return captured["conn"]
+
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+        monkeypatch.setattr(
+            mcp_tools,
+            "_create_instance",
+            lambda **_kwargs: pytest.fail("hygiene audit must not initialize Mnemosyne"),
+        )
+        monkeypatch.setattr(doctor, "open_readonly_doctor_db", _open_readonly)
+        monkeypatch.setattr(
+            hygiene,
+            "audit_noise",
+            lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("audit failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="audit failed"):
+            handle_tool_call("mnemosyne_hygiene_audit", {})
+
+        with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+            captured["conn"].execute("SELECT 1")
+
+    def test_hygiene_audit_readonly_open_failure_has_no_writable_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        """A missing default DB fails at the read-only open without running audit_noise."""
+        data_dir = tmp_path / "missing-data"
+        from mnemosyne.core import hygiene
+
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+        monkeypatch.setattr(
+            mcp_tools,
+            "_create_instance",
+            lambda **_kwargs: pytest.fail("hygiene audit must not initialize Mnemosyne"),
+        )
+        monkeypatch.setattr(
+            hygiene,
+            "audit_noise",
+            lambda **_kwargs: pytest.fail("audit must not run after readonly open failure"),
+        )
+
+        with pytest.raises(sqlite3.OperationalError):
+            handle_tool_call("mnemosyne_hygiene_audit", {})
+
+        assert not data_dir.exists()
+
+    def test_hygiene_audit_unknown_bank_never_initializes_or_creates_state(
+        self, tmp_path, monkeypatch
+    ):
+        """Unknown named banks fail before any manager/instance can create state."""
+        data_dir = tmp_path / "fresh-data"
+
+        def _snapshot(root):
+            return (
+                sorted(path.relative_to(root) for path in root.rglob("*"))
+                if root.exists()
+                else []
+            )
+
+        before = _snapshot(data_dir)
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+        monkeypatch.setattr(
+            mcp_tools,
+            "_create_instance",
+            lambda **_kwargs: pytest.fail("unknown bank must not initialize Mnemosyne"),
+        )
+
+        with pytest.raises(ValueError, match="Bank 'unknown' does not exist"):
+            handle_tool_call("mnemosyne_hygiene_audit", {"bank": "unknown"})
+
+        assert _snapshot(data_dir) == before
+        assert not (data_dir / "banks").exists()
+        assert not (data_dir / "config").exists()
+
+    def test_hygiene_audit_named_bank_requires_an_existing_database(
+        self, tmp_path, monkeypatch
+    ):
+        """A named bank directory without its DB is rejected without mutations."""
+        data_dir = tmp_path / "data"
+        bank_dir = data_dir / "banks" / "team"
+        bank_dir.mkdir(parents=True)
+        before = sorted(path.relative_to(data_dir) for path in data_dir.rglob("*"))
+
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+        monkeypatch.setattr(
+            mcp_tools,
+            "_create_instance",
+            lambda **_kwargs: pytest.fail("named-bank audit must not initialize Mnemosyne"),
+        )
+
+        with pytest.raises(FileNotFoundError, match="Database for bank 'team' does not exist"):
+            handle_tool_call("mnemosyne_hygiene_audit", {"bank": "team"})
+
+        assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before
+
     def test_hygiene_clean_rejects_invalid_candidates_json(self):
         """Invalid hygiene payloads return the documented MCP error instead of raising."""
         result = handle_tool_call(
@@ -569,6 +743,210 @@ class TestMCPIntegration:
         from mnemosyne import mcp_tools
         assert hasattr(mcp_tools, "TOOLS")
         assert hasattr(mcp_tools, "handle_tool_call")
+
+    def test_mcp_tools_fresh_import_does_not_materialize_default_state(self, tmp_path):
+        """A fresh MCP import must not initialize the legacy default database."""
+        data_dir = tmp_path / "data"
+        mnemosyne_home = tmp_path / "mnemosyne-home"
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(tmp_path / "home"),
+            "MNEMOSYNE_HOME": str(mnemosyne_home),
+            "MNEMOSYNE_DATA_DIR": str(data_dir),
+        })
+        script = """
+import json
+import os
+from pathlib import Path
+
+import mnemosyne.mcp_tools
+
+root = Path(os.environ["MNEMOSYNE_DATA_DIR"])
+print(json.dumps(sorted(str(path.relative_to(root)) for path in root.rglob("*")) if root.exists() else []))
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        assert json.loads(completed.stdout) == []
+        assert not data_dir.exists()
+        assert not (data_dir / "mnemosyne.db").exists()
+        assert not (data_dir / "mnemosyne.db-wal").exists()
+        assert not (data_dir / "mnemosyne.db-shm").exists()
+        assert not (data_dir / "config").exists()
+        assert not mnemosyne_home.exists()
+
+    def test_mcp_tools_runtime_type_hints_are_resolvable_without_default_state(self, tmp_path):
+        """Lazy imports must not break runtime type-hint consumers or create state."""
+        data_dir = tmp_path / "data"
+        mnemosyne_home = tmp_path / "mnemosyne-home"
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(tmp_path / "home"),
+            "MNEMOSYNE_HOME": str(mnemosyne_home),
+            "MNEMOSYNE_DATA_DIR": str(data_dir),
+        })
+        script = """
+import json
+import os
+from pathlib import Path
+import sys
+import typing
+
+import mnemosyne.mcp_tools as m
+
+assert typing.get_type_hints(m._create_instance)["return"] is typing.Any
+assert typing.get_type_hints(m._WrapperBatchAdapter.__init__)["mem"] is typing.Any
+assert "mnemosyne.core.memory" not in sys.modules
+root = Path(os.environ["MNEMOSYNE_DATA_DIR"])
+print(json.dumps(sorted(str(path.relative_to(root)) for path in root.rglob("*")) if root.exists() else []))
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        assert json.loads(completed.stdout) == []
+        assert not data_dir.exists()
+        assert not mnemosyne_home.exists()
+
+    def test_mcp_tools_public_mnemosyne_export_is_lazy_and_canonical(self, tmp_path):
+        """The legacy public export resolves to the canonical class on demand."""
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(tmp_path / "home"),
+            "MNEMOSYNE_HOME": str(tmp_path / "mnemosyne-home"),
+            "MNEMOSYNE_DATA_DIR": str(tmp_path / "data"),
+        })
+        script = """
+import json
+
+from mnemosyne.mcp_tools import Mnemosyne
+from mnemosyne.core.memory import Mnemosyne as CoreMnemosyne
+
+print(json.dumps({"is_canonical": Mnemosyne is CoreMnemosyne}))
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        assert json.loads(completed.stdout) == {"is_canonical": True}
+
+    def test_mcp_tools_star_import_preserves_legacy_export_surface(self, tmp_path):
+        """Star imports retain every old public name and resolve Mnemosyne canonically."""
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(tmp_path / "home"),
+            "MNEMOSYNE_HOME": str(tmp_path / "mnemosyne-home"),
+            "MNEMOSYNE_DATA_DIR": str(tmp_path / "data"),
+        })
+        expected = [
+            "ALL_TOOL_SCHEMAS",
+            "Any",
+            "BatchValidationError",
+            "BeamMemory",
+            "CallToolResult",
+            "Dict",
+            "ErrorData",
+            "List",
+            "Mnemosyne",
+            "Path",
+            "TOOLS",
+            "TextContent",
+            "Tool",
+            "apply_beam_batch",
+            "batch_validation_error_payload",
+            "dry_run_batch",
+            "get_tool_definitions",
+            "handle_tool_call",
+            "json",
+            "math",
+            "os",
+            "sqlite3",
+            "validate_batch_operations",
+        ]
+        script = f"""
+import json
+
+ns = {{}}
+exec("from mnemosyne.mcp_tools import *", ns)
+from mnemosyne.core.memory import Mnemosyne as CoreMnemosyne
+
+names = sorted(name for name in ns if name != "__builtins__")
+assert names == {expected!r}
+assert ns["Mnemosyne"] is CoreMnemosyne
+assert not {{"TYPE_CHECKING", "TypeAlias", "MnemosyneInstance"}} & ns.keys()
+print(json.dumps({{"names": names, "count": len(names)}}))
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        assert json.loads(completed.stdout) == {"names": expected, "count": len(expected)}
+
+    def test_named_bank_hygiene_audit_in_fresh_process_creates_no_default_state(self, tmp_path):
+        """A real named-bank audit never initializes default state in a fresh process."""
+        data_dir = tmp_path / "data"
+        named_db = data_dir / "banks" / "team" / "mnemosyne.db"
+        named_db.parent.mkdir(parents=True)
+        sqlite3.connect(named_db).close()
+        before = sorted(str(path.relative_to(data_dir)) for path in data_dir.rglob("*"))
+        mnemosyne_home = tmp_path / "mnemosyne-home"
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(tmp_path / "home"),
+            "MNEMOSYNE_HOME": str(mnemosyne_home),
+            "MNEMOSYNE_DATA_DIR": str(data_dir),
+        })
+        script = """
+import json
+import os
+from pathlib import Path
+
+from mnemosyne.mcp_tools import handle_tool_call
+
+root = Path(os.environ["MNEMOSYNE_DATA_DIR"])
+result = handle_tool_call("mnemosyne_hygiene_audit", {"bank": "team"})
+after = sorted(str(path.relative_to(root)) for path in root.rglob("*"))
+print(json.dumps({"result": result, "after": after}))
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        payload = json.loads(completed.stdout)
+        assert payload["result"]["status"] == "audited"
+        assert payload["result"]["bank"] == "team"
+        assert payload["after"] == before
+        assert not (data_dir / "mnemosyne.db").exists()
+        assert not (data_dir / "mnemosyne.db-wal").exists()
+        assert not (data_dir / "mnemosyne.db-shm").exists()
+        assert not (data_dir / "config").exists()
+        assert not mnemosyne_home.exists()
 
     def test_get_tool_definitions_returns_all(self):
         """get_tool_definitions returns all registered tools."""


### PR DESCRIPTION
## Summary

Make `mnemosyne_hygiene_audit` read-only across its complete MCP process path.

- avoid importing `core.memory` during normal MCP-module import; retain its historical public export lazily and preserve the historical star-import surface
- resolve existing default and named-bank database paths without constructing `Mnemosyne` or `BankManager`
- open the audit database through the existing `mode=ro` + `PRAGMA query_only=ON` Doctor connector, pass that exact connection to `audit_noise`, and close it on success or failure

## Regression coverage

- real SQLite write rejection and `query_only` assertion
- exact connection forwarding and lifecycle on audit success and failure
- missing/default/named-bank failures have no writable fallback or filesystem materialization
- fresh subprocess contracts for normal import, runtime type-hint resolution, lazy public/star imports, and a named-bank audit with no default-state artifacts
- historical star-import API parity checked against `main`

## Validation

- `104 passed, 1 skipped` across focused MCP and bank suites
- Ruff and `git diff --check` pass
- independent spec/API and security/quality reviews: PASS / APPROVED


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Keeps `mnemosyne_hygiene_audit` strictly read-only by resolving existing database paths without constructing `Mnemosyne` or `BankManager`.
- Uses a Doctor SQLite connection with `mode=ro` and `PRAGMA query_only=ON`, forwards the exact connection to `audit_noise`, and reliably closes it.
- Preserves lazy `Mnemosyne` imports, runtime typing, and historical star-import compatibility for MCP integrations.
- Adds coverage for write rejection, connection lifecycle, missing and named-bank paths, subprocess import behavior, and prevention of unintended default-state creation.
- Strengthens privacy and local-first guarantees: MCP audits cannot mutate memory databases or create local state as a side effect.
- No changes to tiered memory, retrieval, consolidation, veracity, sync, or benchmark methodology. Hermes and CLI behavior remain unaffected; MCP’s integration surface becomes safer and more maintainable.
- This is the right architectural call: side-effect-free imports and explicitly read-only diagnostics reduce agent-induced mutation risk while preserving compatibility.

Validation: 104 tests passed, 1 skipped; Ruff and `git diff --check` passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->