### PR TITLE
fix(hermes): align packaged manifest version

### DIFF
--- a/hermes_memory_provider/plugin.yaml
+++ b/hermes_memory_provider/plugin.yaml
@@ -1,5 +1,5 @@
 name: mnemosyne
-version: 3.15.1
+version: 3.15.2
 description: "Native local memory for Hermes — SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, temporal triples, and bidirectional sync with optional client-side encryption. Zero cloud. Zero latency."
 author: Abdias J
 provides_tools:

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-mnemosyne
-version: 0.4.0
+version: 0.5.0
 description: "Native local memory for Hermes - SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, and temporal triples. Zero cloud. Zero latency. Pipx-installable via `pipx install mnemosyne-hermes`."
 author: Abdias J
 pip_dependencies:

--- a/integrations/hermes/src/mnemosyne_hermes/plugin.yaml
+++ b/integrations/hermes/src/mnemosyne_hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-mnemosyne
-version: 0.4.0
+version: 0.5.0
 description: "Native local memory for Hermes — SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, temporal triples, and bidirectional sync with optional client-side encryption. Zero cloud. Zero latency."
 author: Abdias J
 provides_tools:

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -7,6 +7,9 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
+
+import mnemosyne_hermes
 from mnemosyne_hermes import install
 
 
@@ -211,6 +214,8 @@ def test_install_plugin_wrapper_creates_persistent_shim(tmp_path):
         "package": "mnemosyne_hermes",
     }
     assert (target / "plugin.yaml").is_file()
+    installed_plugin = yaml.safe_load((target / "plugin.yaml").read_text(encoding="utf-8"))
+    assert installed_plugin["version"] == mnemosyne_hermes.__version__
 
     state = install.plugin_state(hermes_home_path=tmp_path)
     assert state.status == "installed"

--- a/tests/test_plugin_manifest_versions.py
+++ b/tests/test_plugin_manifest_versions.py
@@ -1,0 +1,77 @@
+"""Prevent static Hermes plugin manifests from drifting from their packages."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _assignment_version(path: Path) -> str:
+    match = re.search(
+        r'^__version__\s*=\s*["\']([^"\']+)["\']',
+        path.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert match, f"missing __version__ assignment in {path}"
+    return match.group(1)
+
+
+def _manifest_version(path: Path) -> str:
+    manifest = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(manifest, dict), f"invalid plugin manifest in {path}"
+    version = manifest.get("version")
+    assert isinstance(version, str), f"missing manifest version in {path}"
+    return version
+
+
+def _source_manifest_paths() -> set[Path]:
+    generated_roots = {".git", ".venv", "venv", "env", "build", "dist"}
+    return {
+        path
+        for path in ROOT.rglob("plugin.yaml")
+        if not any(
+            part in generated_roots or part.endswith(".egg-info")
+            for part in path.relative_to(ROOT).parts
+        )
+    }
+
+
+def test_all_plugin_manifests_have_an_explicit_version_contract():
+    core_version = _assignment_version(ROOT / "mnemosyne" / "__init__.py")
+    hermes_root = ROOT / "integrations" / "hermes"
+    hermes_version = _assignment_version(
+        hermes_root / "src" / "mnemosyne_hermes" / "__init__.py"
+    )
+    expected_versions = {
+        ROOT / "hermes_memory_provider" / "plugin.yaml": core_version,
+        hermes_root / "plugin.yaml": hermes_version,
+        hermes_root / "src" / "mnemosyne_hermes" / "plugin.yaml": hermes_version,
+    }
+
+    assert _source_manifest_paths() == set(expected_versions)
+    for manifest_path, expected_version in expected_versions.items():
+        assert _manifest_version(manifest_path) == expected_version
+
+
+def test_package_metadata_uses_the_same_version_contract():
+    core_project = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert re.search(
+        r'^version\s*=\s*\{attr\s*=\s*"mnemosyne\.__version__"\}$',
+        core_project,
+        re.MULTILINE,
+    )
+
+    hermes_project = (
+        ROOT / "integrations" / "hermes" / "pyproject.toml"
+    ).read_text(encoding="utf-8")
+    hermes_version = _assignment_version(
+        ROOT / "integrations" / "hermes" / "src" / "mnemosyne_hermes" / "__init__.py"
+    )
+    assert re.search(
+        rf'^version\s*=\s*"{re.escape(hermes_version)}"$',
+        hermes_project,
+        re.MULTILINE,
+    )


### PR DESCRIPTION
## Summary

Fixes the remaining #579 drift in the packaged `mnemosyne-hermes` manifests.

- aligns both packaged manifests with the `0.5.0` package version
- adds regression coverage for core and packaged metadata, static manifests, and the installed wrapper manifest

## Why this path

Hermes discovers `plugin.yaml` statically before importing plugin Python, so runtime version lookup cannot eliminate drift. The tests make static parity a release gate instead.

## Non-goals

No installer refactor, release-automation redesign, tool-schema normalization, or core version bump. The legacy manifest is already aligned on current `main`.

## Verification

```text
pytest -q tests/test_plugin_manifest_versions.py integrations/hermes/tests/test_install_status.py::test_install_plugin_wrapper_creates_persistent_shim integrations/hermes/tests/test_install_cli_entrypoint.py::test_package_version_matches_distribution_metadata
4 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Aligns both packaged `mnemosyne-hermes` manifests with version `0.5.0`.
- Updates the `hermes_memory_provider` manifest to `3.15.2`.
- Adds regression tests for static manifests, package metadata, and the installed wrapper manifest.
- Prevents future version drift through explicit version contracts.

## Architectural impact

- **Core memory architecture:** Unchanged. Working, episodic, and BEAM memory layers are not modified.
- **Retrieval, consolidation, veracity, and sync:** Unchanged.
- **Privacy posture and local-first guarantees:** Preserved. The changes affect local packaging metadata only.
- **Hermes integration:** Improved. Static manifest parity supports Hermes discovery before Python import. This is the right call for reliable agent integration.
- **MCP and CLI:** Unchanged.
- **Long-term maintainability:** Improved through explicit version contracts and installed-wrapper validation.
- **Benchmark methodology:** Unchanged.
- **Architectural risk:** No risk identified. The changes do not erode the local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->