### PR TITLE
fix: make global working memories gettable cross-session

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4227,7 +4227,7 @@ class BeamMemory:
             SELECT id, content, source, timestamp, session_id,
                    importance, metadata_json, veracity, created_at
             FROM working_memory
-            WHERE id = ? AND session_id = ?
+            WHERE id = ? AND (session_id = ? OR scope = 'global')
         """, (memory_id, self.session_id))
         row = cursor.fetchone()
         if row:

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -38,6 +38,7 @@ def test_get_working_memory_respects_global_cross_session_visibility(temp_db):
     cross_session_global = reader.get(global_id)
     assert cross_session_global is not None
     assert cross_session_global["id"] == global_id
+    assert cross_session_global["memory_store"] == "working"
     assert reader.get(private_id) is None
 
 

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -21,6 +21,26 @@ def temp_db():
         yield db_path
 
 
+def test_get_working_memory_respects_global_cross_session_visibility(temp_db):
+    writer = BeamMemory(session_id="session-a", db_path=temp_db)
+    global_id = writer.remember("global get visibility", source="test", scope="global")
+    private_id = writer.remember("private get visibility", source="test", scope="session")
+
+    # Same-session lookup remains available for both visibility scopes.
+    same_session_global = writer.get(global_id)
+    same_session_private = writer.get(private_id)
+    assert same_session_global is not None
+    assert same_session_global["id"] == global_id
+    assert same_session_private is not None
+    assert same_session_private["id"] == private_id
+
+    reader = BeamMemory(session_id="session-b", db_path=temp_db)
+    cross_session_global = reader.get(global_id)
+    assert cross_session_global is not None
+    assert cross_session_global["id"] == global_id
+    assert reader.get(private_id) is None
+
+
 class _FakeAnnotations:
     def __init__(self, rows):
         self._rows = rows


### PR DESCRIPTION
## Summary
- Restore the intended visibility contract for global `working_memory` rows in `BeamMemory.get()`.
- A global item created in session A is now retrievable by ID from session B; private/session-scoped rows remain private.

## Why this path
The episodic fallback and sibling invalidation/forget paths already use this same `session_id OR scope = global` authorization rule. This keeps `get()` aligned without changing schema, provider behavior, or mutation authorization.

## Verification
- Regression reproduced red before the predicate change: cross-session `get(global_id)` returned `None`.
- `python -m pytest -q tests/test_beam.py::test_get_working_memory_respects_global_cross_session_visibility` → 1 passed.
- `python -m pytest -q tests/test_beam.py tests/test_mcp_server.py` → 126 passed, 10 skipped.
- Independent spec review: PASS; code-quality review: APPROVED; narrow Claude/Opus review: no blockers.

## Non-goals
- No changes to provider wiring, schema/migrations, returned payload shape, or write authorization.

Restores the intended fix described in #257, whose previously cited commit is not present in current `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated BEAM `BeamMemory.get()` to retrieve `working_memory` rows by `id` across sessions when (and only when) the row is explicitly globally scoped (`scope='global'`), while keeping session-scoped rows private to their `session_id`.
- Episodic memory lookup and the overall BEAM retrieval/recall behavior are unchanged.
- Added regression coverage for: same-session visibility for both scopes, cross-session visibility for global items, and cross-session isolation for session-scoped items.

## Core architectural impact (tiered memory + retrieval)

- Clarifies and enforces tier boundaries in the BEAM layer: only the **working-memory** `get()` authorization predicate changes to match the existing `session_id OR scope='global'` authorization model used elsewhere in BEAM.
- Leaves **episodic** lookup semantics intact (no change to fallback behavior, query shape, or returned structure).
- No changes to schema, provider behavior, mutation authorization, or response payloads—this is a read-path consistency fix for BEAM working-memory by primary key.

## Privacy posture + local-first guarantees

- Preserves the privacy model: global visibility is opt-in via `scope='global'`; `scope='session'` remains isolated across sessions.
- Maintains local-first behavior: the change affects authorization checks during local reads (SQLite-backed memory) and does not introduce any new remote access, background services, or sync dependencies.

## Agent integration surfaces (Hermes, MCP, CLI)

- No changes required for Hermes, MCP, or CLI integration surfaces: they continue to call into BEAM, but now benefit from consistent cross-session visibility behavior for explicitly global working-memory items.

## Long-term maintainability

- Small, targeted change aligning `get()` with the same authorization rule already used by other BEAM working-memory operations.
- Adds a focused regression test to prevent future privacy/auth regressions in cross-session behavior.

## Verification

- Relevant test suites pass: **126 passed, 10 skipped**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->