### PR TITLE
fix(hermes): log hermes_plugin import fallback at debug instead of silent pass

### DIFF
--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -3830,14 +3830,18 @@ def register(ctx):
         handler_fn=mnemosyne_command,
     )
 
-    # Also register tools and hooks from hermes_plugin (sibling directory).
-    # This way a single symlink to hermes_memory_provider/ gives us the
-    # full Mnemosyne experience: CLI + tools + hooks.
+    # Legacy fallback: register a vendored hermes_plugin sibling's hooks if
+    # present. Removed from this repo in v3.0 (commit 0ee4d80); normally a
+    # debug-level no-op (issue #578). Only the expected missing-module error is
+    # swallowed; a real registration failure must propagate, not be hidden.
     try:
         _repo_root = str(Path(__file__).resolve().parent.parent)
         if _repo_root not in sys.path:
             sys.path.insert(0, _repo_root)
         from hermes_plugin import register as _plugin_register
+    except ImportError as exc:
+        logger.debug(
+            "hermes_plugin sibling not importable (expected since v3.0): %s", exc
+        )
+    else:
         _plugin_register(ctx)
-    except Exception:
-        pass  # Graceful degradation — CLI still works without plugin tools

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -3832,14 +3832,19 @@ def register(ctx):
 
     # Legacy fallback: register a vendored hermes_plugin sibling's hooks if
     # present. Removed from this repo in v3.0 (commit 0ee4d80); normally a
-    # debug-level no-op (issue #578). Only the expected missing-module error is
-    # swallowed; a real registration failure must propagate, not be hidden.
+    # debug-level no-op (issue #578).
     try:
         _repo_root = str(Path(__file__).resolve().parent.parent)
         if _repo_root not in sys.path:
             sys.path.insert(0, _repo_root)
         from hermes_plugin import register as _plugin_register
-    except ImportError as exc:
+    except ModuleNotFoundError as exc:
+        # Swallow only the expected absent-sibling case. A present-but-broken
+        # sibling raises a different ModuleNotFoundError.name (a missing
+        # transitive dependency) or a plain ImportError; those must propagate,
+        # not be hidden as "expected".
+        if exc.name != "hermes_plugin":
+            raise
         logger.debug(
             "hermes_plugin sibling not importable (expected since v3.0): %s", exc
         )

--- a/tests/test_register_fallback.py
+++ b/tests/test_register_fallback.py
@@ -1,10 +1,11 @@
 """Tests for the hermes_plugin fallback in hermes_memory_provider.register().
 
-Covers the three behaviours required by review on #581 (issue #578):
+Covers the four behaviours required by review on #581 (issue #578):
 - absent hermes_plugin sibling -> debug log, no raise;
 - a present-but-broken sibling (missing transitive dependency) -> the
   ModuleNotFoundError propagates instead of being swallowed;
-- a sibling whose register() raises -> that error propagates.
+- a sibling whose register() raises -> that error propagates;
+- a sibling that does not export register() -> plain ImportError propagates.
 """
 import logging
 import sys
@@ -18,9 +19,17 @@ from hermes_memory_provider import register
 
 @pytest.fixture
 def clean_hermes_plugin(monkeypatch):
-    """Ensure no cached hermes_plugin import leaks between tests."""
+    """Ensure no cached hermes_plugin import leaks between tests.
+
+    monkeypatch.delitem restores the pre-test state, but a fake hermes_plugin
+    imported during the test is added to sys.modules by the import machinery
+    itself and is not tracked by monkeypatch. Pop it on teardown too, or it
+    leaks into later consumers that import hermes_plugin (e.g. the autouse
+    fixtures in conftest.py, or other test files).
+    """
     monkeypatch.delitem(sys.modules, "hermes_plugin", raising=False)
     yield
+    sys.modules.pop("hermes_plugin", None)
 
 
 def _install_fake_hermes_plugin(monkeypatch, tmp_path, init_py):
@@ -73,3 +82,20 @@ def test_register_plugin_register_failure_propagates(
     )
     with pytest.raises(RuntimeError, match="plugin registration failed"):
         register(MagicMock())
+
+
+def test_register_sibling_without_register_attr_propagates(
+    clean_hermes_plugin, monkeypatch, tmp_path
+):
+    """A sibling that exists but does not export register() raises a plain
+    ImportError (not ModuleNotFoundError); it must propagate, not be swallowed."""
+    _install_fake_hermes_plugin(
+        monkeypatch,
+        tmp_path,
+        """
+        # intentionally does not define register()
+        """,
+    )
+    with pytest.raises(ImportError) as excinfo:
+        register(MagicMock())
+    assert not isinstance(excinfo.value, ModuleNotFoundError)

--- a/tests/test_register_fallback.py
+++ b/tests/test_register_fallback.py
@@ -1,0 +1,75 @@
+"""Tests for the hermes_plugin fallback in hermes_memory_provider.register().
+
+Covers the three behaviours required by review on #581 (issue #578):
+- absent hermes_plugin sibling -> debug log, no raise;
+- a present-but-broken sibling (missing transitive dependency) -> the
+  ModuleNotFoundError propagates instead of being swallowed;
+- a sibling whose register() raises -> that error propagates.
+"""
+import logging
+import sys
+import textwrap
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_memory_provider import register
+
+
+@pytest.fixture
+def clean_hermes_plugin(monkeypatch):
+    """Ensure no cached hermes_plugin import leaks between tests."""
+    monkeypatch.delitem(sys.modules, "hermes_plugin", raising=False)
+    yield
+
+
+def _install_fake_hermes_plugin(monkeypatch, tmp_path, init_py):
+    """Create an importable hermes_plugin package in tmp_path."""
+    pkg = tmp_path / "hermes_plugin"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(textwrap.dedent(init_py))
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+
+def test_register_absent_hermes_plugin_logs_and_returns(clean_hermes_plugin, caplog):
+    """Absent sibling: register() does not raise and logs the expected no-op."""
+    ctx = MagicMock()
+    with caplog.at_level(logging.DEBUG, logger="hermes_memory_provider"):
+        register(ctx)  # must not raise
+    assert any(
+        "hermes_plugin sibling not importable" in r.message for r in caplog.records
+    )
+
+
+def test_register_broken_transitive_import_propagates(
+    clean_hermes_plugin, monkeypatch, tmp_path
+):
+    """A present sibling with a missing transitive dep must surface, not be hidden."""
+    _install_fake_hermes_plugin(
+        monkeypatch,
+        tmp_path,
+        """
+        import nonexistent_transitive_xyz  # missing dep -> ModuleNotFoundError
+        def register(ctx):
+            raise AssertionError("should not reach register()")
+        """,
+    )
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        register(MagicMock())
+    assert excinfo.value.name == "nonexistent_transitive_xyz"
+
+
+def test_register_plugin_register_failure_propagates(
+    clean_hermes_plugin, monkeypatch, tmp_path
+):
+    """A failure inside the sibling's register(ctx) must propagate."""
+    _install_fake_hermes_plugin(
+        monkeypatch,
+        tmp_path,
+        """
+        def register(ctx):
+            raise RuntimeError("plugin registration failed")
+        """,
+    )
+    with pytest.raises(RuntimeError, match="plugin registration failed"):
+        register(MagicMock())


### PR DESCRIPTION
Closes #578.

## Problem
`register()` in `hermes_memory_provider/__init__.py` had a fallback that imports the sibling `hermes_plugin` module, wrapped in a bare `except Exception: pass`. This silently swallowed any error (including real hook-registration failures from `_plugin_register(ctx)`), so operators could not distinguish "hooks registered" from "hooks silently dropped".

## Fix
Since the v3.0 modularization (commit `0ee4d80`) the `hermes_plugin` sibling was removed and hooks are registered by the provider class directly, so the fallback firing is expected. Replace the bare `pass` with a `logger.debug(...)` carrying the exception, correct the now-stale lead-in comment, and **narrow the catch to `ImportError`** with `_plugin_register(ctx)` moved into an `else:` clause. Only the expected missing-module error is swallowed; a real registration failure now propagates instead of being hidden. Debug level (not warning) because the condition is expected; matches the codebase's `logger.debug("...: %s", exc)` idiom (e.g. L1884) and the `except ImportError` optional-import idiom (L1268).

## Review
Ran `/simplify` (4 angles) and `/code-review` (high) on the diff before pushing, and re-ran both after narrowing the `except`. Verdict: ready to merge, no critical/important findings; the narrowing was mechanically verified (`ModuleNotFoundError` subclasses `ImportError`; a raising `_plugin_register` now propagates end-to-end). Altitude note (out of scope here): the entire try/except is dead code, `hermes_plugin/` having been deleted in `0ee4d80`, so the deeper fix is to delete the block; left to a separate maintainer follow-up rather than expanded into this patch.

## Testing
- `tests/test_provider_all_15_tools.py`: 32 passed.
- No new failures introduced. Two tests fail in a combined run (`TestUpdate::test_update_content`, `TestForget::test_forget_existing`) with `recall_diagnostics.py:40: AttributeError: module 'logging' has no attribute 'getLogger'`; this is a pre-existing test-isolation / `logging`-shadow issue that reproduces identically on clean `main` without this change (verified via stash).

## Follow-ups (out of scope)
- Delete the dead `hermes_plugin` import block here and the parallel stale `import hermes_plugin` in `tests/conftest.py` (both dead since `0ee4d80`).
- Optional regression test locking in "sibling absent -> no raise" and "registration failure propagates".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Logs the expected missing `hermes_plugin` import at debug level.
- Propagates missing transitive dependencies, plain `ImportError`, and plugin registration failures.
- Preserves Hermes provider operation and local-first SQLite memory behavior.
- Does not change MCP, CLI, tiered memory, retrieval, consolidation, veracity, sync, privacy, or benchmark methodology.
- Improves failure diagnostics and long-term maintainability. This is the right call.
- The provider tool test suite passed 32 tests. Two combined-run failures remain pre-existing `logging` shadowing issues reproducible on `main`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->