### PR TITLE
fix: avoid version regex backtracking

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -207,6 +207,10 @@ except Exception:
 import os
 import re
 
+_VERSION_STRING_RE = re.compile(
+    r'([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*)\s+v?(\d+\.\d+(?:\.\d+)?)'
+)
+
 # On Fly.io and other ephemeral VMs, only ~/.hermes is persisted.
 # Default to the legacy Hermes path so memories survive restarts.
 _DEFAULT_ROOT = Path(
@@ -4748,7 +4752,7 @@ class BeamMemory:
 
         # Version strings — two patterns:
         # Pattern A: "PostgreSQL v14.2", "Docker 27.1.1" (name directly before version)
-        for m in _re.finditer(r'([A-Z][a-zA-Z]+(?:\s*[A-Z][a-zA-Z]+)*)\s+v?(\d+\.\d+(?:\.\d+)?)', content):
+        for m in _VERSION_STRING_RE.finditer(content):
             name = m.group(1).strip()
             ver = m.group(2)
             key = f"{name.lower().replace(' ', '_')}_version"

--- a/tests/test_version_regex_backtracking.py
+++ b/tests/test_version_regex_backtracking.py
@@ -1,0 +1,70 @@
+"""Regression coverage for version-string extraction performance and captures."""
+
+import subprocess
+import sys
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+
+
+_PATHOLOGICAL_INPUT = ("AAAAAA " * 20) + "v1."
+_LEGACY_REPRODUCER = r'''
+import re
+
+pattern = re.compile(
+    r"([A-Z][a-zA-Z]+(?:\s*[A-Z][a-zA-Z]+)*)\s+v?(\d+\.\d+(?:\.\d+)?)"
+)
+pattern.search(("AAAAAA " * 20) + "v1.")
+'''
+_CURRENT_REPRODUCER = (
+    "from mnemosyne.core.beam import _VERSION_STRING_RE\n"
+    f"assert _VERSION_STRING_RE.search({_PATHOLOGICAL_INPUT!r}) is None\n"
+)
+
+
+def test_version_regex_avoids_legacy_backtracking():
+    """The old nested quantifier times out while the replacement returns safely."""
+    with pytest.raises(subprocess.TimeoutExpired):
+        subprocess.run(
+            [sys.executable, "-c", _LEGACY_REPRODUCER],
+            timeout=2,
+        )
+
+    current = subprocess.run(
+        [sys.executable, "-c", _CURRENT_REPRODUCER],
+        capture_output=True,
+        text=True,
+        timeout=2,
+    )
+    assert current.returncode == 0, current.stderr
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_pair"),
+    [
+        ("PostgreSQL v14.2", ("postgresql_version", "14.2")),
+        ("Docker 27.1.1", ("docker_version", "27.1.1")),
+        ("Ubuntu Linux 22.04", ("ubuntu_linux_version", "22.04")),
+        ("Product v1.2", ("product_version", "1.2")),
+        # With no separator, the old and new patterns both treat this as one name.
+        ("PostgreSQLServer 14.2", ("postgresqlserver_version", "14.2")),
+        ("PostgreSQL v1.", None),
+    ],
+)
+def test_version_regex_preserves_public_extraction(tmp_path, text, expected_pair):
+    """The fixed regex preserves version facts through the BEAM public path."""
+    beam = BeamMemory(session_id="version-regex", db_path=tmp_path / "beam.db")
+    try:
+        beam.extract_and_store_facts(text)
+        rows = beam.conn.execute(
+            "SELECT key, value FROM memoria_facts WHERE fact_type = 'version'"
+        ).fetchall()
+        version_pairs = {(row["key"], row["value"]) for row in rows}
+
+        if expected_pair is None:
+            assert not version_pairs
+        else:
+            assert expected_pair in version_pairs
+    finally:
+        beam.conn.close()

--- a/tests/test_version_regex_backtracking.py
+++ b/tests/test_version_regex_backtracking.py
@@ -65,6 +65,6 @@ def test_version_regex_preserves_public_extraction(tmp_path, text, expected_pair
         if expected_pair is None:
             assert not version_pairs
         else:
-            assert expected_pair in version_pairs
+            assert version_pairs == {expected_pair}
     finally:
         beam.conn.close()


### PR DESCRIPTION
## Summary

Fix Pattern A version extraction so capitalized multi-word names require whitespace between words. This removes the nested `\s*` ambiguity that allowed exponential regex backtracking on malformed version text.

## Why this path

The leading name token already consumes contiguous letters greedily, so successful captures stay compatible. Pattern B has no equivalent nested quantifier and is intentionally unchanged.

## Scope

Only the Pattern A regex and its focused regression coverage. No extraction-policy expansion or general regex cleanup.

## Validation

- Focused regression suite: `7 passed`
- `py_compile` passed
- Ruff clean for the new test
- `git diff --check` clean
- Independent Opus review: pass with no blockers

## Regression coverage

- Legacy pathological input times out in an isolated subprocess.
- The fixed pattern completes within the same controlled boundary.
- Public BEAM extraction preserves normal version facts, CamelCase no-separator compatibility, and rejects an incomplete version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Hardened BEAM “Pattern A” version-string extraction in `mnemosyne/core/beam.py` by switching to a module-level compiled regex (`_VERSION_STRING_RE`) and tightening the name matcher to require whitespace between capitalized multi-word tokens.
- Removes nested `\s*` ambiguity to prevent catastrophic regex backtracking on malformed/pathological inputs, improving robustness of local, offline fact extraction (no new dependencies, no network activity).
- Added focused regression coverage in `tests/test_version_regex_backtracking.py` to ensure:
  - the legacy regex would time out while the new regex safely completes,
  - normal BEAM “public” extraction still produces the expected `memoria_facts` version key/value pairs,
  - incomplete version strings are rejected,
  - CamelCase/compatibility edge cases behave as expected.
- Pattern B and all other Mnemosyne architecture surfaces—tiered memory (working/episodic/BEAM), retrieval, consolidation, veracity, sync, privacy posture, and agent integration surfaces (Hermes/MCP/CLI)—remain unchanged.
- This is the right call for long-term maintainability: safer parsing with clearer intent (compiled, reusable regex) and targeted tests, without eroding local-first guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->