### PR TITLE
docs: surface sponsors near the top of the README, fix the blog scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@
 
 </div>
 
+<div align="center">
+<sub>
+
+Compute and tooling for benchmarks and CI provided by
+<a href="https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=mnemosyne">Atlas Cloud</a>
+&nbsp;·&nbsp;
+<a href="https://mnemosyne.site/partners">Partner with Mnemosyne</a>
+
+</sub>
+</div>
+
 **Mnemosyne** is a universal, Hermes-first memory layer that works with any agent framework (Claude Code, Cursor, Codex, OpenWebUI, OpenClaw, or your own custom agent). One `pip install`, one SQLite database. No external services required.
 
 ---

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -351,9 +351,20 @@ def cmd_announce(args: argparse.Namespace) -> int:
 
     bullets = "\n".join(f"- {i}" for i in items) or "- (fill in the headline changes)"
 
+    # The website has no mdx-components.tsx, so plain markdown elements get
+    # no styling at all: a post written with `##` and `-` renders as bare
+    # unstyled HTML. Every existing post hand-writes JSX with Tailwind
+    # classes, so the scaffold has to as well. This was learned the hard way.
+    P = 'className="font-serif-alt text-lg leading-relaxed text-charcoal mb-6"'
+    H2 = 'className="font-serif text-2xl lg:text-3xl text-charcoal mt-12 mb-4"'
+    UL = 'className="font-serif-alt text-lg leading-relaxed text-charcoal mb-6 ml-6 list-disc"'
+
+    li = "\n".join(f'  <li className="mb-2">{i}</li>' for i in items) or \
+         '  <li className="mb-2">TODO the headline changes</li>'
+
     blog = f"""---
 title: "Mnemosyne {version}"
-excerpt: "TODO one or two sentences. What changed and why a user should care."
+excerpt: "TODO one or two sentences. What changed and why a reader should care."
 date: "{today}"
 readTime: "4 min read"
 category: "Release"
@@ -362,27 +373,41 @@ featured: false
 image: "/hero-demo.jpg"
 ---
 
-<p className="font-serif-alt text-lg leading-relaxed text-charcoal mb-6">
+<p {P}>
   TODO: open with the one thing that matters most in this release.
 </p>
 
-## What changed
+<h2 {H2}>
+  What changed
+</h2>
 
-{bullets}
+<ul {UL}>
+{li}
+</ul>
 
-## Upgrading
+<h2 {H2}>
+  Upgrading
+</h2>
+
+<p {P}>
+  Run
+  <code className="text-accent-terracotta bg-cream-dark px-1 rounded">pip install --upgrade 'mnemosyne-memory[embeddings]'</code>.
+  TODO note any migration or config change, or say there is none.
+</p>
 
 <CodeBlock code={{`pip install --upgrade 'mnemosyne-memory[embeddings]'`}} language="bash" />
 
-Full notes: https://github.com/mnemosyne-oss/mnemosyne/releases/tag/v{version}
+<p {P}>
+  Full notes on the
+  <a href="https://github.com/mnemosyne-oss/mnemosyne/releases/tag/v{version}" className="text-accent-terracotta underline underline-offset-2 hover:text-charcoal">v{version} release page</a>.
+</p>
 """
 
     # X has a 280 character budget, so build the shortest honest version and
-    # let the caller expand it. Two items, trimmed, no install line: the link
-    # carries that. A draft that already fits is likelier to get posted than
-    # one the author has to cut down first.
+    # let the author expand it. Two items, trimmed. A draft that already fits
+    # is likelier to get posted than one that must be cut down first.
     def _short(s: str, n: int = 78) -> str:
-        return s if len(s) <= n else s[: n - 1].rstrip() + "…"
+        return s if len(s) <= n else s[: n - 1].rstrip() + "\u2026"
 
     x_lines = "\n".join(f"- {_short(i)}" for i in items[:2])
     x_post = f"""Mnemosyne {version} is out.


### PR DESCRIPTION
## README

Sponsors lived at line 459, well below the fold of a long README. This adds a single small line beneath the badges naming the current compute partner and linking the partners page.

Kept to one line of `<sub>` text on purpose. A sponsor banner at the top of a README for a project whose pitch is that it is not a commercial product reads wrong, and the ask was for subtle.

## Blog scaffold

`release.py announce` emitted a markdown blog post. The website has **no `mdx-components.tsx`**, so markdown elements render entirely unstyled there — which is why the 3.15.1 post shipped looking broken.

The template now emits the site's house JSX with its Tailwind classes. Verified by generating a scaffold, building it on the site, and asserting the rendered HTML carries styled elements rather than bare ones.

Paired with AxDSan/mnemosyne-website#6, which fixes the already-published 3.15.1 post and adds the partner strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds a centered Atlas Cloud sponsor callout to the README, including partner links.
- Updates `release.py announce` to generate styled MDX/JSX blog scaffolds with Tailwind classes, while preserving code blocks and release links.
- No changes to Mnemosyne’s memory architecture, retrieval, consolidation, veracity, sync, privacy posture, local-first guarantees, agent integrations, or benchmark methodology.
- Improves release-content maintainability by aligning generated posts with the website’s existing presentation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->