### PR TITLE
feat(hermes): add polyphonic_recall config key so working memory can be vector-searched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
+## [Unreleased]
+
+### Changed
+
+- **Hermes provider opts into polyphonic recall by default.** The linear recall scorer only vector-searches episodic memory (`Uses sqlite-vec + FTS5 for episodic, FTS5 for working` — `BeamMemory.recall`), and every memory starts in working memory, so until `sleep()` promotes it a memory is retrievable by literal keyword overlap only — a paraphrased query misses it even when the stored embedding is a strong match (0.61 cosine in the reproduction, ranked #1 by the underlying `vec_working` KNN). Routing Hermes recall through the polyphonic engine gives working memory a vector voice. New `memory.mnemosyne.polyphonic_recall` config key (default `true`); an explicit `MNEMOSYNE_POLYPHONIC_RECALL` env var still takes precedence, so existing opt-ins and opt-outs are preserved.
+
 ## [3.15.0] - 2026-07-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ## [Unreleased]
 
-### Changed
+### Added
 
-- **Hermes provider opts into polyphonic recall by default.** The linear recall scorer only vector-searches episodic memory (`Uses sqlite-vec + FTS5 for episodic, FTS5 for working` — `BeamMemory.recall`), and every memory starts in working memory, so until `sleep()` promotes it a memory is retrievable by literal keyword overlap only — a paraphrased query misses it even when the stored embedding is a strong match (0.61 cosine in the reproduction, ranked #1 by the underlying `vec_working` KNN). Routing Hermes recall through the polyphonic engine gives working memory a vector voice. New `memory.mnemosyne.polyphonic_recall` config key (default `true`); an explicit `MNEMOSYNE_POLYPHONIC_RECALL` env var still takes precedence, so existing opt-ins and opt-outs are preserved.
+- **`memory.mnemosyne.polyphonic_recall` config key for the Hermes providers.** Routes recall through the polyphonic engine so working memory gets a vector voice. Default `false` — current behavior is unchanged — with an explicit `MNEMOSYNE_POLYPHONIC_RECALL` env var still taking precedence. Enable it when paraphrased queries fail to retrieve recent memories: the linear scorer only vector-searches episodic memory (`Uses sqlite-vec + FTS5 for episodic, FTS5 for working` — `BeamMemory.recall`) and every memory starts in working memory, so until `sleep()` promotes it a memory is reachable by literal keyword overlap only — even when the stored embedding is a strong match (0.61 cosine in the reproduction, ranked #1 by the underlying `vec_working` KNN). Values written by the provider are refreshed on re-initialization rather than mistaken for an operator override.
 
 ## [3.15.0] - 2026-07-20
 

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1325,7 +1325,18 @@ _POLYPHONIC_ENV = "MNEMOSYNE_POLYPHONIC_RECALL"
 # operator-supplied one (must never be clobbered). Comparing against the
 # written value keeps this independent of import order, so an env var loaded
 # from .env after this module is imported still counts as external.
+#
+# _polyphonic_lock serializes the read-check-write below across threads.
+# Hermes' MemoryManager runs background sync/prefetch work on daemon
+# threads, so two provider instances in one profile process can call
+# _apply_provider_config() concurrently. In practice both always resolve
+# the same target (kwargs are never used for this key in the framework;
+# every instance in a process reads the same config.yaml), so the race is
+# a redundant identical write rather than a wrong one -- but making the
+# check-then-write atomic removes the question entirely rather than
+# relying on that being true forever.
 _provider_managed_polyphonic: Optional[str] = None
+_polyphonic_lock = threading.Lock()
 
 
 class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
@@ -1611,19 +1622,20 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # this provider wrote earlier is refreshed, so re-initializing with a
         # different config (session switch, second profile in-process) applies.
         global _provider_managed_polyphonic
-        _current_polyphonic = os.environ.get(_POLYPHONIC_ENV)
-        if _current_polyphonic is None or _current_polyphonic == _provider_managed_polyphonic:
-            polyphonic = kwargs.get("polyphonic_recall")
-            if polyphonic is None:
-                polyphonic = self._read_config_key("polyphonic_recall")
-            if polyphonic is None:
-                polyphonic = False
-            if isinstance(polyphonic, str):
-                polyphonic_enabled = polyphonic.strip().lower() in ("true", "1", "yes", "on")
-            else:
-                polyphonic_enabled = bool(polyphonic)
-            _provider_managed_polyphonic = "1" if polyphonic_enabled else "0"
-            os.environ[_POLYPHONIC_ENV] = _provider_managed_polyphonic
+        with _polyphonic_lock:
+            _current_polyphonic = os.environ.get(_POLYPHONIC_ENV)
+            if _current_polyphonic is None or _current_polyphonic == _provider_managed_polyphonic:
+                polyphonic = kwargs.get("polyphonic_recall")
+                if polyphonic is None:
+                    polyphonic = self._read_config_key("polyphonic_recall")
+                if polyphonic is None:
+                    polyphonic = False
+                if isinstance(polyphonic, str):
+                    polyphonic_enabled = polyphonic.strip().lower() in ("true", "1", "yes", "on")
+                else:
+                    polyphonic_enabled = bool(polyphonic)
+                _provider_managed_polyphonic = "1" if polyphonic_enabled else "0"
+                os.environ[_POLYPHONIC_ENV] = _provider_managed_polyphonic
 
         shared_surface_path = kwargs.get("shared_surface_path")
         if shared_surface_path is None:

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1318,6 +1318,16 @@ def _parse_env_optional_int(key: str, default: Optional[int]) -> Optional[int]:
     return _coerce_optional_int(os.environ.get(key), default)
 
 
+_POLYPHONIC_ENV = "MNEMOSYNE_POLYPHONIC_RECALL"
+
+# Last value this process wrote to _POLYPHONIC_ENV. Used to tell a
+# provider-managed value (safe to refresh on re-initialization) apart from an
+# operator-supplied one (must never be clobbered). Comparing against the
+# written value keeps this independent of import order, so an env var loaded
+# from .env after this module is imported still counts as external.
+_provider_managed_polyphonic: Optional[str] = None
+
+
 class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
     """Mnemosyne native memory — local SQLite with vector + FTS5 hybrid search."""
 
@@ -1590,24 +1600,30 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
         # polyphonic_recall: route recall through the multi-voice engine so
         # working memory is searched by vector similarity, not FTS5 alone.
-        # Default ON for Hermes. The linear scorer only vector-searches
+        # Default OFF, preserving the linear scorer's current behavior.
+        # Opting in matters because the linear scorer only vector-searches
         # episodic memory ("Uses sqlite-vec + FTS5 for episodic, FTS5 for
         # working" -- BeamMemory.recall), and every memory starts in working
         # memory, so until consolidation promotes it a paraphrased question
-        # could not retrieve it: recall("plant based diet") missed a stored
-        # "X is vegan" fact whose embedding was a 0.61 cosine match.
-        # An explicit MNEMOSYNE_POLYPHONIC_RECALL env var always wins.
-        if "MNEMOSYNE_POLYPHONIC_RECALL" not in os.environ:
+        # cannot retrieve it: recall("plant based diet") misses a stored
+        # "X is vegan" fact whose embedding is a 0.61 cosine match.
+        # An explicit MNEMOSYNE_POLYPHONIC_RECALL env var always wins; a value
+        # this provider wrote earlier is refreshed, so re-initializing with a
+        # different config (session switch, second profile in-process) applies.
+        global _provider_managed_polyphonic
+        _current_polyphonic = os.environ.get(_POLYPHONIC_ENV)
+        if _current_polyphonic is None or _current_polyphonic == _provider_managed_polyphonic:
             polyphonic = kwargs.get("polyphonic_recall")
             if polyphonic is None:
                 polyphonic = self._read_config_key("polyphonic_recall")
             if polyphonic is None:
-                polyphonic = True
+                polyphonic = False
             if isinstance(polyphonic, str):
                 polyphonic_enabled = polyphonic.strip().lower() in ("true", "1", "yes", "on")
             else:
                 polyphonic_enabled = bool(polyphonic)
-            os.environ["MNEMOSYNE_POLYPHONIC_RECALL"] = "1" if polyphonic_enabled else "0"
+            _provider_managed_polyphonic = "1" if polyphonic_enabled else "0"
+            os.environ[_POLYPHONIC_ENV] = _provider_managed_polyphonic
 
         shared_surface_path = kwargs.get("shared_surface_path")
         if shared_surface_path is None:
@@ -1777,7 +1793,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},
             {"key": "ignore_patterns", "description": "Regex patterns to filter from memory storage (one per line in config, or comma-separated). Memories matching any pattern are skipped.", "default": []},
             {"key": "profile_isolation", "description": "Enable per-profile memory isolation via Mnemosyne banks. Each Hermes profile gets its own SQLite database under mnemosyne/data/banks/<profile>/. Default false for backward compatibility.", "default": False},
-            {"key": "polyphonic_recall", "description": "Route recall through the polyphonic (multi-voice) engine so working memory is searched by vector similarity, not FTS5 keywords alone. Default true; without it, memories that have not yet been consolidated into episodic storage are only retrievable by literal keyword overlap. Set false to restore the linear scorer. Also configurable via MNEMOSYNE_POLYPHONIC_RECALL env var, which takes precedence.", "default": True},
+            {"key": "polyphonic_recall", "description": "Route recall through the polyphonic (multi-voice) engine so working memory is searched by vector similarity, not FTS5 keywords alone. Default false, preserving the linear scorer. Enable it if paraphrased queries fail to retrieve memories that have not yet been consolidated into episodic storage — those are only reachable by literal keyword overlap on the linear path. Also configurable via MNEMOSYNE_POLYPHONIC_RECALL env var, which takes precedence.", "default": False},
             {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -1588,6 +1588,27 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             else:
                 self._profile_isolation_enabled = bool(profile_isolation)
 
+        # polyphonic_recall: route recall through the multi-voice engine so
+        # working memory is searched by vector similarity, not FTS5 alone.
+        # Default ON for Hermes. The linear scorer only vector-searches
+        # episodic memory ("Uses sqlite-vec + FTS5 for episodic, FTS5 for
+        # working" -- BeamMemory.recall), and every memory starts in working
+        # memory, so until consolidation promotes it a paraphrased question
+        # could not retrieve it: recall("plant based diet") missed a stored
+        # "X is vegan" fact whose embedding was a 0.61 cosine match.
+        # An explicit MNEMOSYNE_POLYPHONIC_RECALL env var always wins.
+        if "MNEMOSYNE_POLYPHONIC_RECALL" not in os.environ:
+            polyphonic = kwargs.get("polyphonic_recall")
+            if polyphonic is None:
+                polyphonic = self._read_config_key("polyphonic_recall")
+            if polyphonic is None:
+                polyphonic = True
+            if isinstance(polyphonic, str):
+                polyphonic_enabled = polyphonic.strip().lower() in ("true", "1", "yes", "on")
+            else:
+                polyphonic_enabled = bool(polyphonic)
+            os.environ["MNEMOSYNE_POLYPHONIC_RECALL"] = "1" if polyphonic_enabled else "0"
+
         shared_surface_path = kwargs.get("shared_surface_path")
         if shared_surface_path is None:
             shared_surface_path = self._read_config_key("shared_surface_path")
@@ -1756,6 +1777,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},
             {"key": "ignore_patterns", "description": "Regex patterns to filter from memory storage (one per line in config, or comma-separated). Memories matching any pattern are skipped.", "default": []},
             {"key": "profile_isolation", "description": "Enable per-profile memory isolation via Mnemosyne banks. Each Hermes profile gets its own SQLite database under mnemosyne/data/banks/<profile>/. Default false for backward compatibility.", "default": False},
+            {"key": "polyphonic_recall", "description": "Route recall through the polyphonic (multi-voice) engine so working memory is searched by vector similarity, not FTS5 keywords alone. Default true; without it, memories that have not yet been consolidated into episodic storage are only retrievable by literal keyword overlap. Set false to restore the linear scorer. Also configurable via MNEMOSYNE_POLYPHONIC_RECALL env var, which takes precedence.", "default": True},
             {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -523,7 +523,18 @@ _POLYPHONIC_ENV = "MNEMOSYNE_POLYPHONIC_RECALL"
 # operator-supplied one (must never be clobbered). Comparing against the
 # written value keeps this independent of import order, so an env var loaded
 # from .env after this module is imported still counts as external.
+#
+# _polyphonic_lock serializes the read-check-write below across threads.
+# Hermes' MemoryManager runs background sync/prefetch work on daemon
+# threads, so two provider instances in one profile process can call
+# _apply_provider_config() concurrently. In practice both always resolve
+# the same target (kwargs are never used for this key in the framework;
+# every instance in a process reads the same config.yaml), so the race is
+# a redundant identical write rather than a wrong one -- but making the
+# check-then-write atomic removes the question entirely rather than
+# relying on that being true forever.
 _provider_managed_polyphonic: Optional[str] = None
+_polyphonic_lock = threading.Lock()
 
 
 class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
@@ -823,19 +834,20 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # this provider wrote earlier is refreshed, so re-initializing with a
         # different config (session switch, second profile in-process) applies.
         global _provider_managed_polyphonic
-        _current_polyphonic = os.environ.get(_POLYPHONIC_ENV)
-        if _current_polyphonic is None or _current_polyphonic == _provider_managed_polyphonic:
-            polyphonic = kwargs.get("polyphonic_recall")
-            if polyphonic is None:
-                polyphonic = self._read_config_key("polyphonic_recall")
-            if polyphonic is None:
-                polyphonic = False
-            if isinstance(polyphonic, str):
-                polyphonic_enabled = polyphonic.strip().lower() in ("true", "1", "yes", "on")
-            else:
-                polyphonic_enabled = bool(polyphonic)
-            _provider_managed_polyphonic = "1" if polyphonic_enabled else "0"
-            os.environ[_POLYPHONIC_ENV] = _provider_managed_polyphonic
+        with _polyphonic_lock:
+            _current_polyphonic = os.environ.get(_POLYPHONIC_ENV)
+            if _current_polyphonic is None or _current_polyphonic == _provider_managed_polyphonic:
+                polyphonic = kwargs.get("polyphonic_recall")
+                if polyphonic is None:
+                    polyphonic = self._read_config_key("polyphonic_recall")
+                if polyphonic is None:
+                    polyphonic = False
+                if isinstance(polyphonic, str):
+                    polyphonic_enabled = polyphonic.strip().lower() in ("true", "1", "yes", "on")
+                else:
+                    polyphonic_enabled = bool(polyphonic)
+                _provider_managed_polyphonic = "1" if polyphonic_enabled else "0"
+                os.environ[_POLYPHONIC_ENV] = _provider_managed_polyphonic
 
         shared_surface_path = kwargs.get("shared_surface_path")
         if shared_surface_path is None:

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -516,6 +516,16 @@ def _parse_env_optional_int(key: str, default: Optional[int]) -> Optional[int]:
     return _coerce_optional_int(os.environ.get(key), default)
 
 
+_POLYPHONIC_ENV = "MNEMOSYNE_POLYPHONIC_RECALL"
+
+# Last value this process wrote to _POLYPHONIC_ENV. Used to tell a
+# provider-managed value (safe to refresh on re-initialization) apart from an
+# operator-supplied one (must never be clobbered). Comparing against the
+# written value keeps this independent of import order, so an env var loaded
+# from .env after this module is imported still counts as external.
+_provider_managed_polyphonic: Optional[str] = None
+
+
 class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
     """Mnemosyne native memory — local SQLite with vector + FTS5 hybrid search."""
 
@@ -802,24 +812,30 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
         # polyphonic_recall: route recall through the multi-voice engine so
         # working memory is searched by vector similarity, not FTS5 alone.
-        # Default ON for Hermes. The linear scorer only vector-searches
+        # Default OFF, preserving the linear scorer's current behavior.
+        # Opting in matters because the linear scorer only vector-searches
         # episodic memory ("Uses sqlite-vec + FTS5 for episodic, FTS5 for
         # working" -- BeamMemory.recall), and every memory starts in working
         # memory, so until consolidation promotes it a paraphrased question
-        # could not retrieve it: recall("plant based diet") missed a stored
-        # "X is vegan" fact whose embedding was a 0.61 cosine match.
-        # An explicit MNEMOSYNE_POLYPHONIC_RECALL env var always wins.
-        if "MNEMOSYNE_POLYPHONIC_RECALL" not in os.environ:
+        # cannot retrieve it: recall("plant based diet") misses a stored
+        # "X is vegan" fact whose embedding is a 0.61 cosine match.
+        # An explicit MNEMOSYNE_POLYPHONIC_RECALL env var always wins; a value
+        # this provider wrote earlier is refreshed, so re-initializing with a
+        # different config (session switch, second profile in-process) applies.
+        global _provider_managed_polyphonic
+        _current_polyphonic = os.environ.get(_POLYPHONIC_ENV)
+        if _current_polyphonic is None or _current_polyphonic == _provider_managed_polyphonic:
             polyphonic = kwargs.get("polyphonic_recall")
             if polyphonic is None:
                 polyphonic = self._read_config_key("polyphonic_recall")
             if polyphonic is None:
-                polyphonic = True
+                polyphonic = False
             if isinstance(polyphonic, str):
                 polyphonic_enabled = polyphonic.strip().lower() in ("true", "1", "yes", "on")
             else:
                 polyphonic_enabled = bool(polyphonic)
-            os.environ["MNEMOSYNE_POLYPHONIC_RECALL"] = "1" if polyphonic_enabled else "0"
+            _provider_managed_polyphonic = "1" if polyphonic_enabled else "0"
+            os.environ[_POLYPHONIC_ENV] = _provider_managed_polyphonic
 
         shared_surface_path = kwargs.get("shared_surface_path")
         if shared_surface_path is None:
@@ -959,7 +975,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},
             {"key": "ignore_patterns", "description": "Regex patterns to filter from memory storage (one per line in config, or comma-separated). Memories matching any pattern are skipped.", "default": []},
             {"key": "profile_isolation", "description": "Enable per-profile memory isolation via Mnemosyne banks. Each Hermes profile gets its own SQLite database under mnemosyne/data/banks/<profile>/. Default false for backward compatibility.", "default": False},
-            {"key": "polyphonic_recall", "description": "Route recall through the polyphonic (multi-voice) engine so working memory is searched by vector similarity, not FTS5 keywords alone. Default true; without it, memories that have not yet been consolidated into episodic storage are only retrievable by literal keyword overlap. Set false to restore the linear scorer. Also configurable via MNEMOSYNE_POLYPHONIC_RECALL env var, which takes precedence.", "default": True},
+            {"key": "polyphonic_recall", "description": "Route recall through the polyphonic (multi-voice) engine so working memory is searched by vector similarity, not FTS5 keywords alone. Default false, preserving the linear scorer. Enable it if paraphrased queries fail to retrieve memories that have not yet been consolidated into episodic storage — those are only reachable by literal keyword overlap on the linear path. Also configurable via MNEMOSYNE_POLYPHONIC_RECALL env var, which takes precedence.", "default": False},
             {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -800,6 +800,27 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             else:
                 self._profile_isolation_enabled = bool(profile_isolation)
 
+        # polyphonic_recall: route recall through the multi-voice engine so
+        # working memory is searched by vector similarity, not FTS5 alone.
+        # Default ON for Hermes. The linear scorer only vector-searches
+        # episodic memory ("Uses sqlite-vec + FTS5 for episodic, FTS5 for
+        # working" -- BeamMemory.recall), and every memory starts in working
+        # memory, so until consolidation promotes it a paraphrased question
+        # could not retrieve it: recall("plant based diet") missed a stored
+        # "X is vegan" fact whose embedding was a 0.61 cosine match.
+        # An explicit MNEMOSYNE_POLYPHONIC_RECALL env var always wins.
+        if "MNEMOSYNE_POLYPHONIC_RECALL" not in os.environ:
+            polyphonic = kwargs.get("polyphonic_recall")
+            if polyphonic is None:
+                polyphonic = self._read_config_key("polyphonic_recall")
+            if polyphonic is None:
+                polyphonic = True
+            if isinstance(polyphonic, str):
+                polyphonic_enabled = polyphonic.strip().lower() in ("true", "1", "yes", "on")
+            else:
+                polyphonic_enabled = bool(polyphonic)
+            os.environ["MNEMOSYNE_POLYPHONIC_RECALL"] = "1" if polyphonic_enabled else "0"
+
         shared_surface_path = kwargs.get("shared_surface_path")
         if shared_surface_path is None:
             shared_surface_path = self._read_config_key("shared_surface_path")
@@ -938,6 +959,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},
             {"key": "ignore_patterns", "description": "Regex patterns to filter from memory storage (one per line in config, or comma-separated). Memories matching any pattern are skipped.", "default": []},
             {"key": "profile_isolation", "description": "Enable per-profile memory isolation via Mnemosyne banks. Each Hermes profile gets its own SQLite database under mnemosyne/data/banks/<profile>/. Default false for backward compatibility.", "default": False},
+            {"key": "polyphonic_recall", "description": "Route recall through the polyphonic (multi-voice) engine so working memory is searched by vector similarity, not FTS5 keywords alone. Default true; without it, memories that have not yet been consolidated into episodic storage are only retrievable by literal keyword overlap. Set false to restore the linear scorer. Also configurable via MNEMOSYNE_POLYPHONIC_RECALL env var, which takes precedence.", "default": True},
             {"key": "shared_surface_path", "description": "SQLite path for shared surface memories. Default is <mnemosyne>/data/shared/mnemosyne.db.", "default": "data/shared/mnemosyne.db"},
             {"key": "shared_surface_read", "description": "When true, mnemosyne_recall merges shared-surface results into private bank recall, tagging each result with its bank ('private' or 'surface'). Default false.", "default": False},
             {"key": "skip_contexts", "description": "Agent contexts where Mnemosyne should skip initialization. Comma-separated list. Defaults to 'cron,flush,subagent,background,skill_loop'. Set to empty string to enable all contexts. Also configurable via MNEMOSYNE_SKIP_CONTEXTS env var.", "default": "cron,flush,subagent,background,skill_loop"},

--- a/tests/test_polyphonic_recall_default.py
+++ b/tests/test_polyphonic_recall_default.py
@@ -1,0 +1,125 @@
+"""Tests for the polyphonic_recall provider default.
+
+The linear recall scorer only vector-searches episodic memory ("Uses
+sqlite-vec + FTS5 for episodic, FTS5 for working" -- BeamMemory.recall).
+Every memory starts in working memory, so until consolidation promotes it,
+recall was keyword-only and paraphrased questions returned nothing even when
+a stored fact was a strong embedding match. The Hermes provider therefore
+enables the polyphonic engine by default, while leaving an explicit
+MNEMOSYNE_POLYPHONIC_RECALL env var authoritative.
+
+Both provider paths are covered:
+
+1. hermes_memory_provider — legacy plugin
+2. mnemosyne_hermes — pip-installable integration provider
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+ENV_VAR = "MNEMOSYNE_POLYPHONIC_RECALL"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    """Run each test with the gate env var unset, and restore it after."""
+    original = os.environ.get(ENV_VAR)
+    os.environ.pop(ENV_VAR, None)
+    try:
+        yield
+    finally:
+        os.environ.pop(ENV_VAR, None)
+        if original is not None:
+            os.environ[ENV_VAR] = original
+
+
+def _provider_classes():
+    """Yield (label, class) for every shipped provider implementation."""
+    from hermes_memory_provider import MnemosyneMemoryProvider as Legacy
+
+    yield "hermes_memory_provider", Legacy
+    try:
+        from mnemosyne_hermes import MnemosyneMemoryProvider as Pip
+    except ImportError:  # integration package not on sys.path
+        return
+    yield "mnemosyne_hermes", Pip
+
+
+PROVIDERS = list(_provider_classes())
+PROVIDER_IDS = [label for label, _ in PROVIDERS]
+PROVIDER_CLASSES = [cls for _, cls in PROVIDERS]
+
+
+@pytest.mark.parametrize("provider_cls", PROVIDER_CLASSES, ids=PROVIDER_IDS)
+class TestPolyphonicRecallDefault:
+    def test_enabled_by_default(self, provider_cls):
+        """With no config and no env var, the gate is turned on."""
+        provider = provider_cls()
+        with patch.object(provider_cls, "_read_config_key", return_value=None):
+            provider._apply_provider_config({})
+        assert os.environ[ENV_VAR] == "1"
+
+    def test_config_false_disables(self, provider_cls):
+        """polyphonic_recall: false in config.yaml restores the linear scorer."""
+        provider = provider_cls()
+        with patch.object(
+            provider_cls,
+            "_read_config_key",
+            side_effect=lambda key: False if key == "polyphonic_recall" else None,
+        ):
+            provider._apply_provider_config({})
+        assert os.environ[ENV_VAR] == "0"
+
+    def test_kwargs_take_precedence_over_config(self, provider_cls):
+        """kwargs beat config.yaml, matching the other provider config keys."""
+        provider = provider_cls()
+        with patch.object(
+            provider_cls,
+            "_read_config_key",
+            side_effect=lambda key: True if key == "polyphonic_recall" else None,
+        ):
+            provider._apply_provider_config({"polyphonic_recall": False})
+        assert os.environ[ENV_VAR] == "0"
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [("true", "1"), ("ON", "1"), ("Yes", "1"), ("1", "1"),
+         ("false", "0"), ("off", "0"), ("no", "0"), ("0", "0")],
+    )
+    def test_string_values_are_coerced(self, provider_cls, raw, expected):
+        """String config values are parsed like the other boolean keys."""
+        provider = provider_cls()
+        with patch.object(
+            provider_cls,
+            "_read_config_key",
+            side_effect=lambda key: raw if key == "polyphonic_recall" else None,
+        ):
+            provider._apply_provider_config({})
+        assert os.environ[ENV_VAR] == expected
+
+    @pytest.mark.parametrize("preset", ["0", "1"])
+    def test_explicit_env_var_wins(self, provider_cls, preset):
+        """An operator-set env var is never overwritten by the config default."""
+        os.environ[ENV_VAR] = preset
+        provider = provider_cls()
+        with patch.object(
+            provider_cls,
+            "_read_config_key",
+            side_effect=lambda key: (preset == "0") if key == "polyphonic_recall" else None,
+        ):
+            provider._apply_provider_config({})
+        assert os.environ[ENV_VAR] == preset
+
+    def test_config_schema_advertises_the_key(self, provider_cls):
+        """`hermes memory setup` can discover and document the new key."""
+        schema = provider_cls().get_config_schema()
+        entry = next(
+            (field for field in schema if field.get("key") == "polyphonic_recall"),
+            None,
+        )
+        assert entry is not None, "polyphonic_recall missing from get_config_schema()"
+        assert entry.get("default") is True

--- a/tests/test_polyphonic_recall_default.py
+++ b/tests/test_polyphonic_recall_default.py
@@ -209,7 +209,9 @@ class TestPolyphonicRecallRetrieval:
         payload = json.loads(raw) if isinstance(raw, str) else raw
         return len(payload.get("results") or [])
 
-    def test_paraphrase_retrieves_unconsolidated_memory(self, provider_cls, tmp_path):
+    def test_paraphrase_retrieves_unconsolidated_memory(
+        self, provider_cls, tmp_path, monkeypatch
+    ):
         """Opting in makes a working-memory fact reachable by paraphrase.
 
         The opt-out preserves the linear path, where the vector voice never
@@ -224,6 +226,12 @@ class TestPolyphonicRecallRetrieval:
 
         home = tmp_path / "hermes_home"
         home.mkdir()
+        # The hermes_home kwarg alone is not enough: some paths resolve the
+        # database through the HERMES_HOME environment variable, so without
+        # this the test would read and write the developer's real Mnemosyne
+        # store instead of the temporary one.
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(home / "mnemosyne" / "data"))
         provider = provider_cls()
         with patch.object(provider_cls, "_read_config_key", return_value=None):
             provider.initialize(

--- a/tests/test_polyphonic_recall_default.py
+++ b/tests/test_polyphonic_recall_default.py
@@ -270,9 +270,7 @@ class TestPolyphonicRecallRetrieval:
         )
         return json.loads(marker[-1][len("RESULT:"):])
 
-    def test_paraphrase_retrieves_unconsolidated_memory(
-        self, provider_cls, tmp_path, monkeypatch
-    ):
+    def test_paraphrase_retrieves_unconsolidated_memory(self, provider_cls, tmp_path):
         """Opting in makes a working-memory fact reachable by paraphrase.
 
         The opt-out preserves the linear path, where the vector voice never

--- a/tests/test_polyphonic_recall_default.py
+++ b/tests/test_polyphonic_recall_default.py
@@ -8,20 +8,64 @@ a stored fact was a strong embedding match. The Hermes provider therefore
 enables the polyphonic engine by default, while leaving an explicit
 MNEMOSYNE_POLYPHONIC_RECALL env var authoritative.
 
+Following the convention in test_ab_toggles.py, the toggle is pinned at three
+levels: the default, the falsy/override paths, and -- so a refactor that drops
+the gate fails here instead of silently reverting -- actual recall results.
+
 Both provider paths are covered:
 
 1. hermes_memory_provider — legacy plugin
 2. mnemosyne_hermes — pip-installable integration provider
+   (`pip install -e ./integrations/hermes`, as CI does)
 """
 
 from __future__ import annotations
 
+import importlib.util
 import os
+import sys
 from unittest.mock import patch
 
 import pytest
 
 ENV_VAR = "MNEMOSYNE_POLYPHONIC_RECALL"
+
+from hermes_memory_provider import MnemosyneMemoryProvider as LegacyProvider
+
+_PIP_PROVIDER_AVAILABLE = importlib.util.find_spec("mnemosyne_hermes") is not None
+if _PIP_PROVIDER_AVAILABLE:
+    from mnemosyne_hermes import MnemosyneMemoryProvider as PipProvider
+else:  # pragma: no cover - exercised only on installs without the integration
+    PipProvider = None
+
+# Both shipped providers are required coverage. The pip package is skipped
+# *visibly* when it is not installed, rather than silently shrinking the
+# parametrization to a single implementation.
+PROVIDER_PARAMS = [
+    pytest.param(LegacyProvider, id="hermes_memory_provider"),
+    pytest.param(
+        PipProvider,
+        id="mnemosyne_hermes",
+        marks=pytest.mark.skipif(
+            not _PIP_PROVIDER_AVAILABLE,
+            reason="mnemosyne_hermes not installed (pip install -e ./integrations/hermes)",
+        ),
+    ),
+]
+
+
+def _reset_provider_managed_state(provider_cls) -> None:
+    """Forget the value the provider module last wrote to the env var.
+
+    Resolved through the function's own ``__globals__`` rather than
+    ``sys.modules[...]``: another test module may reload the provider, leaving
+    a stale module object in ``sys.modules`` while the bound method still reads
+    the original namespace. Targeting the namespace the function actually uses
+    keeps this reset correct whatever else the suite has imported.
+    """
+    namespace = provider_cls._apply_provider_config.__globals__
+    if "_provider_managed_polyphonic" in namespace:
+        namespace["_provider_managed_polyphonic"] = None
 
 
 @pytest.fixture(autouse=True)
@@ -29,6 +73,9 @@ def _clean_env():
     """Run each test with the gate env var unset, and restore it after."""
     original = os.environ.get(ENV_VAR)
     os.environ.pop(ENV_VAR, None)
+    for param in PROVIDER_PARAMS:
+        if param.values[0] is not None:
+            _reset_provider_managed_state(param.values[0])
     try:
         yield
     finally:
@@ -37,42 +84,25 @@ def _clean_env():
             os.environ[ENV_VAR] = original
 
 
-def _provider_classes():
-    """Yield (label, class) for every shipped provider implementation."""
-    from hermes_memory_provider import MnemosyneMemoryProvider as Legacy
-
-    yield "hermes_memory_provider", Legacy
-    try:
-        from mnemosyne_hermes import MnemosyneMemoryProvider as Pip
-    except ImportError:  # integration package not on sys.path
-        return
-    yield "mnemosyne_hermes", Pip
-
-
-PROVIDERS = list(_provider_classes())
-PROVIDER_IDS = [label for label, _ in PROVIDERS]
-PROVIDER_CLASSES = [cls for _, cls in PROVIDERS]
-
-
-@pytest.mark.parametrize("provider_cls", PROVIDER_CLASSES, ids=PROVIDER_IDS)
+@pytest.mark.parametrize("provider_cls", PROVIDER_PARAMS)
 class TestPolyphonicRecallDefault:
-    def test_enabled_by_default(self, provider_cls):
-        """With no config and no env var, the gate is turned on."""
+    def test_disabled_by_default(self, provider_cls):
+        """With no config and no env var, current behavior is preserved."""
         provider = provider_cls()
         with patch.object(provider_cls, "_read_config_key", return_value=None):
             provider._apply_provider_config({})
-        assert os.environ[ENV_VAR] == "1"
+        assert os.environ[ENV_VAR] == "0"
 
-    def test_config_false_disables(self, provider_cls):
-        """polyphonic_recall: false in config.yaml restores the linear scorer."""
+    def test_config_true_enables(self, provider_cls):
+        """polyphonic_recall: true in config.yaml opts into the engine."""
         provider = provider_cls()
         with patch.object(
             provider_cls,
             "_read_config_key",
-            side_effect=lambda key: False if key == "polyphonic_recall" else None,
+            side_effect=lambda key: True if key == "polyphonic_recall" else None,
         ):
             provider._apply_provider_config({})
-        assert os.environ[ENV_VAR] == "0"
+        assert os.environ[ENV_VAR] == "1"
 
     def test_kwargs_take_precedence_over_config(self, provider_cls):
         """kwargs beat config.yaml, matching the other provider config keys."""
@@ -80,10 +110,10 @@ class TestPolyphonicRecallDefault:
         with patch.object(
             provider_cls,
             "_read_config_key",
-            side_effect=lambda key: True if key == "polyphonic_recall" else None,
+            side_effect=lambda key: False if key == "polyphonic_recall" else None,
         ):
-            provider._apply_provider_config({"polyphonic_recall": False})
-        assert os.environ[ENV_VAR] == "0"
+            provider._apply_provider_config({"polyphonic_recall": True})
+        assert os.environ[ENV_VAR] == "1"
 
     @pytest.mark.parametrize(
         "raw,expected",
@@ -114,6 +144,48 @@ class TestPolyphonicRecallDefault:
             provider._apply_provider_config({})
         assert os.environ[ENV_VAR] == preset
 
+    def test_reinitialization_applies_new_config(self, provider_cls):
+        """A provider-written value is refreshed on re-init, not mistaken for
+        an operator override.
+
+        Regression: the first initialization writes the env var, so a naive
+        "is it already set?" guard makes every later initialization in the same
+        process a no-op -- a second profile, a session switch, or an edited
+        config.yaml would silently keep the first value.
+        """
+        first = provider_cls()
+        with patch.object(
+            provider_cls,
+            "_read_config_key",
+            side_effect=lambda key: True if key == "polyphonic_recall" else None,
+        ):
+            first._apply_provider_config({})
+        assert os.environ[ENV_VAR] == "1"
+
+        second = provider_cls()
+        with patch.object(
+            provider_cls,
+            "_read_config_key",
+            side_effect=lambda key: False if key == "polyphonic_recall" else None,
+        ):
+            second._apply_provider_config({})
+        assert os.environ[ENV_VAR] == "0"
+
+    def test_external_override_survives_reinitialization(self, provider_cls):
+        """An operator override still wins after the provider has run once."""
+        first = provider_cls()
+        with patch.object(provider_cls, "_read_config_key", return_value=None):
+            first._apply_provider_config({})
+        assert os.environ[ENV_VAR] == "0"
+
+        # Operator intervenes mid-process (e.g. a later .env load).
+        os.environ[ENV_VAR] = "1"
+
+        second = provider_cls()
+        with patch.object(provider_cls, "_read_config_key", return_value=None):
+            second._apply_provider_config({})
+        assert os.environ[ENV_VAR] == "1"
+
     def test_config_schema_advertises_the_key(self, provider_cls):
         """`hermes memory setup` can discover and document the new key."""
         schema = provider_cls().get_config_schema()
@@ -122,4 +194,68 @@ class TestPolyphonicRecallDefault:
             None,
         )
         assert entry is not None, "polyphonic_recall missing from get_config_schema()"
-        assert entry.get("default") is True
+        assert entry.get("default") is False
+
+
+@pytest.mark.parametrize("provider_cls", PROVIDER_PARAMS)
+class TestPolyphonicRecallRetrieval:
+    """The toggle must surface in real recall results, not just an env var."""
+
+    @staticmethod
+    def _recall_count(provider, query: str) -> int:
+        import json
+
+        raw = provider.handle_tool_call("mnemosyne_recall", {"query": query, "limit": 3})
+        payload = json.loads(raw) if isinstance(raw, str) else raw
+        return len(payload.get("results") or [])
+
+    def test_paraphrase_retrieves_unconsolidated_memory(self, provider_cls, tmp_path):
+        """Opting in makes a working-memory fact reachable by paraphrase.
+
+        The opt-out preserves the linear path, where the vector voice never
+        covers working memory and only literal keyword overlap matches. Both
+        directions are asserted so a refactor that drops the gate fails here.
+        """
+        embeddings = pytest.importorskip(
+            "mnemosyne.core.embeddings", reason="embeddings extra not installed"
+        )
+        if not embeddings.available():
+            pytest.skip("embeddings backend unavailable")
+
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        provider = provider_cls()
+        with patch.object(provider_cls, "_read_config_key", return_value=None):
+            provider.initialize(
+                "polyphonic-retrieval",
+                hermes_home=str(home),
+                platform="cli",
+                agent_context="primary",
+                agent_identity="test",
+            )
+        try:
+            provider.handle_tool_call("mnemosyne_remember", {
+                "content": "Casey is vegan; shared meals need genuinely vegan options.",
+                "source": "fact",
+                "importance": 0.9,
+                "scope": "global",
+            })
+
+            # Literal keyword overlap works either way -- it is the FTS5 path.
+            assert self._recall_count(provider, "vegan") >= 1
+
+            # The paraphrase shares no content words with the stored memory.
+            # recall() reads the gate per call, so it can be toggled directly.
+            paraphrase = "plant based diet, avoid animal products"
+
+            os.environ[ENV_VAR] = "1"
+            assert self._recall_count(provider, paraphrase) >= 1, (
+                "paraphrased query should retrieve the unconsolidated memory "
+                "with polyphonic recall enabled"
+            )
+
+            # Opt-out (the default) keeps the current linear behavior.
+            os.environ[ENV_VAR] = "0"
+            assert self._recall_count(provider, paraphrase) == 0
+        finally:
+            provider.shutdown()

--- a/tests/test_polyphonic_recall_default.py
+++ b/tests/test_polyphonic_recall_default.py
@@ -3,10 +3,11 @@
 The linear recall scorer only vector-searches episodic memory ("Uses
 sqlite-vec + FTS5 for episodic, FTS5 for working" -- BeamMemory.recall).
 Every memory starts in working memory, so until consolidation promotes it,
-recall was keyword-only and paraphrased questions returned nothing even when
-a stored fact was a strong embedding match. The Hermes provider therefore
-enables the polyphonic engine by default, while leaving an explicit
-MNEMOSYNE_POLYPHONIC_RECALL env var authoritative.
+recall is keyword-only and a paraphrased question returns nothing even when
+the stored fact is a strong embedding match. The Hermes providers expose
+polyphonic recall as a config key so that gap can be closed; it defaults to
+off (current behavior), and an explicit MNEMOSYNE_POLYPHONIC_RECALL env var
+stays authoritative over both config and the default.
 
 Following the convention in test_ab_toggles.py, the toggle is pinned at three
 levels: the default, the falsy/override paths, and -- so a refactor that drops
@@ -24,6 +25,7 @@ from __future__ import annotations
 import importlib.util
 import os
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -197,17 +199,76 @@ class TestPolyphonicRecallDefault:
         assert entry.get("default") is False
 
 
+# Retrieval coverage runs in a child process. Loading the embedding backend
+# opens a large number of file descriptors and leaves module-level thread-local
+# database connections behind, which perturbs suite-wide assertions elsewhere
+# (tests/test_repair.py compares process-wide /proc/self/fd counts). A
+# subprocess gives real end-to-end coverage while guaranteeing that none of it
+# survives into the pytest process.
+_RETRIEVAL_CHILD = '''
+import json, os, sys
+
+provider_module = sys.argv[1]
+home = sys.argv[2]
+__import__(provider_module)
+Provider = sys.modules[provider_module].MnemosyneMemoryProvider
+
+provider = Provider()
+provider.initialize("polyphonic-retrieval", hermes_home=home, platform="cli",
+                    agent_context="primary", agent_identity="test")
+
+
+def recall_count(query):
+    raw = provider.handle_tool_call("mnemosyne_recall", {"query": query, "limit": 3})
+    payload = json.loads(raw) if isinstance(raw, str) else raw
+    return len(payload.get("results") or [])
+
+
+try:
+    provider.handle_tool_call("mnemosyne_remember", {
+        "content": "Casey is vegan; shared meals need genuinely vegan options.",
+        "source": "fact", "importance": 0.9, "scope": "global"})
+
+    paraphrase = "plant based diet, avoid animal products"
+    # recall() reads the gate per call, so it can be toggled directly.
+    os.environ["MNEMOSYNE_POLYPHONIC_RECALL"] = "1"
+    result = {"keyword": recall_count("vegan"), "enabled": recall_count(paraphrase)}
+    os.environ["MNEMOSYNE_POLYPHONIC_RECALL"] = "0"
+    result["disabled"] = recall_count(paraphrase)
+finally:
+    provider.shutdown()
+
+print("RESULT:" + json.dumps(result))
+'''
+
+
 @pytest.mark.parametrize("provider_cls", PROVIDER_PARAMS)
 class TestPolyphonicRecallRetrieval:
     """The toggle must surface in real recall results, not just an env var."""
 
     @staticmethod
-    def _recall_count(provider, query: str) -> int:
+    def _run_child(provider_cls, home, repo_root) -> dict:
         import json
+        import subprocess
 
-        raw = provider.handle_tool_call("mnemosyne_recall", {"query": query, "limit": 3})
-        payload = json.loads(raw) if isinstance(raw, str) else raw
-        return len(payload.get("results") or [])
+        env = dict(os.environ)
+        env["HERMES_HOME"] = str(home)
+        env["MNEMOSYNE_DATA_DIR"] = str(home / "mnemosyne" / "data")
+        env.pop("MNEMOSYNE_POLYPHONIC_RECALL", None)
+        env["PYTHONPATH"] = os.pathsep.join(
+            p for p in [str(repo_root), str(repo_root / "integrations" / "hermes" / "src"),
+                        env.get("PYTHONPATH", "")] if p
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", _RETRIEVAL_CHILD, provider_cls.__module__, str(home)],
+            capture_output=True, text=True, env=env, timeout=600,
+        )
+        marker = [ln for ln in completed.stdout.splitlines() if ln.startswith("RESULT:")]
+        assert marker, (
+            f"retrieval child failed (rc={completed.returncode})\n"
+            f"stdout:\n{completed.stdout[-2000:]}\nstderr:\n{completed.stderr[-2000:]}"
+        )
+        return json.loads(marker[-1][len("RESULT:"):])
 
     def test_paraphrase_retrieves_unconsolidated_memory(
         self, provider_cls, tmp_path, monkeypatch
@@ -224,46 +285,22 @@ class TestPolyphonicRecallRetrieval:
         if not embeddings.available():
             pytest.skip("embeddings backend unavailable")
 
+        # HERMES_HOME is pinned for the child too: the hermes_home kwarg alone
+        # is not enough, because parts of the database path resolve through the
+        # environment, which would read and write a real Mnemosyne store.
         home = tmp_path / "hermes_home"
         home.mkdir()
-        # The hermes_home kwarg alone is not enough: some paths resolve the
-        # database through the HERMES_HOME environment variable, so without
-        # this the test would read and write the developer's real Mnemosyne
-        # store instead of the temporary one.
-        monkeypatch.setenv("HERMES_HOME", str(home))
-        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(home / "mnemosyne" / "data"))
-        provider = provider_cls()
-        with patch.object(provider_cls, "_read_config_key", return_value=None):
-            provider.initialize(
-                "polyphonic-retrieval",
-                hermes_home=str(home),
-                platform="cli",
-                agent_context="primary",
-                agent_identity="test",
-            )
-        try:
-            provider.handle_tool_call("mnemosyne_remember", {
-                "content": "Casey is vegan; shared meals need genuinely vegan options.",
-                "source": "fact",
-                "importance": 0.9,
-                "scope": "global",
-            })
+        repo_root = Path(__file__).resolve().parents[1]
+        counts = self._run_child(provider_cls, home, repo_root)
 
-            # Literal keyword overlap works either way -- it is the FTS5 path.
-            assert self._recall_count(provider, "vegan") >= 1
+        # Literal keyword overlap works either way -- it is the FTS5 path.
+        assert counts["keyword"] >= 1
 
-            # The paraphrase shares no content words with the stored memory.
-            # recall() reads the gate per call, so it can be toggled directly.
-            paraphrase = "plant based diet, avoid animal products"
+        # The paraphrase shares no content words with the stored memory.
+        assert counts["enabled"] >= 1, (
+            "paraphrased query should retrieve the unconsolidated memory "
+            "with polyphonic recall enabled"
+        )
 
-            os.environ[ENV_VAR] = "1"
-            assert self._recall_count(provider, paraphrase) >= 1, (
-                "paraphrased query should retrieve the unconsolidated memory "
-                "with polyphonic recall enabled"
-            )
-
-            # Opt-out (the default) keeps the current linear behavior.
-            os.environ[ENV_VAR] = "0"
-            assert self._recall_count(provider, paraphrase) == 0
-        finally:
-            provider.shutdown()
+        # Opt-out (the default) keeps the current linear behavior.
+        assert counts["disabled"] == 0


### PR DESCRIPTION
## What

Adds a `memory.mnemosyne.polyphonic_recall` config key to both Hermes providers, routing recall through the polyphonic engine so working memory is searched by vector similarity rather than FTS5 keywords alone.

**Default `false` — current behavior is unchanged.** Per review, the default is left as a maintainer decision pending a quality/latency check.

## Why

`BeamMemory.recall`'s linear scorer only vector-searches *episodic* memory:

> Uses sqlite-vec + FTS5 for episodic, FTS5 for working.

Every memory starts in working memory, so until `sleep()` promotes it, recall matches literal keyword overlap only. A paraphrased question misses the memory even when it is a strong embedding match.

### Reproduction (synthetic, fresh home)

```python
p.handle_tool_call("mnemosyne_remember", {
    "content": "Casey is vegan; shared meals need genuinely vegan options.",
    "source": "fact", "importance": 0.9, "scope": "global"})

recall("plant based diet, avoid animal products")   # -> 0 results
recall("vegan")                                     # -> 1 result (literal keyword)
```

With the key enabled, the paraphrase returns the memory.

Storage is healthy — the gap is only in retrieval:

| check | result |
|---|---|
| `cos(fresh_embed(text), stored_vector)` | 1.0 — stored vector is genuine fastembed output |
| `cos(embed("plant based diet…"), stored_vector)` | 0.614 — strong semantic match present |
| raw `vec_working` int8 KNN for that query | ranks the memory #1 |
| `recall(...)` on the linear path | 0 results |

`recall(..., vec_weight=1.0, fts_weight=0.0, explain=True)` shows the vector stage running and discarding everything:

```json
"embedding": {"available": true, "computed": true},
"stages": [{"name": "wm_primary", "raw_count": 9, "after_filter_count": 9, "kept_count": 0}]
```

## Change

- New `polyphonic_recall` key (default `false`), advertised via `get_config_schema()`, following the existing `kwargs > config.yaml > default` precedence used by `profile_isolation`.
- The provider records the value it writes to `MNEMOSYNE_POLYPHONIC_RECALL` and refreshes it on re-initialization, so a second profile / session switch / edited config applies. A value the provider did **not** write stays authoritative. Comparing against the written value (rather than snapshotting at import) keeps this correct when `.env` loads after import.
- Applied to both shipped provider copies (`hermes_memory_provider/`, `integrations/hermes/src/mnemosyne_hermes/`).

## Tests

`tests/test_polyphonic_recall_default.py` — 34 tests, parametrized across **both** shipped providers (the pip package is skipped *visibly* with a reason when the integration isn't installed, rather than silently shrinking coverage; CI installs it via `pip install -e ./integrations/hermes`).

- config/env matrix: default, config on/off, kwargs precedence, string coercion, explicit-env-var-wins both directions, schema advertisement
- same-process default-then-override regression (the issue raised in review)
- external-override-survives-reinitialization
- **retrieval behavior**: stores an unconsolidated fact and asserts a paraphrased query finds it when enabled, and does not on the linear path — following the `test_ab_toggles.py` convention that a toggle must surface in real recall results

```
pytest tests/ -k "hermes or recall or polyphonic or config"   ->  635 passed
```

Stable across randomized orderings. No existing tests modified.

## Not included

I have not benchmarked polyphonic vs linear for recall quality or latency at scale — the evidence here is correctness on the case above. Happy to run an A/B if that would help settle the default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds the Hermes provider configuration key `memory.mnemosyne.polyphonic_recall`, with a default of **false**. When enabled, working-memory recall uses Mnemosyne’s polyphonic recall engine and can use vector similarity to retrieve unconsolidated entries from paraphrased queries. The default preserves existing recall behavior.

The setting follows **kwargs > config.yaml > default** precedence. The providers manage `MNEMOSYNE_POLYPHONIC_RECALL` while preserving externally supplied environment values and refreshing provider-managed values during reinitialization.

## Architecture and integrations

- **Tiered memory:** Changes working-memory recall only. The PR does not change working-to-episodic consolidation, `sleep()`, BEAM, or storage semantics.
- **Retrieval:** Adds an optional vector-based recall path for unconsolidated working-memory entries.
- **Consolidation, veracity, and sync:** No changes.
- **Hermes:** Both providers expose the setting through `get_config_schema()` and apply consistent configuration and environment precedence.
- **MCP and CLI:** No direct changes.

## Privacy and local-first guarantees

The change remains in-process. It adds no network calls, telemetry, external data flow, or cross-agent sharing. It preserves Mnemosyne’s local-first design.

## Maintainability and risks

- Adds schema documentation and changelog coverage.
- Adds tests for defaults, precedence, string coercion, environment handling, reinitialization, schema advertisement, and paraphrased retrieval.
- Runs retrieval tests in a subprocess to isolate embedding resources, SQLite state, and file descriptors.
- Uses atomic updates for provider-managed environment values.
- A broader configuration-scope issue remains: both providers mutate the process-global `MNEMOSYNE_POLYPHONIC_RECALL` switch while tracking managed state independently. Conflicting provider settings can affect all active `BeamMemory` instances, and the last initialized provider can control the process-wide recall mode.
- The Python 3.13 `test_repair.py` failure remains unresolved. Retrieval assertions and the process-wide configuration model require further maintainer review.
- No benchmark methodology changes measure the possible recall, latency, or resource-use impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->