### PR TITLE
fix: word-boundary the MEMORIA instruction extractor negation keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
+## [3.15.1] - 2026-07-27
+
+### Fixed
+
+- **MEMORIA instruction extraction inverted "whenever X" into "never X" (#507).** The
+  regex-based instruction extractor had no leading word boundary on its negation/modal
+  alternatives, so under `re.IGNORECASE` a keyword like `never` matched *inside* a longer
+  word: `"Good - whenever needed we can use it."` was stored as the instruction
+  `"never needed we can use it"`. Since `memoria_instructions` rows are surfaced at recall
+  as user constraints, an inverted instruction is worse than a missed one. The same class
+  of bug affected German (`nie` inside `Knie`). Added a leading `\b` to all five locale
+  instruction patterns (en/de/ru/it/es).
+
 ## [3.15.0] - 2026-07-20
 
 ### Fixed

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.15.0"
+__version__ = "3.15.1"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/tests/test_memoria_instruction_boundaries.py
+++ b/tests/test_memoria_instruction_boundaries.py
@@ -1,0 +1,90 @@
+"""Regression tests for MEMORIA instruction-pattern word boundaries (issue #507).
+
+Without a leading `\\b`, the instruction pattern's negation/modal alternatives matched
+*inside* longer words under `re.IGNORECASE`:
+
+    "Good - whenever needed we can use it."  ->  stored "never needed we can use it"
+    "Das Knie schmerzt seit Tagen"           ->  stored "nie schmerzt seit Tagen"
+
+Because `memoria_instructions` rows are surfaced at recall time as user constraints, an
+inverted instruction is worse than a missing one, so this is pinned per locale.
+
+These tests exercise the compiled pattern exactly as `extract_and_store_facts` builds it
+(same `IMPVERBS` substitution, same `re.IGNORECASE`) and deliberately avoid touching
+SQLite so they stay fast and platform-independent.
+"""
+
+import re
+
+import pytest
+
+from mnemosyne.core.beam import BeamMemory
+
+
+def compiled_instruction_pattern(lang: str) -> str:
+    """Rebuild the instruction regex the way the extractor does at runtime."""
+    pat = BeamMemory.MULTILINGUAL_PATTERNS[lang]
+    return pat["instruction"].replace("IMPVERBS", pat["instruction_imperative"])
+
+
+def matches(lang: str, text: str):
+    return [m.group(0) for m in re.finditer(compiled_instruction_pattern(lang), text, re.IGNORECASE)]
+
+
+class TestInstructionPatternWordBoundary:
+    """A modal/negation keyword must not match inside a longer word."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Verbatim from the issue's production audit (rows 59 and 38).
+            "Good - whenever needed we can use it. I've disabled it.",
+            "Next useful step, whenever you're ready to continue",
+            "whenever the agent creates a temporary folder for a smoke test",
+        ],
+    )
+    def test_en_whenever_does_not_yield_never_instruction(self, text):
+        assert matches("en", text) == [], (
+            "'never' matched inside 'whenever', which inverts the user's meaning"
+        )
+
+    def test_de_nie_does_not_match_inside_knie(self):
+        assert matches("de", "Das Knie schmerzt seit Tagen und wird nicht besser") == [], (
+            "'nie' matched inside 'Knie'"
+        )
+
+    @pytest.mark.parametrize(
+        ("lang", "text"),
+        [
+            ("en", "never commit directly to the main branch please"),
+            ("en", "always run the full test suite before pushing changes"),
+            ("en", "must not store secrets in the repository configuration"),
+            ("de", "nie ohne Tests committen bitte beachten"),
+            ("de", "immer die Tests vor dem Pushen ausfuehren bitte"),
+            ("it", "mai committare direttamente sul branch principale"),
+            ("es", "siempre ejecuta las pruebas antes de subir los cambios"),
+        ],
+    )
+    def test_genuine_instructions_still_extract(self, lang, text):
+        """The boundary must not cost us real instructions at a word start."""
+        assert matches(lang, text), f"legitimate {lang} instruction no longer extracted"
+
+    @pytest.mark.parametrize(
+        ("lang", "text"),
+        [
+            # A keyword preceded by punctuation/quote is still at a word boundary.
+            ("en", '"never push to main without a review" is the rule here'),
+            ("en", "- always rebase before opening the pull request"),
+        ],
+    )
+    def test_boundary_allows_punctuation_prefix(self, lang, text):
+        assert matches(lang, text), "word boundary should still match after punctuation"
+
+    def test_every_locale_instruction_pattern_is_boundary_anchored(self):
+        """Guard the whole table so a new locale cannot reintroduce issue #507."""
+        unanchored = [
+            lang
+            for lang, pat in BeamMemory.MULTILINGUAL_PATTERNS.items()
+            if not pat["instruction"].startswith(r"\b")
+        ]
+        assert unanchored == [], f"instruction pattern not word-boundary anchored: {unanchored}"


### PR DESCRIPTION
## Description

The MEMORIA instruction extractor's regex had no leading word boundary on its negation/modal alternatives ("never", "nie", ...). Under `re.IGNORECASE`, `re.finditer` matched those keywords *inside* longer words instead of only at a word start, so the extractor could store the opposite of what the user said:

```
"Good - whenever needed we can use it." -> stored "never needed we can use it"
```

`memoria_instructions` rows are surfaced at recall time as user constraints, so an inverted instruction is worse than a missing one. This reproduces the reporter's production audit (rows 59 and 38) exactly.

While verifying the root cause against the real regex table (not just the issue's hypothesis), I found the same bug class also affects German — `"Das Knie schmerzt seit Tagen"` extracted `"nie schmerzt seit Tagen"` (`nie` inside `Knie`) — which the issue did not report. Fixed all five locales (en/de/ru/it/es) rather than only `en`.

Two things worth flagging that I deliberately left untouched, because they're separate concerns from #507 and the CONTRIBUTING guide asks for one focused PR per issue:
- The `ru` locale's `instruction` pattern contains a literal `\\s` (double-escaped) instead of `\s`, so it never matches anything at runtime — a pre-existing, unrelated bug.
- The `ru`/`es` patterns' negated character classes contain a literal `\\n` instead of `\n`, which silently truncates captures at the letter "n" — also pre-existing and unrelated.

I did not attempt the issue's secondary findings (traceback harvesting, subject-less fragments) — those are separate, larger design questions (what counts as "user-authored content", whether a captured instruction needs a subject) better scoped as their own issues/PRs.

## Related Issue

Closes #507

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Existing tests still pass (`pytest tests/ -v`)
- [x] New tests added for any new functionality
- [x] Manual verification (describe what you tested)

**New tests** (`tests/test_memoria_instruction_boundaries.py`, 14 tests) exercise the compiled pattern the same way the extractor builds it at runtime (`IMPVERBS` substitution + `re.IGNORECASE`), without touching SQLite:
- The exact `whenever` inputs from the issue no longer yield a `never` instruction (3 cases).
- The German `Knie`/`nie` case (found during verification, not in the issue).
- 7 genuine instructions across en/de/it/es still extract correctly — the boundary must not cost real matches.
- 2 cases confirm the boundary still matches right after punctuation/quotes.
- A guard test asserts every locale's `instruction` pattern starts with `\b`, so a future locale can't reintroduce this bug silently.

```
$ python -m pytest tests/test_memoria_instruction_boundaries.py -v
...
14 passed in 1.08s
```

**Negative control** — reverted only `mnemosyne/core/beam.py` (kept the new test file) and re-ran the same file:
```
5 failed, 9 passed in 1.58s
FAILED ...test_en_whenever_does_not_yield_never_instruction[Good - whenever needed we can use it. I've disabled it.]
FAILED ...test_en_whenever_does_not_yield_never_instruction[Next useful step, whenever you're ready to continue]
FAILED ...test_en_whenever_does_not_yield_never_instruction[whenever the agent creates a temporary folder for a smoke test]
FAILED ...test_de_nie_does_not_match_inside_knie
FAILED ...test_every_locale_instruction_pattern_is_boundary_anchored
```
Exactly the 5 bug-detecting tests fail without the fix; the 9 "genuine instruction still extracts" tests correctly still pass either way — confirming the failures are attributable to this exact change.

**Broader suite**, same 3 environment facts stated once and applicable throughout: Windows 11, Python 3.13.4, portable venv, `pip install -e ".[dev]"` plus `numpy` and `mnemosyne-hermes` (needed by pre-existing tests, unrelated to this change).

| | Test files | Result |
|---|---|---|
| pristine `main` full suite (`pytest tests/`) | — | `204 failed, 2085 passed, 42 skipped, 344 errors` |
| this branch, same command | — | `204 failed, 2099 passed, 42 skipped, 344 errors` (**+14**, exactly the new tests, 0 new failures) |
| `tests/test_beam.py` pristine | — | `4 failed, 82 passed, 75 errors` |
| `tests/test_beam.py` this branch | — | `4 failed, 96 passed, 75 errors` (**+14**, same delta) |

The 204 failures / 344 errors are pre-existing on `main` and are almost entirely one cause: **796 `PermissionError` occurrences**, the well-known Windows SQLite temp-file-teardown issue (a test tries to delete a `.db`/`.db-wal` file that Windows still has locked). The remainder are `ModuleNotFoundError` for optional extras I didn't install (`nacl`, `cryptography`) — legitimately optional per `pyproject.toml`. None of it touches `memoria_instructions` or the extraction path.

**Ruff** (`python -m ruff check mnemosyne/core/beam.py`): 12 errors — **identical count on pristine `main`**, none on my changed lines (all pre-existing `E402`/`F841`/`F401` elsewhere in a 8,700-line file). I did not fix pre-existing lint issues unrelated to this change.

**Not run:** `make lint` / `make coverage` (repo has no `Makefile`; used the `pyproject.toml`-driven `ruff`/`pytest` directly). No CLI/MCP-server smoke test — this change is isolated to the extraction regex table and doesn't touch any of that surface.

## Checklist

- [x] Version bumped in `mnemosyne/__init__.py` (3.15.0 → 3.15.1)
- [x] `CHANGELOG.md` updated with a brief entry
- [ ] README updated if user-facing behavior changed — n/a, no user-facing behavior changed (only what gets stored internally)
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency

By submitting this PR I confirm I have read and agree to the CLA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixes MEMORIA instruction extraction across English, German, Russian, Italian, and Spanish by enforcing word-boundary matching for negation and modal keywords.
- Prevents false inversions such as interpreting “whenever” as “never” or matching “nie” inside German “Knie.”
- Adds 14 regression tests covering valid extraction, punctuation boundaries, reported reproductions, and all locale patterns.
- Bumps Mnemosyne to 3.15.1 and updates the changelog.

## Architecture and maintainability

- This is a focused correctness fix in the instruction-extraction layer; it does not alter working, episodic, or BEAM memory tiers, retrieval, consolidation, veracity, or synchronization.
- Hermes, MCP, and CLI integration surfaces remain unchanged.
- Local-first guarantees and privacy posture are preserved: no network, storage, or data-flow behavior changes.
- The added cross-locale boundary guard and regression coverage improve long-term maintainability and prevent recurrence.
- Pre-existing Russian escape-sequence issues and unrelated extraction findings remain outside scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->