### PR TITLE
feat(diagnostics): report resolved embedding dimension in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ## [Unreleased]
 
+### Added
+
+- **Embedding dimension in doctor diagnostics.** `collect_runtime_diagnostics` (surfaced by `mnemosyne doctor`) now reports the resolved `embeddings_dim` alongside `embeddings_model`, so operators can confirm their `MNEMOSYNE_EMBEDDING_DIM` / model-table resolution without inspecting a traceback. Complements the fail-loud unknown-model resolver (#521); the version bump is deferred to that PR to avoid a duplicate bump.
+
 ### Fixed
 
 - **Model-refresh confidence: NaN cleared every gate and legacy text crashed sleep mid-batch.** JSON round-trips NaN and Infinity, and `parse_model_update_proposals` clamped NaN to 1.0 (`min` and `max` keep their first argument when a NaN comparison is False), so a NaN-confidence proposal became a top-importance memory; the auto-apply gate's `confidence < minimum` check is also False for NaN, so the same proposal reached the canonical store regardless of threshold. Separately, `apply_model_refresh_proposal` and sleep()'s proposal-remember call site converted stored confidence with a bare `float()`, so a legacy bank's text value (for example `"high"`) raised ValueError. The sleep call site runs after the claim commit, so that raise stranded the group's `consolidation_claimed_at` and orphaned every later group's claimed rows. Non-numeric and non-finite confidence now degrades per site: skipped at parse, 0.0 at the auto-apply gate, 0.5 at apply and at proposal importance. Finite values outside [0.0, 1.0] clamp to the domain bound on every path, so a persisted 2.0 can no longer clear the auto-apply gate or reach the canonical store unbounded. Hardening split out of #546 per review.

--- a/mnemosyne/doctor.py
+++ b/mnemosyne/doctor.py
@@ -467,6 +467,7 @@ _RUNTIME_CHECK_NAMES = frozenset(
         "ctransformers",
         "embeddings_available",
         "embeddings_model",
+        "embeddings_dim",
         "sqlite_vec_available",
         "sqlite_vec_warning",
     }

--- a/mnemosyne/runtime_diagnostics.py
+++ b/mnemosyne/runtime_diagnostics.py
@@ -64,6 +64,10 @@ def collect_runtime_diagnostics() -> dict[str, Any]:
 
         add("core", "embeddings_available", "YES" if _embeddings.available() else "NO")
         add("core", "embeddings_model", "OK", _embeddings._DEFAULT_MODEL)
+        # Surface the resolved dimension so operators can confirm their
+        # MNEMOSYNE_EMBEDDING_DIM / model-table resolution via the doctor,
+        # complementing the fail-loud unknown-model resolver.
+        add("core", "embeddings_dim", "OK", str(_embeddings.EMBEDDING_DIM))
     except Exception:
         add("core", "embeddings_available", "ERROR", "embeddings capability unavailable")
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -332,11 +332,17 @@ def test_runtime_diagnostics_marks_sqlite_vec_available_only_after_loading(monke
     )
 
 
-def test_runtime_diagnostics_reports_embedding_model_and_dim():
+def test_runtime_diagnostics_reports_embedding_model_and_dim(monkeypatch):
     """The doctor surface reports the configured embedding model AND its
-    resolved dimension, so operators can verify MNEMOSYNE_EMBEDDING_DIM /
-    model-table resolution without inspecting a traceback."""
-    from mnemosyne import runtime_diagnostics
+    resolved dimension, and the doctor's sanitization boundary surfaces
+    embeddings_dim (it is allowlisted), so operators can verify
+    MNEMOSYNE_EMBEDDING_DIM / model-table resolution without a traceback."""
+    from mnemosyne import doctor, runtime_diagnostics
+    from mnemosyne.core import embeddings
+
+    # Control the dimension so the test asserts exact propagation rather than
+    # just "some positive integer".
+    monkeypatch.setattr(embeddings, "EMBEDDING_DIM", 123)
 
     result = runtime_diagnostics.collect_runtime_diagnostics()
     checks = {entry["check"]: entry for entry in result["checks"]}
@@ -344,7 +350,13 @@ def test_runtime_diagnostics_reports_embedding_model_and_dim():
     assert checks["embeddings_model"]["status"] == "OK"
     dim = checks["embeddings_dim"]
     assert dim["status"] == "OK"
-    assert int(dim["detail"]) > 0
+    assert dim["detail"] == "123"
+
+    # The doctor surfaces embeddings_dim through its sanitization boundary
+    # (it is in _RUNTIME_CHECK_NAMES); an allowlist regression would silently
+    # drop it.
+    sanitized = doctor._sanitize_runtime_diagnostics(result)
+    assert any(entry["check"] == "embeddings_dim" for entry in sanitized["checks"])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -332,6 +332,21 @@ def test_runtime_diagnostics_marks_sqlite_vec_available_only_after_loading(monke
     )
 
 
+def test_runtime_diagnostics_reports_embedding_model_and_dim():
+    """The doctor surface reports the configured embedding model AND its
+    resolved dimension, so operators can verify MNEMOSYNE_EMBEDDING_DIM /
+    model-table resolution without inspecting a traceback."""
+    from mnemosyne import runtime_diagnostics
+
+    result = runtime_diagnostics.collect_runtime_diagnostics()
+    checks = {entry["check"]: entry for entry in result["checks"]}
+
+    assert checks["embeddings_model"]["status"] == "OK"
+    dim = checks["embeddings_dim"]
+    assert dim["status"] == "OK"
+    assert int(dim["detail"]) > 0
+
+
 @pytest.mark.parametrize(
     ("raw_python_path", "safe_python_executable"),
     [


### PR DESCRIPTION
Follow-up to #521, addressing the "diagnostics surface" coverage gap @AxDSan noted there.

`collect_runtime_diagnostics` (surfaced by `mnemosyne doctor`) reported `embeddings_model` but not the dimension. The fail-loud resolver (#521) makes the dimension the critical config value, so the doctor should show it. This adds `core/embeddings_dim` (the resolved `EMBEDDING_DIM`) alongside `embeddings_model`, allowlists it in the doctor, and tests it.

**Happy to fold this into #521 as a single PR if the maintainers prefer** (it would ride #521's 3.16.0 version bump; the version bump is intentionally deferred here to avoid a duplicate).

- `runtime_diagnostics.collect_runtime_diagnostics`: add `core/embeddings_dim`.
- `doctor._RUNTIME_CHECK_NAMES`: allowlist `embeddings_dim` so the doctor surfaces it.
- `tests/test_doctor.py`: assert model + a positive-integer dim are reported.
- `CHANGELOG`: `[Unreleased]` entry.

Tests: `pytest tests/test_doctor.py` -> 47 passed, 2 skipped. CI ruff (`E9,F63,F7,F82`) clean. Verified empirically: `embeddings_model=BAAI/bge-small-en-v1.5`, `embeddings_dim=384`.

CLA: happy to sign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds resolved embedding dimension reporting to `mnemosyne doctor` through `core/embeddings_dim`, alongside `core/embeddings_model`. The doctor sanitizer allowlist now permits this field. Tests verify exact dimension propagation and `OK` status.

- **Core architecture:** No changes to working, episodic, or BEAM memory tiers; retrieval; consolidation; veracity; sync; or benchmark methodology. This change adds runtime metadata only.
- **Privacy and local-first guarantees:** The change is read-only. It adds no persistence, network activity, provider interaction, or new data flow. It preserves the doctor sanitization boundary.
- **Agent integration:** Only the `mnemosyne doctor` CLI output changes. Hermes and MCP surfaces remain unchanged.
- **Maintainability:** The change is small and focused. Regression coverage and an `[Unreleased]` changelog entry are included. The version bump remains deferred.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->