### PR TITLE
docs(readme): give the sponsor block real presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,23 @@
 </div>
 
 <div align="center">
-<sub>
 
-Compute and tooling for benchmarks and CI provided by
-<a href="https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=mnemosyne">Atlas Cloud</a>
-&nbsp;·&nbsp;
-<a href="https://mnemosyne.site/partners">Partner with Mnemosyne</a>
+### Proudly sponsored by
 
-</sub>
+<a href="https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=mnemosyne">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/partners/atlas-cloud-white.png">
+    <img src="assets/partners/atlas-cloud-black.png" alt="Atlas Cloud" width="240">
+  </picture>
+</a>
+
+**Compute Partner** &nbsp;·&nbsp; inference credits powering the nightly recall benchmarks, multi-model parity tests, and provider coverage in the Hermes plugin.
+
+[Partner with Mnemosyne](https://mnemosyne.site/partners)
+
 </div>
+
+---
 
 **Mnemosyne** is a universal, Hermes-first memory layer that works with any agent framework (Claude Code, Cursor, Codex, OpenWebUI, OpenClaw, or your own custom agent). One `pip install`, one SQLite database. No external services required.
 


### PR DESCRIPTION
The one-line `<sub>` version I added was effectively invisible. That was the wrong read of "subtle".

Replaced with a proper centred block near the top:

- a **Proudly sponsored by** heading
- the Atlas Cloud wordmark at 240px, with `<picture>` light and dark variants so it works in both GitHub themes
- the tier, and one line on what the credits fund
- a link to the partners page

Still above the fold and still ahead of the intro paragraph, but it now looks like a partnership rather than a disclaimer.

Paired with AxDSan/mnemosyne-website#7, which does the same for the landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)