### PR TITLE
feat(hermes): add bounded background prefetch cache

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -15,12 +15,15 @@ a standalone plugin deployed through the plugin system.
 from __future__ import annotations
 
 import json
+import hashlib
 import logging
 import os
 import re
 import sys
 import threading
 import time
+import unicodedata
+from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
@@ -1414,6 +1417,16 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         # Generic extra-source registry: name -> fn(query, *, session_id) -> hits|str.
         # A profile opts a source in via its `sources`. "bank" is built in.
         self._prefetch_sources: Dict[str, Callable[..., Any]] = {}
+        # Provider-local ephemeral cache for Hermes' background prefetch hook.
+        # It intentionally never uses Mnemosyne's persistent QueryCache.
+        self._prefetch_cache_size = 50
+        self._prefetch_cache_lock = threading.Lock()
+        self._prefetch_cache: OrderedDict[Tuple[str, str], Tuple[str, str]] = OrderedDict()
+        self._prefetch_cache_epoch = 0
+        self._prefetch_cache_telemetry: Dict[str, Any] = {
+            "hits": 0, "misses": 0, "evictions": 0, "warm_completed": 0,
+            "warm_failed": 0, "last_duration_ms": None, "total_duration_ms": 0.0,
+        }
         # Profile memory isolation: when enabled, each Hermes profile gets its own
         # Mnemosyne bank (separate SQLite DB). Default OFF for backward compatibility.
         self._profile_isolation_enabled = False
@@ -1514,6 +1527,104 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         except Exception:
             return False
 
+    def _ensure_prefetch_cache(self):
+        """Lazily initialize private cache state for ``__new__`` test instances."""
+        lock = self.__dict__.setdefault("_prefetch_cache_lock", threading.Lock())
+        with lock:
+            self.__dict__.setdefault("_prefetch_cache", OrderedDict())
+            self.__dict__.setdefault("_prefetch_cache_epoch", 0)
+            self.__dict__.setdefault("_prefetch_cache_size", 50)
+            self.__dict__.setdefault("_prefetch_cache_telemetry", {
+                "hits": 0, "misses": 0, "evictions": 0, "warm_completed": 0,
+                "warm_failed": 0, "last_duration_ms": None, "total_duration_ms": 0.0,
+            })
+        return lock
+
+    @staticmethod
+    def _normalized_prefetch_query(query: str) -> str:
+        return " ".join(unicodedata.normalize("NFKC", str(query)).casefold().split())
+
+    def _prefetch_cache_key(self, query: str, session_id: str) -> Tuple[Tuple[str, str], str]:
+        normalized = self._normalized_prefetch_query(query)
+        effective_session_id = str(session_id or getattr(self, "_session_id", ""))
+        return (effective_session_id, hashlib.sha256(normalized.encode("utf-8")).hexdigest()), normalized
+
+    def _prefetch_cache_diagnostics(self) -> Dict[str, Any]:
+        lock = self._ensure_prefetch_cache()
+        with lock:
+            telemetry = self._prefetch_cache_telemetry
+            completed = telemetry["warm_completed"]
+            return {
+                "enabled": self._prefetch_cache_size > 0,
+                "capacity": self._prefetch_cache_size,
+                "entries": len(self._prefetch_cache),
+                "hits": telemetry["hits"], "misses": telemetry["misses"],
+                "evictions": telemetry["evictions"], "warm_completed": completed,
+                "warm_failed": telemetry["warm_failed"],
+                "last_duration_ms": telemetry["last_duration_ms"],
+                "average_duration_ms": (telemetry["total_duration_ms"] / completed) if completed else None,
+            }
+
+    def _invalidate_prefetch_cache(self) -> None:
+        lock = self._ensure_prefetch_cache()
+        with lock:
+            self._prefetch_cache.clear()
+            self._prefetch_cache_epoch += 1
+
+    @staticmethod
+    def _import_stats_have_mutation(stats: Dict[str, Any]) -> bool:
+        """Return whether file-import statistics record a completed write."""
+        mutation_counts = {
+            "imported", "inserted", "overwritten", "updated",
+            "imported_renumbered", "embeddings_inserted",
+        }
+        for key, value in stats.items():
+            if key in mutation_counts and isinstance(value, (int, float)) and not isinstance(value, bool):
+                if value > 0:
+                    return True
+            elif isinstance(value, dict) and MnemosyneMemoryProvider._import_stats_have_mutation(value):
+                return True
+        return False
+
+    def _record_prefetch_warm(self, *, failed: bool, duration_ms: float) -> None:
+        lock = self._ensure_prefetch_cache()
+        with lock:
+            telemetry = self._prefetch_cache_telemetry
+            telemetry["last_duration_ms"] = duration_ms
+            if failed:
+                telemetry["warm_failed"] += 1
+            else:
+                telemetry["warm_completed"] += 1
+                telemetry["total_duration_ms"] += duration_ms
+
+    def _warm_prefetch(self, query: str, session_id: str) -> None:
+        lock = self._ensure_prefetch_cache()
+        key, normalized = self._prefetch_cache_key(query, session_id)
+        with lock:
+            epoch = self._prefetch_cache_epoch
+        started = time.perf_counter()
+        try:
+            # The warm path touches Beam-owned SQLite state beyond recall
+            # (canonical/model slots and identity SQL), so serialize the entire
+            # render—not just a helper's recall call—with sync_turn writes.
+            # The cache lock was released above and is never held while rendering.
+            with self._ensure_beam_access_lock():
+                rendered = self._render_prefetch(query, session_id=session_id)
+        except Exception:
+            self._record_prefetch_warm(failed=True, duration_ms=(time.perf_counter() - started) * 1000.0)
+            logger.debug("Mnemosyne background prefetch failed", exc_info=True)
+            return
+        duration_ms = (time.perf_counter() - started) * 1000.0
+        self._record_prefetch_warm(failed=False, duration_ms=duration_ms)
+        with lock:
+            if self._prefetch_cache_size <= 0 or self._prefetch_cache_epoch != epoch:
+                return
+            self._prefetch_cache[key] = (normalized, rendered)
+            self._prefetch_cache.move_to_end(key)
+            while len(self._prefetch_cache) > self._prefetch_cache_size:
+                self._prefetch_cache.popitem(last=False)
+                self._prefetch_cache_telemetry["evictions"] += 1
+
     def _apply_provider_config(self, kwargs: Dict[str, Any]) -> None:
         """Apply provider-specific config from Hermes kwargs or config.yaml.
 
@@ -1538,6 +1649,22 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             except (TypeError, ValueError):
                 logger.warning("Mnemosyne: invalid sleep_threshold=%r, keeping %d",
                                sleep_threshold, self._auto_sleep_threshold)
+
+        # prefetch_cache_size: kwargs > config.yaml > default 50. Zero disables
+        # storage; only caller-background queue_prefetch() may still render.
+        prefetch_cache_size = kwargs.get("prefetch_cache_size")
+        if prefetch_cache_size is None:
+            prefetch_cache_size = self._read_config_key("prefetch_cache_size")
+        if prefetch_cache_size is not None:
+            try:
+                parsed_cache_size = max(0, int(prefetch_cache_size))
+            except (TypeError, ValueError):
+                logger.warning("Mnemosyne: invalid prefetch_cache_size=%r, keeping %d",
+                               prefetch_cache_size, self._prefetch_cache_size)
+            else:
+                if parsed_cache_size != self._prefetch_cache_size:
+                    self._prefetch_cache_size = parsed_cache_size
+                    self._invalidate_prefetch_cache()
 
         # reflect guardrails: prefer kwargs, then memory.mnemosyne.reflect,
         # then flat memory.mnemosyne keys, then env/defaults set in __init__.
@@ -1752,6 +1879,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         return [
             {"key": "auto_sleep", "description": "Auto-run sleep() when working memory exceeds threshold. Set false to disable. Backward-compatible with MNEMOSYNE_AUTO_SLEEP_ENABLED env var.", "default": True},
             {"key": "sleep_threshold", "description": "Working memory count before auto-sleep triggers", "default": 50},
+            {"key": "prefetch_cache_size", "description": "Bounded per-provider background recall cache capacity. Zero disables storage; cache misses return empty while queue_prefetch can still warm in caller background.", "default": 50},
             {"key": "reflect", "description": "Reflection/sleep guardrails. Supports disabled_for_cron (default true) and max_calls_per_session (default 3; negative disables cap). Env: MNEMOSYNE_REFLECT_DISABLED_FOR_CRON, MNEMOSYNE_REFLECT_MAX_CALLS_PER_SESSION.", "default": {"disabled_for_cron": True, "max_calls_per_session": 3}},
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},
             {"key": "ignore_patterns", "description": "Regex patterns to filter from memory storage (one per line in config, or comma-separated). Memories matching any pattern are skipped.", "default": []},
@@ -1848,6 +1976,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
     def initialize(self, session_id: str, **kwargs) -> None:
         """Initialize Mnemosyne beam for this session."""
+        # A replacement session must never consume a prior session's warmed
+        # context; advancing the epoch also rejects an in-flight old render.
+        self._invalidate_prefetch_cache()
         # C27: clear stale state from any prior init attempt so a re-init
         # returns the provider to a clean slate. _beam reset is critical
         # for the primary->skip-context re-init case (codex review finding
@@ -2003,8 +2134,25 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         built-in memory-bank source and cannot be overridden here."""
         if name and name != "bank":
             self._prefetch_sources[name] = fn
+            self._invalidate_prefetch_cache()
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return a strict session/query cache hit, otherwise an empty result."""
+        if not self._beam or self._agent_context in self._skip_contexts:
+            return ""
+        lock = self._ensure_prefetch_cache()
+        key, normalized = self._prefetch_cache_key(query, session_id)
+        with lock:
+            if self._prefetch_cache_size > 0:
+                cached = self._prefetch_cache.get(key)
+                if cached is not None and cached[0] == normalized:
+                    self._prefetch_cache.move_to_end(key)
+                    self._prefetch_cache_telemetry["hits"] += 1
+                    return cached[1]
+            self._prefetch_cache_telemetry["misses"] += 1
+        return ""
+
+    def _render_prefetch(self, query: str, *, session_id: str = "") -> str:
         """Recall relevant context for injection, driven by the active profile.
 
         The profile selects which sources to merge (default: just the memory
@@ -2207,8 +2355,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             # sessions) should never bypass session scoping.
             if author_id:
                 recall_kwargs["author_id"] = author_id
-            with self._ensure_beam_access_lock():
-                results = self._beam.recall(**recall_kwargs)
+            results = self._beam.recall(**recall_kwargs)
             if not results:
                 return ""
             # Filter out low-relevance results to prevent context pollution.
@@ -2259,7 +2406,10 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             return ""
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
-        pass
+        """Warm the cache in Hermes' caller-owned background execution context."""
+        if not self._beam or self._agent_context in self._skip_contexts:
+            return
+        self._warm_prefetch(query, session_id)
 
     def _ensure_sync_turn_telemetry(self) -> None:
         """Initialize sync_turn telemetry for tests that construct via __new__."""
@@ -2320,6 +2470,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 int(self._sync_turn_telemetry.get("max_queue_length") or 0),
                 in_flight,
             )
+        wrote_memory = False
         try:
             with self._ensure_beam_access_lock():
                 if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
@@ -2332,6 +2483,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                         scope=self._default_scope,
                         extract_entities=True,
                     )
+                    wrote_memory = True
                     self._capture_identity_signals(user_content)
                 if "assistant" in self._sync_roles and assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
                     assistant_limit = _sync_turn_assistant_limit()
@@ -2343,6 +2495,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                         scope=self._default_scope,
                         extract_entities=True,
                     )
+                    wrote_memory = True
+            if wrote_memory:
+                self._invalidate_prefetch_cache()
             self._turn_count += 1
             if self._auto_sleep_enabled and self._turn_count % 10 == 0:
                 self._maybe_auto_sleep()
@@ -2350,6 +2505,10 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 self._sync_turn_telemetry["completed"] += 1
                 self._sync_turn_telemetry["last_error"] = None
         except Exception as e:
+            # remember() can commit before identity capture raises. Preserve the
+            # mutation boundary even though this turn is reported as failed.
+            if wrote_memory:
+                self._invalidate_prefetch_cache()
             with self._sync_turn_lock:
                 self._sync_turn_telemetry["failed"] += 1
                 self._sync_turn_telemetry["last_error"] = self._sanitize_sync_turn_error(e)
@@ -2445,7 +2604,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                             channel_id=beam_ref.channel_id,
                         )
                         with beam_lock:
-                            sleep_beam.sleep()
+                            result = sleep_beam.sleep()
+                        if result.get("status") == "consolidated":
+                            self._invalidate_prefetch_cache()
                     except Exception as inner:
                         logger.debug("Mnemosyne auto-sleep worker failed: %s", inner)
                 sleep_thread = threading.Thread(target=_sleep_isolated, daemon=True)
@@ -2641,6 +2802,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             metadata=metadata,
             veracity=veracity,
         )
+        self._invalidate_prefetch_cache()
         self._audit_event(
             "remember", memory_id=memory_id, bank="private",
             scope=scope, source_tool="mnemosyne_remember",
@@ -2686,7 +2848,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 "message": f"{len(staged)} writes staged for approval. Use mnemosyne_apply_pending to commit.",
             })
 
-        return json.dumps(apply_beam_batch(
+        result = apply_beam_batch(
             self._beam,
             normalized,
             default_scope=self._default_scope,
@@ -2694,7 +2856,10 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             remember_source_tool="mnemosyne_batch",
             audit_event=self._audit_event,
             extract_defaults_global=False,
-        ))
+        )
+        if result.get("status") == "ok":
+            self._invalidate_prefetch_cache()
+        return json.dumps(result)
 
     def _handle_recall(self, args: Dict[str, Any]) -> str:
         query = args.get("query", "")
@@ -2839,6 +3004,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             memory_id=stable_id,
             veracity=veracity,
         )
+        self._invalidate_prefetch_cache()
         self._audit_event(
             "shared_remember", memory_id=memory_id, bank="surface",
             scope="global", source_tool="mnemosyne_shared_remember",
@@ -2878,6 +3044,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             return json.dumps({"error": "memory_id is required"})
         ok = self._surface_beam.forget_working(memory_id)
         if ok:
+            self._invalidate_prefetch_cache()
             self._audit_event(
                 "shared_forget", memory_id=memory_id, bank="surface",
                 source_tool="mnemosyne_shared_forget",
@@ -2904,6 +3071,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         working = self._beam.get_working_stats()
         episodic = self._beam.get_episodic_stats()
         if not dry_run:
+            if result.get("status") == "consolidated":
+                self._invalidate_prefetch_cache()
             self._audit_event(
                 "sleep", bank="private", source_tool="mnemosyne_sleep",
                 metadata={"all_sessions": all_sessions, "status": result.get("status")},
@@ -2928,6 +3097,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             metadata={"replacement_id": replacement_id, "invalidated": ok} if replacement_id else {"invalidated": ok},
         )
         if ok:
+            self._invalidate_prefetch_cache()
             return json.dumps({"status": "invalidated", "memory_id": memory_id})
         return json.dumps({"status": "memory_not_found", "memory_id": memory_id})
 
@@ -3028,6 +3198,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 "memory_id": memory_id,
             })
 
+        self._invalidate_prefetch_cache()
+
         # Audit log if available
         try:
             if hasattr(self, "_audit_event"):
@@ -3074,6 +3246,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                                valid_until=valid_until, source=source,
                                confidence=confidence, supersede=supersede,
                                db_path=self._beam.db_path)
+        self._invalidate_prefetch_cache()
         return json.dumps({"status": "stored", "triple_id": triple_id})
 
     def _handle_triple_end(self, args: Dict[str, Any]) -> str:
@@ -3086,6 +3259,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         from mnemosyne.core.triples import end_triple
         n = end_triple(subject, predicate, object=obj, valid_until=valid_until,
                        db_path=self._beam.db_path)
+        if n:
+            self._invalidate_prefetch_cache()
         return json.dumps({"status": "ended", "count": n})
 
     def _handle_triple_query(self, args: Dict[str, Any]) -> str:
@@ -3126,6 +3301,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             source=source, confidence=confidence,
         )
         status = row.pop("status", "stored")
+        self._invalidate_prefetch_cache()
         self._audit_event(
             "remember_canonical", bank="canonical",
             source_tool="mnemosyne_remember_canonical",
@@ -3188,6 +3364,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             store = CanonicalStore(db_path=self._beam.db_path, conn=self._beam.conn)
             self._beam.canonical = store
         retired = store.forget(owner_id, category, name)
+        if retired:
+            self._invalidate_prefetch_cache()
         return json.dumps({"retired": retired, "owner_id": owner_id,
                            "category": category, "name": name})
 
@@ -3278,6 +3456,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             except Exception as exc:
                 failed.append({"id": pid, "error": str(exc)})
 
+        if applied:
+            self._invalidate_prefetch_cache()
         return json.dumps({
             "applied": applied,
             "failed": failed,
@@ -3372,6 +3552,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 name=task,
                 body=body,
             )
+            self._invalidate_prefetch_cache()
             self._audit_event(
                 "task_progress_set",
                 bank="private",
@@ -3412,7 +3593,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         elif action == "clear":
             if not task:
                 return json.dumps({"error": "task is required for clear"})
-            store.forget(owner_id, "task:progress", task)
+            retired = store.forget(owner_id, "task:progress", task)
+            if retired:
+                self._invalidate_prefetch_cache()
             return json.dumps({"status": "cleared", "task": task})
 
         else:
@@ -3423,6 +3606,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         if not content:
             return json.dumps({"error": "Content is required"})
         pad_id = self._beam.scratchpad_write(content)
+        self._invalidate_prefetch_cache()
         return json.dumps({"status": "written", "id": pad_id})
 
     def _handle_scratchpad_read(self, args: Dict[str, Any]) -> str:
@@ -3431,6 +3615,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
     def _handle_scratchpad_clear(self, args: Dict[str, Any]) -> str:
         self._beam.scratchpad_clear()
+        self._invalidate_prefetch_cache()
         return json.dumps({"status": "cleared"})
 
     def _handle_export(self, args: Dict[str, Any]) -> str:
@@ -3449,6 +3634,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         content = args.get("content")
         importance = args.get("importance")
         ok = self._beam.update_working(memory_id, content=content, importance=importance)
+        if ok:
+            self._invalidate_prefetch_cache()
         return json.dumps({
             "status": "updated" if ok else "not_found",
             "memory_id": memory_id,
@@ -3460,6 +3647,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             return json.dumps({"error": "memory_id is required"})
         ok = self._beam.forget_working(memory_id)
         if ok:
+            self._invalidate_prefetch_cache()
             self._audit_event(
                 "forget", memory_id=memory_id, bank="private",
                 source_tool="mnemosyne_forget",
@@ -3505,6 +3693,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 dry_run=dry_run,
                 channel_id=channel_id,
             )
+            if not dry_run and result.imported > 0:
+                self._invalidate_prefetch_cache()
             return json.dumps(result.to_dict())
 
         if not input_path:
@@ -3513,6 +3703,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                          "(for cross-provider import) is required",
             })
         stats = mem.import_from_file(input_path, force=force)
+        if self._import_stats_have_mutation(stats):
+            self._invalidate_prefetch_cache()
         self._audit_event(
             "import", bank="private", source_tool="mnemosyne_import",
             metadata={"input_path": input_path, "force": force, "stats": stats},
@@ -3520,6 +3712,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         return json.dumps({"status": "imported", "stats": stats})
 
     def _handle_diagnose(self, args: Dict[str, Any]) -> str:
+        # Snapshot cache telemetry before taking the Beam lock; it never exposes
+        # query/session/content values and must not contend with rendering.
+        prefetch_cache = self._prefetch_cache_diagnostics()
         from mnemosyne.diagnose import run_diagnostics
         repair_requested = bool(args.get("repair_vec_working", False))
         dry_run = bool(args.get("dry_run", False))
@@ -3530,7 +3725,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         if self._profile_isolation_enabled and self._beam is not None:
             diagnostic_kwargs["bank"] = self._resolve_profile_bank()
         if self._beam is None:
-            return json.dumps(run_diagnostics(**diagnostic_kwargs), indent=2, default=str)
+            result = run_diagnostics(**diagnostic_kwargs)
+            result["prefetch_cache"] = prefetch_cache
+            return json.dumps(result, indent=2, default=str)
 
         # The active provider bank shares its SQLite database with auto_sleep's
         # separate Beam connection. Keep every active-bank diagnostic access in
@@ -3539,6 +3736,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         with self._ensure_beam_access_lock():
             result = run_diagnostics(**diagnostic_kwargs)
             result["sync_turn"] = self._sync_turn_diagnostics()
+            result["prefetch_cache"] = prefetch_cache
 
             active_db = None
             try:
@@ -3630,6 +3828,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             timestamp=datetime.now().isoformat(),
         )
         self._beam.episodic_graph.add_edge(edge)
+        self._invalidate_prefetch_cache()
         return json.dumps({
             "status": "linked",
             "source": source_id,
@@ -3674,7 +3873,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                         author_type=beam_ref.author_type,
                         channel_id=beam_ref.channel_id,
                     )
-                    sleep_beam.sleep()
+                    result = sleep_beam.sleep()
+                    if result.get("status") == "consolidated":
+                        self._invalidate_prefetch_cache()
                 except Exception as inner:
                     logger.debug("Mnemosyne session-end sleep failed: %s", inner)
 
@@ -3701,6 +3902,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 importance=0.7 if target == "user" else 0.5,
                 scope=scope,
             )
+            self._invalidate_prefetch_cache()
         except Exception as e:
             logger.debug("Mnemosyne mirror write failed: %s", e)
 
@@ -3714,6 +3916,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
     SHUTDOWN_DRAIN_TIMEOUT_SECONDS = _parse_env_float("MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT", 2)
 
     def shutdown(self) -> None:
+        # Reject any late prefetch worker before tearing down this provider.
+        self._invalidate_prefetch_cache()
         # If session_end's daemon thread is still consolidating when shutdown
         # arrives, briefly wait for it. Otherwise clearing the host backend
         # next would race with the in-flight summarize/extract call and a

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -17,14 +17,17 @@ Based on mnemosyne-memory core library. Zero cloud. Zero latency.
 from __future__ import annotations
 
 import json
+import hashlib
 import logging
 import os
 import re
 import sys
 import threading
 import time
+import unicodedata
+from collections import OrderedDict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import uuid
 
@@ -582,6 +585,16 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         }
         self._auto_sleep_threshold = 50
         self._auto_sleep_enabled = _parse_env_bool("MNEMOSYNE_AUTO_SLEEP_ENABLED", True)
+        # Provider-local ephemeral cache for Hermes' caller-owned background
+        # prefetch. It never uses Mnemosyne's persistent QueryCache.
+        self._prefetch_cache_size = 50
+        self._prefetch_cache_lock = threading.Lock()
+        self._prefetch_cache: OrderedDict[Tuple[str, str], Tuple[str, str]] = OrderedDict()
+        self._prefetch_cache_epoch = 0
+        self._prefetch_cache_telemetry: Dict[str, Any] = {
+            "hits": 0, "misses": 0, "evictions": 0, "warm_completed": 0,
+            "warm_failed": 0, "last_duration_ms": None, "total_duration_ms": 0.0,
+        }
         # Reflection/sleep guardrails. "Reflection" maps to Mnemosyne's
         # sleep/consolidation path in the Hermes provider. Cron skipping is
         # default-on per issue #337; max_calls_per_session defaults to 3 and
@@ -729,6 +742,104 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         except Exception:
             return False
 
+    def _ensure_prefetch_cache(self):
+        """Lazily initialize private cache state for ``__new__`` test instances."""
+        lock = self.__dict__.setdefault("_prefetch_cache_lock", threading.Lock())
+        with lock:
+            self.__dict__.setdefault("_prefetch_cache", OrderedDict())
+            self.__dict__.setdefault("_prefetch_cache_epoch", 0)
+            self.__dict__.setdefault("_prefetch_cache_size", 50)
+            self.__dict__.setdefault("_prefetch_cache_telemetry", {
+                "hits": 0, "misses": 0, "evictions": 0, "warm_completed": 0,
+                "warm_failed": 0, "last_duration_ms": None, "total_duration_ms": 0.0,
+            })
+        return lock
+
+    @staticmethod
+    def _normalized_prefetch_query(query: str) -> str:
+        return " ".join(unicodedata.normalize("NFKC", str(query)).casefold().split())
+
+    def _prefetch_cache_key(self, query: str, session_id: str) -> Tuple[Tuple[str, str], str]:
+        normalized = self._normalized_prefetch_query(query)
+        effective_session_id = str(session_id or getattr(self, "_session_id", ""))
+        return (effective_session_id, hashlib.sha256(normalized.encode("utf-8")).hexdigest()), normalized
+
+    def _prefetch_cache_diagnostics(self) -> Dict[str, Any]:
+        lock = self._ensure_prefetch_cache()
+        with lock:
+            telemetry = self._prefetch_cache_telemetry
+            completed = telemetry["warm_completed"]
+            return {
+                "enabled": self._prefetch_cache_size > 0,
+                "capacity": self._prefetch_cache_size,
+                "entries": len(self._prefetch_cache),
+                "hits": telemetry["hits"], "misses": telemetry["misses"],
+                "evictions": telemetry["evictions"], "warm_completed": completed,
+                "warm_failed": telemetry["warm_failed"],
+                "last_duration_ms": telemetry["last_duration_ms"],
+                "average_duration_ms": (telemetry["total_duration_ms"] / completed) if completed else None,
+            }
+
+    def _invalidate_prefetch_cache(self) -> None:
+        lock = self._ensure_prefetch_cache()
+        with lock:
+            self._prefetch_cache.clear()
+            self._prefetch_cache_epoch += 1
+
+    @staticmethod
+    def _import_stats_have_mutation(stats: Dict[str, Any]) -> bool:
+        """Return whether file-import statistics record a completed write."""
+        mutation_counts = {
+            "imported", "inserted", "overwritten", "updated",
+            "imported_renumbered", "embeddings_inserted",
+        }
+        for key, value in stats.items():
+            if key in mutation_counts and isinstance(value, (int, float)) and not isinstance(value, bool):
+                if value > 0:
+                    return True
+            elif isinstance(value, dict) and MnemosyneMemoryProvider._import_stats_have_mutation(value):
+                return True
+        return False
+
+    def _record_prefetch_warm(self, *, failed: bool, duration_ms: float) -> None:
+        lock = self._ensure_prefetch_cache()
+        with lock:
+            telemetry = self._prefetch_cache_telemetry
+            telemetry["last_duration_ms"] = duration_ms
+            if failed:
+                telemetry["warm_failed"] += 1
+            else:
+                telemetry["warm_completed"] += 1
+                telemetry["total_duration_ms"] += duration_ms
+
+    def _warm_prefetch(self, query: str, session_id: str) -> None:
+        lock = self._ensure_prefetch_cache()
+        key, normalized = self._prefetch_cache_key(query, session_id)
+        with lock:
+            epoch = self._prefetch_cache_epoch
+        started = time.perf_counter()
+        try:
+            # The warm path touches Beam-owned SQLite state beyond recall
+            # (canonical/model slots and identity SQL), so serialize the entire
+            # render—not just a helper's recall call—with sync_turn writes.
+            # The cache lock was released above and is never held while rendering.
+            with self._ensure_beam_access_lock():
+                rendered = self._render_prefetch(query, session_id=session_id)
+        except Exception:
+            self._record_prefetch_warm(failed=True, duration_ms=(time.perf_counter() - started) * 1000.0)
+            logger.debug("Mnemosyne background prefetch failed", exc_info=True)
+            return
+        duration_ms = (time.perf_counter() - started) * 1000.0
+        self._record_prefetch_warm(failed=False, duration_ms=duration_ms)
+        with lock:
+            if self._prefetch_cache_size <= 0 or self._prefetch_cache_epoch != epoch:
+                return
+            self._prefetch_cache[key] = (normalized, rendered)
+            self._prefetch_cache.move_to_end(key)
+            while len(self._prefetch_cache) > self._prefetch_cache_size:
+                self._prefetch_cache.popitem(last=False)
+                self._prefetch_cache_telemetry["evictions"] += 1
+
     def _apply_provider_config(self, kwargs: Dict[str, Any]) -> None:
         """Apply provider-specific config from Hermes kwargs or config.yaml.
 
@@ -753,6 +864,22 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             except (TypeError, ValueError):
                 logger.warning("Mnemosyne: invalid sleep_threshold=%r, keeping %d",
                                sleep_threshold, self._auto_sleep_threshold)
+
+        # prefetch_cache_size: kwargs > config.yaml > default 50. Zero disables
+        # storage; only caller-background queue_prefetch() may still render.
+        prefetch_cache_size = kwargs.get("prefetch_cache_size")
+        if prefetch_cache_size is None:
+            prefetch_cache_size = self._read_config_key("prefetch_cache_size")
+        if prefetch_cache_size is not None:
+            try:
+                parsed_cache_size = max(0, int(prefetch_cache_size))
+            except (TypeError, ValueError):
+                logger.warning("Mnemosyne: invalid prefetch_cache_size=%r, keeping %d",
+                               prefetch_cache_size, self._prefetch_cache_size)
+            else:
+                if parsed_cache_size != self._prefetch_cache_size:
+                    self._prefetch_cache_size = parsed_cache_size
+                    self._invalidate_prefetch_cache()
 
         # reflect guardrails: prefer kwargs, then memory.mnemosyne.reflect,
         # then flat memory.mnemosyne keys, then env/defaults set in __init__.
@@ -937,6 +1064,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         return [
             {"key": "auto_sleep", "description": "Auto-run sleep() when working memory exceeds threshold. Set false to disable. Backward-compatible with MNEMOSYNE_AUTO_SLEEP_ENABLED env var.", "default": True},
             {"key": "sleep_threshold", "description": "Working memory count before auto-sleep triggers", "default": 50},
+            {"key": "prefetch_cache_size", "description": "Bounded per-provider background recall cache capacity. Zero disables storage; cache misses return empty while queue_prefetch can still warm in caller background.", "default": 50},
             {"key": "reflect", "description": "Reflection/sleep guardrails. Supports disabled_for_cron (default true) and max_calls_per_session (default 3; negative disables cap). Env: MNEMOSYNE_REFLECT_DISABLED_FOR_CRON, MNEMOSYNE_REFLECT_MAX_CALLS_PER_SESSION.", "default": {"disabled_for_cron": True, "max_calls_per_session": 3}},
             {"key": "vector_type", "description": "Vector storage type (note: not yet wired to BeamMemory at runtime; reserved for future use)", "choices": ["float32", "int8", "bit"], "default": "int8"},
             {"key": "ignore_patterns", "description": "Regex patterns to filter from memory storage (one per line in config, or comma-separated). Memories matching any pattern are skipped.", "default": []},
@@ -1033,6 +1161,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
     def initialize(self, session_id: str, **kwargs) -> None:
         """Initialize Mnemosyne beam for this session."""
+        # A replacement session must never consume a prior session's warmed
+        # context; advancing the epoch also rejects an in-flight old render.
+        self._invalidate_prefetch_cache()
         # C27: clear stale state from any prior init attempt so a re-init
         # returns the provider to a clean slate. _beam reset is critical
         # for the primary->skip-context re-init case (codex review finding
@@ -1214,6 +1345,23 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         return ""
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return a strict session/query cache hit, otherwise an empty result."""
+        self._maybe_retry_init()
+        if not self._beam or self._agent_context in self._skip_contexts:
+            return ""
+        lock = self._ensure_prefetch_cache()
+        key, normalized = self._prefetch_cache_key(query, session_id)
+        with lock:
+            if self._prefetch_cache_size > 0:
+                cached = self._prefetch_cache.get(key)
+                if cached is not None and cached[0] == normalized:
+                    self._prefetch_cache.move_to_end(key)
+                    self._prefetch_cache_telemetry["hits"] += 1
+                    return cached[1]
+            self._prefetch_cache_telemetry["misses"] += 1
+        return ""
+
+    def _render_prefetch(self, query: str, *, session_id: str = "") -> str:
         """Recall relevant context via Mnemosyne hybrid search with temporal weighting.
         
         Only includes memories above a relevance threshold to prevent context pollution
@@ -1238,19 +1386,18 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             # sessions) should never bypass session scoping.
             if author_id:
                 recall_kwargs["author_id"] = author_id
-            with self._ensure_beam_access_lock():
-                results = self._beam.recall(**recall_kwargs)
+            results = self._beam.recall(**recall_kwargs)
 
-                canonical_rows: List[Dict[str, Any]] = []
-                try:
-                    store = getattr(self._beam, "canonical", None)
-                    if store is None:
-                        from mnemosyne.core.canonical import CanonicalStore
-                        store = CanonicalStore(db_path=self._beam.db_path, conn=self._beam.conn)
-                        self._beam.canonical = store
-                    canonical_rows = _canonical_prefetch_rows(store, self._canonical_owner(), query)
-                except Exception:
-                    canonical_rows = []
+            canonical_rows: List[Dict[str, Any]] = []
+            try:
+                store = getattr(self._beam, "canonical", None)
+                if store is None:
+                    from mnemosyne.core.canonical import CanonicalStore
+                    store = CanonicalStore(db_path=self._beam.db_path, conn=self._beam.conn)
+                    self._beam.canonical = store
+                canonical_rows = _canonical_prefetch_rows(store, self._canonical_owner(), query)
+            except Exception:
+                canonical_rows = []
 
             if not results and not canonical_rows:
                 return ""
@@ -1301,7 +1448,11 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             return ""
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
-        pass
+        """Warm the cache in Hermes' caller-owned background execution context."""
+        self._maybe_retry_init()
+        if not self._beam or self._agent_context in self._skip_contexts:
+            return
+        self._warm_prefetch(query, session_id)
 
     def _ensure_sync_turn_telemetry(self) -> None:
         """Initialize sync_turn telemetry for tests that construct via __new__."""
@@ -1363,6 +1514,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 int(self._sync_turn_telemetry.get("max_queue_length") or 0),
                 in_flight,
             )
+        wrote_memory = False
         try:
             with self._ensure_beam_access_lock():
                 if "user" in self._sync_roles and user_content and len(user_content) > 5 and not self._should_filter(user_content):
@@ -1375,6 +1527,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                         scope=self._default_scope,
                         extract_entities=True,
                     )
+                    wrote_memory = True
                     # Check for identity-significant signals in user content
                     self._capture_identity_signals(user_content)
                 if "assistant" in self._sync_roles and assistant_content and len(assistant_content) > 10 and not self._should_filter(assistant_content):
@@ -1387,6 +1540,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                         scope=self._default_scope,
                         extract_entities=True,
                     )
+                    wrote_memory = True
+            if wrote_memory:
+                self._invalidate_prefetch_cache()
             self._turn_count += 1
             if self._auto_sleep_enabled and self._turn_count % 10 == 0:
                 self._maybe_auto_sleep()
@@ -1394,6 +1550,10 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 self._sync_turn_telemetry["completed"] += 1
                 self._sync_turn_telemetry["last_error"] = None
         except Exception as e:
+            # remember() can commit before identity capture raises. Preserve the
+            # mutation boundary even though this turn is reported as failed.
+            if wrote_memory:
+                self._invalidate_prefetch_cache()
             with self._sync_turn_lock:
                 self._sync_turn_telemetry["failed"] += 1
                 self._sync_turn_telemetry["last_error"] = self._sanitize_sync_turn_error(e)
@@ -1493,7 +1653,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                             channel_id=beam_ref.channel_id,
                         )
                         with beam_lock:
-                            (sleep_beam.sleep_all_sessions if sleep_all_sessions else sleep_beam.sleep)()
+                            result = (sleep_beam.sleep_all_sessions if sleep_all_sessions else sleep_beam.sleep)()
+                        if result.get("status") == "consolidated":
+                            self._invalidate_prefetch_cache()
                     except Exception as inner:
                         logger.debug("Mnemosyne auto-sleep worker failed: %s", inner)
 
@@ -1686,6 +1848,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             metadata=metadata,
             veracity=veracity,
         )
+        self._invalidate_prefetch_cache()
         self._audit_event(
             "remember", memory_id=memory_id, bank="private",
             scope=scope, source_tool="mnemosyne_remember",
@@ -1732,7 +1895,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 "message": "Batch write staged for approval. Use mnemosyne_apply_pending to commit.",
             })
 
-        return json.dumps(apply_beam_batch(
+        result = apply_beam_batch(
             self._beam,
             normalized,
             default_scope=self._default_scope,
@@ -1740,7 +1903,10 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             remember_source_tool="mnemosyne_batch",
             audit_event=self._audit_event,
             extract_defaults_global=False,
-        ))
+        )
+        if result.get("status") == "ok":
+            self._invalidate_prefetch_cache()
+        return json.dumps(result)
 
     def _handle_recall(self, args: Dict[str, Any]) -> str:
         query = args.get("query", "")
@@ -1904,6 +2070,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             memory_id=stable_id,
             veracity=veracity,
         )
+        self._invalidate_prefetch_cache()
         self._audit_event(
             "shared_remember", memory_id=memory_id, bank="surface",
             scope="global", source_tool="mnemosyne_shared_remember",
@@ -1943,6 +2110,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             return json.dumps({"error": "memory_id is required"})
         ok = self._surface_beam.forget_working(memory_id)
         if ok:
+            self._invalidate_prefetch_cache()
             self._audit_event(
                 "shared_forget", memory_id=memory_id, bank="surface",
                 source_tool="mnemosyne_shared_forget",
@@ -1969,6 +2137,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         working = self._beam.get_working_stats()
         episodic = self._beam.get_episodic_stats()
         if not dry_run:
+            if result.get("status") == "consolidated":
+                self._invalidate_prefetch_cache()
             self._audit_event(
                 "sleep", bank="private", source_tool="mnemosyne_sleep",
                 metadata={"all_sessions": all_sessions, "status": result.get("status")},
@@ -1986,7 +2156,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         replacement_id = args.get("replacement_id", None) or None
         if not memory_id:
             return json.dumps({"error": "memory_id is required"})
-        self._beam.invalidate(memory_id, replacement_id=replacement_id if replacement_id else None)
+        ok = self._beam.invalidate(memory_id, replacement_id=replacement_id if replacement_id else None)
+        if ok:
+            self._invalidate_prefetch_cache()
         self._audit_event(
             "invalidate", memory_id=memory_id, bank="private",
             source_tool="mnemosyne_invalidate",
@@ -2091,6 +2263,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 "memory_id": memory_id,
             })
 
+        self._invalidate_prefetch_cache()
+
         # Audit log if available
         try:
             if hasattr(self, "_audit_event"):
@@ -2137,6 +2311,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                                valid_until=valid_until, source=source,
                                confidence=confidence, supersede=supersede,
                                db_path=self._beam.db_path)
+        self._invalidate_prefetch_cache()
         return json.dumps({"status": "stored", "triple_id": triple_id})
 
     def _handle_triple_end(self, args: Dict[str, Any]) -> str:
@@ -2149,6 +2324,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         from mnemosyne.core.triples import end_triple
         n = end_triple(subject, predicate, object=obj, valid_until=valid_until,
                        db_path=self._beam.db_path)
+        if n:
+            self._invalidate_prefetch_cache()
         return json.dumps({"status": "ended", "count": n})
 
 
@@ -2195,6 +2372,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             source=source, confidence=confidence,
         )
         status = row.pop("status", "stored")
+        self._invalidate_prefetch_cache()
         self._audit_event(
             "remember_canonical", bank="canonical",
             source_tool="mnemosyne_remember_canonical",
@@ -2258,6 +2436,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             store = CanonicalStore(db_path=self._beam.db_path, conn=self._beam.conn)
             self._beam.canonical = store
         retired = store.forget(owner_id, category, name)
+        if retired:
+            self._invalidate_prefetch_cache()
         return json.dumps({"retired": retired, "owner_id": owner_id,
                            "category": category, "name": name})
 
@@ -2317,6 +2497,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 applied.append({"id": pid, "memory_id": mid})
             except Exception as exc:
                 failed.append({"id": pid, "error": str(exc)})
+        if applied:
+            self._invalidate_prefetch_cache()
         return json.dumps({"applied": applied, "failed": failed,
                            "applied_count": len(applied), "failed_count": len(failed)})
 
@@ -2365,6 +2547,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         if not content:
             return json.dumps({"error": "Content is required"})
         pad_id = self._beam.scratchpad_write(content)
+        self._invalidate_prefetch_cache()
         return json.dumps({"status": "written", "id": pad_id})
 
     def _handle_scratchpad_read(self, args: Dict[str, Any]) -> str:
@@ -2373,6 +2556,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
 
     def _handle_scratchpad_clear(self, args: Dict[str, Any]) -> str:
         self._beam.scratchpad_clear()
+        self._invalidate_prefetch_cache()
         return json.dumps({"status": "cleared"})
 
     def _handle_export(self, args: Dict[str, Any]) -> str:
@@ -2391,6 +2575,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         content = args.get("content")
         importance = args.get("importance")
         ok = self._beam.update_working(memory_id, content=content, importance=importance)
+        if ok:
+            self._invalidate_prefetch_cache()
         return json.dumps({
             "status": "updated" if ok else "not_found",
             "memory_id": memory_id,
@@ -2402,6 +2588,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             return json.dumps({"error": "memory_id is required"})
         ok = self._beam.forget_working(memory_id)
         if ok:
+            self._invalidate_prefetch_cache()
             self._audit_event(
                 "forget", memory_id=memory_id, bank="private",
                 source_tool="mnemosyne_forget",
@@ -2447,6 +2634,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 dry_run=dry_run,
                 channel_id=channel_id,
             )
+            if not dry_run and result.imported > 0:
+                self._invalidate_prefetch_cache()
             return json.dumps(result.to_dict())
 
         if not input_path:
@@ -2455,6 +2644,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                          "(for cross-provider import) is required",
             })
         stats = mem.import_from_file(input_path, force=force)
+        if self._import_stats_have_mutation(stats):
+            self._invalidate_prefetch_cache()
         self._audit_event(
             "import", bank="private", source_tool="mnemosyne_import",
             metadata={"input_path": input_path, "force": force, "stats": stats},
@@ -2462,6 +2653,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         return json.dumps({"status": "imported", "stats": stats})
 
     def _handle_diagnose(self, args: Dict[str, Any]) -> str:
+        # Snapshot cache telemetry before taking the Beam lock; it never exposes
+        # query/session/content values and must not contend with rendering.
+        prefetch_cache = self._prefetch_cache_diagnostics()
         from mnemosyne.diagnose import run_diagnostics
         repair_requested = bool(args.get("repair_vec_working", False))
         dry_run = bool(args.get("dry_run", False))
@@ -2472,13 +2666,16 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         if self._profile_isolation_enabled and self._beam is not None:
             diagnostic_kwargs["bank"] = self._resolve_profile_bank()
         if self._beam is None:
-            return json.dumps(run_diagnostics(**diagnostic_kwargs), indent=2, default=str)
+            result = run_diagnostics(**diagnostic_kwargs)
+            result["prefetch_cache"] = prefetch_cache
+            return json.dumps(result, indent=2, default=str)
 
         # The active provider bank shares its SQLite database with auto_sleep.
         # Serialize the complete active-bank diagnostic operation (#498).
         with self._ensure_beam_access_lock():
             result = run_diagnostics(**diagnostic_kwargs)
             result["sync_turn"] = self._sync_turn_diagnostics()
+            result["prefetch_cache"] = prefetch_cache
 
             active_db = None
             try:
@@ -2591,6 +2788,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 name=task,
                 body=body,
             )
+            self._invalidate_prefetch_cache()
             self._audit_event(
                 "task_progress_set",
                 bank="private",
@@ -2632,7 +2830,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             if not task:
                 return json.dumps({"error": "task is required for clear"})
             # Use forget to delete the canonical slot
-            store.forget(owner_id, "task:progress", task)
+            retired = store.forget(owner_id, "task:progress", task)
+            if retired:
+                self._invalidate_prefetch_cache()
             return json.dumps({"status": "cleared", "task": task})
 
         else:
@@ -2685,6 +2885,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
             timestamp=datetime.now().isoformat(),
         )
         self._beam.episodic_graph.add_edge(edge)
+        self._invalidate_prefetch_cache()
         return json.dumps({
             "status": "linked",
             "source": source_id,
@@ -2718,7 +2919,9 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 # severity the previous synchronous version used, instead
                 # of bubbling out as an uncaught daemon-thread traceback.
                 try:
-                    beam.sleep()
+                    result = beam.sleep()
+                    if result.get("status") == "consolidated":
+                        self._invalidate_prefetch_cache()
                 except Exception as inner:
                     logger.debug("Mnemosyne session-end sleep failed: %s", inner)
 
@@ -2745,6 +2948,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 importance=0.7 if target == "user" else 0.5,
                 scope=scope,
             )
+            self._invalidate_prefetch_cache()
         except Exception as e:
             logger.debug("Mnemosyne mirror write failed: %s", e)
 
@@ -2758,6 +2962,8 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
     SHUTDOWN_DRAIN_TIMEOUT_SECONDS = _parse_env_float("MNEMOSYNE_SHUTDOWN_DRAIN_TIMEOUT", 2)
 
     def shutdown(self) -> None:
+        # Reject any late prefetch worker before tearing down this provider.
+        self._invalidate_prefetch_cache()
         # If session_end's daemon thread is still consolidating when shutdown
         # arrives, briefly wait for it. Otherwise clearing the host backend
         # next would race with the in-flight summarize/extract call and a

--- a/integrations/hermes/tests/test_init_retry.py
+++ b/integrations/hermes/tests/test_init_retry.py
@@ -93,6 +93,7 @@ def test_retry_waits_for_the_interval(monkeypatch):
 
     # _retry_init_at is ~60s in the future; surface calls must not retry yet.
     provider.system_prompt_block()
+    provider.queue_prefetch("query")
     provider.prefetch("query")
     assert calls["n"] == attempts_after_init
 

--- a/integrations/hermes/tests/test_prefetch_hardening.py
+++ b/integrations/hermes/tests/test_prefetch_hardening.py
@@ -35,6 +35,7 @@ def test_prefetch_excludes_assistant_transcript_rows():
          "importance": 0.8, "score": 0.7, "keyword_score": 0.7, "trust_tier": "STATED"},
     ])
 
+    p.queue_prefetch("Mnemosyne injection correction")
     block = p.prefetch("Mnemosyne injection correction")
 
     assert "distilled correction" in block
@@ -51,6 +52,7 @@ def test_prefetch_requires_topic_signal_not_importance_only():
          "importance": 0.7, "score": 0.6, "keyword_score": 0.6, "trust_tier": "STATED"},
     ])
 
+    p.queue_prefetch("make Mnemosyne memory-context injection more relevant")
     block = p.prefetch("make Mnemosyne memory-context injection more relevant")
 
     assert "topical relevance" in block

--- a/tests/test_hermes_memory_provider_diagnose_active_db.py
+++ b/tests/test_hermes_memory_provider_diagnose_active_db.py
@@ -66,7 +66,20 @@ def test_diagnose_without_active_beam_keeps_base_diagnostics(monkeypatch):
 
     result = json.loads(provider._handle_diagnose({}))
 
-    assert result == {"checks_total": 1, "key_findings": ["base finding"]}
+    assert result["checks_total"] == 1
+    assert result["key_findings"] == ["base finding"]
+    assert result["prefetch_cache"] == {
+        "enabled": True,
+        "capacity": 50,
+        "entries": 0,
+        "hits": 0,
+        "misses": 0,
+        "evictions": 0,
+        "warm_completed": 0,
+        "warm_failed": 0,
+        "last_duration_ms": None,
+        "average_duration_ms": None,
+    }
 
 
 def test_diagnose_reports_count_error_without_failing(tmp_path, monkeypatch):

--- a/tests/test_hermes_memory_provider_thread_isolation.py
+++ b/tests/test_hermes_memory_provider_thread_isolation.py
@@ -185,8 +185,11 @@ def test_prefetch_scopes_to_thread(tmp_path, monkeypatch):
 
     # Prefetch with a query broad enough to match all memories.
     # prefetch() returns formatted string, not JSON.
-    prefetch_a_output = prov_a.prefetch(query="animals nature sky ocean")
-    prefetch_b_output = prov_b.prefetch(query="animals nature sky ocean")
+    query = "animals nature sky ocean"
+    prov_a.queue_prefetch(query=query)
+    prov_b.queue_prefetch(query=query)
+    prefetch_a_output = prov_a.prefetch(query=query)
+    prefetch_b_output = prov_b.prefetch(query=query)
 
     # Thread A should see its session memory + global
     assert "Secret A: the sky is green" in prefetch_a_output, \

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -129,6 +129,7 @@ def test_provider_config_defaults_match(provider_modules):
     assert root_config["default_scope"]["choices"] == ["session", "global"]
     assert root_config["default_scope"]["default"] == "session"
     assert root_config["tools"]["default"] is None
+    assert root_config["prefetch_cache_size"]["default"] == 50
 
 
 def test_auto_sleep_runtime_default_enabled(monkeypatch, provider_modules):
@@ -758,6 +759,592 @@ def test_provider_sync_turn_zero_limit_means_untruncated(monkeypatch, provider_m
         "[USER] user-content",
         "[ASSISTANT] assistant-content",
     ]
+
+
+def _cache_provider(module):
+    """Build a minimal live provider without invoking a real Beam recall."""
+    provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+    provider._beam = object()
+    provider._agent_context = ""
+    provider._skip_contexts = set()
+    provider._session_id = "provider-session"
+    # The packaged provider retries initialization at the public hook boundary.
+    provider._maybe_retry_init = lambda: None
+    return provider
+
+
+def _install_renderer(provider):
+    calls = []
+    cache_lock_violations = []
+
+    def render(query, *, session_id=""):
+        # Cache synchronization must not be held while the potentially slow
+        # render/Beam path is running.
+        if provider._prefetch_cache_lock.acquire(blocking=False):
+            provider._prefetch_cache_lock.release()
+        else:
+            cache_lock_violations.append((query, session_id))
+        calls.append((query, session_id))
+        return f"rendered:{query}:{session_id}"
+
+    provider._render_prefetch = render
+    return calls, cache_lock_violations
+
+
+@pytest.mark.parametrize("provider_name", ["hermes_memory_provider", "mnemosyne_hermes"])
+def test_prefetch_cache_cold_miss_does_not_render_in_foreground(provider_modules, provider_name):
+    """A cold pre-LLM lookup must not wait for the potentially slow recall path."""
+    provider = _cache_provider(provider_modules[provider_name])
+    calls = []
+    renderer_started = threading.Event()
+    renderer_release = threading.Event()
+
+    def slow_render(query, *, session_id=""):
+        calls.append((query, session_id))
+        renderer_started.set()
+        renderer_release.wait(timeout=1)
+        return f"rendered:{query}:{session_id}"
+
+    provider._render_prefetch = slow_render
+    try:
+        assert provider.prefetch("cold query", session_id="session-a") == ""
+        assert calls == []
+        assert not renderer_started.is_set()
+    finally:
+        renderer_release.set()
+
+    diagnostics = provider._prefetch_cache_diagnostics()
+    assert diagnostics["hits"] == 0
+    assert diagnostics["misses"] == 1
+    assert diagnostics["warm_completed"] == 0
+
+
+def test_queue_prefetch_serializes_full_render_with_sync_turn_write(provider_modules):
+    """A caller-owned warm render cannot overlap the provider's sync-turn DB phase."""
+    for module in provider_modules.values():
+        provider = _new_provider(module, roles=("user",))
+        write_entered = threading.Event()
+        release_write = threading.Event()
+        render_started = threading.Event()
+
+        class BlockingBeam:
+            def remember(self, **_kwargs):
+                write_entered.set()
+                assert release_write.wait(timeout=1), "test did not release sync_turn"
+
+        provider._beam = BlockingBeam()
+        lock = _ObservedLock()
+        provider._beam_access_lock = lock
+
+        def controlled_render(_query, *, session_id=""):
+            # Rendering must retain Beam serialization but never the cache lock.
+            assert provider._prefetch_cache_lock.acquire(blocking=False)
+            provider._prefetch_cache_lock.release()
+            render_started.set()
+            return f"rendered:{session_id}"
+
+        provider._render_prefetch = controlled_render
+        sync_worker = threading.Thread(
+            target=lambda: provider.sync_turn("sufficient user content", "")
+        )
+        warm_worker = threading.Thread(
+            target=lambda: provider.queue_prefetch("query", session_id="session-a")
+        )
+        sync_worker.start()
+        assert write_entered.wait(timeout=1), "sync_turn did not reach its protected write"
+        lock.waiting.clear()
+        warm_worker.start()
+        try:
+            assert lock.waiting.wait(timeout=1), "warm render did not attempt the shared Beam lock"
+            assert not render_started.is_set(), "warm render overlapped sync_turn's protected write"
+        finally:
+            release_write.set()
+        sync_worker.join(timeout=1)
+        warm_worker.join(timeout=1)
+        assert not sync_worker.is_alive()
+        assert not warm_worker.is_alive()
+        assert render_started.is_set()
+        # The committed sync turn may invalidate the just-warmed entry; this
+        # regression proves serialization, not cache publication ordering.
+        assert provider._prefetch_cache_diagnostics()["warm_completed"] == 1
+
+
+def test_prefetch_cache_normalizes_exact_warm_hits_and_never_spawns_threads(
+    monkeypatch, provider_modules
+):
+    """Warm results are reusable only after NFKC/case/whitespace normalization."""
+    for module in provider_modules.values():
+        provider = _cache_provider(module)
+        provider._ensure_prefetch_cache()
+        calls, cache_lock_violations = _install_renderer(provider)
+        original_threading = module.threading
+        created_threads = []
+
+        class TrackingThreading:
+            def Thread(self, *args, **kwargs):
+                created_threads.append((args, kwargs))
+                return original_threading.Thread(*args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(original_threading, name)
+
+        # Replace only this provider module's binding. The proxy delegates every
+        # non-Thread attribute to stdlib threading, avoiding process-wide state.
+        monkeypatch.setattr(module, "threading", TrackingThreading())
+        provider.queue_prefetch("  ＣＡＦＥ\u3000PLAN  ", session_id="session-a")
+        assert provider.prefetch("cafe plan", session_id="session-a") == "rendered:  ＣＡＦＥ\u3000PLAN  :session-a"
+        assert calls == [("  ＣＡＦＥ\u3000PLAN  ", "session-a")]
+        assert cache_lock_violations == []
+        assert created_threads == []
+        diagnostics = provider._prefetch_cache_diagnostics()
+        assert diagnostics["hits"] == 1
+        assert diagnostics["misses"] == 0
+        assert diagnostics["warm_completed"] == 1
+
+
+@pytest.mark.parametrize("provider_name", ["hermes_memory_provider", "mnemosyne_hermes"])
+def test_prefetch_cache_uses_strict_session_and_normalized_query_match(
+    monkeypatch, provider_modules, provider_name
+):
+    """A digest collision cannot leak a warm result across query or session boundaries."""
+    collision_hash = types.SimpleNamespace(sha256=lambda _payload: types.SimpleNamespace(hexdigest=lambda: "same"))
+    module = provider_modules[provider_name]
+    provider = _cache_provider(module)
+    calls, cache_lock_violations = _install_renderer(provider)
+    monkeypatch.setattr(module, "hashlib", collision_hash)
+
+    provider.queue_prefetch("alpha", session_id="session-a")
+    assert provider.prefetch("beta", session_id="session-a") == ""
+    assert calls == [("alpha", "session-a")]
+    assert provider.prefetch("alpha", session_id="session-b") == ""
+    assert calls == [("alpha", "session-a")]
+    assert provider.prefetch("  ALPHA  ", session_id="session-a") == "rendered:alpha:session-a"
+    assert calls == [("alpha", "session-a")]
+    assert cache_lock_violations == []
+    diagnostics = provider._prefetch_cache_diagnostics()
+    assert diagnostics["hits"] == 1
+    assert diagnostics["misses"] == 2
+
+
+def test_prefetch_cache_lru_zero_config_and_schema_parity(tmp_path, provider_modules):
+    """Cache capacity is bounded, recent hits refresh LRU order, and zero stores nothing."""
+    observed = {}
+    for name, module in provider_modules.items():
+        provider = _cache_provider(module)
+        provider._prefetch_cache_size = 2
+        calls, cache_lock_violations = _install_renderer(provider)
+        provider.queue_prefetch("one", session_id="s")
+        provider.queue_prefetch("two", session_id="s")
+        assert provider.prefetch("one", session_id="s") == "rendered:one:s"
+        provider.queue_prefetch("three", session_id="s")
+        assert provider.prefetch("one", session_id="s") == "rendered:one:s"
+        assert provider.prefetch("two", session_id="s") == ""
+        provider._prefetch_cache_size = 0
+        provider._invalidate_prefetch_cache()
+        provider.queue_prefetch("zero", session_id="s")
+        assert provider.prefetch("zero", session_id="s") == ""
+        assert cache_lock_violations == []
+        observed[name] = {
+            "calls": calls,
+            "diagnostics": provider._prefetch_cache_diagnostics(),
+        }
+
+        hermes_home = tmp_path / name
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n  provider: mnemosyne\n  mnemosyne:\n    prefetch_cache_size: 0\n"
+        )
+        configured = _provider_for_config(module, hermes_home)
+        configured._apply_provider_config({})
+        assert configured._prefetch_cache_size == 0
+        configured._apply_provider_config({"prefetch_cache_size": 3})
+        assert configured._prefetch_cache_size == 3
+
+    assert observed["hermes_memory_provider"]["calls"] == observed["mnemosyne_hermes"]["calls"]
+    assert observed["hermes_memory_provider"]["calls"] == [
+        ("one", "s"), ("two", "s"), ("three", "s"), ("zero", "s"),
+    ]
+    for result in observed.values():
+        assert result["diagnostics"]["entries"] == 0
+        assert result["diagnostics"]["evictions"] == 1
+        assert result["diagnostics"]["warm_completed"] == 4
+        assert result["diagnostics"]["misses"] == 2
+
+
+def test_prefetch_cache_rejects_late_warm_after_epoch_invalidation(provider_modules):
+    """A reinitialize/invalidation race cannot publish context from the old epoch."""
+    for module in provider_modules.values():
+        provider = _cache_provider(module)
+        provider._ensure_prefetch_cache()
+
+        def late_render(_query, *, session_id=""):
+            provider._invalidate_prefetch_cache()
+            return f"late:{session_id}"
+
+        provider._render_prefetch = late_render
+        provider.queue_prefetch("old query", session_id="old-session")
+        assert provider._prefetch_cache == {}
+        assert provider._prefetch_cache_diagnostics()["warm_completed"] == 1
+
+
+def test_prefetch_cache_invalidates_only_after_successful_writes_including_memory_hook(
+    monkeypatch, provider_modules
+):
+    """Failed/staged writes keep a warm result; completed mutations invalidate it."""
+    for module in provider_modules.values():
+        provider = _cache_provider(module)
+        invalidations = []
+        original_invalidate = provider._invalidate_prefetch_cache
+
+        def record_invalidate():
+            invalidations.append("invalidate")
+            original_invalidate()
+
+        provider._invalidate_prefetch_cache = record_invalidate
+        provider._default_scope = "session"
+        provider._audit_event = lambda *_args, **_kwargs: None
+
+        monkeypatch.setattr(module, "_write_approval_enabled", lambda: False)
+        monkeypatch.setattr(module, "apply_beam_batch", lambda *_args, **_kwargs: {"status": "failed"})
+        assert json.loads(provider._handle_batch({"operations": [{"action": "remember", "content": "x"}]}))["status"] == "failed"
+        assert invalidations == []
+        monkeypatch.setattr(module, "apply_beam_batch", lambda *_args, **_kwargs: {"status": "ok"})
+        assert json.loads(provider._handle_batch({"operations": [{"action": "remember", "content": "x"}]}))["status"] == "ok"
+        assert invalidations == ["invalidate"]
+
+        staged_writes = []
+        monkeypatch.setattr(module, "_write_approval_enabled", lambda: True)
+        monkeypatch.setattr(
+            module,
+            "_stage_pending_write",
+            lambda payload: staged_writes.append(payload) or f"pending-{len(staged_writes)}",
+        )
+        monkeypatch.setattr(
+            module,
+            "apply_beam_batch",
+            lambda *_args, **_kwargs: pytest.fail("approval-gated batch must not write"),
+        )
+        staged = json.loads(provider._handle_batch({"operations": [{"action": "remember", "content": "x"}]}))
+        assert staged["status"] == "staged"
+        staged_ids = staged.get("pending_ids") or [item["pending_id"] for item in staged["staged"]]
+        assert staged_ids == ["pending-1"]
+        assert staged.get("count", staged.get("staged_count")) == 1
+        assert len(staged_writes) == 1
+        assert staged_writes[0]["tool"] == "mnemosyne_batch"
+        assert staged_writes[0]["action"] == "remember"
+        assert staged_writes[0]["scope"] == "session"
+        assert invalidations == ["invalidate"]
+
+        class FailingBeam:
+            def remember(self, **_kwargs):
+                raise RuntimeError("write failed")
+
+        provider._beam = FailingBeam()
+        provider.on_memory_write("add", "user", "private write")
+        provider.on_memory_write("delete", "user", "private write")
+        assert invalidations == ["invalidate"]
+
+        class SuccessBeam:
+            def remember(self, **_kwargs):
+                return "memory-id"
+
+        provider._beam = SuccessBeam()
+        provider.on_memory_write("replace", "agent", "private write")
+        assert invalidations == ["invalidate", "invalidate"]
+
+        class TaskStore:
+            retired = False
+
+            def forget(self, *_args):
+                return self.retired
+
+        store = TaskStore()
+        provider._beam = types.SimpleNamespace(canonical=store)
+        provider._canonical_owner = lambda: "owner"
+        assert json.loads(provider._handle_task_progress({"action": "clear", "task": "job"}))["status"] == "cleared"
+        assert invalidations == ["invalidate", "invalidate"]
+        store.retired = True
+        assert json.loads(provider._handle_task_progress({"action": "clear", "task": "job"}))["status"] == "cleared"
+        assert invalidations == ["invalidate", "invalidate", "invalidate"]
+
+
+def test_sync_turn_invalidates_after_committed_write_even_if_identity_capture_fails(provider_modules):
+    """A post-commit identity-capture failure cannot leave a warm result stale."""
+    for module in provider_modules.values():
+        provider = _new_provider(module, roles=("user",))
+        invalidations = []
+        provider._invalidate_prefetch_cache = lambda: invalidations.append("invalidate")
+
+        class PartialBeam:
+            def __init__(self):
+                self.calls = 0
+
+            def remember(self, **_kwargs):
+                self.calls += 1
+                if self.calls == 2:
+                    raise RuntimeError("identity capture failed after user commit")
+
+        provider._beam = PartialBeam()
+        del provider._capture_identity_signals
+        provider.sync_turn("I feel like a capable engineer", "")
+        assert provider._beam.calls == 2
+        assert invalidations == ["invalidate"]
+        assert provider._sync_turn_diagnostics()["failed"] == 1
+
+        class FailingBeam:
+            def remember(self, **_kwargs):
+                raise RuntimeError("user write failed before commit")
+
+        provider = _new_provider(module, roles=("user",))
+        provider._beam = FailingBeam()
+        provider._invalidate_prefetch_cache = lambda: invalidations.append("unexpected")
+        provider.sync_turn("ordinary user content", "")
+        assert invalidations == ["invalidate"]
+
+        provider = _new_provider(module, roles=())
+        provider._invalidate_prefetch_cache = lambda: invalidations.append("unexpected")
+        provider.sync_turn("ordinary user content", "")
+        assert invalidations == ["invalidate"]
+
+
+@pytest.mark.parametrize(
+    ("sleep_status", "expected_invalidations"),
+    [("no_op", 0), ("consolidated", 1)],
+)
+def test_prefetch_cache_sleep_workers_invalidate_only_after_consolidation(
+    monkeypatch, provider_modules, sleep_status, expected_invalidations
+):
+    """Auto- and session-end sleep preserve warm cache when no consolidation occurs."""
+    for module in provider_modules.values():
+        class SourceBeam:
+            session_id = "session"
+            db_path = "test.db"
+            author_id = "author"
+            author_type = "agent"
+            channel_id = "channel"
+
+            def get_working_stats(self):
+                return {"total": 2}
+
+            def _count_unconsolidated_before(self, _cutoff):
+                return 1
+
+            def sleep(self):
+                return {"status": sleep_status}
+
+        class IsolatedBeam:
+            def __init__(self, **_kwargs):
+                pass
+
+            def sleep(self):
+                return {"status": sleep_status}
+
+        monkeypatch.setattr(module, "_get_beam_class", lambda: IsolatedBeam)
+        for worker in ("auto", "session_end"):
+            provider = _cache_provider(module)
+            provider._beam = SourceBeam()
+            provider._beam_access_lock = threading.Lock()
+            provider._auto_sleep_threshold = 1
+            provider._AUTO_SLEEP_TIMEOUT_SECONDS = 1
+            provider.SESSION_END_SLEEP_TIMEOUT_SECONDS = 1
+            provider._reserve_reflection_budget = lambda _source: None
+            provider._ensure_prefetch_cache()
+            provider._prefetch_cache["warm"] = "cached result"
+            invalidations = []
+            original_invalidate = provider._invalidate_prefetch_cache
+
+            def record_invalidate():
+                invalidations.append("invalidate")
+                original_invalidate()
+
+            provider._invalidate_prefetch_cache = record_invalidate
+            if worker == "auto":
+                provider._maybe_auto_sleep()
+            else:
+                provider.on_session_end(messages=[])
+                provider._session_end_thread.join(timeout=1)
+
+            assert invalidations == ["invalidate"] * expected_invalidations
+            assert (provider._prefetch_cache == {}) is (expected_invalidations == 1)
+
+
+@pytest.mark.parametrize(
+    ("path", "result", "expected_invalidations"),
+    [
+        ("provider", {"imported": 0, "skipped": 1, "failed": 1}, 0),
+        ("provider", {"imported": 1, "skipped": 0, "failed": 0}, 1),
+        (
+            "file",
+            {
+                "beam": {"working_memory": {"inserted": 0, "skipped": 2, "overwritten": 0}},
+                "triples": {"inserted": 0, "skipped": 1, "overwritten": 0},
+            },
+            0,
+        ),
+        (
+            "file",
+            {
+                "beam": {"scratchpad": {"inserted": 0, "updated": 1}},
+                "triples": {"inserted": 0, "skipped": 0, "overwritten": 1},
+            },
+            1,
+        ),
+    ],
+)
+def test_prefetch_cache_import_invalidates_only_after_successful_writes(
+    monkeypatch, provider_modules, path, result, expected_invalidations
+):
+    """Provider and file imports leave warm cache intact for zero-write outcomes."""
+    from mnemosyne.core import importers
+    from mnemosyne.core import memory as memory_module
+    from mnemosyne.core.importers.base import ImporterResult
+
+    class FakeMemory:
+        def __init__(self, **_kwargs):
+            pass
+
+        def import_from_file(self, _input_path, *, force):
+            assert force is False
+            return result
+
+    monkeypatch.setattr(memory_module, "Mnemosyne", FakeMemory)
+    for module in provider_modules.values():
+        provider = _cache_provider(module)
+        provider._beam = types.SimpleNamespace(db_path="test.db")
+        provider._session_id = "session"
+        provider._audit_event = lambda *_args, **_kwargs: None
+        invalidations = []
+        provider._invalidate_prefetch_cache = lambda: invalidations.append("invalidate")
+
+        if path == "provider":
+            importer_result = ImporterResult("fake", **result)
+            monkeypatch.setattr(importers, "import_from_provider", lambda *_args, **_kwargs: importer_result)
+            payload = json.loads(provider._handle_import({"provider": "fake", "api_key": "key"}))
+            assert payload["imported"] == result["imported"]
+        else:
+            payload = json.loads(provider._handle_import({"input_path": "export.json"}))
+            assert payload["stats"] == result
+
+        assert invalidations == ["invalidate"] * expected_invalidations
+
+
+@pytest.mark.parametrize("provider_name", ["hermes_memory_provider", "mnemosyne_hermes"])
+def test_prefetch_cache_invalidates_after_successful_tool_mutations(
+    monkeypatch, provider_modules, provider_name
+):
+    """Every successful mutation invalidates after its write in both provider copies."""
+    module = provider_modules[provider_name]
+    provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+    invalidations = []
+
+    class Graph:
+        def add_edge(self, edge):
+            self.edge = edge
+
+    class Beam:
+        db_path = "test.db"
+        episodic_graph = Graph()
+
+        def scratchpad_write(self, content):
+            self.written = content
+            return "pad-1"
+
+        def scratchpad_clear(self):
+            self.cleared = True
+
+    provider._beam = Beam()
+    provider._invalidate_prefetch_cache = lambda: invalidations.append("invalidate")
+    monkeypatch.setattr(module, "_get_triple_module", lambda: (lambda *_args, **_kwargs: "triple-1", None))
+    monkeypatch.setattr("mnemosyne.core.triples.end_triple", lambda *_args, **_kwargs: 1)
+
+    assert json.loads(provider._handle_triple_add({"subject": "a", "predicate": "is", "object": "b"})) == {
+        "status": "stored", "triple_id": "triple-1"
+    }
+    assert json.loads(provider._handle_triple_end({"subject": "a", "predicate": "is"})) == {
+        "status": "ended", "count": 1
+    }
+    assert json.loads(provider._handle_graph_link({
+        "source_id": "memory-a", "target_id": "memory-b", "relationship": "related",
+    }))["status"] == "linked"
+    assert json.loads(provider._handle_scratchpad_write({"content": "working note"})) == {
+        "status": "written", "id": "pad-1"
+    }
+    assert json.loads(provider._handle_scratchpad_clear({})) == {"status": "cleared"}
+    assert invalidations == ["invalidate"] * 5
+
+
+@pytest.mark.parametrize("provider_name", ["hermes_memory_provider", "mnemosyne_hermes"])
+def test_prefetch_cache_skips_invalidations_for_tool_failures_and_noops(
+    monkeypatch, provider_modules, provider_name
+):
+    """Validation errors, failed writes, and a zero-count end leave warm results intact."""
+    module = provider_modules[provider_name]
+    provider = module.MnemosyneMemoryProvider.__new__(module.MnemosyneMemoryProvider)
+    invalidations = []
+
+    class FailingGraph:
+        def add_edge(self, _edge):
+            raise RuntimeError("graph write failed")
+
+    class FailingBeam:
+        db_path = "test.db"
+        episodic_graph = FailingGraph()
+
+        def scratchpad_write(self, _content):
+            raise RuntimeError("scratchpad write failed")
+
+        def scratchpad_clear(self):
+            raise RuntimeError("scratchpad clear failed")
+
+    provider._beam = FailingBeam()
+    provider._invalidate_prefetch_cache = lambda: invalidations.append("invalidate")
+    monkeypatch.setattr(module, "_get_triple_module", lambda: (lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("triple add failed")), None))
+    monkeypatch.setattr("mnemosyne.core.triples.end_triple", lambda *_args, **_kwargs: 0)
+
+    assert "error" in json.loads(provider._handle_triple_add({}))
+    assert json.loads(provider._handle_triple_end({"subject": "a", "predicate": "is"})) == {
+        "status": "ended", "count": 0
+    }
+    assert "error" in json.loads(provider._handle_graph_link({"source_id": "", "target_id": "b", "relationship": "related"}))
+    assert "error" in json.loads(provider._handle_scratchpad_write({"content": "  "}))
+    with pytest.raises(RuntimeError, match="triple add failed"):
+        provider._handle_triple_add({"subject": "a", "predicate": "is", "object": "b"})
+    with pytest.raises(RuntimeError, match="graph write failed"):
+        provider._handle_graph_link({"source_id": "a", "target_id": "b", "relationship": "related"})
+    with pytest.raises(RuntimeError, match="scratchpad write failed"):
+        provider._handle_scratchpad_write({"content": "working note"})
+    with pytest.raises(RuntimeError, match="scratchpad clear failed"):
+        provider._handle_scratchpad_clear({})
+    assert invalidations == []
+
+
+@pytest.mark.parametrize("active", [False, True])
+def test_prefetch_cache_diagnostics_are_present_on_both_paths_and_private(
+    monkeypatch, provider_modules, active
+):
+    """Diagnostics publish counters only—never warm query/session/content values."""
+    secret_query = "QUERY-SECRET-998"
+    secret_session = "SESSION-SECRET-998"
+
+    def fake_run_diagnostics(**_kwargs):
+        return {"checks_total": 0, "key_findings": [], "entries": []}
+
+    monkeypatch.setattr("mnemosyne.diagnose.run_diagnostics", fake_run_diagnostics)
+    for module in provider_modules.values():
+        provider = _cache_provider(module)
+        provider._profile_isolation_enabled = False
+        provider._sync_turn_diagnostics = lambda: {}
+        _calls, cache_lock_violations = _install_renderer(provider)
+        provider.queue_prefetch(secret_query, session_id=secret_session)
+        provider._beam = object() if active else None
+        payload = json.loads(provider._handle_diagnose({}))
+        cache = payload["prefetch_cache"]
+        assert cache["capacity"] == 50
+        assert cache["warm_completed"] == 1
+        assert cache["entries"] == 1
+        assert cache_lock_violations == []
+        assert secret_query not in json.dumps(payload)
+        assert secret_session not in json.dumps(payload)
 
 
 def test_sync_adapter_schema_and_lifecycle_surface_match(sync_modules):

--- a/tests/test_model_refresh_stress.py
+++ b/tests/test_model_refresh_stress.py
@@ -209,16 +209,22 @@ def test_prefetch_injects_only_relevant_model_slots(tmp_path, monkeypatch):
     store.remember("default", "model:user", "communication_style", "Prefers concise diagnostic answers without flattery.")
     store.remember("default", "model:project", "music_notes", "Ambient playlist tags include drone and texture.")
 
-    pr_block = provider.prefetch("how should we structure this PR strategy")
+    pr_query = "how should we structure this PR strategy"
+    provider.queue_prefetch(pr_query)
+    pr_block = provider.prefetch(pr_query)
     assert "## Mnemosyne Model Context" in pr_block
     assert "pr strategy" in pr_block
     assert "upstreamable PRs" in pr_block
     assert "Ambient playlist" not in pr_block
 
-    shell_block = provider.prefetch("what command checks disk usage")
+    shell_query = "what command checks disk usage"
+    provider.queue_prefetch(shell_query)
+    shell_block = provider.prefetch(shell_query)
     assert "## Mnemosyne Model Context" not in shell_block
 
-    style_block = provider.prefetch("what communication style should you use")
+    style_query = "what communication style should you use"
+    provider.queue_prefetch(style_query)
+    style_block = provider.prefetch(style_query)
     assert "communication style" in style_block
     assert "concise diagnostic" in style_block
 

--- a/tests/test_prefetch_content_truncation.py
+++ b/tests/test_prefetch_content_truncation.py
@@ -40,6 +40,7 @@ def test_prefetch_preserves_full_memory_content_by_default(monkeypatch):
     provider = MnemosyneMemoryProvider()
     provider._beam = FakeBeam(long_content)
 
+    provider.queue_prefetch("critical tail fact")
     rendered = provider.prefetch("critical tail fact")
 
     assert "critical-tail-fact-survives" in rendered
@@ -56,6 +57,7 @@ def test_prefetch_content_limit_is_opt_in_and_word_boundary(monkeypatch):
     provider = MnemosyneMemoryProvider()
     provider._beam = FakeBeam("alpha beta gamma delta")
 
+    provider.queue_prefetch("alpha")
     rendered = provider.prefetch("alpha")
 
     assert "alpha beta..." in rendered

--- a/tests/test_prefetch_identity_always_inject.py
+++ b/tests/test_prefetch_identity_always_inject.py
@@ -76,7 +76,8 @@ def test_identity_surfaces_on_non_matching_generic_query(provider_factory):
         "session-A",
     )
     # A short, generic opener with zero semantic overlap with the identity.
-    block = p.prefetch("Hi")
+    p.queue_prefetch("Hi", session_id="session-A")
+    block = p.prefetch("Hi", session_id="session-A")
     assert "[IDENTITY]" in block
     assert "Contact A is the lead engineer on the payments team." in block
 
@@ -91,12 +92,14 @@ def test_identity_does_not_leak_across_sessions(provider_factory):
     )
 
     pb = provider_factory("session-B")
-    block_b = pb.prefetch("Hi")
+    pb.queue_prefetch("Hi", session_id="session-B")
+    block_b = pb.prefetch("Hi", session_id="session-B")
     assert "Contact A" not in block_b
     assert "[IDENTITY]" not in block_b
 
     # Sanity: session A still sees its own identity.
-    block_a = pa.prefetch("Hi")
+    pa.queue_prefetch("Hi", session_id="session-A")
+    block_a = pa.prefetch("Hi", session_id="session-A")
     assert "Contact A is the lead engineer on the payments team." in block_a
 
 
@@ -118,7 +121,8 @@ def test_no_duplicate_when_query_matches_identity(provider_factory):
         }]
 
     p._beam.recall = fake_recall
-    block = p.prefetch("who is the lead engineer on payments")
+    p.queue_prefetch("who is the lead engineer on payments", session_id="session-A")
+    block = p.prefetch("who is the lead engineer on payments", session_id="session-A")
     # The identity content appears exactly once across the whole block.
     assert block.count(identity_text) == 1
 
@@ -127,5 +131,6 @@ def test_no_identity_rows_is_a_noop(provider_factory):
     """With no identity rows, behavior is unchanged (no [IDENTITY] block)."""
     p = provider_factory("session-A")
     p._beam.recall = lambda **kwargs: []
-    block = p.prefetch("Hi")
+    p.queue_prefetch("Hi", session_id="session-A")
+    block = p.prefetch("Hi", session_id="session-A")
     assert "[IDENTITY]" not in block

--- a/tests/test_prefetch_low_quality.py
+++ b/tests/test_prefetch_low_quality.py
@@ -51,6 +51,7 @@ def test_prefetch_drops_fragments_and_keeps_real_memory(monkeypatch):
     provider = MnemosyneMemoryProvider()
     provider._beam = FakeBeam()
 
+    provider.queue_prefetch("what matters most")
     block = provider.prefetch("what matters most")
 
     assert "Paris is the capital of France" in block

--- a/tests/test_prefetch_profiles.py
+++ b/tests/test_prefetch_profiles.py
@@ -48,6 +48,7 @@ def test_general_is_the_default_and_passes_no_tuning_weights():
         {"content": "Paris is the capital of France", "timestamp": "2026-05-14T12:00:00Z",
          "importance": 0.9, "score": 0.9, "keyword_score": 0.9, "trust_tier": "STATED"},
     ])
+    p.queue_prefetch("capital of France")
     block = p.prefetch("capital of France")
     assert block.startswith("## Mnemosyne Context")
     assert "Paris is the capital of France" in block
@@ -61,6 +62,7 @@ def test_social_chat_passes_its_tuning_to_recall():
         {"content": "the team ships on Friday", "timestamp": "2026-05-14T12:00:00Z",
          "importance": 0.9, "score": 0.4, "keyword_score": 0.4, "trust_tier": "STATED"},
     ])
+    p.queue_prefetch("when do we ship")
     p.prefetch("when do we ship")
     assert p._beam.last_kwargs["importance_weight"] == 0.6
     assert p._beam.last_kwargs["temporal_weight"] == 0.35
@@ -78,6 +80,7 @@ def test_registered_source_is_merged():
     p._prefetch_profile = "t-merge"
     p.register_prefetch_source(
         "dummy", lambda q, *, session_id="": [{"content": "Lake Baikal is the deepest lake"}])
+    p.queue_prefetch("geography")
     block = p.prefetch("geography")
     assert "Paris is the capital of France" in block
     assert "Lake Baikal is the deepest lake" in block
@@ -99,6 +102,7 @@ def test_dedup_collapses_duplicate_content_across_sources():
     p._prefetch_profile = "t-dedup"
     p.register_prefetch_source(
         "dummy", lambda q, *, session_id="": [{"content": "Mount Everest is the tallest mountain"}])
+    p.queue_prefetch("mountains")
     block = p.prefetch("mountains")
     assert block.count("Mount Everest is the tallest mountain") == 1
 
@@ -112,6 +116,7 @@ def test_env_content_chars_override_beats_profile(monkeypatch):
         {"content": long_content, "timestamp": "2026-05-14T12:00:00Z",
          "importance": 0.9, "score": 0.9, "keyword_score": 0.9, "trust_tier": "STATED"},
     ])
+    p.queue_prefetch("everest")
     block = p.prefetch("everest")
     assert "tail" not in block          # truncated by the env limit
     assert block.rstrip().endswith("...")
@@ -129,6 +134,7 @@ def test_prefetch_excludes_assistant_transcript_rows_by_default():
          "importance": 0.8, "score": 0.7, "keyword_score": 0.7, "trust_tier": "STATED"},
     ])
 
+    p.queue_prefetch("Mnemosyne injection correction")
     block = p.prefetch("Mnemosyne injection correction")
 
     assert "distilled correction" in block
@@ -145,6 +151,7 @@ def test_prefetch_does_not_let_importance_alone_inject_weak_raw_chat():
          "importance": 0.7, "score": 0.6, "keyword_score": 0.6, "trust_tier": "STATED"},
     ])
 
+    p.queue_prefetch("make Mnemosyne memory-context injection more relevant")
     block = p.prefetch("make Mnemosyne memory-context injection more relevant")
 
     assert "topical relevance" in block
@@ -161,6 +168,7 @@ def test_prefetch_semantic_dedup_keeps_distilled_variant_over_raw_duplicate():
          "importance": 0.85, "score": 0.75, "keyword_score": 0.75, "trust_tier": "STATED"},
     ])
 
+    p.queue_prefetch("Mnemosyne injection relevance hardening")
     block = p.prefetch("Mnemosyne injection relevance hardening")
 
     assert "Operators want Mnemosyne" in block
@@ -177,6 +185,7 @@ def test_prefetch_default_caps_injection_to_five_relevance_sorted_rows():
     ]
     p = _provider("general", rows)
 
+    p.queue_prefetch("relevant distilled memory")
     block = p.prefetch("relevant distilled memory")
 
     injected = [line for line in block.splitlines() if "Relevant distilled memory" in line]
@@ -190,6 +199,7 @@ def test_prefetch_collapses_content_newlines_inside_memory_rows():
          "importance": 0.8, "score": 0.7, "keyword_score": 0.7, "trust_tier": "STATED"},
     ])
 
+    p.queue_prefetch("Mnemosyne injection line")
     block = p.prefetch("Mnemosyne injection line")
 
     assert "first line second line" in block


### PR DESCRIPTION
## Summary

Adds a provider-local, in-memory prefetch cache for Hermes background recall. `queue_prefetch()` is the only warm-render path. `prefetch()` is a cache-only exact read, so a cold miss never renders or touches Beam.

- Uses a bounded per-provider LRU keyed by effective session plus a SHA-256 of normalized query text.
- Preserves root and packaged provider parity.
- Invalidates only after successful mutations, including partial `sync_turn()` success before a later identity-capture failure.
- Serializes complete warm rendering against the provider's instance Beam lock without holding the cache lock.
- Adds cache-only, concurrency, privacy, session-safety, and success-only invalidation regression coverage.

## Verification

- `tests/test_hermes_provider_parity.py`: 74 passed
- Relevant root prefetch, migrated, and sync suite: 121 passed
- Packaged focused tests: 8 passed
- Full installed packaged integration suite: 84 passed
- `ruff check --select E9,F63,F7,F82`, `py_compile`, and `git diff --check` passed

## Notes

This is provider-local only. It adds no core cache schema, migration, provider-owned background thread, or persistence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds a bounded, provider-local in-memory LRU cache for Hermes background prefetch renders (`prefetch_cache_size`, default 50; `0` disables cache storage).
- Splits the workflow into two steps:
  - `queue_prefetch()` is the only warming path (renders and populates the cache).
  - `prefetch()` is cache-only: it returns a formatted `## Mnemosyne Context` block on a strict normalized warm hit, otherwise returns empty and does **not** render or access BEAM.
- Cache entries are per-provider, session-scoped, and keyed by `(effective_session_id, sha256(normalized_query_text))`, preventing cross-session leakage and digest collisions.
- Adds an epoch-based invalidation mechanism and clears cache **only after successful mutations**, including cases like partially successful `sync_turn()` and confirmed tool/memory/graph/consolidation writes; it does not invalidate on failures/no-ops.
- Serializes warm rendering with the provider/Beam lock while avoiding holding the cache lock during Beam access.
- Extends diagnose output with cache telemetry counters (hits/misses/evictions/warm completion/durations) while keeping warm query/session/content out of serialized diagnostics.

## Architectural impact (Mnemosyne core)

- **Memory architecture (working/episodic/BEAM):** No tier/schema changes, no migration, no persistence, and no changes to consolidation, veracity, or BEAM storage semantics. The improvement is strictly in how Hermes supplies *prefetched* context to the agent.
- **Retrieval strategy:** Cold foreground retrieval is intentionally prevented from doing render/recall; the cache only serves exact normalized warm hits. This keeps the “local-first” guarantee stronger by avoiding additional BEAM access on demand.
- **Sync/consolidation correctness:** Broad, success-only cache invalidation is wired to the points where memory state can change (memory/graph/canonical/scratchpad/tool mutations, consolidation/session-end flows), reducing stale-context risk without widening the BEAM access surface.
- **Privacy posture:** The cache is ephemeral and provider-local (no shared/global storage, no background thread ownership, no persistence). Session scoping plus normalized-query hashing constrains leakage across threads/sessions, and diagnostics expose only operational counters.

## Integration surface impact

- **Hermes:** Provider contract shifts to explicit queue-then-read behavior for prefetching; tests updated accordingly. Root and packaged provider behavior remains aligned.
- **MCP/CLI:** No evidence of MCP/CLI integration changes in this repo search; the changes appear confined to the Hermes provider + its diagnostics and tests.

## Maintainability & safety

- Clear separation of “warm render” vs “cache-only read”, bounded LRU eviction, epoch-safe rejection of late warm publications after invalidation, and lock discipline (Beam serialization without holding cache lock).
- Adds substantial regression coverage for concurrency, session safety, privacy constraints, bounded behavior (including zero-capacity), and success-only invalidation timing.
- No new core cache schema, migrations, provider-owned background threads, or persistence—i.e., preserves local-first design choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->