### PR TITLE
feat(llm): add MiniMax provider preset (regional endpoints + model config)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,33 @@ When `MNEMOSYNE_LLM_BASE_URL` is set, Mnemosyne uses the remote endpoint for con
 
 Works with: llama.cpp server, vLLM, Ollama, LM Studio, or any OpenAI-compatible API.
 
+#### Provider presets
+
+Instead of memorizing per-region base URLs, name a provider preset and let
+Mnemosyne resolve the OpenAI-compatible base URL and a default model:
+
+| Variable | Default | Description |
+|---|---|---|
+| `MNEMOSYNE_LLM_PROVIDER` | *(none)* | Named provider preset. Currently: `minimax`. |
+| `MNEMOSYNE_LLM_REGION` | *(provider default)* | Region within the preset. For `minimax`: `global_en` (default) or `cn_zh`. |
+
+Explicit `MNEMOSYNE_LLM_BASE_URL` / `MNEMOSYNE_LLM_MODEL` always take precedence
+over a preset, so existing configurations are unchanged.
+
+**MiniMax** (`MNEMOSYNE_LLM_PROVIDER=minimax`):
+
+| Region | OpenAI-compatible base URL | Anthropic-compatible base URL |
+|---|---|---|
+| `global_en` | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| `cn_zh` | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+| Model | Context window | Input / output (USD / 1M tokens) | Input modalities | Thinking |
+|---|---|---|---|---|
+| `MiniMax-M3` (default) | 1,000,000 | 0.6 / 2.4 | text, image, video | adaptive, disabled |
+| `MiniMax-M2.7` | 204,800 | 0.3 / 1.2 | text | always_on |
+
+Set `MNEMOSYNE_LLM_MODEL=MiniMax-M2.7` to select the non-default model.
+
 ### Host LLM Adapter (Hermes / agent integration)
 
 Route consolidation and fact extraction through a host-provided LLM (e.g., Hermes' authenticated `agent.auxiliary_client.call_llm`). Useful for OAuth-backed providers like `openai-codex` that don't fit the URL+API-key remote shape.

--- a/mnemosyne/core/llm_providers.py
+++ b/mnemosyne/core/llm_providers.py
@@ -1,0 +1,167 @@
+"""
+Mnemosyne remote LLM provider presets
+======================================
+The OpenAI-compatible remote LLM client (:mod:`mnemosyne.core.local_llm`)
+accepts a base URL and model name through raw environment variables
+(``MNEMOSYNE_LLM_BASE_URL`` / ``MNEMOSYNE_LLM_MODEL``). That works for any
+endpoint but requires operators to memorize per-region URLs and model ids.
+
+This module adds named provider presets so an operator can set
+``MNEMOSYNE_LLM_PROVIDER`` (and optionally ``MNEMOSYNE_LLM_REGION``) and have
+the client resolve the correct OpenAI-compatible base URL and a sensible
+default model. Explicit ``MNEMOSYNE_LLM_BASE_URL`` / ``MNEMOSYNE_LLM_MODEL``
+values always win, so existing configurations are unchanged.
+
+Each preset records, per region, both the OpenAI-compatible base URL and the
+Anthropic-compatible base URL, plus per-model metadata (context window,
+per-million-token pricing, input modalities, and supported thinking modes).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Preset registry
+# ---------------------------------------------------------------------------
+#
+# Structure per provider:
+#   default_region: region key used when MNEMOSYNE_LLM_REGION is unset
+#   default_model:  model id used when MNEMOSYNE_LLM_MODEL is unset
+#   regions:        region key -> {openai_base_url, anthropic_base_url, docs_root}
+#   models:         model id  -> {context_window, pricing_usd_per_million_tokens,
+#                                 input_modalities, thinking}
+#
+# The remote client is OpenAI-compatible, so it consumes ``openai_base_url``;
+# ``anthropic_base_url`` is recorded for completeness and future use.
+
+PROVIDER_PRESETS: Dict[str, Dict[str, Any]] = {
+    "minimax": {
+        "name": "MiniMax",
+        "default_region": "global_en",
+        "default_model": "MiniMax-M3",
+        "regions": {
+            "global_en": {
+                "openai_base_url": "https://api.minimax.io/v1",
+                "anthropic_base_url": "https://api.minimax.io/anthropic",
+                "docs_root": "https://platform.minimax.io/docs",
+            },
+            "cn_zh": {
+                "openai_base_url": "https://api.minimaxi.com/v1",
+                "anthropic_base_url": "https://api.minimaxi.com/anthropic",
+                "docs_root": "https://platform.minimaxi.com/docs",
+            },
+        },
+        "models": {
+            "MiniMax-M3": {
+                "context_window": 1_000_000,
+                "pricing_usd_per_million_tokens": {
+                    "input": 0.6,
+                    "output": 2.4,
+                    "cache_read": 0.12,
+                    "cache_write": None,
+                },
+                "input_modalities": ["text", "image", "video"],
+                "thinking": ["adaptive", "disabled"],
+            },
+            "MiniMax-M2.7": {
+                "context_window": 204_800,
+                "pricing_usd_per_million_tokens": {
+                    "input": 0.3,
+                    "output": 1.2,
+                    "cache_read": 0.06,
+                    "cache_write": 0.375,
+                },
+                "input_modalities": ["text"],
+                "thinking": ["always_on"],
+            },
+        },
+    },
+}
+
+
+def _normalize(name: str) -> str:
+    """Lower-case and trim a provider or region name for lookup."""
+    return (name or "").strip().lower()
+
+
+def get_provider_preset(name: str) -> Optional[Dict[str, Any]]:
+    """Return the preset for ``name`` (case-insensitive), or None if unknown."""
+    return PROVIDER_PRESETS.get(_normalize(name))
+
+
+def list_providers() -> List[str]:
+    """Return the list of known provider preset keys."""
+    return sorted(PROVIDER_PRESETS.keys())
+
+
+def resolve_region(name: str, region: str = "") -> Optional[str]:
+    """Return the region key to use for ``name``.
+
+    Falls back to the preset's ``default_region`` when ``region`` is empty or
+    unknown. Returns None if the provider itself is unknown.
+    """
+    preset = get_provider_preset(name)
+    if preset is None:
+        return None
+    regions = preset.get("regions", {})
+    key = _normalize(region)
+    if key and key in regions:
+        return key
+    return preset.get("default_region")
+
+
+def get_base_url(name: str, region: str = "", api: str = "openai") -> Optional[str]:
+    """Return the base URL for ``name`` in ``region``.
+
+    ``api`` selects ``"openai"`` (default, OpenAI-compatible) or
+    ``"anthropic"``. Returns None when the provider, region, or API family is
+    unknown. Any trailing slash is stripped.
+    """
+    preset = get_provider_preset(name)
+    if preset is None:
+        return None
+    region_key = resolve_region(name, region)
+    region_cfg = preset.get("regions", {}).get(region_key or "", {})
+    field = "anthropic_base_url" if _normalize(api) == "anthropic" else "openai_base_url"
+    url = region_cfg.get(field)
+    return url.rstrip("/") if isinstance(url, str) else None
+
+
+def default_model(name: str) -> Optional[str]:
+    """Return the preset's default model id, or None if the provider is unknown."""
+    preset = get_provider_preset(name)
+    if preset is None:
+        return None
+    return preset.get("default_model")
+
+
+def list_models(name: str) -> List[str]:
+    """Return the model ids configured for ``name`` (empty list if unknown)."""
+    preset = get_provider_preset(name)
+    if preset is None:
+        return []
+    return list(preset.get("models", {}).keys())
+
+
+def get_model_config(name: str, model_id: str) -> Optional[Dict[str, Any]]:
+    """Return the per-model metadata dict for ``model_id``, or None if absent."""
+    preset = get_provider_preset(name)
+    if preset is None:
+        return None
+    return preset.get("models", {}).get(model_id)
+
+
+def resolve_provider_defaults(
+    name: str, region: str = ""
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve ``(openai_base_url, default_model)`` for a provider preset.
+
+    Used by the remote LLM client to fill in a base URL and model only when
+    the operator has not set them explicitly. Returns ``(None, None)`` for an
+    unknown provider so callers can leave their existing values untouched.
+    """
+    preset = get_provider_preset(name)
+    if preset is None:
+        return (None, None)
+    return (get_base_url(name, region, api="openai"), default_model(name))

--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -36,6 +36,23 @@ if _env_repo and _env_file:
 LLM_BASE_URL = os.environ.get("MNEMOSYNE_LLM_BASE_URL", "").rstrip("/")
 LLM_API_KEY = os.environ.get("MNEMOSYNE_LLM_API_KEY", "")
 LLM_REMOTE_MODEL = os.environ.get("MNEMOSYNE_LLM_MODEL", "")
+
+# Optional named provider preset. When MNEMOSYNE_LLM_PROVIDER names a known
+# preset (see mnemosyne.core.llm_providers), it fills in the OpenAI-compatible
+# base URL and a default model for the selected MNEMOSYNE_LLM_REGION. Explicit
+# MNEMOSYNE_LLM_BASE_URL / MNEMOSYNE_LLM_MODEL always win, so existing
+# raw-env-var configurations behave exactly as before.
+LLM_PROVIDER = os.environ.get("MNEMOSYNE_LLM_PROVIDER", "").strip()
+LLM_REGION = os.environ.get("MNEMOSYNE_LLM_REGION", "").strip()
+if LLM_PROVIDER:
+    from mnemosyne.core.llm_providers import resolve_provider_defaults
+
+    _preset_base_url, _preset_model = resolve_provider_defaults(LLM_PROVIDER, LLM_REGION)
+    if not LLM_BASE_URL and _preset_base_url:
+        LLM_BASE_URL = _preset_base_url.rstrip("/")
+    if not LLM_REMOTE_MODEL and _preset_model:
+        LLM_REMOTE_MODEL = _preset_model
+
 LLM_TIMEOUT = float(os.environ.get("MNEMOSYNE_LLM_TIMEOUT", "60"))
 
 # Retryable errors only: 404/400 (model-not-found), 5xx, connection. Not 401/403/429.

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -1,0 +1,160 @@
+"""Tests for named remote-LLM provider presets (mnemosyne.core.llm_providers)."""
+
+import ast
+import os
+import subprocess
+import sys
+
+from mnemosyne.core import llm_providers as lp
+
+
+class TestPresetRegistry:
+    def test_minimax_preset_exists(self):
+        preset = lp.get_provider_preset("minimax")
+        assert preset is not None
+        assert preset["name"] == "MiniMax"
+        assert preset["default_model"] == "MiniMax-M3"
+        assert preset["default_region"] == "global_en"
+
+    def test_lookup_is_case_insensitive(self):
+        assert lp.get_provider_preset("MiniMax") is lp.get_provider_preset("minimax")
+        assert lp.get_provider_preset("  MINIMAX  ") is lp.get_provider_preset("minimax")
+
+    def test_unknown_provider_returns_none(self):
+        assert lp.get_provider_preset("does-not-exist") is None
+
+    def test_list_providers_includes_minimax(self):
+        assert "minimax" in lp.list_providers()
+
+
+class TestRegionsAndEndpoints:
+    def test_global_region_openai_and_anthropic_urls(self):
+        assert lp.get_base_url("minimax", "global_en", api="openai") == "https://api.minimax.io/v1"
+        assert (
+            lp.get_base_url("minimax", "global_en", api="anthropic")
+            == "https://api.minimax.io/anthropic"
+        )
+
+    def test_cn_region_openai_and_anthropic_urls(self):
+        assert lp.get_base_url("minimax", "cn_zh", api="openai") == "https://api.minimaxi.com/v1"
+        assert (
+            lp.get_base_url("minimax", "cn_zh", api="anthropic")
+            == "https://api.minimaxi.com/anthropic"
+        )
+
+    def test_empty_region_falls_back_to_default(self):
+        assert lp.resolve_region("minimax", "") == "global_en"
+        assert lp.get_base_url("minimax", "") == "https://api.minimax.io/v1"
+
+    def test_unknown_region_falls_back_to_default(self):
+        assert lp.resolve_region("minimax", "mars") == "global_en"
+        assert lp.get_base_url("minimax", "mars") == "https://api.minimax.io/v1"
+
+    def test_unknown_provider_urls_are_none(self):
+        assert lp.get_base_url("nope", "global_en") is None
+        assert lp.resolve_region("nope") is None
+
+
+class TestModels:
+    def test_model_ids(self):
+        assert lp.list_models("minimax") == ["MiniMax-M3", "MiniMax-M2.7"]
+
+    def test_m3_configuration(self):
+        cfg = lp.get_model_config("minimax", "MiniMax-M3")
+        assert cfg["context_window"] == 1_000_000
+        assert cfg["pricing_usd_per_million_tokens"] == {
+            "input": 0.6,
+            "output": 2.4,
+            "cache_read": 0.12,
+            "cache_write": None,
+        }
+        assert cfg["input_modalities"] == ["text", "image", "video"]
+        assert cfg["thinking"] == ["adaptive", "disabled"]
+
+    def test_m2_7_configuration(self):
+        cfg = lp.get_model_config("minimax", "MiniMax-M2.7")
+        assert cfg["context_window"] == 204_800
+        assert cfg["pricing_usd_per_million_tokens"] == {
+            "input": 0.3,
+            "output": 1.2,
+            "cache_read": 0.06,
+            "cache_write": 0.375,
+        }
+        assert cfg["input_modalities"] == ["text"]
+        assert cfg["thinking"] == ["always_on"]
+
+    def test_default_model(self):
+        assert lp.default_model("minimax") == "MiniMax-M3"
+
+    def test_unknown_model_config_is_none(self):
+        assert lp.get_model_config("minimax", "MiniMax-X9") is None
+
+
+class TestResolveProviderDefaults:
+    def test_defaults_for_known_provider(self):
+        base_url, model = lp.resolve_provider_defaults("minimax")
+        assert base_url == "https://api.minimax.io/v1"
+        assert model == "MiniMax-M3"
+
+    def test_defaults_for_cn_region(self):
+        base_url, model = lp.resolve_provider_defaults("minimax", "cn_zh")
+        assert base_url == "https://api.minimaxi.com/v1"
+        assert model == "MiniMax-M3"
+
+    def test_defaults_for_unknown_provider(self):
+        assert lp.resolve_provider_defaults("nope") == (None, None)
+
+
+class TestLocalLLMWiring:
+    """The remote client fills base URL / model from the preset at import time."""
+
+    def _import_with_env(self, env_extra):
+        env = os.environ.copy()
+        for key in (
+            "MNEMOSYNE_LLM_BASE_URL",
+            "MNEMOSYNE_LLM_MODEL",
+            "MNEMOSYNE_LLM_PROVIDER",
+            "MNEMOSYNE_LLM_REGION",
+        ):
+            env.pop(key, None)
+        env.update(env_extra)
+        code = (
+            "from mnemosyne.core import local_llm as m;"
+            "print(repr(m.LLM_BASE_URL));print(repr(m.LLM_REMOTE_MODEL))"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True, check=True, env=env, text=True,
+        )
+        lines = out.stdout.splitlines()
+        base_url = ast.literal_eval(lines[0])
+        model = ast.literal_eval(lines[1])
+        return base_url, model
+
+    def test_provider_fills_base_url_and_model(self):
+        base_url, model = self._import_with_env({"MNEMOSYNE_LLM_PROVIDER": "minimax"})
+        assert base_url == "https://api.minimax.io/v1"
+        assert model == "MiniMax-M3"
+
+    def test_provider_region_selects_cn_endpoint(self):
+        base_url, model = self._import_with_env(
+            {"MNEMOSYNE_LLM_PROVIDER": "minimax", "MNEMOSYNE_LLM_REGION": "cn_zh"}
+        )
+        assert base_url == "https://api.minimaxi.com/v1"
+        assert model == "MiniMax-M3"
+
+    def test_explicit_base_url_and_model_win_over_preset(self):
+        base_url, model = self._import_with_env(
+            {
+                "MNEMOSYNE_LLM_PROVIDER": "minimax",
+                "MNEMOSYNE_LLM_BASE_URL": "http://localhost:8080/v1",
+                "MNEMOSYNE_LLM_MODEL": "my-model",
+            }
+        )
+        assert base_url == "http://localhost:8080/v1"
+        assert model == "my-model"
+
+    def test_no_provider_leaves_base_url_empty(self):
+        base_url, model = self._import_with_env({})
+        assert base_url == ""
+        assert model == ""


### PR DESCRIPTION
Reason: The remote LLM client only accepted a base URL and model through raw env vars, with no MiniMax provider preset, regional endpoint mapping, or MiniMax-M3 / MiniMax-M2.7 model configuration.

## What this changes

The OpenAI-compatible remote LLM client (`mnemosyne/core/local_llm.py`) already
accepts `MNEMOSYNE_LLM_BASE_URL` / `MNEMOSYNE_LLM_MODEL`, but operators had to
know each region's URL and model id. This adds named provider presets.

- **New module `mnemosyne/core/llm_providers.py`** — a `PROVIDER_PRESETS`
  registry plus small resolver helpers (`get_provider_preset`, `get_base_url`,
  `default_model`, `list_models`, `get_model_config`, `resolve_provider_defaults`).
  It ships a **MiniMax** preset with:
  - regional endpoint mapping — `global_en` (`https://api.minimax.io/v1`,
    `https://api.minimax.io/anthropic`) and `cn_zh` (`https://api.minimaxi.com/v1`,
    `https://api.minimaxi.com/anthropic`);
  - model configuration for `MiniMax-M3` (default; 1,000,000-token context;
    input `text, image, video`; thinking `adaptive, disabled`) and
    `MiniMax-M2.7` (204,800-token context; input `text`; thinking `always_on`),
    each with per-million-token pricing.
- **Wired into the client** — new opt-in `MNEMOSYNE_LLM_PROVIDER` and
  `MNEMOSYNE_LLM_REGION` env vars resolve the OpenAI-compatible base URL and a
  default model at import time. Explicit `MNEMOSYNE_LLM_BASE_URL` /
  `MNEMOSYNE_LLM_MODEL` always take precedence, so existing configurations are
  unchanged (verified by regression tests).
- **Docs** — a "Provider presets" subsection in `docs/configuration.md`
  documenting the new variables, endpoints, and models.

## Checks

- `ruff check --select E9,F63,F7,F82 mnemosyne/core/llm_providers.py mnemosyne/core/local_llm.py tests/test_llm_providers.py` — passed
- `pytest tests/test_llm_providers.py tests/test_local_llm.py` — 60 passed
- `pytest tests/test_config_profiles.py tests/test_llm_backends.py` — 83 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a MiniMax provider preset system for the OpenAI-compatible remote LLM client.

- Adds regional MiniMax endpoints, model metadata, pricing, context limits, input types, and thinking modes.
- Adds `MNEMOSYNE_LLM_PROVIDER` and `MNEMOSYNE_LLM_REGION`.
- Preserves explicit `MNEMOSYNE_LLM_BASE_URL` and `MNEMOSYNE_LLM_MODEL` precedence.
- Documents provider configuration and adds comprehensive registry, resolution, and environment-wiring tests.

## Architectural impact

This change is isolated to remote LLM configuration. It does not alter tiered memory (working, episodic, or BEAM), retrieval, consolidation, veracity, synchronization, benchmarks, or Hermes/MCP/CLI integration surfaces.

## Privacy and local-first posture

The local-first architecture is preserved: no existing defaults are changed unless an operator opts into a provider preset. Explicit endpoint and model settings remain authoritative. However, selecting MiniMax intentionally routes LLM requests to a remote service, so deployments should assess provider privacy and data-handling implications.

## Maintainability

Centralizing provider, region, endpoint, and model metadata in a registry is the right call: it avoids scattered conditionals and provides reusable resolution helpers. Case-insensitive lookup, regional fallback, explicit override precedence, and focused tests improve operational predictability and future provider extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->