### PR TITLE
fix(hermes): report memory_not_found when invalidate matches no row

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -1986,12 +1986,14 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
         replacement_id = args.get("replacement_id", None) or None
         if not memory_id:
             return json.dumps({"error": "memory_id is required"})
-        self._beam.invalidate(memory_id, replacement_id=replacement_id if replacement_id else None)
+        ok = self._beam.invalidate(memory_id, replacement_id=replacement_id if replacement_id else None)
         self._audit_event(
             "invalidate", memory_id=memory_id, bank="private",
             source_tool="mnemosyne_invalidate",
-            metadata={"replacement_id": replacement_id} if replacement_id else None,
+            metadata={"replacement_id": replacement_id, "invalidated": ok} if replacement_id else {"invalidated": ok},
         )
+        if not ok:
+            return json.dumps({"status": "memory_not_found", "memory_id": memory_id})
         return json.dumps({"status": "invalidated", "memory_id": memory_id})
 
     def _handle_validate(self, args: Dict[str, Any]) -> str:

--- a/integrations/hermes/tests/test_canonical_tools.py
+++ b/integrations/hermes/tests/test_canonical_tools.py
@@ -139,3 +139,17 @@ def test_active_adapter_exposes_canonical_tool_schemas():
 
     assert "mnemosyne_remember_canonical" in names
     assert "mnemosyne_recall_canonical" in names
+
+
+def test_invalidate_reports_not_found_when_no_row_matched(tmp_path):
+    provider = _provider(tmp_path, profile="profile_a")
+    try:
+        assert provider._beam.invalidate("missing-memory-id") is False
+        result = json.loads(provider.handle_tool_call(
+            "mnemosyne_invalidate",
+            {"memory_id": "missing-memory-id"},
+        ))
+        assert result["status"] == "memory_not_found"
+        assert result["memory_id"] == "missing-memory-id"
+    finally:
+        _close(provider)


### PR DESCRIPTION
## Description

`_handle_invalidate` in `mnemosyne_hermes` discarded the boolean returned by `BeamMemory.invalidate()` and always responded `status=invalidated`, so a wrong, inaccessible, or already-removed `memory_id` looked like a successful mutation. The return value is now checked: `False` yields `status=memory_not_found` and is recorded in the audit metadata. This matches the batch path in `mnemosyne/batch_tool.py`, which already raises `memory_not_found` on the same signal.

## Related Issue

Closes #524

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Existing tests still pass (`pytest integrations/hermes/tests/ -q` — 84 passed; the one failure, `test_package_version_matches_distribution_metadata`, is a pre-existing source-tree artifact requiring installed distribution metadata and fails identically without this change)
- [x] New tests added for any new functionality
- [x] Manual verification (describe what you tested)

New `test_invalidate_reports_not_found_when_no_row_matched` asserts `beam.invalidate()` returns `False` for an unknown id and that the tool then reports `memory_not_found`. Stash-verified: it FAILS without the source fix (`- memory_not_found` / `+ invalidated`) and PASSES with it.

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py` — N/A, left to maintainers' release process
- [ ] `CHANGELOG.md` updated with a brief entry — happy to add one if you'd like it in this PR
- [ ] README updated if user-facing behavior changed — N/A, tool response field only
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes Hermes `mnemosyne_invalidate` responses by honoring `BeamMemory.invalidate()`’s boolean result.
- Returns `memory_not_found` for unknown, inaccessible, or already-removed memory IDs.
- Records the invalidation result in audit metadata.
- Adds regression coverage for unmatched IDs.

## Architectural impact

This is a targeted correctness fix in the BEAM-backed memory mutation path. It does not change tiered memory, retrieval, consolidation, veracity, synchronization, or benchmarking behavior.

The change improves privacy by avoiding false claims that a memory was modified. It preserves local-first execution because invalidation remains local. It improves Hermes agent integration and maintains parity with batch mutation behavior. It does not change MCP or CLI behavior.

Checking the mutation result before returning success is the right call for auditability, agent reliability, and long-term maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->