### PR TITLE
fix(hermes): route diagnostics to active profile bank

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -2207,7 +2207,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             # sessions) should never bypass session scoping.
             if author_id:
                 recall_kwargs["author_id"] = author_id
-            with self._beam_access_lock:
+            with self._ensure_beam_access_lock():
                 results = self._beam.recall(**recall_kwargs)
             if not results:
                 return ""
@@ -2265,8 +2265,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         """Initialize sync_turn telemetry for tests that construct via __new__."""
         if not hasattr(self, "_sync_turn_lock"):
             self._sync_turn_lock = threading.Lock()
-        if not hasattr(self, "_beam_access_lock"):
-            self._beam_access_lock = threading.Lock()
+        self._ensure_beam_access_lock()
         if not hasattr(self, "_sync_turn_telemetry"):
             self._sync_turn_telemetry = {
                 "pending_queue_length": 0,
@@ -2283,6 +2282,15 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 "last_error": None,
                 "in_flight": 0,
             }
+
+    def _ensure_beam_access_lock(self):
+        """Return the per-provider Beam lock, including for __new__ test instances."""
+        try:
+            return self._beam_access_lock
+        except AttributeError:
+            # setdefault atomically publishes one per-instance lock when
+            # concurrent __new__ callers both need lazy initialization.
+            return self.__dict__.setdefault("_beam_access_lock", threading.Lock())
 
     def _sync_turn_diagnostics(self) -> Dict[str, Any]:
         """Return a PII-safe snapshot of sync_turn telemetry."""
@@ -2313,7 +2321,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 in_flight,
             )
         try:
-            with self._beam_access_lock:
+            with self._ensure_beam_access_lock():
                 if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
                     user_limit = _sync_turn_user_limit()
                     uc = user_content[:user_limit] if user_limit > 0 else user_content
@@ -2425,7 +2433,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 # main thread's sync_turn() writes, causing episodic INSERT
                 # failures (commit rolled back by concurrent main-thread writes).
                 beam_ref = self._beam
-                beam_lock = self._beam_access_lock
+                beam_lock = self._ensure_beam_access_lock()
                 def _sleep_isolated():
                     try:
                         BeamClass = _get_beam_class()
@@ -3513,59 +3521,66 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         from mnemosyne.diagnose import run_diagnostics
         repair_requested = bool(args.get("repair_vec_working", False))
         dry_run = bool(args.get("dry_run", False))
-        result = run_diagnostics(repair_vec_working=repair_requested, dry_run=dry_run)
-        if self._beam is not None:
+        diagnostic_kwargs: Dict[str, Any] = {
+            "repair_vec_working": repair_requested,
+            "dry_run": dry_run,
+        }
+        if self._profile_isolation_enabled and self._beam is not None:
+            diagnostic_kwargs["bank"] = self._resolve_profile_bank()
+        if self._beam is None:
+            return json.dumps(run_diagnostics(**diagnostic_kwargs), indent=2, default=str)
+
+        # The active provider bank shares its SQLite database with auto_sleep's
+        # separate Beam connection. Keep every active-bank diagnostic access in
+        # one critical section so checkpointing cannot invalidate statements in
+        # the other connection (#498).
+        with self._ensure_beam_access_lock():
+            result = run_diagnostics(**diagnostic_kwargs)
             result["sync_turn"] = self._sync_turn_diagnostics()
 
-        # run_diagnostics() reports Mnemosyne's legacy/default DB path. When
-        # Hermes profile isolation is enabled, the active provider may use a
-        # profile bank instead (mnemosyne/data/banks/<profile>/mnemosyne.db).
-        # Surface the active provider DB too so operators do not mistake the
-        # diagnostic default path for the live memory bank.
-        active_db = None
-        try:
-            if self._beam is not None:
-                active_db = getattr(self._beam, "db_path", None)
-        except Exception:
             active_db = None
-
-        if active_db:
-            result["active_provider_db_path"] = str(active_db)
-            result["profile_isolation_enabled"] = bool(self._profile_isolation_enabled)
-            result.setdefault("key_findings", []).append(
-                f"Active Hermes Mnemosyne provider DB: {active_db}"
-            )
             try:
-                import sqlite3
-                from mnemosyne.diagnose import _memory_orphan_diagnostics
-                con = sqlite3.connect(str(active_db))
-                try:
-                    cur = con.cursor()
-                    result["active_provider_counts"] = {
-                        "working_memory": cur.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0],
-                        "episodic_memory": cur.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0],
-                        "facts": cur.execute("SELECT COUNT(*) FROM facts").fetchone()[0],
-                    }
-                    result["active_provider_orphan_diagnostics"] = _memory_orphan_diagnostics(con)
-                finally:
-                    con.close()
-                try:
-                    from mnemosyne.core.beam import repair_vec_working as _repair_vec_working, vec_working_coverage
-                    if repair_requested and self._beam is not None:
-                        result["active_provider_vec_working_repair"] = _repair_vec_working(
-                            self._beam.conn, dry_run=dry_run
-                        )
-                        result["active_provider_vec_working"] = result[
-                            "active_provider_vec_working_repair"
-                        ].get("after", {})
-                    elif self._beam is not None:
-                        result["active_provider_vec_working"] = vec_working_coverage(self._beam.conn)
-                except Exception as exc:
-                    result["active_provider_vec_working_error"] = str(exc)
-            except Exception as exc:
-                result["active_provider_counts_error"] = str(exc)
+                active_db = getattr(self._beam, "db_path", None)
+            except Exception:
+                active_db = None
 
-        return json.dumps(result, indent=2, default=str)
+            if active_db:
+                result["active_provider_db_path"] = str(active_db)
+                result["profile_isolation_enabled"] = bool(self._profile_isolation_enabled)
+                result.setdefault("key_findings", []).append(
+                    f"Active Hermes Mnemosyne provider DB: {active_db}"
+                )
+                try:
+                    import sqlite3
+                    from mnemosyne.diagnose import _memory_orphan_diagnostics
+                    con = sqlite3.connect(str(active_db))
+                    try:
+                        cur = con.cursor()
+                        result["active_provider_counts"] = {
+                            "working_memory": cur.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0],
+                            "episodic_memory": cur.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0],
+                            "facts": cur.execute("SELECT COUNT(*) FROM facts").fetchone()[0],
+                        }
+                        result["active_provider_orphan_diagnostics"] = _memory_orphan_diagnostics(con)
+                    finally:
+                        con.close()
+                    try:
+                        from mnemosyne.core.beam import repair_vec_working as _repair_vec_working, vec_working_coverage
+                        if repair_requested:
+                            result["active_provider_vec_working_repair"] = _repair_vec_working(
+                                self._beam.conn, dry_run=dry_run
+                            )
+                            result["active_provider_vec_working"] = result[
+                                "active_provider_vec_working_repair"
+                            ].get("after", {})
+                        else:
+                            result["active_provider_vec_working"] = vec_working_coverage(self._beam.conn)
+                    except Exception as exc:
+                        result["active_provider_vec_working_error"] = str(exc)
+                except Exception as exc:
+                    result["active_provider_counts_error"] = str(exc)
+
+            return json.dumps(result, indent=2, default=str)
 
     def _handle_graph_query(self, args: Dict[str, Any]) -> str:
         seed_id = args.get("seed_memory_id", "").strip()

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -562,6 +562,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         self._agent_context = "primary"
         self._turn_count = 0
         self._sync_turn_lock = threading.Lock()
+        # Serialize Beam/SQLite access with the auto_sleep daemon. Separate
+        # connections to the same WAL database must not run Beam work together.
+        self._beam_access_lock = threading.Lock()
         self._sync_turn_telemetry: Dict[str, Any] = {
             "pending_queue_length": 0,
             "max_queue_length": 0,
@@ -1235,18 +1238,19 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             # sessions) should never bypass session scoping.
             if author_id:
                 recall_kwargs["author_id"] = author_id
-            results = self._beam.recall(**recall_kwargs)
+            with self._ensure_beam_access_lock():
+                results = self._beam.recall(**recall_kwargs)
 
-            canonical_rows: List[Dict[str, Any]] = []
-            try:
-                store = getattr(self._beam, "canonical", None)
-                if store is None:
-                    from mnemosyne.core.canonical import CanonicalStore
-                    store = CanonicalStore(db_path=self._beam.db_path, conn=self._beam.conn)
-                    self._beam.canonical = store
-                canonical_rows = _canonical_prefetch_rows(store, self._canonical_owner(), query)
-            except Exception:
-                canonical_rows = []
+                canonical_rows: List[Dict[str, Any]] = []
+                try:
+                    store = getattr(self._beam, "canonical", None)
+                    if store is None:
+                        from mnemosyne.core.canonical import CanonicalStore
+                        store = CanonicalStore(db_path=self._beam.db_path, conn=self._beam.conn)
+                        self._beam.canonical = store
+                    canonical_rows = _canonical_prefetch_rows(store, self._canonical_owner(), query)
+                except Exception:
+                    canonical_rows = []
 
             if not results and not canonical_rows:
                 return ""
@@ -1303,6 +1307,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         """Initialize sync_turn telemetry for tests that construct via __new__."""
         if not hasattr(self, "_sync_turn_lock"):
             self._sync_turn_lock = threading.Lock()
+        self._ensure_beam_access_lock()
         if not hasattr(self, "_sync_turn_telemetry"):
             self._sync_turn_telemetry = {
                 "pending_queue_length": 0,
@@ -1319,6 +1324,15 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 "last_error": None,
                 "in_flight": 0,
             }
+
+    def _ensure_beam_access_lock(self):
+        """Return the per-provider Beam lock, including for __new__ test instances."""
+        try:
+            return self._beam_access_lock
+        except AttributeError:
+            # setdefault atomically publishes one per-instance lock when
+            # concurrent __new__ callers both need lazy initialization.
+            return self.__dict__.setdefault("_beam_access_lock", threading.Lock())
 
     def _sync_turn_diagnostics(self) -> Dict[str, Any]:
         """Return a PII-safe snapshot of sync_turn telemetry."""
@@ -1350,28 +1364,29 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 in_flight,
             )
         try:
-            if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
-                user_limit = _sync_turn_user_limit()
-                uc = user_content[:user_limit] if user_limit > 0 else user_content
-                self._beam.remember(
-                    content=f"[USER] {uc}",
-                    source="conversation",
-                    importance=0.5,
-                    scope=self._default_scope,
-                    extract_entities=True,
-                )
-                # Check for identity-significant signals in user content
-                self._capture_identity_signals(user_content)
-            if "assistant" in self._sync_roles and assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
-                assistant_limit = _sync_turn_assistant_limit()
-                ac = assistant_content[:assistant_limit] if assistant_limit > 0 else assistant_content
-                self._beam.remember(
-                    content=f"[ASSISTANT] {ac}",
-                    source="conversation",
-                    importance=0.15,
-                    scope=self._default_scope,
-                    extract_entities=True,
-                )
+            with self._ensure_beam_access_lock():
+                if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
+                    user_limit = _sync_turn_user_limit()
+                    uc = user_content[:user_limit] if user_limit > 0 else user_content
+                    self._beam.remember(
+                        content=f"[USER] {uc}",
+                        source="conversation",
+                        importance=0.5,
+                        scope=self._default_scope,
+                        extract_entities=True,
+                    )
+                    # Check for identity-significant signals in user content
+                    self._capture_identity_signals(user_content)
+                if "assistant" in self._sync_roles and assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
+                    assistant_limit = _sync_turn_assistant_limit()
+                    ac = assistant_content[:assistant_limit] if assistant_limit > 0 else assistant_content
+                    self._beam.remember(
+                        content=f"[ASSISTANT] {ac}",
+                        source="conversation",
+                        importance=0.15,
+                        scope=self._default_scope,
+                        extract_entities=True,
+                    )
             self._turn_count += 1
             if self._auto_sleep_enabled and self._turn_count % 10 == 0:
                 self._maybe_auto_sleep()
@@ -1458,8 +1473,31 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                     return
 
                 logger.info("Mnemosyne auto-sleep: working=%d, eligible=%d > threshold=%d", working, eligible, self._auto_sleep_threshold)
-                sleep_fn = self._beam.sleep_all_sessions if hasattr(self._beam, "sleep_all_sessions") else self._beam.sleep
-                sleep_thread = threading.Thread(target=sleep_fn, daemon=True)
+                # The daemon must own a separate BeamMemory/SQLite connection.
+                # The source Beam selects the compatible sleep operation, but is
+                # never used from the worker thread (see root provider #498).
+                beam_ref = self._beam
+                if beam_ref is None:
+                    return
+                sleep_all_sessions = hasattr(beam_ref, "sleep_all_sessions")
+                beam_lock = self._ensure_beam_access_lock()
+
+                def _sleep_isolated():
+                    try:
+                        BeamClass = _get_beam_class()
+                        sleep_beam = BeamClass(
+                            session_id=beam_ref.session_id,
+                            db_path=beam_ref.db_path,
+                            author_id=beam_ref.author_id,
+                            author_type=beam_ref.author_type,
+                            channel_id=beam_ref.channel_id,
+                        )
+                        with beam_lock:
+                            (sleep_beam.sleep_all_sessions if sleep_all_sessions else sleep_beam.sleep)()
+                    except Exception as inner:
+                        logger.debug("Mnemosyne auto-sleep worker failed: %s", inner)
+
+                sleep_thread = threading.Thread(target=_sleep_isolated, daemon=True)
                 sleep_thread.start()
                 sleep_thread.join(timeout=self._AUTO_SLEEP_TIMEOUT_SECONDS)
                 if sleep_thread.is_alive():
@@ -2425,46 +2463,66 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
     def _handle_diagnose(self, args: Dict[str, Any]) -> str:
         from mnemosyne.diagnose import run_diagnostics
-        result = run_diagnostics()
-        if self._beam is not None:
+        repair_requested = bool(args.get("repair_vec_working", False))
+        dry_run = bool(args.get("dry_run", False))
+        diagnostic_kwargs: Dict[str, Any] = {
+            "repair_vec_working": repair_requested,
+            "dry_run": dry_run,
+        }
+        if self._profile_isolation_enabled and self._beam is not None:
+            diagnostic_kwargs["bank"] = self._resolve_profile_bank()
+        if self._beam is None:
+            return json.dumps(run_diagnostics(**diagnostic_kwargs), indent=2, default=str)
+
+        # The active provider bank shares its SQLite database with auto_sleep.
+        # Serialize the complete active-bank diagnostic operation (#498).
+        with self._ensure_beam_access_lock():
+            result = run_diagnostics(**diagnostic_kwargs)
             result["sync_turn"] = self._sync_turn_diagnostics()
 
-        # run_diagnostics() reports Mnemosyne's legacy/default DB path. When
-        # Hermes profile isolation is enabled, the active provider may use a
-        # profile bank instead (mnemosyne/data/banks/<profile>/mnemosyne.db).
-        # Surface the active provider DB too so operators do not mistake the
-        # diagnostic default path for the live memory bank.
-        active_db = None
-        try:
-            if self._beam is not None:
-                active_db = getattr(self._beam, "db_path", None)
-        except Exception:
             active_db = None
-
-        if active_db:
-            result["active_provider_db_path"] = str(active_db)
-            result["profile_isolation_enabled"] = bool(self._profile_isolation_enabled)
-            result.setdefault("key_findings", []).append(
-                f"Active Hermes Mnemosyne provider DB: {active_db}"
-            )
             try:
-                import sqlite3
-                from mnemosyne.diagnose import _memory_orphan_diagnostics
-                con = sqlite3.connect(str(active_db))
-                try:
-                    cur = con.cursor()
-                    result["active_provider_counts"] = {
-                        "working_memory": cur.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0],
-                        "episodic_memory": cur.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0],
-                        "facts": cur.execute("SELECT COUNT(*) FROM facts").fetchone()[0],
-                    }
-                    result["active_provider_orphan_diagnostics"] = _memory_orphan_diagnostics(con)
-                finally:
-                    con.close()
-            except Exception as exc:
-                result["active_provider_counts_error"] = str(exc)
+                active_db = getattr(self._beam, "db_path", None)
+            except Exception:
+                active_db = None
 
-        return json.dumps(result, indent=2, default=str)
+            if active_db:
+                result["active_provider_db_path"] = str(active_db)
+                result["profile_isolation_enabled"] = bool(self._profile_isolation_enabled)
+                result.setdefault("key_findings", []).append(
+                    f"Active Hermes Mnemosyne provider DB: {active_db}"
+                )
+                try:
+                    import sqlite3
+                    from mnemosyne.diagnose import _memory_orphan_diagnostics
+                    con = sqlite3.connect(str(active_db))
+                    try:
+                        cur = con.cursor()
+                        result["active_provider_counts"] = {
+                            "working_memory": cur.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0],
+                            "episodic_memory": cur.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0],
+                            "facts": cur.execute("SELECT COUNT(*) FROM facts").fetchone()[0],
+                        }
+                        result["active_provider_orphan_diagnostics"] = _memory_orphan_diagnostics(con)
+                    finally:
+                        con.close()
+                    try:
+                        from mnemosyne.core.beam import repair_vec_working as _repair_vec_working, vec_working_coverage
+                        if repair_requested:
+                            result["active_provider_vec_working_repair"] = _repair_vec_working(
+                                self._beam.conn, dry_run=dry_run
+                            )
+                            result["active_provider_vec_working"] = result[
+                                "active_provider_vec_working_repair"
+                            ].get("after", {})
+                        else:
+                            result["active_provider_vec_working"] = vec_working_coverage(self._beam.conn)
+                    except Exception as exc:
+                        result["active_provider_vec_working_error"] = str(exc)
+                except Exception as exc:
+                    result["active_provider_counts_error"] = str(exc)
+
+            return json.dumps(result, indent=2, default=str)
 
     def _handle_recall_diagnostics(self, args: Dict[str, Any]) -> str:
         """Return recall path diagnostics (fallback rates, tier hit counts).

--- a/mnemosyne/diagnose.py
+++ b/mnemosyne/diagnose.py
@@ -349,7 +349,11 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False, 
         summary["key_findings"].append("sqlite-vec not available - install with: pip install sqlite-vec")
         summary["fixable"].append("sqlite_vec")
     if embed_ok and vec_ok and ep_vec and ep_vec["status"] == "0":
-        summary["key_findings"].append("Both fastembed and sqlite-vec are available but episodic vectors=0 - memories may not have been consolidated yet. Run: hermes mnemosyne sleep")
+        summary["key_findings"].append(
+            "Both fastembed and sqlite-vec are available but episodic vectors=0 - "
+            "memories may not have been consolidated yet. Use the mnemosyne_sleep "
+            "tool or call BeamMemory.sleep()."
+        )
     if embed_ok and vec_ok and ep_vec and int(ep_vec["status"]) > 0:
         vtype = ep_vec_type["status"] if ep_vec_type else "unknown"
         msg = f"Semantic search is active with {ep_vec['status']} vectors in episodic memory (backend: {vtype})"

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -37,6 +37,30 @@ def test_diagnose_treats_ctransformers_as_optional(tmp_path, monkeypatch):
     assert ctransformers["status"] not in {"MISSING", "ERROR"}
 
 
+def test_diagnose_vector_guidance_uses_valid_sleep_actions(tmp_path, monkeypatch):
+    monkeypatch.setattr(diagnose, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr(
+        diagnose,
+        "collect_runtime_diagnostics",
+        lambda: {
+            "checks": [
+                {"category": "deps", "check": "embeddings_available", "status": "YES", "detail": ""},
+                {"category": "deps", "check": "sqlite_vec_available", "status": "YES", "detail": ""},
+            ]
+        },
+    )
+
+    summary = diagnose.run_diagnostics()
+
+    finding = next(
+        finding for finding in summary["key_findings"] if "episodic vectors=0" in finding
+    )
+    assert "mnemosyne_sleep" in finding
+    assert "BeamMemory.sleep()" in finding
+    assert "hermes" + " mnemosyne sleep" not in finding
+
+
 def test_memory_orphan_diagnostics_tolerates_missing_optional_tables(tmp_path):
     db_path = tmp_path / "legacy.db"
     conn = sqlite3.connect(db_path)

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 import json
 import sys
+import threading
+import types
 from pathlib import Path
 
 import pytest
@@ -374,6 +376,335 @@ def _new_provider(module, *, scope="session", roles=("user", "assistant")):
     provider._auto_sleep_enabled = False
     provider._audit_event = lambda *args, **kwargs: None
     return provider
+
+
+@pytest.mark.parametrize(
+    ("profile_isolation", "has_active_beam", "args", "expected_kwargs"),
+    [
+        (
+            True,
+            True,
+            {"repair_vec_working": True, "dry_run": True},
+            {
+                "repair_vec_working": True,
+                "dry_run": True,
+                "bank": "isolated-profile",
+            },
+        ),
+        (
+            True,
+            True,
+            {},
+            {
+                "repair_vec_working": False,
+                "dry_run": False,
+                "bank": "isolated-profile",
+            },
+        ),
+        (False, True, {}, {"repair_vec_working": False, "dry_run": False}),
+        (True, False, {}, {"repair_vec_working": False, "dry_run": False}),
+    ],
+)
+def test_provider_diagnose_forwards_options_and_routes_only_active_isolated_bank(
+    monkeypatch, provider_modules, profile_isolation, has_active_beam, args, expected_kwargs
+):
+    """Both shipped providers must preserve diagnose options and active-bank routing."""
+    calls = []
+
+    def fake_run_diagnostics(**kwargs):
+        calls.append(kwargs)
+        return {"checks_total": 0, "key_findings": [], "entries": []}
+
+    monkeypatch.setattr("mnemosyne.diagnose.run_diagnostics", fake_run_diagnostics)
+
+    observed = {}
+    for name, module in provider_modules.items():
+        provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+        provider._beam = object() if has_active_beam else None
+        provider._profile_isolation_enabled = profile_isolation
+        provider._sync_turn_diagnostics = lambda: {}
+
+        def resolve_profile_bank():
+            if not (profile_isolation and has_active_beam):
+                pytest.fail("inactive or non-isolated diagnostics must not resolve a named bank")
+            return "isolated-profile"
+
+        provider._resolve_profile_bank = resolve_profile_bank
+        json.loads(provider._handle_diagnose(args))
+        observed[name] = calls[-1]
+
+    assert len(calls) == len(provider_modules)
+    assert observed == {name: expected_kwargs for name in provider_modules}
+
+
+class _ObservedLock:
+    """A real lock with a deterministic signal when a worker tries to enter it."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.waiting = threading.Event()
+
+    def acquire(self, *args, **kwargs):
+        self.waiting.set()
+        return self._lock.acquire(*args, **kwargs)
+
+    def release(self):
+        self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *args):
+        self.release()
+
+
+def test_provider_lazy_beam_lock_initialization_is_thread_safe(monkeypatch, provider_modules):
+    """Concurrent __new__ callers publish and receive one lock in both providers."""
+    real_lock = threading.Lock
+
+    for module in provider_modules.values():
+        module_threading = module.threading
+        provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+        creation_barrier = threading.Barrier(2)
+        created = []
+        returned = []
+        failures = []
+
+        def racing_lock():
+            # Each worker has already observed a missing lock before either
+            # candidate can be constructed. This makes the old check-then-set
+            # implementation reliably install and return separate locks.
+            creation_barrier.wait(timeout=1)
+            candidate = real_lock()
+            created.append(candidate)
+            return candidate
+
+        def get_lock():
+            try:
+                returned.append(provider._ensure_beam_access_lock())
+            except BaseException as exc:  # pragma: no cover - asserted below
+                failures.append(exc)
+
+        workers = [threading.Thread(target=get_lock) for _ in range(2)]
+        # `threading` is a shared stdlib module, so replace only this provider
+        # module's binding rather than patching threading.Lock process-wide.
+        monkeypatch.setattr(module, "threading", types.SimpleNamespace(Lock=racing_lock))
+        try:
+            for worker in workers:
+                worker.start()
+            for worker in workers:
+                worker.join(timeout=1)
+        finally:
+            monkeypatch.setattr(module, "threading", module_threading)
+
+        assert not any(worker.is_alive() for worker in workers)
+        assert failures == []
+        assert len(created) == 2
+        assert len(returned) == 2
+        assert returned[0] is returned[1]
+        assert provider._beam_access_lock is returned[0]
+
+
+def test_provider_diagnose_waits_for_held_active_beam_lock(monkeypatch, provider_modules):
+    """Both providers serialize active diagnostics with auto-sleep Beam access."""
+    started = threading.Event()
+
+    def fake_run_diagnostics(**_kwargs):
+        started.set()
+        return {"checks_total": 0, "key_findings": [], "entries": []}
+
+    monkeypatch.setattr("mnemosyne.diagnose.run_diagnostics", fake_run_diagnostics)
+
+    for module in provider_modules.values():
+        provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+        provider._beam = type("Beam", (), {"db_path": None})()
+        provider._profile_isolation_enabled = False
+        provider._sync_turn_diagnostics = lambda: {}
+        lock = _ObservedLock()
+        provider._beam_access_lock = lock
+        lock.acquire()
+        lock.waiting.clear()
+        result = []
+        worker = threading.Thread(target=lambda: result.append(provider._handle_diagnose({})))
+        try:
+            worker.start()
+            assert lock.waiting.wait(timeout=1), "diagnostics did not attempt the active Beam lock"
+            assert not started.is_set(), "diagnostics ran while Beam access was held"
+        finally:
+            lock.release()
+            worker.join(timeout=1)
+        assert not worker.is_alive(), "diagnostics did not finish after Beam access was released"
+        assert started.is_set()
+        assert json.loads(result[0])["checks_total"] == 0
+        started.clear()
+
+
+def test_provider_diagnose_reports_isolated_bank_not_populated_default(
+    tmp_path, monkeypatch, provider_modules
+):
+    """Provider diagnostics must report named-bank counts instead of default-bank counts."""
+    from mnemosyne import diagnose
+    from mnemosyne.core.memory import Mnemosyne
+
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr(diagnose, "LOG_DIR", tmp_path / "logs")
+
+    default_memory = Mnemosyne(session_id="default-session")
+    default_memory.beam.remember("default one", source="test")
+    default_memory.beam.remember("default two", source="test")
+    isolated_memory = Mnemosyne(session_id="isolated-session", bank="isolated-profile")
+    isolated_memory.beam.remember("isolated one", source="test")
+
+    def active_bank_rows():
+        """Snapshot the source rows a vec_working repair is allowed to inspect."""
+        conn = isolated_memory.beam.conn
+        snapshot: dict[str, object] = {}
+        for table in ("working_memory", "memory_embeddings", "vec_working"):
+            try:
+                columns = [row[1] for row in conn.execute(f"PRAGMA table_info({table})")]
+                order_column = columns[0]
+                snapshot[table] = conn.execute(
+                    f"SELECT * FROM {table} ORDER BY {order_column}"
+                ).fetchall()
+            except Exception as exc:
+                snapshot[table] = ("unavailable", type(exc).__name__)
+        return snapshot
+
+    def vec_working_output(result):
+        return {
+            key: result[key]
+            for key in (
+                "active_provider_vec_working",
+                "active_provider_vec_working_error",
+                "active_provider_vec_working_repair",
+            )
+            if key in result
+        }
+
+    observed = {}
+    for name, module in provider_modules.items():
+        provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+        provider._beam = isolated_memory.beam
+        provider._profile_isolation_enabled = True
+        provider._resolve_profile_bank = lambda: "isolated-profile"
+        provider._sync_turn_diagnostics = lambda: {}
+
+        result = json.loads(provider._handle_diagnose({}))
+        entries = {entry["check"]: entry["status"] for entry in result["entries"]}
+        source_before_dry_run = active_bank_rows()
+        dry_run = json.loads(provider._handle_diagnose({"repair_vec_working": True, "dry_run": True}))
+        source_after_dry_run = active_bank_rows()
+        assert source_after_dry_run == source_before_dry_run
+        observed[name] = {
+            "resolved_bank": result["resolved_bank"],
+            "working_total": entries["working_total"],
+            "db_path": entries["db_path"],
+            "vec_working": vec_working_output(result),
+            "vec_working_dry_run": vec_working_output(dry_run),
+        }
+
+    assert {
+        name: {key: observed[name][key] for key in ("resolved_bank", "working_total", "db_path")}
+        for name in provider_modules
+    } == {
+        name: {
+            "resolved_bank": "isolated-profile",
+            "working_total": "1",
+            "db_path": str(isolated_memory.db_path),
+        }
+        for name in provider_modules
+    }
+    for result in observed.values():
+        assert set(result["vec_working"]) & {
+            "active_provider_vec_working",
+            "active_provider_vec_working_error",
+        }
+        assert set(result["vec_working_dry_run"]) & {
+            "active_provider_vec_working_repair",
+            "active_provider_vec_working_error",
+        }
+        repair = result["vec_working_dry_run"].get("active_provider_vec_working_repair")
+        if repair is not None:
+            assert repair["status"] == "dry_run"
+            assert repair["inserted"] == 0
+            assert repair["after"] == repair["before"]
+    assert observed["hermes_memory_provider"]["vec_working"] == observed["mnemosyne_hermes"]["vec_working"]
+    assert observed["hermes_memory_provider"]["vec_working_dry_run"] == observed["mnemosyne_hermes"][
+        "vec_working_dry_run"
+    ]
+
+
+def test_packaged_provider_auto_sleep_uses_worker_local_beam(monkeypatch, provider_modules):
+    """The packaged daemon must never pass its main-thread Beam into sleep."""
+    module = provider_modules["mnemosyne_hermes"]
+    provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+    source_calls = []
+    worker_beams = []
+
+    class SourceBeam:
+        session_id = "session-a"
+        db_path = "/tmp/isolated.db"
+        author_id = "author-a"
+        author_type = "user"
+        channel_id = "channel-a"
+
+        def get_working_stats(self):
+            return {"total": 2}
+
+        def _count_unconsolidated_before(self, _cutoff):
+            return 1
+
+        def sleep_all_sessions(self):
+            source_calls.append("sleep_all_sessions")
+
+        def sleep(self):
+            source_calls.append("sleep")
+
+    class WorkerBeam:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            worker_beams.append(self)
+
+        def sleep_all_sessions(self):
+            source_calls.append(("worker", "sleep_all_sessions"))
+
+        def sleep(self):
+            source_calls.append(("worker", "sleep"))
+
+    class InlineThread:
+        def __init__(self, *, target, daemon):
+            assert daemon is True
+            self._target = target
+
+        def start(self):
+            self._target()
+
+        def join(self, timeout=None):
+            assert timeout == provider._AUTO_SLEEP_TIMEOUT_SECONDS
+
+        def is_alive(self):
+            return False
+
+    provider._beam = SourceBeam()
+    provider._auto_sleep_threshold = 1
+    provider._beam_access_lock = threading.Lock()
+    provider._reserve_reflection_budget = lambda _reason: None
+    monkeypatch.setattr(module, "_get_beam_class", lambda: WorkerBeam)
+    monkeypatch.setattr(module, "threading", types.SimpleNamespace(Thread=InlineThread))
+
+    provider._maybe_auto_sleep()
+
+    assert len(worker_beams) == 1
+    assert worker_beams[0] is not provider._beam
+    assert worker_beams[0].kwargs == {
+        "session_id": "session-a",
+        "db_path": "/tmp/isolated.db",
+        "author_id": "author-a",
+        "author_type": "user",
+        "channel_id": "channel-a",
+    }
+    assert source_calls == [("worker", "sleep_all_sessions")]
 
 
 def test_provider_remember_extract_uses_default_scope(provider_modules):


### PR DESCRIPTION
## Summary
- Route Hermes `mnemosyne_diagnose` through the active profile bank when profile isolation is enabled.
- Keep default/root diagnostics unchanged for non-isolated or unavailable provider paths.
- Keep both shipped provider copies in parity for `repair_vec_working`, `dry_run`, and bank routing.
- Replace the invalid `hermes mnemosyne sleep` suggestion with the valid `mnemosyne_sleep` tool / `BeamMemory.sleep()` action.

## Why this path
The CLI routing fixed by #363 already resolves profile banks, but the agent-tool provider diagnostic path still called `run_diagnostics()` without that bank and then only appended the active path/counts. The core diagnostic entries and findings could therefore describe the wrong DB.

## Verification
- Focused provider/diagnostic/tool matrix: `94 passed, 1 skipped`.
- Independent spec review: PASS; quality review: APPROVED after repairing the packaged-provider option-forwarding gap.
- High-reasoning review: no proven blockers; follow-ups verified (both providers define the resolver/attributes, schemas expose the flags, bank-name sanitizer is in place, call-count assertion added).
- `git diff --check` clean; current upstream/main base verified.

## Scope
- No schema, migration, or configuration changes.
- Restores the remaining diagnostics follow-up from #362 (the original issue is already closed after #363).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Hermes diagnostics are now **bank-aware under profile isolation**: when `profile_isolation` is enabled and a BEAM/active provider is available, diagnostics route through the **active profile’s isolated Mnemosyne bank**; otherwise they fall back to safe default/root diagnostics without forcing bank resolution.
- Both Hermes provider implementations were kept consistent: `_handle_diagnose()` forwards `repair_vec_working` and `dry_run` into `run_diagnostics(...)`, enriches results with **`sync_turn` telemetry**, and conditionally injects `bank=...` only for isolated/available-provider paths.
- Diagnostic guidance for missing episodic vectors is corrected to use the valid action **`mnemosyne_sleep`** (tool) or **`BeamMemory.sleep()`** (API), removing the invalid `hermes mnemosyne sleep` wording.
- Adds/extends tests for Hermes provider parity (bank routing + parameter forwarding), concurrency correctness, and diagnostic guidance wording (reported: 94 passed, 1 skipped).

## Core architecture (tiered memory, sync/consolidation) & local-first/privacy impact

- **Preserves profile-isolation boundaries** by aligning diagnostics with the same per-profile **SQLite “bank”** the active profile uses, reducing the chance of cross-profile mixing via diagnostic metadata (e.g., `resolved_bank`, `db_path`).
- **Tiered memory remains local-first**: the change doesn’t alter retrieval or ranking logic; it adjusts *where diagnostics and optional repair run* within the local BEAM/SQLite-backed tier structure.
- **Working/coverage repair is integrated into diagnostics**: `repair_vec_working` (with `dry_run`) and `vec_working_coverage` are executed under the same BEAM critical section as diagnostics, keeping optional consolidation/repair operations deterministic under concurrency.
- **Sync layer consistency and safety**: `sync_turn()` and the auto-sleep/consolidation path are protected by the same BEAM/SQLite serialization, and diagnostics capture **PII-safe** `sync_turn` telemetry via a sanitized snapshot.

## Sync / BEAM safety guarantees (architectural win)

- Introduces/standardizes a per-instance, lazily created **`_beam_access_lock`** and uses it to serialize all key BEAM/SQLite touchpoints relevant to Hermes:
  - diagnostics execution (including optional repairs + active-provider DB/orphan checks)
  - `sync_turn()` episodic/BEAM writes (`remember()` + identity-signal capture)
  - bank prefetch/recall paths
  - the auto-sleep daemon consolidation wrapper
- This strengthens local determinism and reduces concurrency/race risks around WAL-backed SQLite access—important for both correctness and trustworthy diagnostics.

## Agent integration surfaces (Hermes, MCP/CLI) & operator tooling

- **Hermes agent integration**: diagnose handling becomes consistent with what agents actually write to under isolation—diagnostics report/act on the correct isolated bank when applicable.
- **Operator action correctness**: diagnostic “sleep” remediation now points to the correct tool/API (**`mnemosyne_sleep`** / **`BeamMemory.sleep()`**), improving usability for agent-driven or operator-driven consolidation workflows.
- No MCP or CLI interface changes were introduced beyond behavior consistency (existing surfaces already support `bank`, and the corrected guidance matches the available sleep tooling).

## Maintainability / long-term evolution

- Centralizing BEAM serialization behind `_ensure_beam_access_lock()` makes the synchronization contract explicit and harder to regress when adding future diagnostics/sync/consolidation features.
- Strong parity + concurrency regression coverage across both shipped Hermes providers helps ensure future changes preserve:
  - correct conditional bank routing under profile isolation
  - correct forwarding of `repair_vec_working`/`dry_run`
  - lock initialization and blocking semantics for BEAM access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->