### PR TITLE
fix(import): make annotation import idempotent on (memory_id, kind, value) collisions

### DIFF
--- a/mnemosyne/core/annotations.py
+++ b/mnemosyne/core/annotations.py
@@ -472,12 +472,25 @@ class AnnotationStore:
                 else:
                     explicit_no_collision.append(item)
 
+            # No id-collision, but the ``idx_annot_unique`` index on
+            # ``(memory_id, kind, value)`` can still reject an insert when
+            # that triple already exists under a *different* id (common on
+            # cross-instance import). Treat it as the same logical
+            # annotation and skip -- crashing here would abort the whole
+            # import and roll back every prior row (mirrors the renumber
+            # path below, and keeps import idempotent / re-runnable).
             for item in explicit_no_collision:
-                _insert_with_id(item, item["id"])
-                stats["inserted"] += 1
+                try:
+                    _insert_with_id(item, item["id"])
+                    stats["inserted"] += 1
+                except sqlite3.IntegrityError:
+                    stats["skipped"] += 1
             for item in no_id:
-                _insert_without_id(item)
-                stats["inserted"] += 1
+                try:
+                    _insert_without_id(item)
+                    stats["inserted"] += 1
+                except sqlite3.IntegrityError:
+                    stats["skipped"] += 1
 
             for item in collisions:
                 row_id = item["id"]

--- a/tests/test_c28_import_all_content_aware.py
+++ b/tests/test_c28_import_all_content_aware.py
@@ -506,6 +506,45 @@ class TestCodexReviewFinding3AnnotationsUniqueIndex(_TwoStoreFixture, unittest.T
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["source"], "A")
 
+    def test_new_id_colliding_content_skips_without_crash(self):
+        # Regression: the (memory_id, kind, value) unique index can also
+        # be violated by a row that does NOT collide on id -- it lands in
+        # the ``explicit_no_collision`` bucket. Pre-fix that bucket did
+        # not catch IntegrityError, so a single such row aborted the
+        # ENTIRE import and rolled back every prior row (making import
+        # non-re-runnable after a partial run). It must skip instead.
+        self.dst.add("mem-1", "fact", "same value", source="A")  # id=1
+        imported = [{
+            "id": 999,  # no id-collision with the existing id=1
+            "memory_id": "mem-1", "kind": "fact", "value": "same value",
+            "source": "B", "confidence": 0.5,
+            "created_at": "2099-01-01T00:00:00",
+        }]
+        stats = self.dst.import_all(imported)
+        self.assertEqual(stats["skipped"], 1)
+        self.assertEqual(stats["inserted"], 0)
+        rows = self.dst.export_all()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["source"], "A")  # original preserved
+
+    def test_new_id_colliding_row_does_not_abort_whole_batch(self):
+        # The colliding row must not take unrelated rows down with it:
+        # a fresh row in the same batch still imports.
+        self.dst.add("mem-1", "fact", "same value")  # id=1
+        imported = [
+            {"id": 999, "memory_id": "mem-1", "kind": "fact",
+             "value": "same value", "source": "B"},          # collides -> skip
+            {"id": 1000, "memory_id": "mem-2", "kind": "fact",
+             "value": "brand new", "source": "C"},           # fresh   -> insert
+        ]
+        stats = self.dst.import_all(imported)
+        self.assertEqual(stats["skipped"], 1)
+        self.assertEqual(stats["inserted"], 1)
+        # Sum-of-stats invariant holds.
+        self.assertEqual(sum(stats.values()), len(imported))
+        values = {r["value"] for r in self.dst.export_all()}
+        self.assertIn("brand new", values)
+
 
 class TestCodexReviewFinding4TransactionRollback(_TwoStoreFixture, unittest.TestCase):
     """Finding #4: if any insert fails mid-batch, the transaction must


### PR DESCRIPTION
## Problem

`AnnotationStore.import_all` (`mnemosyne/core/annotations.py`) only caught the `(memory_id, kind, value)` UNIQUE-index violation in the **id-collision / renumber** path. Rows with a **new id** whose content triple already existed in the destination fall into the `explicit_no_collision` / `no_id` buckets, whose inserts were **unguarded**.

So a single such row raised `sqlite3.IntegrityError: UNIQUE constraint failed: annotations.memory_id, annotations.kind, annotations.value`, and — because the whole thing runs in one `BEGIN IMMEDIATE` — **rolled back the entire import batch**.

Real-world impact (hit while mirroring one instance's memories into another via `mnemosyne export` → `mnemosyne import`):
- `mnemosyne import` is **not re-runnable** — a partial/retried run crashes on the annotations it already inserted.
- Cross-instance import (DB-A → DB-B where the same entity annotations already exist) fails outright.
- Working/episodic/triples import fine (they run first + use idempotent paths); annotations are the only casualty, which masks the breakage.

## Fix

Wrap the `explicit_no_collision` and `no_id` inserts in the same `try/except sqlite3.IntegrityError` the renumber path already uses: treat the row as the same logical annotation (per the schema's uniqueness invariant), **skip** it, and count it under `stats["skipped"]` — preserving the documented `sum(stats.values()) == len(input)` invariant.

## Tests

Added two regression tests to `TestCodexReviewFinding3AnnotationsUniqueIndex`:
- `test_new_id_colliding_content_skips_without_crash` — new id + colliding content → `skipped`, no crash, original preserved. **Verified to fail on the pre-fix code** (reproduces the exact `IntegrityError` at `annotations.py:428`).
- `test_new_id_colliding_row_does_not_abort_whole_batch` — a colliding row no longer takes unrelated fresh rows in the same batch down with it.

`tests/test_c28_import_all_content_aware.py` + `tests/test_annotations.py`: **41 passed**. Ruff: no new violations introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Makes `AnnotationStore.import_all` idempotent for duplicate `(memory_id, kind, value)` annotations. Duplicate inserts are skipped and counted in `stats["skipped"]` instead of aborting the transaction, while unrelated rows in the same batch continue importing.

## Architecture impact

- Strengthens the local annotation store and sync/import boundary by making rerunnable imports safe.
- Preserves existing annotations when logical duplicates arrive under new or missing IDs.
- Maintains import statistics invariants and improves long-term maintainability with focused regression coverage.
- No changes to tiered memory, retrieval, consolidation, veracity, benchmarks, or public APIs.
- No impact on Hermes, MCP, or CLI integration surfaces.
- Reinforces rather than erodes Mnemosyne’s local-first design: conflict handling remains local, deterministic, and transaction-safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->