### PR TITLE
fix(recall): treat blank query_time as unset (#555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
+## [Unreleased]
+
+### Fixed
+
+- **`mnemosyne_recall` crashed on its own schema default (#555).** The tool schema declared `query_time` with `"default": ""`, but `_parse_query_time` mapped only `None` to "now" — a blank string fell through to the ISO parser and raised `Invalid query_time format: ''`. Any MCP harness that sends declared defaults could not call `mnemosyne_recall` at all. Blank and whitespace-only values are now treated as unset, the MCP handler normalizes `""` to `None` (matching the `or None` idiom already used for `valid_until` and `as_of`), and the schema no longer advertises a default that means "omitted". Thanks @dalkommatt for the report and the diagnosis.
+- **Enhanced Recall served invalidated rows until TTL expiry (#550, #554).** `BeamMemory.invalidate()` now clears the query cache after a successful update, including the persisted `query_cache.db` when the instance has no in-memory cache of its own. Missing or unauthorized IDs leave the cache untouched. Remaining gaps are tracked in #552 (live peer coherence), #553 (`forget_working`) and #556 (`remember`/update paths).
+- **Catastrophic regex backtracking in version-string extraction (#544).** The pattern used by `extract_and_store_facts` could be driven into exponential backtracking by Title-Case input, hanging every `remember()` and import on attacker- or user-supplied content. The separator is now `\s+`, which makes each whitespace-delimited word consumable exactly one way. Behavioral equivalence was verified across a 200,000-string fuzz with zero differences.
+
 ## [3.15.0] - 2026-07-20
 
 ### Fixed

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.15.0"
+__version__ = "3.15.1"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1463,9 +1463,10 @@ def _parse_query_time(query_time: Optional[Union[str, datetime]]) -> datetime:
     - datetime -> normalized to UTC
     Naive values are treated as UTC for backward compatibility.
 
-    A blank string is treated as "unset" because the ``mnemosyne_recall`` tool
-    schema declares ``query_time`` with ``"default": ""``, so MCP harnesses that
-    send declared defaults deliver ``""`` rather than omitting the field.
+    A blank string is treated as "unset" for compatibility with callers that
+    send ``""`` to mean "omitted" — notably MCP harnesses built against the
+    older ``mnemosyne_recall`` schema, which declared ``query_time`` with
+    ``"default": ""`` (see #555). Non-string falsey values are still rejected.
     """
     if query_time is None:
         return datetime.now(timezone.utc)

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1454,12 +1454,18 @@ def _recency_decay(timestamp_str: str, halflife_hours: float = RECENCY_HALFLIFE_
 def _parse_query_time(query_time: Optional[Union[str, datetime]]) -> datetime:
     """Parse query_time parameter into a timezone-aware UTC datetime object.
 
-    - None -> current UTC time
+    - None (or a blank/whitespace-only string) -> current UTC time
     - str  -> parsed from ISO format and normalized to UTC
     - datetime -> normalized to UTC
     Naive values are treated as UTC for backward compatibility.
+
+    A blank string is treated as "unset" because the ``mnemosyne_recall`` tool
+    schema declares ``query_time`` with ``"default": ""``, so MCP harnesses that
+    send declared defaults deliver ``""`` rather than omitting the field.
     """
     if query_time is None:
+        return datetime.now(timezone.utc)
+    if isinstance(query_time, str) and not query_time.strip():
         return datetime.now(timezone.utc)
     if isinstance(query_time, datetime):
         return _normalize_datetime_utc(query_time)

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -332,7 +332,7 @@ def _handle_recall(arguments: Dict[str, Any]) -> Dict[str, Any]:
     top_k = int(arguments.get("limit", arguments.get("top_k", 5)))
     bank = _resolve_bank(arguments)
     temporal_weight = arguments.get("temporal_weight", 0.0)
-    query_time = arguments.get("query_time")
+    query_time = arguments.get("query_time") or None
     temporal_halflife = arguments.get("temporal_halflife", 24)
     vec_weight = arguments.get("vec_weight")
     fts_weight = arguments.get("fts_weight")

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -332,7 +332,13 @@ def _handle_recall(arguments: Dict[str, Any]) -> Dict[str, Any]:
     top_k = int(arguments.get("limit", arguments.get("top_k", 5)))
     bank = _resolve_bank(arguments)
     temporal_weight = arguments.get("temporal_weight", 0.0)
-    query_time = arguments.get("query_time") or None
+    query_time = arguments.get("query_time")
+    # "" (and whitespace) means "omitted" for callers built against the older
+    # schema (#555). Deliberately narrower than `or None`, which both misses
+    # whitespace-only strings (truthy) and swallows falsey non-strings such as
+    # 0/False/[] that must still reach _parse_query_time's TypeError.
+    if isinstance(query_time, str) and not query_time.strip():
+        query_time = None
     temporal_halflife = arguments.get("temporal_halflife", 24)
     vec_weight = arguments.get("vec_weight")
     fts_weight = arguments.get("fts_weight")

--- a/mnemosyne/tool_schemas.py
+++ b/mnemosyne/tool_schemas.py
@@ -61,8 +61,7 @@ RECALL_SCHEMA = {
             },
             "query_time": {
                 "type": "string",
-                "description": "ISO timestamp to treat as 'now' for temporal scoring. Default is current time.",
-                "default": "",
+                "description": "ISO timestamp to treat as 'now' for temporal scoring. Omit to use the current time.",
             },
             "temporal_halflife": {
                 "type": "number",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -387,6 +387,51 @@ class TestToolHandlers:
         assert kwargs["fts_weight"] == 0.3
         assert kwargs["importance_weight"] == 0.1
 
+    def test_handle_recall_normalizes_blank_query_time(self, mock_mnemosyne):
+        """Blank query_time reaches Mnemosyne.recall() as unset, not as "" (#555).
+
+        Harnesses built against the older schema sent the declared default "",
+        which used to reach _parse_query_time and raise.
+        """
+        for blank in ("", "   ", "\t"):
+            mock_mnemosyne.recall.reset_mock()
+            with patch("mnemosyne.mcp_tools._create_instance", return_value=mock_mnemosyne):
+                handle_tool_call("mnemosyne_recall", {
+                    "query": "test query",
+                    "bank": "default",
+                    "query_time": blank,
+                })
+            _, kwargs = mock_mnemosyne.recall.call_args
+            assert kwargs["query_time"] is None, f"blank {blank!r} not normalized"
+
+    def test_handle_recall_preserves_explicit_query_time(self, mock_mnemosyne):
+        """A real ISO timestamp is forwarded untouched."""
+        with patch("mnemosyne.mcp_tools._create_instance", return_value=mock_mnemosyne):
+            handle_tool_call("mnemosyne_recall", {
+                "query": "test query",
+                "bank": "default",
+                "query_time": "2026-04-29T12:00:00",
+            })
+        _, kwargs = mock_mnemosyne.recall.call_args
+        assert kwargs["query_time"] == "2026-04-29T12:00:00"
+
+    def test_handle_recall_does_not_swallow_falsey_non_strings(self, mock_mnemosyne):
+        """0/False/[] are type errors, not "unset" — they must not become None.
+
+        Guards against normalizing with `or None`, which would silently accept
+        them and suppress _parse_query_time's TypeError.
+        """
+        for bad in (0, False, []):
+            mock_mnemosyne.recall.reset_mock()
+            with patch("mnemosyne.mcp_tools._create_instance", return_value=mock_mnemosyne):
+                handle_tool_call("mnemosyne_recall", {
+                    "query": "test query",
+                    "bank": "default",
+                    "query_time": bad,
+                })
+            _, kwargs = mock_mnemosyne.recall.call_args
+            assert kwargs["query_time"] is not None, f"{bad!r} silently treated as unset"
+
     def test_handle_sleep(self, mock_mnemosyne):
         """handle_sleep returns consolidation stats."""
         with patch("mnemosyne.mcp_tools._create_instance", return_value=mock_mnemosyne):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -430,7 +430,9 @@ class TestToolHandlers:
                     "query_time": bad,
                 })
             _, kwargs = mock_mnemosyne.recall.call_args
-            assert kwargs["query_time"] is not None, f"{bad!r} silently treated as unset"
+            # Identity, not equality: 0 == False in Python, so `==` would let a
+            # bool/int mix-up pass. The exact object must be forwarded.
+            assert kwargs["query_time"] is bad, f"{bad!r} not forwarded unchanged"
 
     def test_handle_sleep(self, mock_mnemosyne):
         """handle_sleep returns consolidation stats."""

--- a/tests/test_temporal_recall.py
+++ b/tests/test_temporal_recall.py
@@ -112,6 +112,39 @@ class TestParseQueryTime(unittest.TestCase):
         result = _parse_query_time("2026-04-29")
         self.assertEqual(result, datetime(2026, 4, 29, 0, 0, 0, tzinfo=timezone.utc))
 
+    def test_blank_string_returns_now(self):
+        """Empty string -> current UTC time (issue #555).
+
+        The mnemosyne_recall tool schema previously declared query_time with
+        ``"default": ""``, so MCP harnesses that send declared defaults deliver
+        "" rather than omitting the field. That must not be an error.
+        """
+        result = _parse_query_time("")
+        self.assertIsInstance(result, datetime)
+        self.assertEqual(result.tzinfo, timezone.utc)
+        self.assertLess((datetime.now(timezone.utc) - result).total_seconds(), 1.0)
+
+    def test_whitespace_string_returns_now(self):
+        """Whitespace-only string is treated as unset, not as a bad timestamp."""
+        for blank in ("   ", "\t", "\n"):
+            with self.subTest(blank=repr(blank)):
+                result = _parse_query_time(blank)
+                self.assertEqual(result.tzinfo, timezone.utc)
+                self.assertLess(
+                    (datetime.now(timezone.utc) - result).total_seconds(), 1.0
+                )
+
+    def test_recall_tool_schema_does_not_declare_blank_default(self):
+        """The schema must not advertise a default that means 'unset' (issue #555)."""
+        from mnemosyne.tool_schemas import ALL_TOOL_SCHEMAS
+
+        recall = next(
+            schema for schema in ALL_TOOL_SCHEMAS
+            if schema["name"] == "mnemosyne_recall"
+        )
+        query_time = recall["parameters"]["properties"]["query_time"]
+        self.assertNotIn("default", query_time)
+
     def test_invalid_string_raises(self):
         """Invalid string raises ValueError."""
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Fixes #555.

## The bug

`tool_schemas.py` declared the `mnemosyne_recall` tool's `query_time` with `"default": ""`, but `_parse_query_time` (`beam.py:1454`) mapped only `None` to "now". A blank string fell through to the `str` branch and raised:

```
Invalid query_time format: ''. Expected ISO datetime string.
```

So **any MCP harness that sends declared defaults could not call `mnemosyne_recall` at all** — the tool hard-failed on its own advertised default, while passing an explicit ISO timestamp worked. @dalkommatt observed this with Claude Code / eve-style harnesses.

## Why it was a one-off

Every sibling blank-defaulted parameter already guards for this — `valid_until` uses `arguments.get(...) or None` (`mcp_tools.py:270`), and `as_of` is `or`-guarded inside `TripleStore.query` (`triples.py:205`). `query_time` at `mcp_tools.py:335` was the single place that missed the idiom. I audited the other `"default": ""` parameters (`valid_from`, `valid_until`, `as_of`, `subject`/`predicate`/`object`, `replacement_id`, `validator`, `new_content`, `note`) and found no second instance.

## Fix

Three layers, so this is closed for SDK callers too, not just MCP:

1. **`_parse_query_time`** treats blank/whitespace-only strings as unset, honoring the docstring's `None -> current UTC time` contract.
2. **The MCP handler** normalizes `""` to `None`, matching the existing sibling idiom.
3. **The schema** no longer advertises a default that means "omitted".

## Tests

Three added to `TestParseQueryTime`, all verified to **fail on unpatched source and pass patched**:

| test | on unpatched `main` |
|---|---|
| `test_blank_string_returns_now` | FAILED |
| `test_whitespace_string_returns_now` | SUBFAILED ×3 (`'   '`, `'\t'`, `'\n'`) |
| `test_recall_tool_schema_does_not_declare_blank_default` | FAILED |

`tests/test_temporal_recall.py`: 27 passed (24 pre-existing + 3 new). Adjacent suites show an **identical failure set before and after** the change, so no regressions. (`tests/test_mcp_server.py` has 6 failures in my local env from missing optional deps; they are present on pristine `main` too and CI is green.)

## Also in this PR

The CHANGELOG entries owed for #544 and #554, which both landed without one despite `CONTRIBUTING.md:32`, plus the `3.15.1` bump. Flagging that I merged those two in that state — my inconsistency, swept up here rather than bounced back to the contributors.

Reported and correctly diagnosed by @dalkommatt, who also proposed essentially this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Treats `mnemosyne_recall` `query_time` values that are `""` or whitespace-only as “unset,” so recall uses the current UTC time instead of attempting ISO parsing.
- Normalizes blank values at the MCP/tool boundary (converting blank/whitespace strings to `None`), removes the schema’s blank-string default, and preserves explicit ISO timestamps; non-string falsey inputs remain rejected.
- Adds regression coverage for parser behavior, schema defaults, MCP normalization, and explicit timestamps.
- Improves local query-cache consistency by clearing enhanced-recall/query cache only after successful `BeamMemory.invalidate()` updates (avoids touching cache for missing/unauthorized IDs).
- Hardens long-running regex work in fact extraction: version-string extraction regex was tightened to avoid catastrophic backtracking risk.

## Architectural impact

- **Core memory architecture (working/episodic/BEAM):** No changes to tiering, consolidation pipeline, veracity/trust scoring, or the underlying storage model. The change only affects *how recall interprets a time parameter* (temporal boost input) and *cache invalidation correctness*.
- **Retrieval strategy:** Retrieval logic remains the same; only the temporal query-time interpretation is adjusted so the temporal scoring path receives a valid UTC datetime (now) when the caller “omits” `query_time` via blank defaults.
- **Local-first / privacy posture:** Preserved. Updates are confined to local input normalization, local database state changes, and local cache invalidation—no added network calls, telemetry, or sharing behavior.
- **Agent integration surfaces (Hermes/MCP/CLI):** Improves MCP harness compatibility with tool schema defaults by preventing blank `query_time` from propagating into ISO parsing. Schema documentation now reflects omission semantics rather than advertising a blank default; CLI and core recall API semantics are otherwise unchanged.
- **Maintainability:** Clearer “omit vs explicit timestamp” contract via schema + boundary normalization, with defense-in-depth in the core parser. The cache invalidation and regex hardening reduce hard-to-debug state skew and performance hazards, respectively.

## Long-term risk assessment

- **Architectural win:** The right-call layering—tool/MCP normalization plus core parser behavior—prevents brittle dependence on upstream schema defaults and makes temporal recall more robust.
- **Local-first erosion check:** No erosion. The only functional behavior change is deterministic/local (timestamp parsing + cache invalidation + safer regex), not a new integration surface or data-exchange pathway.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->