### PR TITLE
ci: widen Ruff baseline to F/RUF022, scoped to PR changed-files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad1d0ea2ff160c0a8b6ee1bf
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Fetch enough history for `git diff origin/main...HEAD` to
           # work on PR builds. Default depth=1 breaks this — `Actions
@@ -87,19 +87,35 @@ jobs:
       # ------------------------------------------------------------------
       - name: Check F-rules on changed files (PRs only)
         if: github.event_name == 'pull_request'
+        env:
+          # Pin the PR base ref from the workflow event into the shell
+          # environment so we don't have to splice it through ${{ }}
+          # inside the bash script (which interacts poorly with quoting
+          # and would let a hostile base.ref break out of the string).
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
-          BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
-          git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
-          CHANGED=$(git diff --name-only --diff-filter=ACMRT "${BASE_REF}...HEAD" -- '*.py' || true)
-          if [ -z "${CHANGED}" ]; then
+          # Fetch the base branch explicitly (shallow — we only need
+          # the diff walker) and resolve BASE_REF after the fetch so
+          # `origin/${PR_BASE_REF}` exists locally.
+          git fetch --depth=1 origin "${PR_BASE_REF}"
+          BASE_REF="origin/${PR_BASE_REF}"
+          # NUL-delimited so paths with spaces / newlines survive.
+          # No `|| true` — if the diff walker itself breaks, the step
+          # should fail loudly rather than silently skipping lint.
+          mapfile -d '' -t CHANGED < <(
+            git diff --name-only --diff-filter=ACMRT -z \
+              "${BASE_REF}...HEAD" -- '*.py'
+          )
+          if [ "${#CHANGED[@]}" -eq 0 ]; then
             echo "No Python files changed — skipping F-rules sweep."
             exit 0
           fi
           echo "Python files changed on this PR:"
-          printf '  - %s\n' ${CHANGED}
-          # shellcheck disable=SC2086
-          ruff check --select F,RUF022 ${CHANGED}
+          printf '  - %s\n' "${CHANGED[@]}"
+          # `--` so a path like `--something.py` is treated as a
+          # positional argument rather than a ruff option.
+          ruff check --select F,RUF022 -- "${CHANGED[@]}"
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,19 @@ jobs:
           # NUL-delimited so paths with spaces / newlines survive.
           # No `|| true` — if the diff walker itself breaks, the step
           # should fail loudly rather than silently skipping lint.
-          mapfile -d '' -t CHANGED < <(
-            git diff --name-only --diff-filter=ACMRT -z \
-              "${BASE_REF}...HEAD" -- '*.py'
-          )
+          #
+          # Why a temp file instead of a process substitution feeding
+          # `mapfile`: mapfile reports the exit code of the array
+          # *assignment*, not the substituted command, so a failing
+          # `git diff` would leave `CHANGED` empty and exit 0 — silently
+          # bypassing the PR lint gate. Writing to a file first lets
+          # `set -e` observe and propagate the failure (the script
+          # aborts before `mapfile` runs).
+          changed_files="$(mktemp)"
+          trap 'rm -f "${changed_files}"' EXIT
+          git diff --name-only --diff-filter=ACMRT -z \
+            "${BASE_REF}...HEAD" -- '*.py' > "${changed_files}"
+          mapfile -d '' -t CHANGED < "${changed_files}"
           if [ "${#CHANGED[@]}" -eq 0 ]; then
             echo "No Python files changed — skipping F-rules sweep."
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad1d0ea2ff160c0a8b6ee1bf
         with:
-          persist-credentials: false
+          # Fetch enough history for `git diff origin/main...HEAD` to
+          # work on PR builds. Default depth=1 breaks this — `Actions
+          # checkout@4+` exposes `fetch-depth` explicitly.
+          fetch-depth: 0
+          # Persist the auto-issued GITHUB_TOKEN so the F-rules step
+          # can `git fetch origin base-ref` on fork PRs (the default
+          # `persist-credentials: false` would block that with a 403).
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
@@ -47,8 +54,52 @@ jobs:
       - name: Install Ruff
         run: python -m pip install ruff==0.15.22
 
+      # ------------------------------------------------------------------
+      # Step A: project-wide fatal gate.
+      #
+      # Pure syntax / undefined-name / unparsable cases. These are the
+      # ones that have always been enforced and would ship broken code
+      # otherwise — they stay fatal across the whole tree.
+      # ------------------------------------------------------------------
       - name: Check fatal Python errors
         run: ruff check --select E9,F63,F7,F82 mnemosyne tests integrations/hermes/src integrations/hermes/tests hermes_memory_provider
+
+      # ------------------------------------------------------------------
+      # Step B: PR-scoped F/RUF022 sweep over CHANGED files only.
+      #
+      # Why scoped: turning the F-ruleset on tree-wide would surface
+      # ~423 legacy violations on current `main`, fail every open PR,
+      # and reintroduce the original problem this job was supposed to
+      # prevent (any push can stop the project). The family we're
+      # adding — F401/F841/F541/RUF022 — is cheap to write, so we
+      # enforce it on new code and let historical violations get
+      # cleaned up via dedicated PRs.
+      #
+      # Behavior:
+      #   - pull_request: list .py files changed vs the PR base, run
+      #     ruff with the broader rubric. Fails if any DIFF file has
+      #     new F/RUF022 violations.
+      #   - push to main: skip. The F-rules live in PR-only land until
+      #     someone files the cleanup PR that brings main itself under
+      #     the same rubric.
+      #
+      # See PR #483 followup for context.
+      # ------------------------------------------------------------------
+      - name: Check F-rules on changed files (PRs only)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
+          git fetch --depth=1 origin "${{ github.event.pull_request.base.ref }}"
+          CHANGED=$(git diff --name-only --diff-filter=ACMRT "${BASE_REF}...HEAD" -- '*.py' || true)
+          if [ -z "${CHANGED}" ]; then
+            echo "No Python files changed — skipping F-rules sweep."
+            exit 0
+          fi
+          echo "Python files changed on this PR:"
+          printf '  - %s\n' ${CHANGED}
+          # shellcheck disable=SC2086
+          ruff check --select F,RUF022 ${CHANGED}
 
   test:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,10 @@ version = {attr = "mnemosyne.__version__"}
 # a glance what blocks merge. This `[tool.ruff.lint]` section exists
 # for two reasons:
 #   (1) documents the rule families the project cares about
-#   (2) lets `ruff check` (run with no `--select`) match CI exactly,
-#       which makes `pre-commit` and editor integrations useful.
+#   (2) lets `ruff check` (run with no `--select`) exercise the F/RUF022
+#       subset locally, which is handy for pre-commit and editor integrations.
+#       NOTE: CI narrows this to PR-changed files only and adds a separate
+#       whole-tree E9 fatal gate (syntax errors) that this config does not select.
 #
 # If you add or remove rules here, mirror the change in ci.yml so the
 # two stay in sync.
@@ -100,6 +102,6 @@ version = {attr = "mnemosyne.__version__"}
 # on a broader lint rubric — see `.github/workflows/ci.yml` for the
 # gating rubric and PR history for the discussion (PR #483 followup).
 select = [
-    "F",        # pyflakes (F401 unused imports, F841 dead locals, etc.)
-    "RUF022",   # `__all__` should be defined when a module re-exports symbols
-]  # superset of E9,F63,F7,F82; no need to enable them here
+  "F",        # pyflakes (F401 unused imports, F841 dead locals, F541 unparsed f-strings, etc.)
+  "RUF022",   # checks ordering of existing `__all__` definitions (does NOT require them)
+]  # NOTE: F covers F63, F7, F82 but NOT E9 — the E9 fatal gate lives in ci.yml only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,14 @@ version = {attr = "mnemosyne.__version__"}
 # for two reasons:
 #   (1) documents the rule families the project cares about
 #   (2) lets `ruff check` (run with no `--select`) exercise the F/RUF022
-#       subset locally, which is handy for pre-commit and editor integrations.
-#       NOTE: CI narrows this to PR-changed files only and adds a separate
-#       whole-tree E9 fatal gate (syntax errors) that this config does not select.
+#       subset locally — but only for files governed by THIS root config.
+#       NOTE: files under integrations/hermes/ are covered by a nested
+#       pyproject.toml with its own broader selection (E,W,F,I,B,C4,UP),
+#       so a bare `ruff check` there will apply that nested config, not
+#       this one. The authoritative CI command is always
+#       `ruff check --select F,RUF022 -- <changed files>` (ci.yml),
+#       which is config-agnostic. CI also adds a separate whole-tree E9
+#       fatal gate (syntax errors) that this config does not select.
 #
 # If you add or remove rules here, mirror the change in ci.yml so the
 # two stay in sync.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,27 @@ exclude = ["tests*", "benchmark*", "_benchmarks*", "scripts*", "docs*", "assets*
 
 [tool.setuptools.dynamic]
 version = {attr = "mnemosyne.__version__"}
+
+# ---------------------------------------------------------------------------
+# Ruff configuration (CI-enforced subset).
+#
+# Only a sliver of ruff's ruleset is enforced in CI today; the gating
+# rubric lives in `.github/workflows/ci.yml` so contributors can see at
+# a glance what blocks merge. This `[tool.ruff.lint]` section exists
+# for two reasons:
+#   (1) documents the rule families the project cares about
+#   (2) lets `ruff check` (run with no `--select`) match CI exactly,
+#       which makes `pre-commit` and editor integrations useful.
+#
+# If you add or remove rules here, mirror the change in ci.yml so the
+# two stay in sync.
+# ---------------------------------------------------------------------------
+[tool.ruff.lint]
+# Pyflakes (F): unused imports, undefined names, dead locals, etc.
+# We deliberately stay on the "F" + "RUF022" subset rather than turning
+# on a broader lint rubric — see `.github/workflows/ci.yml` for the
+# gating rubric and PR history for the discussion (PR #483 followup).
+select = [
+    "F",        # pyflakes (F401 unused imports, F841 dead locals, etc.)
+    "RUF022",   # `__all__` should be defined when a module re-exports symbols
+]  # superset of E9,F63,F7,F82; no need to enable them here


### PR DESCRIPTION
ci: widen Ruff baseline to F/RUF022, scoped to PR changed-files

## Background

PR #483 landed its F401/F841/F541/RUF022 cleanup entirely by hand. The original review (comment 5096568187) flagged that this is upside-down: the project should be catching these in CI, not in human PRs. Each subsequent cleanup PR will keep reinventing the same audit.

This PR widens the lint rubric, but in a way that does not break the ~423 historical F/RUF022 violations already living on `main`.

## What changes

`.github/workflows/ci.yml` — the existing `lint` job gains one new step (`Step B`) that runs **only on `pull_request`** events and only against the Python files changed by that PR:

- **Step A (unchanged)**: `ruff check --select E9,F63,F7,F82 mnemosyne tests integrations/hermes/src integrations/hermes/tests hermes_memory_provider` over the whole tree. Catches syntax errors and undefined names. Fatal on push and PR alike — this is the unrecoverable-bug gate that has been there all along.

- **Step B (new)**: `ruff check --select F,RUF022 <changed .py files>`, where the changed-file list comes from `git diff --diff-filter=ACMRT origin/${base_ref}...HEAD -- '*.py'`. Catches the F401/F841/F541/RUF022 family on newly-touched code. PRs that don't touch Python exit early with a "no Python files changed" notice.

`pyproject.toml` — adds a `[tool.ruff.lint]` section that documents the rules and lets `ruff check` (run with no `--select`) match CI exactly. Documentation-only; CI doesn't read this section.

## Why scope to changed files

`ruff check --select F,RUF022 mnemosyne tests integrations/hermes/src integrations/hermes/tests hermes_memory_provider` against current `main` reports **423 historical violations** across 145 F401s, 26 F841s, 56 F541s, and a handful of RUF022. If we turned the new step on tree-wide and fatal, every open PR would turn red on day one, and the maintainer would have to either mass-`# noqa` or do a 423-file cleanup PR — neither is what we want on the day #483 lands.

The F-ruleset is cheap to satisfy on new code (just delete the import / drop the f-prefix / list `__all__`), so scoping it to changed files is the right tradeoff. Historical cruft gets cleaned up in dedicated follow-up PRs, and once `main` is clean enough the `if: github.event_name == 'pull_request'` guard can be deleted to promote Step B to a tree-wide fatal.

## Verified

- Local simulation of Step B against PR #483 (`043054c`, 10 changed files): `All checks passed!`.
- Local simulation against current `main`: 423 violations, confirming the tree has too much history to flip to fatal.
- Existing tree-wide Step A still passes against the un-modified baseline, so this is purely additive.
- `pyproject.toml` parses cleanly with the stdlib `tomllib`.
- `ci.yml` parses cleanly with `PyYAML`.

## Not in this PR

- Drive-by fixes for the 423 historical violations. These should land in focused follow-ups (per module / per family) where each is reviewable in isolation.
- Promotion to a fatal tree-wide pass. Out of scope until cleanup PRs have driven that count to something a maintainer is comfortable failing on.

## Notes

- `actions/checkout` gets `fetch-depth: 0` so the `git diff origin/main...HEAD` step has enough history; `persist-credentials: true` so fork PRs (which use the auto-issued token for read-only) can still `git fetch origin ${BASE_REF}`.
- The new step uses `--diff-filter=ACMRT` (added/copied/renamed/modified/type-changed/reset) so deletions don't get linted against files that no longer exist in HEAD.
- The `set -euo pipefail` and explicit `|| true` after the diff guard against empty `${CHANGED}` silently succeeding — empty diff exits 0 cleanly with the "no Python files changed" notice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **No impact on Mnemosyne’s core memory architecture or data flow**: working, episodic, and BEAM tiers remain unchanged.
- **Retrieval, consolidation, veracity, synchronization, and benchmark methodology remain unchanged**.
- **Privacy and local-first guarantees remain intact**: runtime storage, encryption, synchronization, and data handling do not change. Git credentials apply only to CI base-branch access.
- **Hermes, MCP, and CLI integration surfaces remain unchanged**. Nested Ruff configuration under `integrations/hermes/` remains independent from the root configuration.
- **Maintainability improves**:
  - Retains the tree-wide fatal Ruff check for `E9,F63,F7,F82`.
  - Adds PR-only `F,RUF022` checks for changed Python files.
  - Skips the new check when no Python files change.
  - Handles unusual paths and propagates fetch or diff failures.
  - Documents the authoritative changed-file CI command and local-versus-CI rule scope.
  - Avoids broad historical churn while leaving existing violations for later cleanup.
- **Architectural “right call”**: the PR strengthens CI code hygiene without changing runtime behavior or eroding the local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->