### PR TITLE
fix: invalidate enhanced recall cache on memory invalidation

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -3979,6 +3979,25 @@ class BeamMemory:
                 )
         return rows
 
+    def _invalidate_query_cache(self) -> None:
+        """Clear the existing enhanced-recall cache without creating an empty one."""
+        cache = getattr(self, "_query_cache", None)
+        if cache is not None:
+            cache.invalidate()
+            return
+        if QueryCache is None:
+            return
+
+        cache_db = self.db_path.parent / "query_cache.db"
+        if not cache_db.exists():
+            return
+
+        cache = QueryCache(db_path=cache_db)
+        try:
+            cache.invalidate()
+        finally:
+            cache.close()
+
     def invalidate(self, memory_id: str, replacement_id: str = None) -> bool:
         """
         Mark a memory as invalid/superseded.
@@ -3995,6 +4014,7 @@ class BeamMemory:
         """, (now, replacement_id, memory_id, self.session_id))
         if cursor.rowcount > 0:
             self.conn.commit()
+            self._invalidate_query_cache()
             return True
         # Try episodic_memory
         cursor.execute("""
@@ -4002,8 +4022,11 @@ class BeamMemory:
             SET valid_until = ?, superseded_by = ?
             WHERE id = ? AND (session_id = ? OR scope = 'global')
         """, (now, replacement_id, memory_id, self.session_id))
+        invalidated = cursor.rowcount > 0
         self.conn.commit()
-        return cursor.rowcount > 0
+        if invalidated:
+            self._invalidate_query_cache()
+        return invalidated
 
     def _detect_conflicts(self, rows: List[Dict], similarity_threshold: float = 0.88) -> List[tuple]:
         """

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -54,6 +54,137 @@ def _call(memory: BeamMemory, query: str = "private query", **kwargs):
     )
 
 
+def _close_memory(memory: BeamMemory | None) -> None:
+    if memory is None:
+        return
+    try:
+        cache = getattr(memory, "_query_cache", None)
+        if cache is not None:
+            cache.close()
+    finally:
+        memory.conn.close()
+
+
+def test_successful_invalidate_clears_persisted_enhanced_recall_cache(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "1")
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    monkeypatch.setattr(
+        beam_module, "resolve_beam_runtime", lambda: SimpleNamespace(cross_session=False)
+    )
+    db_path = tmp_path / "memories.db"
+    memory = None
+    fresh = None
+    try:
+        memory = BeamMemory(session_id="session-a", db_path=db_path)
+        memory_id = memory.remember(
+            "issue 550 persistent cache invalidation sentinel",
+            source="test",
+            importance=1.0,
+        )
+        warm = _call(memory, "issue 550 persistent cache invalidation sentinel", top_k=3)
+        assert memory_id in {result["id"] for result in warm}
+        assert _call(memory, "issue 550 persistent cache invalidation sentinel", top_k=3) == warm
+        assert memory._query_cache is not None
+
+        cache_version = memory._query_cache.stats()["version"]
+        assert memory.invalidate("missing-memory") is False
+        assert memory._query_cache.stats()["version"] == cache_version
+
+        assert memory.invalidate(memory_id) is True
+        assert memory._query_cache.stats()["version"] == cache_version + 1
+        current = _call(memory, "issue 550 persistent cache invalidation sentinel", top_k=3)
+        assert memory_id not in {result["id"] for result in current}
+
+        fresh = BeamMemory(session_id="session-a", db_path=db_path)
+        reloaded = _call(fresh, "issue 550 persistent cache invalidation sentinel", top_k=3)
+        assert memory_id not in {result["id"] for result in reloaded}
+    finally:
+        try:
+            _close_memory(fresh)
+        finally:
+            _close_memory(memory)
+
+
+def test_invalidate_without_local_query_cache_clears_persisted_enhanced_recall_cache(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "1")
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    monkeypatch.setattr(
+        beam_module, "resolve_beam_runtime", lambda: SimpleNamespace(cross_session=False)
+    )
+    db_path = tmp_path / "memories.db"
+    source = None
+    invalidator = None
+    fresh = None
+    try:
+        source = BeamMemory(session_id="session-a", db_path=db_path)
+        memory_id = source.remember(
+            "issue 554 cross-instance persistent cache invalidation sentinel",
+            source="test",
+            importance=1.0,
+        )
+        warm = _call(source, "issue 554 cross-instance persistent cache invalidation sentinel", top_k=3)
+        assert memory_id in {result["id"] for result in warm}
+        assert source._query_cache is not None
+
+        cache_db = db_path.parent / "query_cache.db"
+        assert cache_db.is_file()
+        invalidator = BeamMemory(session_id="session-a", db_path=db_path)
+        assert not hasattr(invalidator, "_query_cache")
+        assert invalidator.invalidate(memory_id) is True
+
+        fresh = BeamMemory(session_id="session-a", db_path=db_path)
+        reloaded = _call(fresh, "issue 554 cross-instance persistent cache invalidation sentinel", top_k=3)
+        assert memory_id not in {result["id"] for result in reloaded}
+    finally:
+        try:
+            _close_memory(fresh)
+        finally:
+            try:
+                _close_memory(invalidator)
+            finally:
+                _close_memory(source)
+
+
+def test_successful_invalidate_episodic_memory_invalidates_enhanced_recall_cache(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "1")
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    monkeypatch.setattr(
+        beam_module, "resolve_beam_runtime", lambda: SimpleNamespace(cross_session=False)
+    )
+    memory = None
+    fresh = None
+    try:
+        memory = BeamMemory(session_id="session-a", db_path=tmp_path / "memories.db")
+        episodic_id = memory.consolidate_to_episodic(
+            "issue 550 episodic cache invalidation sentinel",
+            source_wm_ids=[],
+            source="test",
+            importance=1.0,
+        )
+
+        warm = _call(memory, "issue 550 episodic cache invalidation sentinel", top_k=3)
+        episodic_result = next(result for result in warm if result["id"] == episodic_id)
+        assert episodic_result["tier"] == "episodic"
+        assert memory._query_cache is not None
+
+        cache_version = memory._query_cache.stats()["version"]
+        assert memory.invalidate(episodic_id) is True
+        assert memory._query_cache.stats()["version"] == cache_version + 1
+        fresh = BeamMemory(session_id="session-a", db_path=memory.db_path)
+        current = _call(fresh, "issue 550 episodic cache invalidation sentinel", top_k=3)
+        assert fresh._query_cache is not None
+        assert episodic_id not in {result["id"] for result in current}
+    finally:
+        try:
+            _close_memory(fresh)
+        finally:
+            _close_memory(memory)
+
+
 def test_v2_request_digest_is_opaque_persisted_and_exact_hits_once(enhanced):
     memory, calls = enhanced
 


### PR DESCRIPTION
## Summary

Fixes #550 by invalidating the Enhanced Recall query cache after a successful `BeamMemory.invalidate()` update.

- preserves the existing boolean return contract;
- leaves the cache untouched for missing or unauthorized IDs;
- covers both working and episodic rows;
- proves a fresh `BeamMemory` no longer reloads the stale persisted result.

## Validation

```text
MNEMOSYNE_NO_EMBEDDINGS=1 pytest -q tests/test_enhanced_recall_cache.py tests/test_query_cache_synonyms.py
19 passed
```

## Scope

This remains a narrow same-owner/fresh-instance fix. Live peer coherence is tracked separately in #552; `forget_working()` cache invalidation is tracked in #553.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes stale Enhanced Recall results after `BeamMemory.invalidate()` by clearing the enhanced-recall `QueryCache` only when a row update successfully invalidates data (working-memory first, otherwise episodic-memory). The new `_invalidate_query_cache()` helper invalidates the in-memory cache when present; if not, it invalidates the persisted on-disk `query_cache.db` only when the file already exists, and always closes any `QueryCache` it opens. This preserves `invalidate()`’s boolean return contract and leaves the cache untouched for missing/unauthorized IDs.

Regression tests verify a fresh `BeamMemory` instance (including a second SQLite/WAL connection scenario) does not reload stale persisted Enhanced Recall cache entries, and that both working and episodic rows are handled.

## Architectural impact

- **Tiered memory (working/episodic/BEAM):** Retrieval correctness improves without changing BEAM’s tiering rules or episodic consolidation logic. Cache invalidation is now correctly coordinated with successful working/episodic invalidation commits.
- **Retrieval strategy:** No ranking/TTL/eviction/retrieval-design changes—only cache coherence for Enhanced Recall.
- **Local-first / privacy posture:** Strengthens local consistency by ensuring invalidated local memories are not returned from warm persisted Enhanced Recall cache after a new process/connection. No new network calls or sync behavior introduced; cache-only coherence is handled locally and defensively (doesn’t create an empty cache DB).
- **Maintainability:** The right call for limited scope—centralizing cache-clearing in a single helper reduces duplication and makes the “invalidate-then-clear-cache” success semantics explicit. Tests also harden teardown by deterministically closing query-cache resources.

## Explicitly unchanged / out of scope

- No changes to the consolidation pipeline, veracity system, sync layer, or benchmark methodology.
- **`forget_working()` cascade behavior** remains separate; it does not include Enhanced Recall query-cache invalidation in this patch, consistent with the stated scope limitation.
- No API surface changes are required for **Hermes, MCP, SDK, or CLI**: they already route through `BeamMemory`, so correctness improves transparently without modifying integration layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->