### PR TITLE
feat: add provenance-preserving evidence packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Added
 
+- **`recall_with_evidence_pack()` adds opt-in supplemental recall evidence (#545).** The API preserves the normal primary ranking and returns a bounded, provenance-preserving `evidence_pack` from eligible additional sessions. Candidate retrieval is telemetry-neutral, honors recall visibility and temporal filters, excludes consolidated and synthetic rows, and never exposes the raw candidate pool.
+
 - **Multimodal memory: images, video and audio can become recallable memories (RFCs 0002, 0003, 0004).** `BeamMemory.remember_media(ref)` takes a reference to a piece of media, registers it, describes it through a configured modality provider, and writes the description back as an ordinary memory that hybrid recall already understands. Nothing about text recall changes.
 
   The stack is additive throughout. Two sidecar tables, `media_assets` and `media_moments`, are created `IF NOT EXISTS` by their own store when a bank is opened, so existing databases acquire them with no migration step and no change to any existing table. No new package dependency is introduced.

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6094,11 +6094,15 @@ class BeamMemory:
             raise ValueError("internal recall controls are managed by recall_with_evidence_pack")
 
         primary = self.recall(query, top_k=top_k, **kwargs)
+        primary_rows = primary.get("results", []) if isinstance(primary, dict) else primary
+        from mnemosyne.core.evidence_packs import build_evidence_pack
+        if pack_k == 0:
+            return build_evidence_pack(primary_rows, [], max_items=0)
+
         candidates = self.recall(
             query, top_k=candidate_k, _track_recall=False,
             _include_vector_only_candidates=True, **kwargs
         )
-        primary_rows = primary.get("results", []) if isinstance(primary, dict) else primary
         candidate_rows = candidates.get("results", []) if isinstance(candidates, dict) else candidates
         # Only storage-backed tiers can receive a verified source-session backfill.
         candidate_rows = [
@@ -6149,7 +6153,6 @@ class BeamMemory:
             if session_id is not None:
                 row["session_id"] = session_id
 
-        from mnemosyne.core.evidence_packs import build_evidence_pack
         return build_evidence_pack(primary_rows, candidate_rows, max_items=pack_k)
 
     def recall(self, query: str, top_k: int = 40, *,

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6090,7 +6090,7 @@ class BeamMemory:
             raise ValueError("candidate_k must exceed top_k when pack_k is positive")
         if kwargs.get("explain"):
             raise ValueError("explain is not supported by recall_with_evidence_pack")
-        if {"_track_recall", "_include_vector_only_candidates"}.intersection(kwargs):
+        if "_track_recall" in kwargs:
             raise ValueError("internal recall controls are managed by recall_with_evidence_pack")
 
         primary = self.recall(query, top_k=top_k, **kwargs)
@@ -6099,10 +6099,7 @@ class BeamMemory:
         if pack_k == 0:
             return build_evidence_pack(primary_rows, [], max_items=0)
 
-        candidates = self.recall(
-            query, top_k=candidate_k, _track_recall=False,
-            _include_vector_only_candidates=True, **kwargs
-        )
+        candidates = self.recall(query, top_k=candidate_k, _track_recall=False, **kwargs)
         candidate_rows = candidates.get("results", []) if isinstance(candidates, dict) else candidates
         # Only storage-backed tiers can receive a verified source-session backfill.
         candidate_rows = [
@@ -6172,8 +6169,7 @@ class BeamMemory:
                explain: bool = False,
                _cross_session: Optional[bool] = None,
                _resolved_weights: Optional[_RecallWeightSnapshot] = None,
-               _track_recall: bool = True,
-               _include_vector_only_candidates: bool = False) -> List[Dict]:
+               _track_recall: bool = True) -> List[Dict]:
         """
         Hybrid recall across working_memory + episodic_memory.
         Uses sqlite-vec + FTS5 for episodic, FTS5 for working.
@@ -6243,7 +6239,6 @@ class BeamMemory:
                 veracity=veracity, memory_type=memory_type,
                 cross_session=cross_session,
                 _track_recall=_track_recall,
-                _include_vector_only_candidates=_include_vector_only_candidates,
             )
             # [C4] Polyphonic path diagnostics. The linear-path recording
             # below (record_call / record_tier_hits at the end of recall())
@@ -6578,24 +6573,9 @@ class BeamMemory:
                 relevance = _lexical_relevance(query_words, row["content"], query_lower)
                 row_min_relevance = single_token_relevance if broad_multi_hit_query else min_relevance
             vec_sim = wm_vec_sims.get(row["id"], 0.0)
-            vector_only_rank_eligible = (
-                _include_vector_only_candidates
-                and row["id"] in wm_vec_sims
-                and row["id"] not in wm_ranks
-                and wm_vec_ranks.get(row["id"], top_k + 1) <= top_k
-                # The evidence-only semantic path needs an absolute quality
-                # floor as well as a relative vector rank.  0.84 preserves the
-                # validated multi-session evidence while rejecting arbitrary
-                # nearest neighbours in small banks.
-                and vec_sim >= 0.84
-            )
-            lexical_relevance_reported = relevance
-            if vector_only_rank_eligible:
-                relevance = max(relevance, vec_sim)
             if (
                 relevance >= row_min_relevance
                 or (wm_ranks and len(query_words) <= 1 and relevance > 0)
-                or vector_only_rank_eligible
             ):
                 decay = _recency_decay(row["timestamp"])
                 # Phase 4: configurable scoring for working memory
@@ -6638,9 +6618,9 @@ class BeamMemory:
                     "timestamp": row["timestamp"],
                     "tier": "working",
                     "score": round(score, 4),
-                    "keyword_score": round(lexical_relevance_reported, 4),
+                    "keyword_score": round(relevance, 4),
                     "dense_score": round(vec_sim, 4),
-                    "fts_score": round(lexical_relevance_reported, 4) if row["id"] in wm_ranks else 0.0,
+                    "fts_score": round(relevance, 4) if wm_ranks else 0.0,
                     "importance": row["importance"],
                     "recall_count": row["recall_count"] or 0,
                     "last_recalled": row["last_recalled"],
@@ -8140,8 +8120,7 @@ class BeamMemory:
                            veracity: Optional[str] = None,
                            memory_type: Optional[str] = None,
                            cross_session: Optional[bool] = None,
-                           _track_recall: bool = True,
-                           _include_vector_only_candidates: bool = False) -> List[Dict]:
+                           _track_recall: bool = True) -> List[Dict]:
         """[E5] Polyphonic recall path.
 
         Delegates to PolyphonicRecallEngine when MNEMOSYNE_POLYPHONIC_RECALL=1.
@@ -8293,10 +8272,6 @@ class BeamMemory:
         # the linear path updates them and downstream features (decay
         # scheduling, importance reinforcement) depend on the signal.
         # /review caught the missing update as a silent telemetry loss.
-        # Polyphonic recall is vector-backed by design, so vector-only
-        # candidates are already available on this path. Keep the private
-        # flag in the signature for parity with recall()'s internal caller.
-        del _include_vector_only_candidates
         if _track_recall and recalled_episodic_ids:
             placeholders = ",".join("?" * len(recalled_episodic_ids))
             params = [now_iso, *recalled_episodic_ids, *_rec_scope_params()]

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6086,6 +6086,10 @@ class BeamMemory:
             raise ValueError("candidate_k must be at least top_k")
         if pack_k < 0:
             raise ValueError("pack_k must be non-negative")
+        if pack_k > 0 and candidate_k <= top_k:
+            raise ValueError("candidate_k must exceed top_k when pack_k is positive")
+        if kwargs.get("explain"):
+            raise ValueError("explain is not supported by recall_with_evidence_pack")
         if {"_track_recall", "_include_vector_only_candidates"}.intersection(kwargs):
             raise ValueError("internal recall controls are managed by recall_with_evidence_pack")
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6100,6 +6100,10 @@ class BeamMemory:
         )
         primary_rows = primary.get("results", []) if isinstance(primary, dict) else primary
         candidate_rows = candidates.get("results", []) if isinstance(candidates, dict) else candidates
+        # Only storage-backed tiers can receive a verified source-session backfill.
+        candidate_rows = [
+            row for row in candidate_rows if row.get("tier") in {"working", "episodic"}
+        ]
         # Keep consolidated originals available to normal recall for provenance,
         # but do not let them compete with hot memories in supplemental packs.
         # The candidate rows already passed recall()'s visibility filters.
@@ -6266,9 +6270,10 @@ class BeamMemory:
                 for _v, _t in _voice_tier_map.items():
                     if _vs.get(_v):
                         _tier_kept[_t] += 1
-            for _t, _n in _tier_kept.items():
-                _recall_diag.record_tier_hits(_t, _n)
-            _recall_diag.record_call(truly_empty=(_kept == 0))
+            if _track_recall:
+                for _t, _n in _tier_kept.items():
+                    _recall_diag.record_tier_hits(_t, _n)
+                _recall_diag.record_call(truly_empty=(_kept == 0))
             if explain:
                 return {
                     "query": query,

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6096,6 +6096,29 @@ class BeamMemory:
         )
         primary_rows = primary.get("results", []) if isinstance(primary, dict) else primary
         candidate_rows = candidates.get("results", []) if isinstance(candidates, dict) else candidates
+        # Keep consolidated originals available to normal recall for provenance,
+        # but do not let them compete with hot memories in supplemental packs.
+        # The candidate rows already passed recall()'s visibility filters.
+        working_candidate_ids = {
+            str(row["id"])
+            for row in candidate_rows
+            if row.get("tier") == "working" and row.get("id") is not None
+        }
+        if working_candidate_ids:
+            placeholders = ",".join("?" * len(working_candidate_ids))
+            consolidated_ids = {
+                str(row["id"])
+                for row in self.conn.execute(
+                    f"SELECT id FROM working_memory WHERE id IN ({placeholders}) "
+                    "AND consolidated_at IS NOT NULL",
+                    tuple(working_candidate_ids),
+                ).fetchall()
+            }
+            candidate_rows = [
+                row
+                for row in candidate_rows
+                if not (row.get("tier") == "working" and str(row.get("id")) in consolidated_ids)
+            ]
         all_rows = primary_rows + candidate_rows
         sessions: dict[tuple[str, str], str] = {}
         for table, tier in (("working_memory", "working"), ("episodic_memory", "episodic")):
@@ -6208,6 +6231,8 @@ class BeamMemory:
                 channel_id=channel_id,
                 veracity=veracity, memory_type=memory_type,
                 cross_session=cross_session,
+                _track_recall=_track_recall,
+                _include_vector_only_candidates=_include_vector_only_candidates,
             )
             # [C4] Polyphonic path diagnostics. The linear-path recording
             # below (record_call / record_tier_hits at the end of recall())
@@ -6476,7 +6501,8 @@ class BeamMemory:
         # avoids double-counting against the kept-row accumulators.
         _wm_fallback_used = not wm_ids
         if _wm_fallback_used:
-            _recall_diag.record_fallback_used(wm=True)
+            if _track_recall:
+                _recall_diag.record_fallback_used(wm=True)
 
         if wm_ids:
             placeholders = ",".join("?" * len(wm_ids))
@@ -7116,7 +7142,8 @@ class BeamMemory:
             # rather than vec/FTS. High em_fallback_rate during a
             # benchmark means recall scores aren't measuring what
             # the experiment thinks they're measuring.
-            _recall_diag.record_fallback_used(em=True)
+            if _track_recall:
+                _recall_diag.record_fallback_used(em=True)
             cursor = self.conn.cursor()
             cursor.execute(f"""
                 SELECT rowid, id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope, author_id, author_type, channel_id, memory_type, binary_vector
@@ -7439,32 +7466,33 @@ class BeamMemory:
             """, (*rec_params,))
         self.conn.commit()
 
-        # [C4] Final tier-attribution records. Each counter holds the
-        # number of kept rows attributed to that tier on this call.
-        # Summing across tiers gives total kept rows for the call.
-        # `truly_empty` is gated on whether ANY layer (primary OR
-        # fallback) produced candidates -- distinct from "final
-        # results empty after top_k slicing / post-filter dropouts."
-        _recall_diag.record_tier_hits("wm_fts", _wm_fts_kept)
-        _recall_diag.record_tier_hits("wm_vec", _wm_vec_kept)
-        _recall_diag.record_tier_hits("wm_fallback", _wm_fallback_kept)
-        _recall_diag.record_tier_hits("em_fts", _em_fts_kept)
-        _recall_diag.record_tier_hits("em_vec", _em_vec_kept)
-        _recall_diag.record_tier_hits("em_fallback", _em_fallback_kept)
-        # truly_empty = final results empty AND no tier attributed
-        # a kept row. Distinguishes "post-filter dropouts" (some
-        # tier counted hits but they got filtered) from "no signal
-        # anywhere" (zero kept across all tiers). top_k=0 callers
-        # also land here, but that's an artifact of the caller's
-        # choice, not a recall failure -- operators wanting to
-        # exclude artifact cases can check top_k > 0 from their
-        # side.
-        _total_kept = (
-            _wm_fts_kept + _wm_vec_kept + _wm_fallback_kept
-            + _em_fts_kept + _em_vec_kept + _em_fallback_kept
-        )
-        _truly_empty = (len(final_results) == 0) and (_total_kept == 0)
-        _recall_diag.record_call(truly_empty=_truly_empty)
+        if _track_recall:
+            # [C4] Final tier-attribution records. Each counter holds the
+            # number of kept rows attributed to that tier on this call.
+            # Summing across tiers gives total kept rows for the call.
+            # `truly_empty` is gated on whether ANY layer (primary OR
+            # fallback) produced candidates -- distinct from "final
+            # results empty after top_k slicing / post-filter dropouts."
+            _recall_diag.record_tier_hits("wm_fts", _wm_fts_kept)
+            _recall_diag.record_tier_hits("wm_vec", _wm_vec_kept)
+            _recall_diag.record_tier_hits("wm_fallback", _wm_fallback_kept)
+            _recall_diag.record_tier_hits("em_fts", _em_fts_kept)
+            _recall_diag.record_tier_hits("em_vec", _em_vec_kept)
+            _recall_diag.record_tier_hits("em_fallback", _em_fallback_kept)
+            # truly_empty = final results empty AND no tier attributed
+            # a kept row. Distinguishes "post-filter dropouts" (some
+            # tier counted hits but they got filtered) from "no signal
+            # anywhere" (zero kept across all tiers). top_k=0 callers
+            # also land here, but that's an artifact of the caller's
+            # choice, not a recall failure -- operators wanting to
+            # exclude artifact cases can check top_k > 0 from their
+            # side.
+            _total_kept = (
+                _wm_fts_kept + _wm_vec_kept + _wm_fallback_kept
+                + _em_fts_kept + _em_vec_kept + _em_fallback_kept
+            )
+            _truly_empty = (len(final_results) == 0) and (_total_kept == 0)
+            _recall_diag.record_call(truly_empty=_truly_empty)
 
         # [Fact Recall Integration] Optionally merge LLM-extracted facts
         # into the standard recall output. Gated behind
@@ -8098,7 +8126,9 @@ class BeamMemory:
                            channel_id: Optional[str] = None,
                            veracity: Optional[str] = None,
                            memory_type: Optional[str] = None,
-                           cross_session: Optional[bool] = None) -> List[Dict]:
+                           cross_session: Optional[bool] = None,
+                           _track_recall: bool = True,
+                           _include_vector_only_candidates: bool = False) -> List[Dict]:
         """[E5] Polyphonic recall path.
 
         Delegates to PolyphonicRecallEngine when MNEMOSYNE_POLYPHONIC_RECALL=1.
@@ -8250,7 +8280,11 @@ class BeamMemory:
         # the linear path updates them and downstream features (decay
         # scheduling, importance reinforcement) depend on the signal.
         # /review caught the missing update as a silent telemetry loss.
-        if recalled_episodic_ids:
+        # Polyphonic recall is vector-backed by design, so vector-only
+        # candidates are already available on this path. Keep the private
+        # flag in the signature for parity with recall()'s internal caller.
+        del _include_vector_only_candidates
+        if _track_recall and recalled_episodic_ids:
             placeholders = ",".join("?" * len(recalled_episodic_ids))
             params = [now_iso, *recalled_episodic_ids, *_rec_scope_params()]
             self.conn.execute(
@@ -8258,7 +8292,7 @@ class BeamMemory:
                 f"last_recalled = ? WHERE id IN ({placeholders}) AND {rec_scope}",
                 tuple(params),
             )
-        if recalled_working_ids:
+        if _track_recall and recalled_working_ids:
             placeholders = ",".join("?" * len(recalled_working_ids))
             params = [now_iso, *recalled_working_ids, *_rec_scope_params()]
             self.conn.execute(
@@ -8266,7 +8300,7 @@ class BeamMemory:
                 f"last_recalled = ? WHERE id IN ({placeholders}) AND {rec_scope}",
                 tuple(params),
             )
-        if recalled_episodic_ids or recalled_working_ids:
+        if _track_recall and (recalled_episodic_ids or recalled_working_ids):
             self.conn.commit()
 
         # --- MEMORIA structured fact supplement (polyphonic path) ---

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6069,6 +6069,58 @@ class BeamMemory:
             return {"context": "\n".join(ctx_lines), "facts": facts, "source": "memoria_preferences"}
         return {"context": "", "facts": [], "source": "fallback"}
 
+    def recall_with_evidence_pack(
+        self, query: str, top_k: int = 10, *, candidate_k: int = 20,
+        pack_k: int = 5, **kwargs: Any,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Return normal recall plus bounded supplemental evidence.
+
+        The primary call preserves the public ``recall()`` behavior. The wider
+        candidate call reuses its exact visibility scope and filters but does
+        not update recall-use telemetry. Consequently, session-scoped calls
+        normally return an empty pack; multi-session evidence requires an
+        already-authorized cross-session/global recall scope. This method is
+        opt-in and never exposes the raw candidate pool.
+        """
+        if candidate_k < top_k:
+            raise ValueError("candidate_k must be at least top_k")
+        if pack_k < 0:
+            raise ValueError("pack_k must be non-negative")
+        if {"_track_recall", "_include_vector_only_candidates"}.intersection(kwargs):
+            raise ValueError("internal recall controls are managed by recall_with_evidence_pack")
+
+        primary = self.recall(query, top_k=top_k, **kwargs)
+        candidates = self.recall(
+            query, top_k=candidate_k, _track_recall=False,
+            _include_vector_only_candidates=True, **kwargs
+        )
+        primary_rows = primary.get("results", []) if isinstance(primary, dict) else primary
+        candidate_rows = candidates.get("results", []) if isinstance(candidates, dict) else candidates
+        all_rows = primary_rows + candidate_rows
+        sessions: dict[tuple[str, str], str] = {}
+        for table, tier in (("working_memory", "working"), ("episodic_memory", "episodic")):
+            ids = list({str(row["id"]) for row in all_rows if row.get("tier") == tier and row.get("id") is not None})
+            if not ids:
+                continue
+            placeholders = ",".join("?" * len(ids))
+            rows = self.conn.execute(
+                f"SELECT id, session_id FROM {table} WHERE id IN ({placeholders})", ids
+            ).fetchall()
+            sessions.update(
+                {
+                    (tier, str(row["id"])): str(row["session_id"])
+                    for row in rows
+                    if row["session_id"] is not None
+                }
+            )
+        for row in all_rows:
+            session_id = sessions.get((str(row.get("tier")), str(row.get("id"))))
+            if session_id is not None:
+                row["session_id"] = session_id
+
+        from mnemosyne.core.evidence_packs import build_evidence_pack
+        return build_evidence_pack(primary_rows, candidate_rows, max_items=pack_k)
+
     def recall(self, query: str, top_k: int = 40, *,
                from_date: Optional[str] = None, to_date: Optional[str] = None,
                source: Optional[str] = None, topic: Optional[str] = None,
@@ -6085,7 +6137,9 @@ class BeamMemory:
                importance_weight: float = None,
                explain: bool = False,
                _cross_session: Optional[bool] = None,
-               _resolved_weights: Optional[_RecallWeightSnapshot] = None) -> List[Dict]:
+               _resolved_weights: Optional[_RecallWeightSnapshot] = None,
+               _track_recall: bool = True,
+               _include_vector_only_candidates: bool = False) -> List[Dict]:
         """
         Hybrid recall across working_memory + episodic_memory.
         Uses sqlite-vec + FTS5 for episodic, FTS5 for working.
@@ -6395,6 +6449,9 @@ class BeamMemory:
 
         # ---- Working memory (vector search) ----
         wm_vec_sims = {}
+        # Kept only for the opt-in evidence-pack candidate path. Primary
+        # recall remains lexical-gated and therefore ranking-identical.
+        wm_vec_ranks = {}
         if embeddings_available:
             try:
                 emb_result = _get_query_embedding()
@@ -6403,8 +6460,9 @@ class BeamMemory:
                                               k=max(top_k, 20) if _BEAM_MODE else max(top_k * 3, 50),
                                               where_sql=wm_vec_where,
                                               where_params=tuple(wm_params))
-                    for vr in wm_vec:
+                    for vec_rank, vr in enumerate(wm_vec, start=1):
                         wm_vec_sims[vr["id"]] = vr["sim"]
+                        wm_vec_ranks[vr["id"]] = vec_rank
                         wm_ids.add(vr["id"])  # Merge vector results with FTS5 results
             except Exception:
                 logger.info("Regex extraction failed, skipping", exc_info=True)
@@ -6481,7 +6539,25 @@ class BeamMemory:
             else:
                 relevance = _lexical_relevance(query_words, row["content"], query_lower)
                 row_min_relevance = single_token_relevance if broad_multi_hit_query else min_relevance
-            if relevance >= row_min_relevance or (wm_ranks and len(query_words) <= 1 and relevance > 0):
+            vec_sim = wm_vec_sims.get(row["id"], 0.0)
+            vector_only_rank_eligible = (
+                _include_vector_only_candidates
+                and row["id"] in wm_vec_sims
+                and row["id"] not in wm_ranks
+                and wm_vec_ranks.get(row["id"], top_k + 1) <= top_k
+                # The evidence-only semantic path needs an absolute quality
+                # floor as well as a relative vector rank.  0.84 preserves the
+                # validated multi-session evidence while rejecting arbitrary
+                # nearest neighbours in small banks.
+                and vec_sim >= 0.84
+            )
+            if vector_only_rank_eligible:
+                relevance = max(relevance, vec_sim)
+            if (
+                relevance >= row_min_relevance
+                or (wm_ranks and len(query_words) <= 1 and relevance > 0)
+                or vector_only_rank_eligible
+            ):
                 decay = _recency_decay(row["timestamp"])
                 # Phase 4: configurable scoring for working memory
                 # keyword_share = (1 - importance_weight) * 0.6, recency_share = (1 - importance_weight) * 0.4
@@ -7337,7 +7413,7 @@ class BeamMemory:
             rec_scope = "(1=1)"
         else:
             rec_scope = _session_scope_filter(cross_session=cross_session)
-        if wm_ids:
+        if _track_recall and wm_ids:
             placeholders = ",".join("?" * len(wm_ids))
             rec_params = [now_iso, *tuple(wm_ids)]
             if channel_id:
@@ -7349,7 +7425,7 @@ class BeamMemory:
                 SET recall_count = recall_count + 1, last_recalled = ?
                 WHERE id IN ({placeholders}) AND {rec_scope}
             """, (*rec_params,))
-        if em_ids:
+        if _track_recall and em_ids:
             placeholders = ",".join("?" * len(em_ids))
             rec_params = [now_iso, *tuple(em_ids)]
             if channel_id:

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6090,7 +6090,7 @@ class BeamMemory:
             raise ValueError("candidate_k must exceed top_k when pack_k is positive")
         if kwargs.get("explain"):
             raise ValueError("explain is not supported by recall_with_evidence_pack")
-        if "_track_recall" in kwargs:
+        if any(name.startswith("_") for name in kwargs):
             raise ValueError("internal recall controls are managed by recall_with_evidence_pack")
 
         primary = self.recall(query, top_k=top_k, **kwargs)

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6589,6 +6589,7 @@ class BeamMemory:
                 # nearest neighbours in small banks.
                 and vec_sim >= 0.84
             )
+            lexical_relevance_reported = relevance
             if vector_only_rank_eligible:
                 relevance = max(relevance, vec_sim)
             if (
@@ -6637,9 +6638,9 @@ class BeamMemory:
                     "timestamp": row["timestamp"],
                     "tier": "working",
                     "score": round(score, 4),
-                    "keyword_score": round(relevance, 4),
+                    "keyword_score": round(lexical_relevance_reported, 4),
                     "dense_score": round(vec_sim, 4),
-                    "fts_score": round(relevance, 4) if wm_ranks else 0.0,
+                    "fts_score": round(lexical_relevance_reported, 4) if row["id"] in wm_ranks else 0.0,
                     "importance": row["importance"],
                     "recall_count": row["recall_count"] or 0,
                     "last_recalled": row["last_recalled"],

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6481,9 +6481,6 @@ class BeamMemory:
 
         # ---- Working memory (vector search) ----
         wm_vec_sims = {}
-        # Kept only for the opt-in evidence-pack candidate path. Primary
-        # recall remains lexical-gated and therefore ranking-identical.
-        wm_vec_ranks = {}
         if embeddings_available:
             try:
                 emb_result = _get_query_embedding()
@@ -6492,9 +6489,8 @@ class BeamMemory:
                                               k=max(top_k, 20) if _BEAM_MODE else max(top_k * 3, 50),
                                               where_sql=wm_vec_where,
                                               where_params=tuple(wm_params))
-                    for vec_rank, vr in enumerate(wm_vec, start=1):
+                    for vr in wm_vec:
                         wm_vec_sims[vr["id"]] = vr["sim"]
-                        wm_vec_ranks[vr["id"]] = vec_rank
                         wm_ids.add(vr["id"])  # Merge vector results with FTS5 results
             except Exception:
                 logger.info("Regex extraction failed, skipping", exc_info=True)

--- a/mnemosyne/core/evidence_packs.py
+++ b/mnemosyne/core/evidence_packs.py
@@ -1,0 +1,103 @@
+"""Provenance-preserving assembly of supplemental retrieval evidence.
+
+This module intentionally does not query storage or change `BeamMemory.recall()`.
+Callers provide two already-scoped result lists:
+
+* `primary`: the normal Top-K ranking shown to the caller;
+* `candidates`: a wider, separately retrieved pool.
+
+The primary ranking is copied unchanged. The pack contains only candidates from
+sessions absent from primary, at most one per explicit session/source group, and
+is ordered chronologically for consumption. A caller must annotate every row
+with a stable `session_id` (or choose a different `group_key`). Rows without a
+resolvable group are dropped: provenance is required for supplemental evidence.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from datetime import datetime, timezone
+from numbers import Real
+from typing import Any
+
+
+Result = Mapping[str, Any]
+
+
+def _row_identity(row: Result) -> tuple[str, str]:
+    """Return a tier-qualified identity to avoid cross-table ID collisions."""
+    return (str(row.get("tier", "")), str(row["id"]))
+
+
+def _chronological_key(row: Mapping[str, Any]) -> tuple[int, float, int]:
+    """Normalize ISO-8601 or numeric timestamps without raising on bad input."""
+    value = row.get("timestamp")
+    if isinstance(value, Real) and not isinstance(value, bool):
+        return (0, float(value), row["evidence_rank"])
+    if isinstance(value, str) and value:
+        try:
+            normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+            parsed = datetime.fromisoformat(normalized)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return (0, parsed.timestamp(), row["evidence_rank"])
+        except ValueError:
+            pass
+    # Unknown timestamps remain deterministic, after known chronology.
+    return (1, 0.0, row["evidence_rank"])
+
+
+def build_evidence_pack(
+    primary: Iterable[Result],
+    candidates: Iterable[Result],
+    *,
+    max_items: int = 5,
+    group_key: str = "session_id",
+) -> dict[str, list[dict[str, Any]]]:
+    """Return an unchanged primary ranking plus compact supplemental evidence.
+
+    `candidates` must be in retrieval-rank order.  The first candidate from
+    each group wins selection; selected rows retain that rank as
+    ``evidence_rank`` and are then ordered by timestamp for chronological
+    consumption.  The function has no database side effects and does not
+    mutate either input list or its row dictionaries.
+    """
+    if max_items < 0:
+        raise ValueError("max_items must be non-negative")
+
+    primary_rows = [deepcopy(dict(row)) for row in primary]
+    primary_ids = {_row_identity(row) for row in primary_rows if row.get("id") is not None}
+    seen_ids = set(primary_ids)
+    seen_groups = {
+        ("group", str(row[group_key]))
+        for row in primary_rows
+        if row.get(group_key) not in (None, "")
+    }
+    selected: list[dict[str, Any]] = []
+
+    for candidate_rank, raw_row in enumerate(candidates, start=1):
+        if len(selected) >= max_items:
+            break
+        row = deepcopy(dict(raw_row))
+        row_id = row.get("id")
+        # A pack needs a stable provenance handle. Do not invent one.
+        if row_id is None:
+            continue
+        row_identity = _row_identity(row)
+        if row_identity in seen_ids:
+            continue
+        seen_ids.add(row_identity)
+        group_value = row.get(group_key)
+        # Evidence packs must preserve session provenance. Unknown tiers or
+        # incomplete rows fail closed rather than appearing as unique groups.
+        if group_value in (None, ""):
+            continue
+        group = ("group", str(group_value))
+        if group in seen_groups:
+            continue
+        seen_groups.add(group)
+        row["evidence_rank"] = candidate_rank
+        selected.append(row)
+
+    selected.sort(key=_chronological_key)
+    return {"primary": primary_rows, "evidence_pack": selected}

--- a/mnemosyne/core/evidence_packs.py
+++ b/mnemosyne/core/evidence_packs.py
@@ -78,16 +78,14 @@ def build_evidence_pack(
     for candidate_rank, raw_row in enumerate(candidates, start=1):
         if len(selected) >= max_items:
             break
-        row = deepcopy(dict(raw_row))
-        row_id = row.get("id")
+        row_id = raw_row.get("id")
         # A pack needs a stable provenance handle. Do not invent one.
-        if row_id is None:
+        if row_id in (None, ""):
             continue
-        row_identity = _row_identity(row)
+        row_identity = _row_identity(raw_row)
         if row_identity in seen_ids:
             continue
-        seen_ids.add(row_identity)
-        group_value = row.get(group_key)
+        group_value = raw_row.get(group_key)
         # Evidence packs must preserve session provenance. Unknown tiers or
         # incomplete rows fail closed rather than appearing as unique groups.
         if group_value in (None, ""):
@@ -95,6 +93,8 @@ def build_evidence_pack(
         group = ("group", str(group_value))
         if group in seen_groups:
             continue
+        row = deepcopy(dict(raw_row))
+        seen_ids.add(row_identity)
         seen_groups.add(group)
         row["evidence_rank"] = candidate_rank
         selected.append(row)

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -172,6 +172,24 @@ def test_evidence_pack_honors_temporal_filters(tmp_path: Path):
     current_id = current_writer.remember(
         "Orion temporal current fixture", source="test", importance=0.8, scope="global"
     )
+    episodic_current_id = "orion-temporal-episodic-current"
+    episodic_future_id = "orion-temporal-episodic-future"
+    reader.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, importance, scope) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            episodic_current_id, "Orion temporal episodic current fixture", "test",
+            "2026-02-01T00:00:00", "episodic-current", 0.8, "global",
+        ),
+    )
+    reader.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, importance, scope) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            episodic_future_id, "Orion temporal episodic future fixture", "test",
+            "2027-01-01T00:00:00", "episodic-future", 0.8, "global",
+        ),
+    )
     reader.conn.execute(
         "UPDATE working_memory SET timestamp = ? WHERE id = ?", ("2020-01-01T00:00:00", old_id)
     )
@@ -181,13 +199,15 @@ def test_evidence_pack_honors_temporal_filters(tmp_path: Path):
     reader.conn.commit()
 
     packed = reader.recall_with_evidence_pack(
-        "Orion temporal", top_k=1, candidate_k=5, pack_k=2,
-        _cross_session=True, from_date="2025-01-01",
+        "Orion temporal", top_k=1, candidate_k=10, pack_k=5,
+        _cross_session=True, from_date="2025-01-01", to_date="2026-06-01",
     )
     returned_ids = {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
 
     assert current_id in returned_ids
+    assert episodic_current_id in returned_ids
     assert old_id not in returned_ids
+    assert episodic_future_id not in returned_ids
 
 
 def test_evidence_pack_excludes_consolidated_working_candidates(tmp_path: Path):

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from mnemosyne.core.beam import BeamMemory
+from mnemosyne.core.config import MnemosyneConfig
 from mnemosyne.core.recall_diagnostics import get_recall_diagnostics, reset_recall_diagnostics
 
 
@@ -20,8 +21,16 @@ def _state(db_path: Path, memory_id: str) -> tuple[int, str | None]:
 
 
 
-def test_evidence_pack_rejects_invalid_internal_controls(tmp_path: Path):
+@pytest.mark.parametrize("internal_control", ("_track_recall", "_cross_session"))
+def test_evidence_pack_rejects_invalid_internal_controls(tmp_path: Path, monkeypatch, internal_control: str):
     beam = BeamMemory(session_id="guards", db_path=tmp_path / "guards.db")
+    calls = []
+
+    def recording_recall(*args, **kwargs):
+        calls.append((args, kwargs))
+        return []
+
+    monkeypatch.setattr(beam, "recall", recording_recall)
     with pytest.raises(ValueError, match="candidate_k"):
         beam.recall_with_evidence_pack("q", top_k=2, candidate_k=1)
     with pytest.raises(ValueError, match="candidate_k must exceed"):
@@ -31,7 +40,16 @@ def test_evidence_pack_rejects_invalid_internal_controls(tmp_path: Path):
     with pytest.raises(ValueError, match="explain"):
         beam.recall_with_evidence_pack("q", explain=True)
     with pytest.raises(ValueError, match="internal recall controls"):
-        beam.recall_with_evidence_pack("q", _track_recall=False)
+        beam.recall_with_evidence_pack("q", **{internal_control: False})
+    assert calls == []
+
+
+def _enable_cross_session_scope(monkeypatch, tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text("cross_session: true\n")
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(config_dir))
+    MnemosyneConfig.reset_instance()
 
 
 def test_candidate_only_recall_does_not_mutate_usage_state(tmp_path: Path):
@@ -153,7 +171,8 @@ def test_zero_pack_allows_equal_candidate_and_top_k(tmp_path: Path):
     assert packed["evidence_pack"] == []
 
 
-def test_cross_session_scope_can_produce_a_bounded_supplemental_pack(tmp_path: Path):
+def test_cross_session_scope_can_produce_a_bounded_supplemental_pack(tmp_path: Path, monkeypatch):
+    _enable_cross_session_scope(monkeypatch, tmp_path)
     db_path = tmp_path / "cross-session-pack.db"
     reader = BeamMemory(session_id="reader", db_path=db_path)
     first = BeamMemory(session_id="first", db_path=db_path)
@@ -163,16 +182,15 @@ def test_cross_session_scope_can_produce_a_bounded_supplemental_pack(tmp_path: P
     second_id = second.remember("Orion cross session beta", source="test", importance=0.8, scope="global")
     third_id = third.remember("Orion cross session gamma", source="test", importance=0.8, scope="global")
 
-    packed = reader.recall_with_evidence_pack(
-        "Orion cross session", top_k=1, candidate_k=5, pack_k=2, _cross_session=True
-    )
+    packed = reader.recall_with_evidence_pack("Orion cross session", top_k=1, candidate_k=5, pack_k=2)
     assert len(packed["evidence_pack"]) == 2
     assert {row["evidence_rank"] for row in packed["evidence_pack"]} == {2, 3}
     returned_ids = {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
     assert {second_id, third_id}.issubset(returned_ids)
 
 
-def test_episodic_candidate_enters_pack_with_backfilled_session(tmp_path: Path):
+def test_episodic_candidate_enters_pack_with_backfilled_session(tmp_path: Path, monkeypatch):
+    _enable_cross_session_scope(monkeypatch, tmp_path)
     db_path = tmp_path / "episodic-pack.db"
     reader = BeamMemory(session_id="reader", db_path=db_path)
     primary = BeamMemory(session_id="primary", db_path=db_path)
@@ -188,16 +206,15 @@ def test_episodic_candidate_enters_pack_with_backfilled_session(tmp_path: Path):
     )
     reader.conn.commit()
 
-    packed = reader.recall_with_evidence_pack(
-        "Orion episodic pack", top_k=1, candidate_k=5, pack_k=5, _cross_session=True
-    )
+    packed = reader.recall_with_evidence_pack("Orion episodic pack", top_k=1, candidate_k=5, pack_k=5)
     pack_row = next(row for row in packed["evidence_pack"] if row["id"] == episodic_id)
 
     assert pack_row["tier"] == "episodic"
     assert pack_row["session_id"] == "episodic-writer"
 
 
-def test_evidence_pack_honors_temporal_filters(tmp_path: Path):
+def test_evidence_pack_honors_temporal_filters(tmp_path: Path, monkeypatch):
+    _enable_cross_session_scope(monkeypatch, tmp_path)
     db_path = tmp_path / "temporal-pack.db"
     reader = BeamMemory(session_id="reader", db_path=db_path)
     old_writer = BeamMemory(session_id="old", db_path=db_path)
@@ -234,7 +251,7 @@ def test_evidence_pack_honors_temporal_filters(tmp_path: Path):
 
     packed = reader.recall_with_evidence_pack(
         "Orion temporal", top_k=1, candidate_k=10, pack_k=5,
-        _cross_session=True, from_date="2025-01-01", to_date="2026-06-01",
+        from_date="2025-01-01", to_date="2026-06-01",
     )
     returned_ids = {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
 
@@ -244,7 +261,8 @@ def test_evidence_pack_honors_temporal_filters(tmp_path: Path):
     assert episodic_future_id not in returned_ids
 
 
-def test_evidence_pack_excludes_consolidated_working_candidates(tmp_path: Path):
+def test_evidence_pack_excludes_consolidated_working_candidates(tmp_path: Path, monkeypatch):
+    _enable_cross_session_scope(monkeypatch, tmp_path)
     db_path = tmp_path / "consolidated-evidence.db"
     reader = BeamMemory(session_id="reader", db_path=db_path)
     primary = BeamMemory(session_id="primary", db_path=db_path)
@@ -262,7 +280,7 @@ def test_evidence_pack_excludes_consolidated_working_candidates(tmp_path: Path):
     reader.conn.commit()
 
     packed = reader.recall_with_evidence_pack(
-        "Orion consolidated evidence", top_k=1, candidate_k=5, pack_k=5, _cross_session=True
+        "Orion consolidated evidence", top_k=1, candidate_k=5, pack_k=5
     )
     evidence_ids = {row["id"] for row in packed["evidence_pack"]}
     assert consolidated_id not in evidence_ids

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -1,0 +1,202 @@
+"""Read-only candidate-recall contract for future evidence packs."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+from mnemosyne.core import beam as beam_module
+
+
+def _state(db_path: Path, memory_id: str) -> tuple[int, str | None]:
+    with sqlite3.connect(str(db_path)) as conn:
+        count, recalled_at = conn.execute(
+            "SELECT recall_count, last_recalled FROM working_memory WHERE id = ?", (memory_id,)
+        ).fetchone()
+    return (count or 0, recalled_at)
+
+
+
+
+def test_evidence_pack_rejects_invalid_internal_controls(tmp_path: Path):
+    beam = BeamMemory(session_id="guards", db_path=tmp_path / "guards.db")
+    with pytest.raises(ValueError, match="candidate_k"):
+        beam.recall_with_evidence_pack("q", top_k=2, candidate_k=1)
+    with pytest.raises(ValueError, match="pack_k"):
+        beam.recall_with_evidence_pack("q", pack_k=-1)
+    with pytest.raises(ValueError, match="internal recall controls"):
+        beam.recall_with_evidence_pack("q", _track_recall=False)
+
+
+def test_candidate_only_recall_does_not_mutate_usage_state(tmp_path: Path):
+    db_path = tmp_path / "evidence-pack.db"
+    beam = BeamMemory(session_id="evidence-pack", db_path=db_path)
+    memory_id = beam.remember("Orion evidence-pack candidate fixture", source="test", importance=0.8)
+
+    before = _state(db_path, memory_id)
+    results = beam.recall("Orion evidence-pack", top_k=5, _track_recall=False)
+    after_candidate = _state(db_path, memory_id)
+    assert memory_id in [row["id"] for row in results]
+    assert after_candidate == before
+
+    beam.recall("Orion evidence-pack", top_k=5)
+    after_normal = _state(db_path, memory_id)
+    assert after_normal[0] == before[0] + 1
+    assert after_normal[1] is not None
+
+
+
+
+def test_candidate_only_recall_does_not_mutate_episodic_usage_state(tmp_path: Path):
+    db_path = tmp_path / "episodic-telemetry.db"
+    beam = BeamMemory(session_id="episodic", db_path=db_path)
+    memory_id = "episodic-telemetry-id"
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, importance, scope) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (memory_id, "episodic telemetry unique phrase", "test", "2026-01-01T00:00:00", "episodic", 0.8, "session"),
+    )
+    beam.conn.commit()
+    before = beam.conn.execute("SELECT recall_count, last_recalled FROM episodic_memory WHERE id = ?", (memory_id,)).fetchone()
+    results = beam.recall("episodic telemetry unique phrase", top_k=5, _track_recall=False)
+    after = beam.conn.execute("SELECT recall_count, last_recalled FROM episodic_memory WHERE id = ?", (memory_id,)).fetchone()
+    assert memory_id in [row["id"] for row in results]
+    assert after == before
+
+
+
+
+def test_real_recall_uses_working_and_episodic_tier_labels(tmp_path: Path):
+    db_path = tmp_path / "tier-labels.db"
+    beam = BeamMemory(session_id="tiers", db_path=db_path)
+    working_id = beam.remember("working tier unique phrase", source="test", importance=0.8)
+    episodic_id = "episodic-tier-id"
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, importance, scope) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (episodic_id, "episodic tier unique phrase", "test", "2026-01-01T00:00:00", "tiers", 0.8, "session"),
+    )
+    beam.conn.commit()
+
+    working = beam.recall("working tier unique phrase", top_k=5, _track_recall=False)
+    episodic = beam.recall("episodic tier unique phrase", top_k=5, _track_recall=False)
+    assert next(row for row in working if row["id"] == working_id)["tier"] == "working"
+    assert next(row for row in episodic if row["id"] == episodic_id)["tier"] == "episodic"
+
+
+def test_evidence_pack_keeps_primary_ranking_and_bounds_supplement(tmp_path: Path):
+    db_path = tmp_path / "pack.db"
+    beam = BeamMemory(session_id="evidence-pack", db_path=db_path)
+    for index in range(4):
+        beam.remember(f"Orion evidence fixture {index}", source="test", importance=0.8)
+
+    primary = beam.recall("Orion evidence", top_k=2)
+    packed = beam.recall_with_evidence_pack("Orion evidence", top_k=2, candidate_k=4, pack_k=1)
+
+    assert [row["id"] for row in packed["primary"]] == [row["id"] for row in primary]
+    assert len(packed["evidence_pack"]) <= 1
+    assert {row["id"] for row in packed["primary"]}.isdisjoint(
+        {row["id"] for row in packed["evidence_pack"]}
+    )
+
+
+def test_evidence_pack_does_not_leak_other_session_rows(tmp_path: Path):
+    db_path = tmp_path / "scope.db"
+    local = BeamMemory(session_id="local", db_path=db_path)
+    other = BeamMemory(session_id="other", db_path=db_path)
+    local_id = local.remember("Orion local scope fixture", source="test", importance=0.8)
+    other_id = other.remember("Orion other scope fixture", source="test", importance=0.8)
+
+    packed = local.recall_with_evidence_pack("Orion scope", top_k=1, candidate_k=5, pack_k=5)
+    returned_ids = {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
+
+    assert local_id in returned_ids
+    assert other_id not in returned_ids
+
+
+def test_cross_session_scope_can_produce_a_supplemental_pack(tmp_path: Path):
+    db_path = tmp_path / "cross-session-pack.db"
+    reader = BeamMemory(session_id="reader", db_path=db_path)
+    first = BeamMemory(session_id="first", db_path=db_path)
+    second = BeamMemory(session_id="second", db_path=db_path)
+    first.remember("Orion cross session alpha", source="test", importance=0.8, scope="global")
+    second_id = second.remember("Orion cross session beta", source="test", importance=0.8, scope="global")
+
+    packed = reader.recall_with_evidence_pack(
+        "Orion cross session", top_k=1, candidate_k=5, pack_k=5, _cross_session=True
+    )
+    assert len(packed["evidence_pack"]) == 1
+    assert [row["evidence_rank"] for row in packed["evidence_pack"]] == [2]
+    assert second_id in {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
+
+
+def test_vector_only_candidate_is_opt_in(tmp_path: Path, monkeypatch):
+    np = pytest.importorskip("numpy")
+    db_path = tmp_path / "vector-only.db"
+    beam = BeamMemory(session_id="local", db_path=db_path)
+    memory_id = beam.remember("semantic-only candidate", source="test", importance=0.8)
+
+    monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
+    monkeypatch.setattr(beam_module._embeddings, "embed_query", lambda query: np.array([1.0], dtype=np.float32))
+    monkeypatch.setattr(beam_module, "_vec_search", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        beam_module, "_wm_vec_search",
+        lambda conn, emb, k=20, **kwargs: [{"id": memory_id, "sim": 0.9}],
+    )
+
+    primary = beam.recall("unrelated lexical query", top_k=5)
+    candidates = beam.recall(
+        "unrelated lexical query", top_k=5,
+        _track_recall=False, _include_vector_only_candidates=True,
+    )
+    assert memory_id not in [row["id"] for row in primary]
+    assert memory_id in [row["id"] for row in candidates]
+
+    monkeypatch.setattr(
+        beam_module, "_wm_vec_search",
+        lambda conn, emb, k=20, **kwargs: [{"id": memory_id, "sim": 0.83}],
+    )
+    low_similarity = beam.recall(
+        "unrelated lexical query", top_k=5,
+        _track_recall=False, _include_vector_only_candidates=True,
+    )
+    assert memory_id not in [row["id"] for row in low_similarity]
+
+
+def test_vector_only_candidate_obeys_session_scope(tmp_path: Path, monkeypatch):
+    np = pytest.importorskip("numpy")
+    db_path = tmp_path / "vector-scope.db"
+    local = BeamMemory(session_id="local", db_path=db_path)
+    foreign = BeamMemory(session_id="foreign", db_path=db_path)
+    foreign_id = foreign.remember("foreign semantic candidate", source="test", importance=0.8)
+    monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
+    monkeypatch.setattr(beam_module._embeddings, "embed_query", lambda query: np.array([1.0], dtype=np.float32))
+    monkeypatch.setattr(beam_module, "_vec_search", lambda *args, **kwargs: [])
+    monkeypatch.setattr(beam_module, "_wm_vec_search", lambda *args, **kwargs: [{"id": foreign_id, "sim": 0.9}])
+    results = local.recall("unrelated lexical query", top_k=5, _track_recall=False, _include_vector_only_candidates=True)
+    assert foreign_id not in [row["id"] for row in results]
+
+
+def test_provenance_backfill_keeps_same_ids_separate_by_tier(tmp_path: Path, monkeypatch):
+    db_path = tmp_path / "collision.db"
+    beam = BeamMemory(session_id="reader", db_path=db_path)
+    shared_id = "same-id"
+    now = "2026-01-01T00:00:00"
+    beam.conn.execute(
+        "INSERT INTO working_memory (id, content, source, timestamp, session_id, importance, scope) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (shared_id, "working", "test", now, "primary-session", 0.5, "global"),
+    )
+    beam.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, importance, scope) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (shared_id, "episodic", "test", now, "candidate-session", 0.5, "global"),
+    )
+    beam.conn.commit()
+    calls = iter([
+        [{"id": shared_id, "tier": "working", "timestamp": now}],
+        [{"id": shared_id, "tier": "episodic", "timestamp": now}],
+    ])
+    monkeypatch.setattr(beam, "recall", lambda *args, **kwargs: next(calls))
+
+    packed = beam.recall_with_evidence_pack("q", top_k=1, candidate_k=2, pack_k=1)
+    assert packed["primary"][0]["session_id"] == "primary-session"
+    assert packed["evidence_pack"][0]["session_id"] == "candidate-session"

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -189,7 +189,11 @@ def test_cross_session_scope_can_produce_a_bounded_supplemental_pack(tmp_path: P
     second_id = second.remember("Orion cross session beta", source="test", importance=0.8, scope="global")
     third_id = third.remember("Orion cross session gamma", source="test", importance=0.8, scope="global")
 
-    packed = reader.recall_with_evidence_pack("Orion cross session", top_k=1, candidate_k=5, pack_k=2)
+    plain_primary = reader.recall("Orion cross session", top_k=1)
+    packed = reader.recall_with_evidence_pack("Orion cross session", top_k=1, candidate_k=5, pack_k=10)
+
+    assert [row["id"] for row in packed["primary"]] == [row["id"] for row in plain_primary]
+    # Only the two non-primary global rows are eligible, even when pack_k is larger.
     assert len(packed["evidence_pack"]) == 2
     assert {row["evidence_rank"] for row in packed["evidence_pack"]} == {2, 3}
     returned_ids = {row["id"] for row in packed["primary"] + packed["evidence_pack"]}

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -122,6 +122,28 @@ def test_evidence_pack_does_not_leak_other_session_rows(tmp_path: Path):
     assert other_id not in returned_ids
 
 
+def test_evidence_pack_zero_skips_candidate_recall(tmp_path: Path, monkeypatch):
+    beam = BeamMemory(session_id="zero-pack", db_path=tmp_path / "zero-pack.db")
+    memory_id = beam.remember("Orion zero pack fixture", source="test", importance=0.8)
+    real_recall = beam.recall
+    calls = []
+
+    def recording_recall(*args, **kwargs):
+        calls.append(kwargs)
+        return real_recall(*args, **kwargs)
+
+    monkeypatch.setattr(beam, "recall", recording_recall)
+    packed = beam.recall_with_evidence_pack(
+        "Orion zero pack", top_k=1, candidate_k=5, pack_k=0
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["top_k"] == 1
+    assert "_track_recall" not in calls[0]
+    assert [row["id"] for row in packed["primary"]] == [memory_id]
+    assert packed["evidence_pack"] == []
+
+
 def test_cross_session_scope_can_produce_a_bounded_supplemental_pack(tmp_path: Path):
     db_path = tmp_path / "cross-session-pack.db"
     reader = BeamMemory(session_id="reader", db_path=db_path)
@@ -139,6 +161,33 @@ def test_cross_session_scope_can_produce_a_bounded_supplemental_pack(tmp_path: P
     assert {row["evidence_rank"] for row in packed["evidence_pack"]} == {2, 3}
     returned_ids = {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
     assert {second_id, third_id}.issubset(returned_ids)
+
+
+def test_evidence_pack_honors_temporal_filters(tmp_path: Path):
+    db_path = tmp_path / "temporal-pack.db"
+    reader = BeamMemory(session_id="reader", db_path=db_path)
+    old_writer = BeamMemory(session_id="old", db_path=db_path)
+    current_writer = BeamMemory(session_id="current", db_path=db_path)
+    old_id = old_writer.remember("Orion temporal old fixture", source="test", importance=0.8, scope="global")
+    current_id = current_writer.remember(
+        "Orion temporal current fixture", source="test", importance=0.8, scope="global"
+    )
+    reader.conn.execute(
+        "UPDATE working_memory SET timestamp = ? WHERE id = ?", ("2020-01-01T00:00:00", old_id)
+    )
+    reader.conn.execute(
+        "UPDATE working_memory SET timestamp = ? WHERE id = ?", ("2026-01-01T00:00:00", current_id)
+    )
+    reader.conn.commit()
+
+    packed = reader.recall_with_evidence_pack(
+        "Orion temporal", top_k=1, candidate_k=5, pack_k=2,
+        _cross_session=True, from_date="2025-01-01",
+    )
+    returned_ids = {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
+
+    assert current_id in returned_ids
+    assert old_id not in returned_ids
 
 
 def test_evidence_pack_excludes_consolidated_working_candidates(tmp_path: Path):

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -13,6 +13,7 @@ from mnemosyne.core.recall_diagnostics import get_recall_diagnostics, reset_reca
 
 @pytest.fixture(autouse=True)
 def _reset_config_singleton_after_test():
+    MnemosyneConfig.reset_instance()
     yield
     MnemosyneConfig.reset_instance()
 

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -144,6 +144,18 @@ def test_evidence_pack_zero_skips_candidate_recall(tmp_path: Path, monkeypatch):
     assert packed["evidence_pack"] == []
 
 
+def test_zero_pack_allows_equal_candidate_and_top_k(tmp_path: Path):
+    beam = BeamMemory(session_id="equal-k", db_path=tmp_path / "equal-k.db")
+    memory_id = beam.remember("Orion equal k fixture", source="test", importance=0.8)
+
+    packed = beam.recall_with_evidence_pack(
+        "Orion equal k", top_k=2, candidate_k=2, pack_k=0
+    )
+
+    assert [row["id"] for row in packed["primary"]] == [memory_id]
+    assert packed["evidence_pack"] == []
+
+
 def test_cross_session_scope_can_produce_a_bounded_supplemental_pack(tmp_path: Path):
     db_path = tmp_path / "cross-session-pack.db"
     reader = BeamMemory(session_id="reader", db_path=db_path)
@@ -161,6 +173,31 @@ def test_cross_session_scope_can_produce_a_bounded_supplemental_pack(tmp_path: P
     assert {row["evidence_rank"] for row in packed["evidence_pack"]} == {2, 3}
     returned_ids = {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
     assert {second_id, third_id}.issubset(returned_ids)
+
+
+def test_episodic_candidate_enters_pack_with_backfilled_session(tmp_path: Path):
+    db_path = tmp_path / "episodic-pack.db"
+    reader = BeamMemory(session_id="reader", db_path=db_path)
+    primary = BeamMemory(session_id="primary", db_path=db_path)
+    primary.remember("Orion episodic pack primary", source="test", importance=0.9, scope="global")
+    episodic_id = "orion-episodic-pack-candidate"
+    reader.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, importance, scope) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            episodic_id, "Orion episodic pack candidate", "test",
+            "2026-01-01T00:00:00", "episodic-writer", 0.8, "global",
+        ),
+    )
+    reader.conn.commit()
+
+    packed = reader.recall_with_evidence_pack(
+        "Orion episodic pack", top_k=1, candidate_k=5, pack_k=5, _cross_session=True
+    )
+    pack_row = next(row for row in packed["evidence_pack"] if row["id"] == episodic_id)
+
+    assert pack_row["tier"] == "episodic"
+    assert pack_row["session_id"] == "episodic-writer"
 
 
 def test_evidence_pack_honors_temporal_filters(tmp_path: Path):
@@ -248,6 +285,20 @@ def test_candidate_only_linear_recall_does_not_mutate_diagnostics(tmp_path: Path
     assert after["by_tier"] == before["by_tier"]
 
 
+def test_evidence_pack_linear_pass_records_one_diagnostic_call(tmp_path: Path):
+    db_path = tmp_path / "linear-diagnostics.db"
+    beam = BeamMemory(session_id="linear", db_path=db_path)
+    beam.remember("Orion linear diagnostics fixture", source="test", importance=0.8)
+    reset_recall_diagnostics()
+
+    beam.recall_with_evidence_pack(
+        "Orion linear diagnostics", top_k=1, candidate_k=5, pack_k=2
+    )
+
+    diagnostics = get_recall_diagnostics()
+    assert diagnostics["totals"]["calls"] == 1
+
+
 def test_evidence_pack_polyphonic_candidate_only_pass_is_telemetry_neutral(tmp_path: Path, monkeypatch):
     from mnemosyne.core.polyphonic_recall import PolyphonicResult
 
@@ -322,7 +373,10 @@ def test_vector_only_candidate_is_opt_in(tmp_path: Path, monkeypatch):
         _track_recall=False, _include_vector_only_candidates=True,
     )
     # The evidence-only vector-similarity floor is inclusive.
-    assert memory_id in [row["id"] for row in at_threshold]
+    candidate = next(row for row in at_threshold if row["id"] == memory_id)
+    assert candidate["keyword_score"] == 0.0
+    assert candidate["fts_score"] == 0.0
+    assert candidate["dense_score"] == 0.84
 
 
 def test_vector_only_candidate_obeys_session_scope(tmp_path: Path, monkeypatch):

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -186,7 +186,7 @@ def test_evidence_pack_polyphonic_candidate_only_pass_is_telemetry_neutral(tmp_p
         def __init__(self, results):
             self.results = results
 
-        def recall(self, *, query, query_embedding, top_k):
+        def recall(self, *, query, query_embedding, top_k, **kwargs):
             return self.results
 
     db_path = tmp_path / "polyphonic-telemetry.db"

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -244,6 +244,17 @@ def test_vector_only_candidate_is_opt_in(tmp_path: Path, monkeypatch):
     )
     assert memory_id not in [row["id"] for row in low_similarity]
 
+    monkeypatch.setattr(
+        beam_module, "_wm_vec_search",
+        lambda conn, emb, k=20, **kwargs: [{"id": memory_id, "sim": 0.84}],
+    )
+    at_threshold = beam.recall(
+        "unrelated lexical query", top_k=5,
+        _track_recall=False, _include_vector_only_candidates=True,
+    )
+    # The evidence-only vector-similarity floor is inclusive.
+    assert memory_id in [row["id"] for row in at_threshold]
+
 
 def test_vector_only_candidate_obeys_session_scope(tmp_path: Path, monkeypatch):
     np = pytest.importorskip("numpy")

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -25,10 +25,16 @@ def test_evidence_pack_rejects_invalid_internal_controls(tmp_path: Path):
     beam = BeamMemory(session_id="guards", db_path=tmp_path / "guards.db")
     with pytest.raises(ValueError, match="candidate_k"):
         beam.recall_with_evidence_pack("q", top_k=2, candidate_k=1)
+    with pytest.raises(ValueError, match="candidate_k must exceed"):
+        beam.recall_with_evidence_pack("q", top_k=2, candidate_k=2, pack_k=1)
     with pytest.raises(ValueError, match="pack_k"):
         beam.recall_with_evidence_pack("q", pack_k=-1)
+    with pytest.raises(ValueError, match="explain"):
+        beam.recall_with_evidence_pack("q", explain=True)
     with pytest.raises(ValueError, match="internal recall controls"):
         beam.recall_with_evidence_pack("q", _track_recall=False)
+    with pytest.raises(ValueError, match="internal recall controls"):
+        beam.recall_with_evidence_pack("q", _include_vector_only_candidates=True)
 
 
 def test_candidate_only_recall_does_not_mutate_usage_state(tmp_path: Path):
@@ -116,20 +122,23 @@ def test_evidence_pack_does_not_leak_other_session_rows(tmp_path: Path):
     assert other_id not in returned_ids
 
 
-def test_cross_session_scope_can_produce_a_supplemental_pack(tmp_path: Path):
+def test_cross_session_scope_can_produce_a_bounded_supplemental_pack(tmp_path: Path):
     db_path = tmp_path / "cross-session-pack.db"
     reader = BeamMemory(session_id="reader", db_path=db_path)
     first = BeamMemory(session_id="first", db_path=db_path)
     second = BeamMemory(session_id="second", db_path=db_path)
+    third = BeamMemory(session_id="third", db_path=db_path)
     first.remember("Orion cross session alpha", source="test", importance=0.8, scope="global")
     second_id = second.remember("Orion cross session beta", source="test", importance=0.8, scope="global")
+    third_id = third.remember("Orion cross session gamma", source="test", importance=0.8, scope="global")
 
     packed = reader.recall_with_evidence_pack(
-        "Orion cross session", top_k=1, candidate_k=5, pack_k=5, _cross_session=True
+        "Orion cross session", top_k=1, candidate_k=5, pack_k=2, _cross_session=True
     )
-    assert len(packed["evidence_pack"]) == 1
-    assert [row["evidence_rank"] for row in packed["evidence_pack"]] == [2]
-    assert second_id in {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
+    assert len(packed["evidence_pack"]) == 2
+    assert {row["evidence_rank"] for row in packed["evidence_pack"]} == {2, 3}
+    returned_ids = {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
+    assert {second_id, third_id}.issubset(returned_ids)
 
 
 def test_evidence_pack_excludes_consolidated_working_candidates(tmp_path: Path):

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -199,12 +199,17 @@ def test_evidence_pack_polyphonic_candidate_only_pass_is_telemetry_neutral(tmp_p
         lambda: FakeEngine([PolyphonicResult(memory_id=memory_id, combined_score=0.9, voice_scores={}, metadata={})]),
     )
 
+    reset_recall_diagnostics()
     before = _state(db_path, memory_id)
     beam.recall_with_evidence_pack("Orion polyphonic", top_k=1, candidate_k=2, pack_k=1)
     after = _state(db_path, memory_id)
-    # The public primary call records one use; the wider internal candidate call records none.
+    diagnostics = get_recall_diagnostics()
+    # Only the public primary call mutates either usage state or diagnostics;
+    # the wider candidate pass is telemetry-neutral under the polyphonic path.
     assert after[0] == before[0] + 1
     assert after[1] is not None
+    assert diagnostics["totals"]["calls"] == 1
+    assert all(tier["total_hits"] == 0 for tier in diagnostics["by_tier"].values())
 
 
 def test_vector_only_candidate_is_opt_in(tmp_path: Path, monkeypatch):
@@ -277,3 +282,16 @@ def test_provenance_backfill_keeps_same_ids_separate_by_tier(tmp_path: Path, mon
     packed = beam.recall_with_evidence_pack("q", top_k=1, candidate_k=2, pack_k=1)
     assert packed["primary"][0]["session_id"] == "primary-session"
     assert packed["evidence_pack"][0]["session_id"] == "candidate-session"
+
+
+def test_evidence_pack_excludes_synthetic_candidate_tiers(tmp_path: Path, monkeypatch):
+    beam = BeamMemory(session_id="reader", db_path=tmp_path / "synthetic-tier.db")
+    calls = iter([
+        [],
+        [{"id": "memoria_source_test", "tier": "memoria", "session_id": "reader"}],
+    ])
+    monkeypatch.setattr(beam, "recall", lambda *args, **kwargs: next(calls))
+
+    packed = beam.recall_with_evidence_pack("q", top_k=1, candidate_k=2, pack_k=1)
+
+    assert packed == {"primary": [], "evidence_pack": []}

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -11,6 +11,12 @@ from mnemosyne.core.config import MnemosyneConfig
 from mnemosyne.core.recall_diagnostics import get_recall_diagnostics, reset_recall_diagnostics
 
 
+@pytest.fixture(autouse=True)
+def _reset_config_singleton_after_test():
+    yield
+    MnemosyneConfig.reset_instance()
+
+
 def _state(db_path: Path, memory_id: str) -> tuple[int, str | None]:
     with sqlite3.connect(str(db_path)) as conn:
         count, recalled_at = conn.execute(

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -8,6 +8,7 @@ import pytest
 
 from mnemosyne.core.beam import BeamMemory
 from mnemosyne.core import beam as beam_module
+from mnemosyne.core.recall_diagnostics import get_recall_diagnostics, reset_recall_diagnostics
 
 
 def _state(db_path: Path, memory_id: str) -> tuple[int, str | None]:
@@ -94,7 +95,8 @@ def test_evidence_pack_keeps_primary_ranking_and_bounds_supplement(tmp_path: Pat
     packed = beam.recall_with_evidence_pack("Orion evidence", top_k=2, candidate_k=4, pack_k=1)
 
     assert [row["id"] for row in packed["primary"]] == [row["id"] for row in primary]
-    assert len(packed["evidence_pack"]) <= 1
+    # Primary already claims this only session, so no supplemental group remains.
+    assert packed["evidence_pack"] == []
     assert {row["id"] for row in packed["primary"]}.isdisjoint(
         {row["id"] for row in packed["evidence_pack"]}
     )
@@ -128,6 +130,72 @@ def test_cross_session_scope_can_produce_a_supplemental_pack(tmp_path: Path):
     assert len(packed["evidence_pack"]) == 1
     assert [row["evidence_rank"] for row in packed["evidence_pack"]] == [2]
     assert second_id in {row["id"] for row in packed["primary"] + packed["evidence_pack"]}
+
+
+def test_evidence_pack_excludes_consolidated_working_candidates(tmp_path: Path):
+    db_path = tmp_path / "consolidated-evidence.db"
+    reader = BeamMemory(session_id="reader", db_path=db_path)
+    primary = BeamMemory(session_id="primary", db_path=db_path)
+    consolidated = BeamMemory(session_id="consolidated", db_path=db_path)
+    hot = BeamMemory(session_id="hot", db_path=db_path)
+    primary.remember("Orion consolidated evidence primary", source="test", importance=0.9, scope="global")
+    consolidated_id = consolidated.remember(
+        "Orion consolidated evidence historical", source="test", importance=0.8, scope="global"
+    )
+    hot_id = hot.remember("Orion consolidated evidence hot", source="test", importance=0.7, scope="global")
+    reader.conn.execute(
+        "UPDATE working_memory SET consolidated_at = ? WHERE id = ?",
+        ("2026-01-01T00:00:00", consolidated_id),
+    )
+    reader.conn.commit()
+
+    packed = reader.recall_with_evidence_pack(
+        "Orion consolidated evidence", top_k=1, candidate_k=5, pack_k=5, _cross_session=True
+    )
+    evidence_ids = {row["id"] for row in packed["evidence_pack"]}
+    assert consolidated_id not in evidence_ids
+    assert hot_id in evidence_ids
+
+
+def test_candidate_only_linear_recall_does_not_mutate_diagnostics(tmp_path: Path):
+    db_path = tmp_path / "diagnostics.db"
+    beam = BeamMemory(session_id="diagnostics", db_path=db_path)
+    beam.remember("Orion diagnostics candidate fixture", source="test", importance=0.8)
+    reset_recall_diagnostics()
+
+    before = get_recall_diagnostics()
+    beam.recall("Orion diagnostics", top_k=5, _track_recall=False)
+    after = get_recall_diagnostics()
+    assert after["totals"] == before["totals"]
+    assert after["by_tier"] == before["by_tier"]
+
+
+def test_evidence_pack_polyphonic_candidate_only_pass_is_telemetry_neutral(tmp_path: Path, monkeypatch):
+    from mnemosyne.core.polyphonic_recall import PolyphonicResult
+
+    class FakeEngine:
+        def __init__(self, results):
+            self.results = results
+
+        def recall(self, *, query, query_embedding, top_k):
+            return self.results
+
+    db_path = tmp_path / "polyphonic-telemetry.db"
+    beam = BeamMemory(session_id="polyphonic", db_path=db_path)
+    memory_id = beam.remember("Orion polyphonic candidate fixture", source="test", importance=0.8)
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+    monkeypatch.setattr(
+        beam,
+        "_get_polyphonic_engine",
+        lambda: FakeEngine([PolyphonicResult(memory_id=memory_id, combined_score=0.9, voice_scores={}, metadata={})]),
+    )
+
+    before = _state(db_path, memory_id)
+    beam.recall_with_evidence_pack("Orion polyphonic", top_k=1, candidate_k=2, pack_k=1)
+    after = _state(db_path, memory_id)
+    # The public primary call records one use; the wider internal candidate call records none.
+    assert after[0] == before[0] + 1
+    assert after[1] is not None
 
 
 def test_vector_only_candidate_is_opt_in(tmp_path: Path, monkeypatch):

--- a/tests/test_evidence_pack_recall.py
+++ b/tests/test_evidence_pack_recall.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pytest
 
 from mnemosyne.core.beam import BeamMemory
-from mnemosyne.core import beam as beam_module
 from mnemosyne.core.recall_diagnostics import get_recall_diagnostics, reset_recall_diagnostics
 
 
@@ -33,8 +32,6 @@ def test_evidence_pack_rejects_invalid_internal_controls(tmp_path: Path):
         beam.recall_with_evidence_pack("q", explain=True)
     with pytest.raises(ValueError, match="internal recall controls"):
         beam.recall_with_evidence_pack("q", _track_recall=False)
-    with pytest.raises(ValueError, match="internal recall controls"):
-        beam.recall_with_evidence_pack("q", _include_vector_only_candidates=True)
 
 
 def test_candidate_only_recall_does_not_mutate_usage_state(tmp_path: Path):
@@ -330,67 +327,6 @@ def test_evidence_pack_polyphonic_candidate_only_pass_is_telemetry_neutral(tmp_p
     assert after[1] is not None
     assert diagnostics["totals"]["calls"] == 1
     assert all(tier["total_hits"] == 0 for tier in diagnostics["by_tier"].values())
-
-
-def test_vector_only_candidate_is_opt_in(tmp_path: Path, monkeypatch):
-    np = pytest.importorskip("numpy")
-    db_path = tmp_path / "vector-only.db"
-    beam = BeamMemory(session_id="local", db_path=db_path)
-    memory_id = beam.remember("semantic-only candidate", source="test", importance=0.8)
-
-    monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
-    monkeypatch.setattr(beam_module._embeddings, "embed_query", lambda query: np.array([1.0], dtype=np.float32))
-    monkeypatch.setattr(beam_module, "_vec_search", lambda *args, **kwargs: [])
-    monkeypatch.setattr(
-        beam_module, "_wm_vec_search",
-        lambda conn, emb, k=20, **kwargs: [{"id": memory_id, "sim": 0.9}],
-    )
-
-    primary = beam.recall("unrelated lexical query", top_k=5)
-    candidates = beam.recall(
-        "unrelated lexical query", top_k=5,
-        _track_recall=False, _include_vector_only_candidates=True,
-    )
-    assert memory_id not in [row["id"] for row in primary]
-    assert memory_id in [row["id"] for row in candidates]
-
-    monkeypatch.setattr(
-        beam_module, "_wm_vec_search",
-        lambda conn, emb, k=20, **kwargs: [{"id": memory_id, "sim": 0.83}],
-    )
-    low_similarity = beam.recall(
-        "unrelated lexical query", top_k=5,
-        _track_recall=False, _include_vector_only_candidates=True,
-    )
-    assert memory_id not in [row["id"] for row in low_similarity]
-
-    monkeypatch.setattr(
-        beam_module, "_wm_vec_search",
-        lambda conn, emb, k=20, **kwargs: [{"id": memory_id, "sim": 0.84}],
-    )
-    at_threshold = beam.recall(
-        "unrelated lexical query", top_k=5,
-        _track_recall=False, _include_vector_only_candidates=True,
-    )
-    # The evidence-only vector-similarity floor is inclusive.
-    candidate = next(row for row in at_threshold if row["id"] == memory_id)
-    assert candidate["keyword_score"] == 0.0
-    assert candidate["fts_score"] == 0.0
-    assert candidate["dense_score"] == 0.84
-
-
-def test_vector_only_candidate_obeys_session_scope(tmp_path: Path, monkeypatch):
-    np = pytest.importorskip("numpy")
-    db_path = tmp_path / "vector-scope.db"
-    local = BeamMemory(session_id="local", db_path=db_path)
-    foreign = BeamMemory(session_id="foreign", db_path=db_path)
-    foreign_id = foreign.remember("foreign semantic candidate", source="test", importance=0.8)
-    monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
-    monkeypatch.setattr(beam_module._embeddings, "embed_query", lambda query: np.array([1.0], dtype=np.float32))
-    monkeypatch.setattr(beam_module, "_vec_search", lambda *args, **kwargs: [])
-    monkeypatch.setattr(beam_module, "_wm_vec_search", lambda *args, **kwargs: [{"id": foreign_id, "sim": 0.9}])
-    results = local.recall("unrelated lexical query", top_k=5, _track_recall=False, _include_vector_only_candidates=True)
-    assert foreign_id not in [row["id"] for row in results]
 
 
 def test_provenance_backfill_keeps_same_ids_separate_by_tier(tmp_path: Path, monkeypatch):

--- a/tests/test_evidence_packs.py
+++ b/tests/test_evidence_packs.py
@@ -70,11 +70,11 @@ def test_primary_session_and_duplicate_candidate_ids_are_not_repeated():
 
 def test_custom_group_key_and_numeric_timestamp_are_supported():
     rows = [
-        {"id": "later", "source": "same", "timestamp": 10},
-        {"id": "first", "source": "same", "timestamp": 9},
-        {"id": "other", "source": "other", "timestamp": 8},
+        {"id": "later", "source": "same", "***": "same", "timestamp": 10},
+        {"id": "first", "source": "same", "***": "same", "timestamp": 9},
+        {"id": "other", "source": "other", "***": "other", "timestamp": 8},
     ]
-    packed = build_evidence_pack([], rows, group_key="source")
+    packed = build_evidence_pack([], rows, group_key="***")
 
     assert [row["id"] for row in packed["evidence_pack"]] == ["other", "later"]
 

--- a/tests/test_evidence_packs.py
+++ b/tests/test_evidence_packs.py
@@ -1,0 +1,108 @@
+"""Contract tests for provenance-preserving supplemental evidence packs."""
+from __future__ import annotations
+
+import pytest
+
+from mnemosyne.core.evidence_packs import build_evidence_pack
+
+
+def _row(memory_id: str, session_id: str | None, timestamp: object, *, score: float = 0.5) -> dict:
+    row = {"id": memory_id, "timestamp": timestamp, "score": score, "content": memory_id}
+    if session_id is not None:
+        row["session_id"] = session_id
+    return row
+
+
+def test_primary_ranking_is_preserved_and_candidates_do_not_mutate_inputs():
+    primary = [_row("p1", "session-primary", "2024-05-03", score=0.9)]
+    candidates = [
+        _row("p1", "session-primary", "2024-05-03", score=0.9),
+        _row("c2", "session-2", "2024-05-02", score=0.8),
+        _row("c3", "session-3", "2024-05-01", score=0.7),
+    ]
+
+    packed = build_evidence_pack(primary, candidates, max_items=2)
+
+    assert packed["primary"] == primary
+    assert [row["id"] for row in packed["evidence_pack"]] == ["c3", "c2"]
+    assert [row["evidence_rank"] for row in packed["evidence_pack"]] == [3, 2]
+    assert "evidence_rank" not in candidates[1]
+
+
+def test_only_first_candidate_per_session_is_selected():
+    packed = build_evidence_pack(
+        [],
+        [
+            _row("first", "same-session", "2024-05-03"),
+            _row("later", "same-session", "2024-05-04"),
+            _row("other", "other-session", "2024-05-05"),
+        ],
+        max_items=5,
+    )
+
+    assert [row["id"] for row in packed["evidence_pack"]] == ["first", "other"]
+    assert [row["evidence_rank"] for row in packed["evidence_pack"]] == [1, 3]
+
+
+def test_missing_session_id_is_dropped_to_preserve_provenance():
+    packed = build_evidence_pack(
+        [],
+        [_row("a", None, "2024-05-01"), _row("b", None, "2024-05-02")],
+        max_items=2,
+    )
+
+    assert packed["evidence_pack"] == []
+
+
+def test_primary_session_and_duplicate_candidate_ids_are_not_repeated():
+    packed = build_evidence_pack(
+        [_row("primary", "already-present", "2024-05-01")],
+        [
+            _row("same-session", "already-present", "2024-05-02"),
+            _row("duplicate", "new-session", "2024-05-03"),
+            _row("duplicate", "other-session", "2024-05-04"),
+            _row("kept", "kept-session", "2024-05-05"),
+        ],
+    )
+
+    assert [row["id"] for row in packed["evidence_pack"]] == ["duplicate", "kept"]
+
+
+def test_custom_group_key_and_numeric_timestamp_are_supported():
+    rows = [
+        {"id": "later", "source": "same", "timestamp": 10},
+        {"id": "first", "source": "same", "timestamp": 9},
+        {"id": "other", "source": "other", "timestamp": 8},
+    ]
+    packed = build_evidence_pack([], rows, group_key="source")
+
+    assert [row["id"] for row in packed["evidence_pack"]] == ["other", "later"]
+
+
+def test_unknown_timestamps_sort_after_known_chronology_deterministically():
+    packed = build_evidence_pack(
+        [],
+        [
+            _row("iso", "iso", "2024-05-01T00:00:00Z"),
+            _row("bad", "bad", "not-a-date"),
+            {"id": "missing", "session_id": "missing"},
+            _row("epoch", "epoch", 10),
+        ],
+    )
+
+    assert [row["id"] for row in packed["evidence_pack"]] == ["epoch", "iso", "bad", "missing"]
+
+
+def test_candidate_without_stable_id_is_not_emitted():
+    packed = build_evidence_pack([], [{"session_id": "s", "timestamp": "2024-05-01"}])
+    assert packed["evidence_pack"] == []
+
+
+def test_zero_capacity_returns_no_supplemental_evidence():
+    packed = build_evidence_pack([], [_row("c", "s", "2024-05-01")], max_items=0)
+    assert packed == {"primary": [], "evidence_pack": []}
+
+
+def test_negative_capacity_is_rejected():
+    with pytest.raises(ValueError, match="max_items"):
+        build_evidence_pack([], [], max_items=-1)

--- a/tests/test_evidence_packs.py
+++ b/tests/test_evidence_packs.py
@@ -98,6 +98,32 @@ def test_candidate_without_stable_id_is_not_emitted():
     assert packed["evidence_pack"] == []
 
 
+def test_candidate_with_empty_id_is_not_emitted():
+    packed = build_evidence_pack([], [{"id": "", "session_id": "s", "timestamp": "2024-05-01"}])
+    assert packed["evidence_pack"] == []
+
+
+def test_tier_qualified_ids_are_distinct_candidates():
+    primary = [{"id": "shared", "tier": "working", "session_id": "primary", "timestamp": 1}]
+    candidates = [{"id": "shared", "tier": "episodic", "session_id": "candidate", "timestamp": 2}]
+
+    packed = build_evidence_pack(primary, candidates)
+
+    assert [row["id"] for row in packed["evidence_pack"]] == ["shared"]
+    assert packed["evidence_pack"][0]["tier"] == "episodic"
+
+
+def test_invalid_candidate_does_not_hide_later_valid_same_id():
+    packed = build_evidence_pack(
+        [],
+        [
+            {"id": "shared", "tier": "working", "timestamp": 1},
+            {"id": "shared", "tier": "working", "session_id": "valid", "timestamp": 2},
+        ],
+    )
+    assert [row["session_id"] for row in packed["evidence_pack"]] == ["valid"]
+
+
 def test_zero_capacity_returns_no_supplemental_evidence():
     packed = build_evidence_pack([], [_row("c", "s", "2024-05-01")], max_items=0)
     assert packed == {"primary": [], "evidence_pack": []}


### PR DESCRIPTION
## Summary
- Keep primary recall and ranking unchanged; expose an opt-in, separate evidence pack.
- Use a read-only broader candidate pass with scope parity, tier-qualified provenance, and fail-closed provenance handling.
- Limit and chronologically order supplemental evidence without mixing it into primary results.

## Validation
- Focused suite: 19 passed.
- Fresh 30-case LongMemEval matrix: primary MRR unchanged at 0.753373; primary hit/complete 28/30 and 26/30; combined hit/complete 29/30 and 28/30.
- Doctors regression: combined evidence 3/3 while primary remains unchanged.

## Notes
- No global dense/vector-only primary-ranking change. Vector-only evidence admission is removed from this PR and deferred to #789; the opt-in, read-only evidence-pack path remains lexical/provenance-preserving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds opt-in, provenance-preserving evidence packs to BEAM recall. Primary recall, ranking, diagnostics, and telemetry remain unchanged.

## Core architecture impact

- Adds `BeamMemory.recall_with_evidence_pack()`.
- Uses a wider, read-only candidate pass for supplemental evidence.
- Preserves tier-qualified provenance across working and episodic memory.
- Excludes consolidated working-memory rows, synthetic candidates, and invalid provenance.
- Bounds, deduplicates, and chronologically orders supplemental evidence.
- Removes uncalibrated vector-only evidence admission.
- Does not change consolidation, veracity, sync, or tier boundaries.

This is the right architectural choice because supplemental context remains separate from primary ranking and cannot silently alter recall behavior.

## Privacy and local-first guarantees

- Evidence construction performs no persistence or background work.
- Candidate recall suppresses telemetry with `_track_recall=False`.
- Evidence remains opt-in and honors visibility, session, and temporal filters.
- Private evidence-pack controls are rejected.
- Fail-closed provenance handling reduces accidental disclosure risk.
- The change adds no remote service, sync operation, or external data path.

The change preserves Mnemosyne’s local-first design and does not erode its privacy posture.

## Agent integration surfaces

Hermes, MCP, and CLI integrations continue to use standard `recall()` behavior. They receive no default schema or response change.

Integrations can adopt evidence packs through the core API. `explain=True` is rejected until an evidence-pack response envelope preserves normal recall query and explanation metadata.

## Maintainability

The isolated `evidence_packs.py` module provides deterministic, non-mutating assembly.

A calibrated vector-only recall path is deferred until metric consistency, index compatibility, integration tests, and distractor benchmarks are defined.

## Validation and benchmarks

- Adds focused coverage for validation, provenance, scoping, telemetry neutrality, tier handling, bounds, and ordering.
- LongMemEval covers 30 cases with unchanged primary MRR of `0.753373`.
- Doctors regression reaches `3/3` with combined evidence while primary results remain unchanged.
- A separate benchmark adapter provides an opt-in harness arm.
- The adapter preserves primary and combined diagnostics and rejects cross-arm resume artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
