### PR TITLE
fix(browser): render dashboard and use canonical bank databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Memory browser startup and bank resolution (#532).** The browser now renders its CSS template safely, resolves the default and named-bank databases using the canonical paths, and opens databases read-only so a missing path cannot create an empty database.
 - **Trim-before-embedding race (#491).** Working-memory embedding storage now atomically checks that its parent row still exists. If trimming or concurrent deletion removes the parent before the fallback insert executes, both fallback and `vec_working` writes become a clean no-op instead of logging an embedding-storage failure.
 - **Jina v2 base embedding models silently fell back to 384 dimensions.** The
   `jinaai/jina-embeddings-v2-base-{es,en,de,zh,code}` models output 768-dim

--- a/mnemosyne/integrations/memory_browser.py
+++ b/mnemosyne/integrations/memory_browser.py
@@ -16,22 +16,23 @@ Then open http://localhost:8081 in your browser.
 
 import argparse
 import logging
-import os
 import sqlite3
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from mnemosyne.core.banks import _default_data_dir, _validate_bank_name
 
 logger = logging.getLogger("mnemosyne-browser")
 
 
 def _resolve_db_path(bank: str = "default") -> str:
     """Resolve the Mnemosyne database path for a given bank."""
-    data_dir = Path(
-        os.environ.get("MNEMOSYNE_DATA_DIR")
-        or os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")) + "/mnemosyne/data"
-    )
-    return str(data_dir / f"{bank}.db")
+    data_dir = _default_data_dir()
+    if bank == "default":
+        return str(data_dir / "mnemosyne.db")
+    _validate_bank_name(bank)
+    return str(data_dir / "banks" / bank / "mnemosyne.db")
 
 
 # ── Database Queries ──────────────────────────────────────────────────
@@ -39,7 +40,7 @@ def _resolve_db_path(bank: str = "default") -> str:
 
 def _get_connection(db_path: str) -> sqlite3.Connection:
     """Get a read-only connection to the Mnemosyne database."""
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(Path(db_path).resolve().as_uri() + "?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA query_only = 1")
     return conn
@@ -194,7 +195,7 @@ PAGE_HTML = """<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Mnemosyne Memory Browser</title>
 <style>
-  :root {
+  :root {{
     --bg: #faf9f6;
     --surface: #ffffff;
     --border: #e2e0dc;
@@ -205,44 +206,44 @@ PAGE_HTML = """<!DOCTYPE html>
     --success: #5a8a6a;
     --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
     --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
-  }
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: var(--font); background: var(--bg); color: var(--text); line-height: 1.6; }
-  .header { background: var(--surface); border-bottom: 1px solid var(--border); padding: 1rem 2rem; display: flex; align-items: center; gap: 1.5rem; flex-wrap: wrap; }
-  .header h1 { font-size: 1.25rem; font-weight: 600; white-space: nowrap; }
-  .header h1 span { color: var(--accent); }
-  .stats { display: flex; gap: 1.5rem; font-size: 0.85rem; }
-  .stat { color: var(--text-secondary); }
-  .stat strong { color: var(--text); }
-  .container { max-width: 1200px; margin: 0 auto; padding: 2rem; }
-  .filters { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.5rem; margin-bottom: 1.5rem; display: flex; gap: 1rem; flex-wrap: wrap; align-items: center; }
-  .filters input, .filters select { padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: 6px; font-size: 0.875rem; background: var(--surface); color: var(--text); }
-  .filters input[type="text"] { flex: 1; min-width: 200px; }
-  .filters button { padding: 0.5rem 1.25rem; background: var(--accent); color: white; border: none; border-radius: 6px; font-size: 0.875rem; cursor: pointer; }
-  .filters button:hover { opacity: 0.9; }
-  .memory-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.5rem; margin-bottom: 0.75rem; }
-  .memory-card:hover { border-color: var(--accent); }
-  .memory-meta { display: flex; gap: 1rem; font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.5rem; flex-wrap: wrap; }
-  .memory-meta .tag { background: var(--accent-light); color: var(--accent); padding: 0.125rem 0.5rem; border-radius: 4px; font-weight: 500; }
-  .memory-content { font-size: 0.9rem; line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
-  .empty { text-align: center; padding: 3rem; color: var(--text-secondary); }
-  .pagination { display: flex; justify-content: center; gap: 0.5rem; margin-top: 1.5rem; }
-  .pagination a { padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: 6px; text-decoration: none; color: var(--text); font-size: 0.875rem; }
-  .pagination a:hover { background: var(--accent-light); border-color: var(--accent); }
-  .pagination a.active { background: var(--accent); color: white; border-color: var(--accent); }
-  .detail { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.5rem; }
-  .detail h2 { font-size: 1rem; margin-bottom: 1rem; }
-  .detail .field { margin-bottom: 0.75rem; }
-  .detail .field-label { font-size: 0.75rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; }
-  .detail .field-value { font-size: 0.9rem; }
-  .back { display: inline-block; margin-bottom: 1rem; color: var(--accent); text-decoration: none; font-size: 0.875rem; }
-  .back:hover { text-decoration: underline; }
-  @media (max-width: 768px) {
-    .header { padding: 1rem; flex-direction: column; align-items: flex-start; }
-    .container { padding: 1rem; }
-    .filters { flex-direction: column; }
-    .filters input[type="text"] { min-width: auto; width: 100%; }
-  }
+  }}
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{ font-family: var(--font); background: var(--bg); color: var(--text); line-height: 1.6; }}
+  .header {{ background: var(--surface); border-bottom: 1px solid var(--border); padding: 1rem 2rem; display: flex; align-items: center; gap: 1.5rem; flex-wrap: wrap; }}
+  .header h1 {{ font-size: 1.25rem; font-weight: 600; white-space: nowrap; }}
+  .header h1 span {{ color: var(--accent); }}
+  .stats {{ display: flex; gap: 1.5rem; font-size: 0.85rem; }}
+  .stat {{ color: var(--text-secondary); }}
+  .stat strong {{ color: var(--text); }}
+  .container {{ max-width: 1200px; margin: 0 auto; padding: 2rem; }}
+  .filters {{ background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.5rem; margin-bottom: 1.5rem; display: flex; gap: 1rem; flex-wrap: wrap; align-items: center; }}
+  .filters input, .filters select {{ padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: 6px; font-size: 0.875rem; background: var(--surface); color: var(--text); }}
+  .filters input[type="text"] {{ flex: 1; min-width: 200px; }}
+  .filters button {{ padding: 0.5rem 1.25rem; background: var(--accent); color: white; border: none; border-radius: 6px; font-size: 0.875rem; cursor: pointer; }}
+  .filters button:hover {{ opacity: 0.9; }}
+  .memory-card {{ background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem 1.5rem; margin-bottom: 0.75rem; }}
+  .memory-card:hover {{ border-color: var(--accent); }}
+  .memory-meta {{ display: flex; gap: 1rem; font-size: 0.75rem; color: var(--text-secondary); margin-bottom: 0.5rem; flex-wrap: wrap; }}
+  .memory-meta .tag {{ background: var(--accent-light); color: var(--accent); padding: 0.125rem 0.5rem; border-radius: 4px; font-weight: 500; }}
+  .memory-content {{ font-size: 0.9rem; line-height: 1.5; white-space: pre-wrap; word-break: break-word; }}
+  .empty {{ text-align: center; padding: 3rem; color: var(--text-secondary); }}
+  .pagination {{ display: flex; justify-content: center; gap: 0.5rem; margin-top: 1.5rem; }}
+  .pagination a {{ padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: 6px; text-decoration: none; color: var(--text); font-size: 0.875rem; }}
+  .pagination a:hover {{ background: var(--accent-light); border-color: var(--accent); }}
+  .pagination a.active {{ background: var(--accent); color: white; border-color: var(--accent); }}
+  .detail {{ background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.5rem; }}
+  .detail h2 {{ font-size: 1rem; margin-bottom: 1rem; }}
+  .detail .field {{ margin-bottom: 0.75rem; }}
+  .detail .field-label {{ font-size: 0.75rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; }}
+  .detail .field-value {{ font-size: 0.9rem; }}
+  .back {{ display: inline-block; margin-bottom: 1rem; color: var(--accent); text-decoration: none; font-size: 0.875rem; }}
+  .back:hover {{ text-decoration: underline; }}
+  @media (max-width: 768px) {{
+    .header {{ padding: 1rem; flex-direction: column; align-items: flex-start; }}
+    .container {{ padding: 1rem; }}
+    .filters {{ flex-direction: column; }}
+    .filters input[type="text"] {{ min-width: auto; width: 100%; }}
+  }}
 </style>
 </head>
 <body>

--- a/tests/test_memory_browser.py
+++ b/tests/test_memory_browser.py
@@ -1,0 +1,30 @@
+"""Regression tests for the optional memory browser helpers."""
+
+from pathlib import Path
+
+from mnemosyne.core.banks import BankManager
+from mnemosyne.integrations import memory_browser
+
+
+def test_build_html_renders_css_template_without_format_key_error():
+    html = memory_browser._build_html([])
+
+    assert "<style>" in html
+    assert "No memories found." in html
+
+
+def test_resolve_db_path_matches_bank_manager_for_default_and_named_banks(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+    manager = BankManager(data_dir=tmp_path)
+
+    assert Path(memory_browser._resolve_db_path("default")) == manager.get_bank_db_path("default")
+    assert Path(memory_browser._resolve_db_path("work")) == manager.get_bank_db_path("work")
+
+
+def test_missing_database_stats_does_not_create_a_database_file(tmp_path):
+    missing_db = tmp_path / "missing.db"
+
+    stats = memory_browser.get_memory_stats(str(missing_db))
+
+    assert "error" in stats
+    assert not missing_db.exists()

--- a/tests/test_memory_browser.py
+++ b/tests/test_memory_browser.py
@@ -1,6 +1,9 @@
 """Regression tests for the optional memory browser helpers."""
 
+import sqlite3
 from pathlib import Path
+
+import pytest
 
 from mnemosyne.core.banks import BankManager
 from mnemosyne.integrations import memory_browser
@@ -10,6 +13,7 @@ def test_build_html_renders_css_template_without_format_key_error():
     html = memory_browser._build_html([])
 
     assert "<style>" in html
+    assert ":root {" in html
     assert "No memories found." in html
 
 
@@ -19,6 +23,26 @@ def test_resolve_db_path_matches_bank_manager_for_default_and_named_banks(tmp_pa
 
     assert Path(memory_browser._resolve_db_path("default")) == manager.get_bank_db_path("default")
     assert Path(memory_browser._resolve_db_path("work")) == manager.get_bank_db_path("work")
+
+
+@pytest.mark.parametrize("bank", ["", "../escape", "work/name"])
+def test_resolve_db_path_rejects_invalid_bank_names(bank):
+    with pytest.raises(ValueError):
+        memory_browser._resolve_db_path(bank)
+
+
+@pytest.mark.parametrize("statement", ["INSERT INTO items VALUES (1)", "CREATE TABLE extra (id INTEGER)"])
+def test_existing_database_connection_rejects_writes(tmp_path, statement):
+    db_path = tmp_path / "existing.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE items (id INTEGER)")
+
+    conn = memory_browser._get_connection(str(db_path))
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute(statement)
+    finally:
+        conn.close()
 
 
 def test_missing_database_stats_does_not_create_a_database_file(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #532 with a deliberately narrow change to `mnemosyne-browser`:
- Escape the literal CSS braces consumed by `PAGE_HTML.format(...)`.
- Resolve default as `<data_dir>/mnemosyne.db` and named banks as `<data_dir>/banks/<bank>/mnemosyne.db`, matching `BankManager` without constructing it (its constructor creates `banks/`).
- Open SQLite through a read-only URI (`mode=ro`), so a missing or wrong path cannot materialize an empty database.

## Reproduction / behavior

Previously, the dashboard index raised `KeyError: \\n    --bg` while formatting its unescaped CSS. Separately, the default browser bank selected `<data_dir>/default.db`, so SQLite silently created and browsed an empty database instead of the CLI-default `<data_dir>/mnemosyne.db`.

## Acceptance results

- RED: `uv run --extra test pytest tests/test_memory_browser.py -q` — 3 expected failures (CSS `KeyError`, wrong default path, missing DB auto-created).
- GREEN/adjacent: `uv run --extra test pytest tests/test_memory_browser.py tests/test_cli_data_dir_resolution.py tests/test_issue_1_cli_bank_selection.py -q` — **12 passed**.
- `python -m compileall -q mnemosyne/integrations/memory_browser.py tests/test_memory_browser.py` — passed.
- `git diff --check` — clean.

The focused regression tests cover HTML rendering, default/named paths against `BankManager`, invalid bank names, read-only writes against an existing database, and the no-file-created behavior for a missing database.

## Non-goals

- No browser UI/design changes, new browser features, FastAPI-server test, data migration, or BankManager lifecycle change.
- Did not switch to `string.Template`: JavaScript can use `$` template expressions, so retaining `.format()` and minimally escaping CSS avoids replacing one delimiter collision with another.

## Changelog

Added the project-conventional `CHANGELOG.md` fixed entry only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixes mnemosyne-browser startup by escaping literal CSS braces in the `PAGE_HTML.format(...)` template.
- Aligns memory browser database resolution with Mnemosyne core:
  - Default bank → `<data_dir>/mnemosyne.db`
  - Named banks → `<data_dir>/banks/<bank>/mnemosyne.db` (using canonical `BankManager`-compatible path logic + bank name validation).
- Hardens the browser as read-only local-first tooling:
  - Opens SQLite via URI `mode=ro` and sets `PRAGMA query_only = 1` (with `sqlite3.Row`), so missing/invalid paths won’t create empty databases and the dashboard can’t perform writes/DDL.
- Adds regression tests and a changelog entry for these behaviors.

## Architectural impact

- No changes to Mnemosyne’s memory tiers (working/episodic/BEAM), retrieval strategies, consolidation pipeline, veracity system, or sync layer.
- The change is isolated to the browser integration layer: it reuses core canonical bank/data-dir utilities and corrects how the browser locates and queries SQLite databases.

## Privacy posture & local-first guarantees

- Strengthens local-first privacy by preventing the dashboard from mutating local state:
  - Read-only SQLite connections + `query_only` ensure browsing can’t accidentally write to databases.
  - Canonical path resolution prevents “wrong DB” drift that could lead to browsing/creating an unintended (empty) database file.

## Agent integration surfaces (Hermes, MCP, CLI)

- No changes to Hermes, MCP, CLI, or `BankManager` lifecycle behavior.
- Indirect win: the browser now matches core bank path conventions, reducing inconsistencies with other surfaces that already rely on `BankManager`.

## Maintainability

- This is the right call: it removes duplicated, environment-derived path logic in favor of Mnemosyne core bank/data-dir helpers and adds targeted regression coverage for CSS templating, path resolution, and read-only enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->