### PR TITLE
fix(mcp): migrate mnemosyne.mcp_server from mcp SDK 1.x to 2.x

### DIFF
--- a/mnemosyne/mcp_server.py
+++ b/mnemosyne/mcp_server.py
@@ -90,26 +90,54 @@ def _resolve_sse_auth(host: str) -> Tuple[bool, Optional[str]]:
 # Server Setup
 # ---------------------------------------------------------------------------
 
+def _build_mcp_server() -> Server:
+    """Build an MCP ``Server`` instance wired to the mnemosyne tool handlers.
+
+    Returns a ``mcp.server.lowlevel.server.Server`` with ``on_list_tools`` and
+    ``on_call_tool`` callbacks installed. Used by both the stdio transport
+    (see ``_run_stdio``) and the SSE transport (see ``_build_sse_app``) so the
+    registration logic stays in one place.
+
+    Migrated from ``mcp`` SDK 1.x to 2.x: the 1.x ``@server.list_tools()`` and
+    ``@server.call_tool()`` decorators were removed in 2.0. The 2.x
+    ``mcp.server.lowlevel.server.Server`` accepts the same callbacks as
+    ``on_list_tools``/``on_call_tool`` keyword arguments on the constructor.
+
+    The ``on_call_tool`` signature also changed in 2.x: callbacks now receive
+    ``(ctx, params)`` where ``params`` is a ``CallToolRequestParams`` carrying
+    ``.name`` and ``.arguments``. The handler returns a ``CallToolResult``
+    instead of a raw list of ``TextContent``.
+    """
+    from mcp.types import CallToolResult, Tool
+
+    async def _on_list_tools(ctx, params):  # noqa: ARG001 — ctx/params unused
+        raw = get_tool_definitions()
+        # The dict from get_tool_definitions() uses ``inputSchema`` (the wire
+        # field name); ``mcp.types.Tool`` accepts it via Pydantic alias and
+        # normalizes to ``input_schema`` on the model. **t spreads both.
+        return [Tool(**t) for t in raw]
+
+    async def _on_call_tool(ctx, params):  # noqa: ARG001 — ctx unused
+        try:
+            result = handle_tool_call(params.name, params.arguments)
+            content = [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+        except Exception as e:
+            content = [TextContent(type="text", text=json.dumps({"status": "error", "message": str(e)}, indent=2))]
+        return CallToolResult(content=content)
+
+    return Server(
+        "mnemosyne",
+        on_list_tools=_on_list_tools,
+        on_call_tool=_on_call_tool,
+    )
+
+
 async def _run_stdio() -> None:
     """Run MCP server over stdio transport."""
     if not _MCP_AVAILABLE:
         raise RuntimeError("MCP not installed. Run: pip install mnemosyne-memory[mcp]")
 
-    server = Server("mnemosyne")
-
-    @server.list_tools()
-    async def list_tools():
-        from mcp.types import Tool
-        raw = get_tool_definitions()
-        return [Tool(**t) for t in raw]
-
-    @server.call_tool()
-    async def call_tool(name: str, arguments: dict) -> list:
-        try:
-            result = handle_tool_call(name, arguments)
-            return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
-        except Exception as e:
-            return [TextContent(type="text", text=json.dumps({"status": "error", "message": str(e)}, indent=2))]
+    server = _build_mcp_server()
 
     async with stdio_server() as (read_stream, write_stream):
         await server.run(read_stream, write_stream, server.create_initialization_options())
@@ -145,21 +173,7 @@ def _build_sse_app(host: str = "127.0.0.1"):
     # /messages/ and Starlette Mount path-prefix matching needs it to
     # agree. Route("/messages") would 404 on every client POST.
     transport = SseServerTransport("/messages/")
-    server = Server("mnemosyne")
-
-    @server.list_tools()
-    async def list_tools():
-        from mcp.types import Tool
-        raw = get_tool_definitions()
-        return [Tool(**t) for t in raw]
-
-    @server.call_tool()
-    async def call_tool(name: str, arguments: dict) -> list:
-        try:
-            result = handle_tool_call(name, arguments)
-            return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
-        except Exception as e:
-            return [TextContent(type="text", text=json.dumps({"status": "error", "message": str(e)}, indent=2))]
+    server = _build_mcp_server()
 
     async def handle_sse(request):
         async with transport.connect_sse(request.scope, request.receive, request._send) as streams:

--- a/mnemosyne/mcp_server.py
+++ b/mnemosyne/mcp_server.py
@@ -108,22 +108,29 @@ def _build_mcp_server() -> Server:
     ``.name`` and ``.arguments``. The handler returns a ``CallToolResult``
     instead of a raw list of ``TextContent``.
     """
-    from mcp.types import CallToolResult, Tool
+    from mcp.types import CallToolResult, ListToolsResult, Tool
 
     async def _on_list_tools(ctx, params):  # noqa: ARG001 — ctx/params unused
         raw = get_tool_definitions()
         # The dict from get_tool_definitions() uses ``inputSchema`` (the wire
         # field name); ``mcp.types.Tool`` accepts it via Pydantic alias and
         # normalizes to ``input_schema`` on the model. **t spreads both.
-        return [Tool(**t) for t in raw]
+        # SDK 2.x contract: the callback must return a ListToolsResult
+        # wrapper, not a bare list of Tool objects.
+        return ListToolsResult(tools=[Tool(**t) for t in raw])
 
     async def _on_call_tool(ctx, params):  # noqa: ARG001 — ctx unused
         try:
             result = handle_tool_call(params.name, params.arguments)
             content = [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+            return CallToolResult(content=content)
         except Exception as e:
+            # SDK 2.x contract: return a CallToolResult with is_error=True so
+            # clients can distinguish implementation failures from successful
+            # calls. Preserves the existing error payload shape for backward
+            # compatibility with any caller already parsing the error content.
             content = [TextContent(type="text", text=json.dumps({"status": "error", "message": str(e)}, indent=2))]
-        return CallToolResult(content=content)
+            return CallToolResult(content=content, is_error=True)
 
     return Server(
         "mnemosyne",

--- a/mnemosyne/mcp_server.py
+++ b/mnemosyne/mcp_server.py
@@ -121,7 +121,7 @@ def _build_mcp_server() -> Server:
 
     async def _on_call_tool(ctx, params):  # noqa: ARG001 — ctx unused
         try:
-            result = handle_tool_call(params.name, params.arguments)
+            result = handle_tool_call(params.name, params.arguments or {})
             content = [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
             return CallToolResult(content=content)
         except Exception as e:

--- a/mnemosyne/mcp_tools.py
+++ b/mnemosyne/mcp_tools.py
@@ -69,8 +69,15 @@ def __getattr__(name: str) -> Any:
 TOOLS: List[Dict[str, Any]] = []
 for _s in ALL_TOOL_SCHEMAS:
     _t = dict(_s)
-    if "parameters" in _t:
-        _t["inputSchema"] = _t.pop("parameters")
+    # ``mcp`` SDK 2.x renamed the wire field on ``Tool`` from the camelCase
+    # ``inputSchema`` (1.x) to the snake_case ``input_schema``. The
+    # canonical Python-side key matches the model field. Pydantic still
+    # accepts the camelCase alias on construction, but internal code that
+    # reads ``tool["input_schema"]`` is the only fully-supported path.
+    if "inputSchema" in _t:
+        _t["input_schema"] = _t.pop("inputSchema")
+    elif "parameters" in _t:
+        _t["input_schema"] = _t.pop("parameters")
     TOOLS.append(_t)
 
 # ---------------------------------------------------------------------------
@@ -78,10 +85,10 @@ for _s in ALL_TOOL_SCHEMAS:
 # ---------------------------------------------------------------------------
 
 def _get_schema(name: str) -> Dict[str, Any]:
-    """Extract inputSchema from TOOLS by tool name."""
+    """Extract input_schema from TOOLS by tool name."""
     for tool in TOOLS:
         if tool["name"] == name:
-            return tool["inputSchema"]
+            return tool["input_schema"]
     raise KeyError(f"Tool not found: {name}")
 
 class _SchemaProxy:
@@ -1193,6 +1200,7 @@ def get_tool_definitions() -> List[Dict[str, Any]]:
 # New typing-only implementation details deliberately stay private to stars.
 __all__ = [
     "ALL_TOOL_SCHEMAS",
+    "TOOLS",
     "Any",
     "BatchValidationError",
     "BeamMemory",
@@ -1202,7 +1210,6 @@ __all__ = [
     "List",
     "Mnemosyne",
     "Path",
-    "TOOLS",
     "TextContent",
     "Tool",
     "apply_beam_batch",

--- a/mnemosyne/tool_schemas.py
+++ b/mnemosyne/tool_schemas.py
@@ -5,7 +5,9 @@ Import from this module rather than defining schemas inline:
     from mnemosyne.tool_schemas import ALL_TOOL_SCHEMAS
 
 Every schema dict uses the key "parameters" (JSON Schema style).
-The MCP server layer renames it to "inputSchema" at registration time.
+The MCP server layer renames it to "input_schema" at registration time
+(matching the ``mcp`` SDK 2.x ``Tool.input_schema`` model field — was
+``inputSchema`` on the wire in SDK 1.x).
 """
 
 from typing import Dict, Any, List

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,11 @@ classifiers = [
 [project.optional-dependencies]
 llm = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20"]
 embeddings = ["fastembed>=0.3.0", "sqlite-vec>=0.1.0"]
-mcp = ["mcp>=1.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"]
+mcp = ["mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"]
 openclaw = ["openclaw>=0.1.0; python_version >= '3.10'"]
 sync = ["cryptography>=41.0"]
 test = ["pytest>=7.0"]
-all = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "sqlite-vec>=0.1.0", "mcp>=1.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'", "cryptography>=41.0"]
+all = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "sqlite-vec>=0.1.0", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'", "cryptography>=41.0"]
 dev = ["pytest>=7.0", "build", "twine", "ruff==0.15.22"]
 
 [project.urls]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1129,16 +1129,18 @@ print(json.dumps({"result": result, "after": after}))
 
         class _Params:
             name = "mnemosyne_stats"
-            arguments = {}
+            arguments = None
 
-        with patch("mnemosyne.mcp_server.handle_tool_call", return_value={"status": "ok"}):
+        with patch("mnemosyne.mcp_server.handle_tool_call", return_value={"status": "ok"}) as handle_call:
             result = asyncio.get_event_loop().run_until_complete(
                 on_call_tool(ctx=None, params=_Params())
             )
+        handle_call.assert_called_once_with("mnemosyne_stats", {})
         assert isinstance(result, CallToolResult)
         assert not result.is_error, (
             "successful tools/call must have is_error=False (or None)"
         )
+        assert json.loads(result.content[0].text) == {"status": "ok"}
 
     def test_top_level_cli_forwards_mcp_arguments(self, tmp_path):
         """`mnemosyne mcp ...` must pass subcommand args to the MCP parser."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1015,10 +1015,7 @@ print(json.dumps({"result": result, "after": after}))
         ``Tool`` carries the same schema as the source dict regardless of
         which key the dict used.
         """
-        try:
-            from mcp.types import Tool
-        except ImportError:
-            pytest.skip("mcp SDK not installed")
+        from mcp.types import Tool
 
         tools = get_tool_definitions()
         for t in tools:
@@ -1031,6 +1028,91 @@ print(json.dumps({"result": result, "after": after}))
             expected = t.get("input_schema", t.get("inputSchema"))
             assert tool.input_schema == expected
 
+        # Keep the legacy-only wire shape covered even though the current
+        # normalizer emits the SDK 2.x canonical key.
+        legacy = dict(tools[0])
+        legacy["inputSchema"] = legacy.pop("input_schema")
+        legacy_tool = Tool(**legacy)
+        assert legacy_tool.input_schema == legacy["inputSchema"]
+
+    def test_mcp_client_request_surface_returns_typed_results(self):
+        """Real SDK client requests exercise list/call registration and dispatch."""
+        from mcp import ClientSession
+        from mcp.shared.memory import create_client_server_memory_streams
+        from mcp.types import CallToolResult, ListToolsResult
+        from mnemosyne.mcp_server import _build_mcp_server
+
+        import asyncio
+        import contextlib
+        from unittest.mock import patch
+
+        async def exercise():
+            server = _build_mcp_server()
+            async with create_client_server_memory_streams() as (client_streams, server_streams):
+                server_task = asyncio.create_task(
+                    server.run(*server_streams, server.create_initialization_options())
+                )
+                try:
+                    async with ClientSession(*client_streams) as client:
+                        await client.initialize()
+                        listed = await client.list_tools()
+                        assert isinstance(listed, ListToolsResult)
+                        assert len(listed.tools) >= 25
+                        with patch(
+                            "mnemosyne.mcp_server.handle_tool_call",
+                            return_value={"status": "ok"},
+                        ) as handle_call:
+                            success = await client.call_tool("mnemosyne_stats", None)
+                        assert isinstance(success, CallToolResult)
+                        assert success.is_error is False
+                        handle_call.assert_called_once_with("mnemosyne_stats", {})
+                finally:
+                    server_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await server_task
+
+        asyncio.run(exercise())
+
+    def test_transport_builders_share_mcp_server(self):
+        """stdio and SSE transport setup both obtain the shared server builder."""
+        from mnemosyne import mcp_server
+
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        async def exercise_stdio():
+            fake_server = type(
+                "FakeServer",
+                (),
+                {
+                    "run": AsyncMock(),
+                    "create_initialization_options": lambda self: object(),
+                },
+            )()
+
+            class _StdioContext:
+                async def __aenter__(self):
+                    return (object(), object())
+
+                async def __aexit__(self, *args):
+                    return False
+
+            with (
+                patch.object(mcp_server, "_build_mcp_server", return_value=fake_server) as build,
+                patch.object(mcp_server, "stdio_server", return_value=_StdioContext()),
+            ):
+                await mcp_server._run_stdio()
+            build.assert_called_once_with()
+            fake_server.run.assert_awaited_once()
+
+        asyncio.run(exercise_stdio())
+
+        with patch.object(mcp_server, "_build_mcp_server", return_value=object()) as build:
+            app = mcp_server._build_sse_app(host="127.0.0.1")
+        build.assert_called_once_with()
+        sse_route = next(route for route in app.routes if getattr(route, "path", None) == "/sse")
+        assert any(cell.cell_contents is build.return_value for cell in (sse_route.endpoint.__closure__ or ()))
+
     def test_build_mcp_server_list_tools_returns_listtoolsresult(self):
         """SDK 2.x contract: the tools/list callback must return a ListToolsResult.
 
@@ -1040,24 +1122,17 @@ print(json.dumps({"result": result, "after": after}))
         a ``ListToolsResult`` object — a bare list breaks the ``tools/list``
         response contract for both stdio and SSE transports.
         """
-        try:
-            from mcp.types import ListToolsResult, Tool
-            from mnemosyne.mcp_server import _build_mcp_server
-        except ImportError:
-            pytest.skip("mcp SDK not installed")
+        from mcp.types import ListToolsResult, Tool
+        from mnemosyne.mcp_server import _build_mcp_server
 
         server = _build_mcp_server()
-        # SDK 2.x exposes handlers via get_request_handler("tools/list"|"tools/call").
-        # The returned HandlerEntry carries the actual async callable in .handler.
-        entry = server.get_request_handler("tools/list") if hasattr(server, "get_request_handler") else None
-        if entry is None or not hasattr(entry, "handler"):
-            pytest.skip("mcp SDK 2.x handler introspection not available")
+        entry = server.get_request_handler("tools/list")
+        assert entry is not None
+        assert callable(entry.handler)
         on_list_tools = entry.handler
 
         import asyncio
-        result = asyncio.get_event_loop().run_until_complete(
-            on_list_tools(ctx=None, params=None)
-        )
+        result = asyncio.run(on_list_tools(ctx=None, params=None))
         assert isinstance(result, ListToolsResult), (
             f"tools/list callback must return ListToolsResult, got {type(result).__name__}"
         )
@@ -1073,16 +1148,13 @@ print(json.dumps({"result": result, "after": after}))
         clients can distinguish implementation failures from successful calls.
         Preserves the existing error payload shape for backward compatibility.
         """
-        try:
-            from mcp.types import CallToolResult
-            from mnemosyne.mcp_server import _build_mcp_server
-        except ImportError:
-            pytest.skip("mcp SDK not installed")
+        from mcp.types import CallToolResult
+        from mnemosyne.mcp_server import _build_mcp_server
 
         server = _build_mcp_server()
-        entry = server.get_request_handler("tools/call") if hasattr(server, "get_request_handler") else None
-        if entry is None or not hasattr(entry, "handler"):
-            pytest.skip("mcp SDK 2.x handler introspection not available")
+        entry = server.get_request_handler("tools/call")
+        assert entry is not None
+        assert callable(entry.handler)
         on_call_tool = entry.handler
 
         # Construct a params-shaped object with empty name → handle_tool_call
@@ -1094,9 +1166,7 @@ print(json.dumps({"result": result, "after": after}))
             arguments = {}
 
         import asyncio
-        result = asyncio.get_event_loop().run_until_complete(
-            on_call_tool(ctx=None, params=_Params())
-        )
+        result = asyncio.run(on_call_tool(ctx=None, params=_Params()))
         assert isinstance(result, CallToolResult)
         assert result.is_error is True, (
             "tools/call failure path must set is_error=True for SDK 2.x contract"
@@ -1109,16 +1179,13 @@ print(json.dumps({"result": result, "after": after}))
 
     def test_build_mcp_server_call_tool_success_returns_is_error_false(self):
         """SDK 2.x contract: successful tools/call must return is_error=False (or unset)."""
-        try:
-            from mcp.types import CallToolResult
-            from mnemosyne.mcp_server import _build_mcp_server
-        except ImportError:
-            pytest.skip("mcp SDK not installed")
+        from mcp.types import CallToolResult
+        from mnemosyne.mcp_server import _build_mcp_server
 
         server = _build_mcp_server()
-        entry = server.get_request_handler("tools/call") if hasattr(server, "get_request_handler") else None
-        if entry is None or not hasattr(entry, "handler"):
-            pytest.skip("mcp SDK 2.x handler introspection not available")
+        entry = server.get_request_handler("tools/call")
+        assert entry is not None
+        assert callable(entry.handler)
         on_call_tool = entry.handler
 
         # Use a real tool definition and call it through the path. We mock
@@ -1132,9 +1199,7 @@ print(json.dumps({"result": result, "after": after}))
             arguments = None
 
         with patch("mnemosyne.mcp_server.handle_tool_call", return_value={"status": "ok"}) as handle_call:
-            result = asyncio.get_event_loop().run_until_complete(
-                on_call_tool(ctx=None, params=_Params())
-            )
+            result = asyncio.run(on_call_tool(ctx=None, params=_Params()))
         handle_call.assert_called_once_with("mnemosyne_stats", {})
         assert isinstance(result, CallToolResult)
         assert not result.is_error, (
@@ -1207,7 +1272,7 @@ class TestImportGuard:
     def test_mcp_server_raises_without_mcp(self):
         """MCP server raises helpful error if mcp not installed."""
         from mnemosyne.mcp_server import _MCP_AVAILABLE, _run_stdio
-        
+
         if _MCP_AVAILABLE:
             # mcp is installed — verify the server function exists and the flag is True
             assert _MCP_AVAILABLE is True

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -61,8 +61,10 @@ class TestToolSchemas:
     def test_tool_schemas_are_valid_json(self):
         """Each tool schema must be valid JSON-serializable."""
         for tool in TOOLS:
-            # Schema must be serializable
-            dumped = json.dumps(tool["inputSchema"])
+            # Schema must be serializable. ``mcp`` SDK 2.x renamed the wire
+            # field to ``input_schema`` (was ``inputSchema`` in 1.x); the
+            # schema dict in ``TOOLS`` uses the new key.
+            dumped = json.dumps(tool["input_schema"])
             loaded = json.loads(dumped)
             assert loaded["type"] == "object"
             assert "properties" in loaded
@@ -70,7 +72,7 @@ class TestToolSchemas:
     def test_remember_schema_has_required_fields(self):
         """mnemosyne_remember requires 'content'."""
         remember_tool = next(t for t in TOOLS if t["name"] == "mnemosyne_remember")
-        schema = remember_tool["inputSchema"]
+        schema = remember_tool["input_schema"]
         assert "required" in schema
         assert "content" in schema["required"]
         assert "properties" in schema
@@ -85,7 +87,7 @@ class TestToolSchemas:
     def test_recall_schema_has_required_fields(self):
         """mnemosyne_recall requires 'query'."""
         recall_tool = next(t for t in TOOLS if t["name"] == "mnemosyne_recall")
-        schema = recall_tool["inputSchema"]
+        schema = recall_tool["input_schema"]
         assert "required" in schema
         assert "query" in schema["required"]
         assert "limit" in schema["properties"]
@@ -104,7 +106,7 @@ class TestToolSchemas:
 
     def test_batch_schema_has_operations(self):
         batch_tool = next(t for t in TOOLS if t["name"] == "mnemosyne_batch")
-        schema = batch_tool["inputSchema"]
+        schema = batch_tool["input_schema"]
         assert "operations" in schema["required"]
         assert schema["properties"]["operations"]["type"] == "array"
         assert schema["properties"]["operations"]["maxItems"] == 50
@@ -1004,11 +1006,14 @@ print(json.dumps({"result": result, "after": after}))
         assert "mnemosyne_remember" in names
 
     def test_tool_definitions_convertible_to_tool_pydantic(self):
-        """Tool dict definitions must be compatible with mcp SDK 1.x Tool Pydantic model.
+        """Tool dict definitions must be compatible with the ``mcp`` SDK 2.x Tool Pydantic model.
 
-        The SDK 1.x list_tools handler expects Tool() instances with typed fields.
-        If get_tool_definitions() returns dicts with unexpected keys or missing
-        required fields, Tool(**t) will raise a ValidationError.
+        The SDK 2.x ``Tool`` model exposes ``input_schema`` (snake_case) as
+        its canonical Python field; ``inputSchema`` is still accepted as a
+        Pydantic alias on construction. This test asserts both paths:
+        (a) ``Tool(**t)`` constructs without raising; (b) the constructed
+        ``Tool`` carries the same schema as the source dict regardless of
+        which key the dict used.
         """
         try:
             from mcp.types import Tool
@@ -1021,7 +1026,10 @@ print(json.dumps({"result": result, "after": after}))
             assert isinstance(tool, Tool)
             assert tool.name == t["name"]
             assert tool.description == t.get("description")
-            assert tool.inputSchema == t["inputSchema"]
+            # Pydantic normalizes both ``inputSchema`` (1.x alias) and
+            # ``input_schema`` (2.x canonical) to ``tool.input_schema``.
+            expected = t.get("input_schema", t.get("inputSchema"))
+            assert tool.input_schema == expected
 
     def test_top_level_cli_forwards_mcp_arguments(self, tmp_path):
         """`mnemosyne mcp ...` must pass subcommand args to the MCP parser."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1031,6 +1031,115 @@ print(json.dumps({"result": result, "after": after}))
             expected = t.get("input_schema", t.get("inputSchema"))
             assert tool.input_schema == expected
 
+    def test_build_mcp_server_list_tools_returns_listtoolsresult(self):
+        """SDK 2.x contract: the tools/list callback must return a ListToolsResult.
+
+        Regression test for the CodeRabbit finding on PR #571 (round 2):
+        ``_on_list_tools`` must wrap the Tool list in ``ListToolsResult(tools=...)``
+        rather than returning a bare list. The SDK 2.x low-level server expects
+        a ``ListToolsResult`` object — a bare list breaks the ``tools/list``
+        response contract for both stdio and SSE transports.
+        """
+        try:
+            from mcp.types import ListToolsResult, Tool
+            from mnemosyne.mcp_server import _build_mcp_server
+        except ImportError:
+            pytest.skip("mcp SDK not installed")
+
+        server = _build_mcp_server()
+        # SDK 2.x exposes handlers via get_request_handler("tools/list"|"tools/call").
+        # The returned HandlerEntry carries the actual async callable in .handler.
+        entry = server.get_request_handler("tools/list") if hasattr(server, "get_request_handler") else None
+        if entry is None or not hasattr(entry, "handler"):
+            pytest.skip("mcp SDK 2.x handler introspection not available")
+        on_list_tools = entry.handler
+
+        import asyncio
+        result = asyncio.get_event_loop().run_until_complete(
+            on_list_tools(ctx=None, params=None)
+        )
+        assert isinstance(result, ListToolsResult), (
+            f"tools/list callback must return ListToolsResult, got {type(result).__name__}"
+        )
+        assert isinstance(result.tools, list)
+        assert all(isinstance(t, Tool) for t in result.tools)
+        assert len(result.tools) >= 25  # matches test_all_tools_present
+
+    def test_build_mcp_server_call_tool_returns_is_error_on_failure(self):
+        """SDK 2.x contract: tools/call must return CallToolResult with is_error=True on failure.
+
+        Regression test for the CodeRabbit finding on PR #571 (round 2):
+        the ``_on_call_tool`` exception path must set ``is_error=True`` so MCP
+        clients can distinguish implementation failures from successful calls.
+        Preserves the existing error payload shape for backward compatibility.
+        """
+        try:
+            from mcp.types import CallToolResult
+            from mnemosyne.mcp_server import _build_mcp_server
+        except ImportError:
+            pytest.skip("mcp SDK not installed")
+
+        server = _build_mcp_server()
+        entry = server.get_request_handler("tools/call") if hasattr(server, "get_request_handler") else None
+        if entry is None or not hasattr(entry, "handler"):
+            pytest.skip("mcp SDK 2.x handler introspection not available")
+        on_call_tool = entry.handler
+
+        # Construct a params-shaped object with empty name → handle_tool_call
+        # raises before returning a valid result. This is the path that was
+        # previously returning a successful-looking CallToolResult with error
+        # content instead of a flagged failure.
+        class _Params:
+            name = ""
+            arguments = {}
+
+        import asyncio
+        result = asyncio.get_event_loop().run_until_complete(
+            on_call_tool(ctx=None, params=_Params())
+        )
+        assert isinstance(result, CallToolResult)
+        assert result.is_error is True, (
+            "tools/call failure path must set is_error=True for SDK 2.x contract"
+        )
+        # Error payload preserved for backward compatibility
+        import json as _json
+        assert len(result.content) >= 1
+        payload = _json.loads(result.content[0].text)
+        assert payload.get("status") == "error"
+
+    def test_build_mcp_server_call_tool_success_returns_is_error_false(self):
+        """SDK 2.x contract: successful tools/call must return is_error=False (or unset)."""
+        try:
+            from mcp.types import CallToolResult
+            from mnemosyne.mcp_server import _build_mcp_server
+        except ImportError:
+            pytest.skip("mcp SDK not installed")
+
+        server = _build_mcp_server()
+        entry = server.get_request_handler("tools/call") if hasattr(server, "get_request_handler") else None
+        if entry is None or not hasattr(entry, "handler"):
+            pytest.skip("mcp SDK 2.x handler introspection not available")
+        on_call_tool = entry.handler
+
+        # Use a real tool definition and call it through the path. We mock
+        # handle_tool_call to return a minimal valid result so we don't need
+        # the full DB-backed stack here.
+        import asyncio
+        from unittest.mock import patch
+
+        class _Params:
+            name = "mnemosyne_stats"
+            arguments = {}
+
+        with patch("mnemosyne.mcp_server.handle_tool_call", return_value={"status": "ok"}):
+            result = asyncio.get_event_loop().run_until_complete(
+                on_call_tool(ctx=None, params=_Params())
+            )
+        assert isinstance(result, CallToolResult)
+        assert not result.is_error, (
+            "successful tools/call must have is_error=False (or None)"
+        )
+
     def test_top_level_cli_forwards_mcp_arguments(self, tmp_path):
         """`mnemosyne mcp ...` must pass subcommand args to the MCP parser."""
         env = os.environ.copy()


### PR DESCRIPTION
## Summary

PR #568 flagged 7 pre-existing test failures on `test (3.11)` as out-of-scope, but they share a root cause: `mcp` was upgraded to `2.0.0` on PyPI while `mnemosyne-oss/mnemosyne` pins `mcp>=1.0.0` and the integration code still uses the 1.x API. This PR migrates the integration layer to 2.x so those tests go green and so we stay aligned with the current `mcp` release line.

## 2.x breaking changes that affect this repo

1. **`mcp.server.lowlevel.server.Server`** removed the `@server.list_tools()` and `@server.call_tool()` decorators. The same callbacks are now accepted as `on_list_tools` and `on_call_tool` keyword arguments on the constructor.

2. The `on_call_tool` callback signature changed from `(name: str, arguments: dict) -> list` to `(ctx, params) -> CallToolResult` where `params` is a `CallToolRequestParams` carrying `.name` and `.arguments`.

3. **`mcp.types.Tool`** is now a Pydantic v2 model. The wire field `inputSchema` (camelCase, 1.x) was renamed to `input_schema` (snake_case, 2.x) on the canonical Python attribute. `inputSchema` is still accepted as a Pydantic alias on construction, so existing dict payloads keep working — but attribute access (e.g. `tool.inputSchema`) now raises `AttributeError`; use `tool.input_schema` instead.

## Changes

- `mnemosyne/mcp_server.py`: factor the two duplicated stdio/SSE handler registrations into a single `_build_mcp_server()` helper that returns a `Server` with `on_list_tools`/`on_call_tool` wired correctly. `_run_stdio` and `_build_sse_app` now just call it.
- `mnemosyne/mcp_tools.py`: `TOOLS` dict entries use the new `input_schema` key (was `inputSchema`). The pre-existing `inputSchema`-keyed branch is preserved as a fallback so any third-party schemas still arriving in the old shape keep working.
- `mnemosyne/tool_schemas.py`: docstring updated to reflect the new key.
- `tests/test_mcp_server.py`: 4 call sites updated to use the `input_schema` key. The Tool-Pydantic-conversion test now compares `tool.input_schema` (Pydantic canonical field) and accepts both `input_schema` and `inputSchema` keys on the source dict (Pydantic alias on construction).
- `pyproject.toml`: `mcp>=1.0.0` → `mcp>=2.0.0` in both the `mcp` and `all` extras.

## Validation

- `tests/test_mcp_server.py` + `tests/test_s1_mcp_sse_auth.py` + `tests/test_mcp_env_loader.py`: **96/96 pass on mcp 2.0.0** (in a local venv that already mirrors the CI environment; no system-level installs touched)
- `ruff check --select F,RUF022` clean on the 4 changed `.py` files (the pre-existing RUF022 on `mcp_tools.py:__all__` is fixed as a side effect of the file being in this PR's changed-files set under the new lint gate from #568)
- The PR-scoped lint gate from #568 itself stays green

## Out of scope (separate PRs)

- `mcp_tools.py` still imports several `mcp.types` symbols (`Tool`, `CallToolResult`, `TextContent`, etc.) at module-top lazy-style. This works but could be moved inside `get_tool_definitions` for symmetry. Not blocking.
- A handful of other tests fail on missing optional deps (`numpy`, `sqlite-vec`, etc.). Those are unrelated to the mcp upgrade and were already failing on `main` before this PR.

## Linked context

- Closes the `test (3.11)` failure lane flagged as out-of-scope by #568
- Test plan mirrors what CI will exercise; see commit message for the per-file breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Migrates Mnemosyne’s agent-facing MCP integration (stdio + SSE transports) from MCP SDK 1.x decorators to MCP SDK 2.x callback wiring, using a shared `_build_mcp_server()` so tool registration and tool-call handling behave identically across transports—the right call to reduce drift between agent surfaces.
- Updates MCP tool schema/result semantics to MCP 2.x conventions: `inputSchema` → `input_schema` (snake_case) with legacy fallback, typed `ListToolsResult`/`CallToolResult` wrapping, tool execution failures flagged with `is_error=True`, and normalization of omitted tool arguments from `None` to `{}` before dispatch.
- Extends regression coverage for the MCP adapter contract (schema key expectations, typed response construction, error flagging, legacy schema compatibility, and omitted-args behavior) to protect long-term maintainability of the external agent integration layer.

### Architectural / core-system impact

This PR does **not** change Mnemosyne’s core memory architecture or local-first guarantees: it does not modify working/episodic/BEAM tiering, retrieval strategies, the consolidation pipeline, veracity/fact system logic, sync behavior, or benchmark methodology. All changes are confined to the MCP transport/adapter layer that exposes Mnemosyne’s existing local memory operations to agent tooling.

### Agent integration surfaces (Hermes / MCP / CLI)

- **MCP:** The stdio and SSE servers now share one construction path and one tool-call contract under MCP 2.x. Typed results and explicit error signaling (`is_error=True`) reduce ambiguity for agent clients and make behavior consistent across transports, including for legacy `inputSchema` payloads and tool calls with omitted arguments.
- **Hermes / CLI:** No architectural changes to these surfaces are indicated; the PR’s behavioral risk is limited to the correctness and determinism of MCP tool execution/response formatting.

### Local-first / privacy posture

No erosion identified: MCP wiring affects how external agents invoke existing local tools, but does not alter what data is stored, how it’s partitioned across tiers, how verification/veracity is computed, or how data syncs outward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->