### PR TITLE
fix(hermes): support root-only plugin installs

### DIFF
--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -92,6 +92,15 @@ hermes config set memory.provider mnemosyne
 hermes memory status
 ```
 
+To install only at the selected Hermes home without linking opted-in child
+profiles, use:
+
+```bash
+mnemosyne-hermes install --no-profile-links
+```
+
+The default continues to link opted-in child profiles for backward compatibility.
+
 That's it. The entry point in `mnemosyne-hermes` registers with Hermes' memory
 provider discovery system (`hermes_agent.memory_providers`). No symlinks. No
 directory copying. No plugin.yaml gymnastics. The provider surfaces

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -725,14 +725,40 @@ def _link_all_profiles(
     return linked
 
 
-def profile_links_enabled(*, hermes_home_path: str | Path | None = None) -> bool:
-    """Return whether opted-in profiles currently link to this home's plugin.
+def _profile_links_preference_path(hermes_home_path: str | Path | None = None) -> Path:
+    """Return the installer-managed profile-link preference for a Hermes home."""
+    base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
+    return base / "plugins" / ".mnemosyne-profile-links.json"
 
-    Upgrade uses the observed state to preserve a prior root-only installation
-    without persisting separate installer configuration. Missing links mean the
-    safer root-only behavior; when no child profiles exist the distinction has
-    no effect.
+
+def _write_profile_links_preference(
+    enabled: bool,
+    *,
+    hermes_home_path: str | Path | None = None,
+) -> None:
+    """Persist the selected profile-link behavior for later upgrades."""
+    path = _profile_links_preference_path(hermes_home_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"link_profiles": enabled}) + "\n", encoding="utf-8")
+
+
+def profile_links_enabled(*, hermes_home_path: str | Path | None = None) -> bool:
+    """Return the selected profile-link behavior for a Hermes home.
+
+    New installs persist the explicit selection, which lets upgrades distinguish
+    the default enabled behavior from an explicit root-only installation even
+    when no opted-in child profile exists yet. Existing installs without the
+    preference file retain the legacy observed-link fallback.
     """
+    try:
+        preference = json.loads(
+            _profile_links_preference_path(hermes_home_path).read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError):
+        preference = None
+    if isinstance(preference, dict) and isinstance(preference.get("link_profiles"), bool):
+        return preference["link_profiles"]
+
     target = plugin_target_dir(hermes_home_path)
     if not (target.is_symlink() or target.exists()):
         return False
@@ -1108,6 +1134,7 @@ def install_plugin(
         os.symlink(str(source), str(target))
         if link_profiles:
             _link_all_profiles(source, hermes_home_path=hermes_home_path, force=force)
+        _write_profile_links_preference(link_profiles, hermes_home_path=hermes_home_path)
         return target
 
     # Validate and fully write the replacement before removing a working wrapper.
@@ -1125,6 +1152,7 @@ def install_plugin(
         shutil.rmtree(staging_parent, ignore_errors=True)
     if link_profiles:
         _link_all_profiles(target, hermes_home_path=hermes_home_path, force=force)
+    _write_profile_links_preference(link_profiles, hermes_home_path=hermes_home_path)
     return target
 
 
@@ -1139,6 +1167,7 @@ def uninstall_plugin(*, hermes_home_path: str | Path | None = None) -> Path:
         target.unlink()
     elif target.exists():
         shutil.rmtree(target)
+    _profile_links_preference_path(hermes_home_path).unlink(missing_ok=True)
     return target
 
 
@@ -1204,6 +1233,14 @@ def cleanup_plugin(
                         actions.append("Reset config: memory.provider from 'mnemosyne' to unset")
         except Exception:
             pass
+
+    preference_path = _profile_links_preference_path(hermes_home_path)
+    if preference_path.exists():
+        if dry_run:
+            actions.append(f"Would remove: {preference_path}")
+        else:
+            preference_path.unlink()
+            actions.append(f"Removed: {preference_path}")
 
     return actions
 

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -725,6 +725,33 @@ def _link_all_profiles(
     return linked
 
 
+def profile_links_enabled(*, hermes_home_path: str | Path | None = None) -> bool:
+    """Return whether opted-in profiles currently link to this home's plugin.
+
+    Upgrade uses the observed state to preserve a prior root-only installation
+    without persisting separate installer configuration. Missing links mean the
+    safer root-only behavior; when no child profiles exist the distinction has
+    no effect.
+    """
+    target = plugin_target_dir(hermes_home_path)
+    if not (target.is_symlink() or target.exists()):
+        return False
+    try:
+        expected = target.resolve()
+    except OSError:
+        return False
+    for profile_home in _iter_mnemosyne_profiles(hermes_home_path):
+        profile_target = profile_home / "plugins" / PLUGIN_NAME
+        if not profile_target.is_symlink():
+            continue
+        try:
+            if profile_target.resolve() == expected:
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def _verify_links(*, hermes_home_path: str | Path | None = None) -> bool:
     """Print PASS/FAIL for each home that should have a resolvable plugin link.
 
@@ -1284,7 +1311,7 @@ def _parser() -> argparse.ArgumentParser:
         dest="link_profiles",
         action="store_false",
         default=True,
-        help="Install only at --hermes-home; do not link opted-in child profiles.",
+        help="Install only at the selected Hermes home; do not link opted-in child profiles.",
     )
     subparsers.add_parser(
         "uninstall",

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -301,13 +301,7 @@ def _provider_init_is_mnemosyne(init_file: Path) -> bool:
             )
         ):
             return True
-        return bool(
-            re.search(
-                r"^class\s+MnemosyneMemoryProvider(?:\s*[:(])",
-                source,
-                flags=re.MULTILINE,
-            )
-        )
+        return False
     except Exception:
         return False
 
@@ -987,7 +981,7 @@ def _unlink_profile_links(links: list[_ProfileLinkSnapshot]) -> None:
                 quarantined.replace(target)
                 moved = False
         except OSError:
-            pass
+            raise
         finally:
             if moved and quarantined is not None:
                 try:
@@ -1020,6 +1014,25 @@ def _unlink_all_profiles(
             recognized_targets=recognized_targets,
         )
     )
+
+
+def _unlink_profile_links_or_restore_preference(
+    links: list[_ProfileLinkSnapshot],
+    preference_path: Path,
+    previous_preference: bytes | None,
+) -> None:
+    """Fail root-only cleanup and restore its preference when link removal fails."""
+    try:
+        _unlink_profile_links(links)
+    except OSError:
+        try:
+            _restore_profile_links_preference(preference_path, previous_preference)
+        except OSError:
+            print(
+                f"⚠ Profile-link preference rollback failed; inspect: {preference_path}",
+                file=sys.stderr,
+            )
+        raise
 
 
 def _prepare_plugin_target(
@@ -1333,6 +1346,10 @@ def install_plugin(
         previous_preference = preference_path.read_bytes()
     except FileNotFoundError:
         previous_preference = None
+        if profile_links_enabled(hermes_home_path=hermes_home_path):
+            # Preserve an effective legacy opt-in even if replacing the root
+            # target changes the no-file fallback before cleanup can fail.
+            previous_preference = b'{"link_profiles": true}\n'
 
     if mode == "symlink":
         if migrate_wrapper_to_symlink and _is_wrapper_plugin_target(target):
@@ -1356,7 +1373,11 @@ def install_plugin(
         if link_profiles:
             _link_all_profiles(source, hermes_home_path=hermes_home_path, force=force)
         else:
-            _unlink_profile_links(profile_links_to_unlink)
+            _unlink_profile_links_or_restore_preference(
+                profile_links_to_unlink,
+                preference_path,
+                previous_preference,
+            )
         return target
 
     # Validate and fully write the replacement before removing a working wrapper.
@@ -1388,7 +1409,11 @@ def install_plugin(
     if link_profiles:
         _link_all_profiles(target, hermes_home_path=hermes_home_path, force=force)
     else:
-        _unlink_profile_links(profile_links_to_unlink)
+        _unlink_profile_links_or_restore_preference(
+            profile_links_to_unlink,
+            preference_path,
+            previous_preference,
+        )
     return target
 
 

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -1037,6 +1037,7 @@ def install_plugin(
     mode: str = "symlink",
     python: str | Path | None = None,
     migrate_wrapper_to_symlink: bool = False,
+    link_profiles: bool = True,
 ) -> Path:
     """Install the Mnemosyne provider into Hermes' user plugin directory.
 
@@ -1044,6 +1045,9 @@ def install_plugin(
     creates a real persistent plugin directory containing a tiny shim that
     activates the selected interpreter's site-packages (including editable
     install ``.pth`` files) and imports ``mnemosyne_hermes`` from there.
+    ``link_profiles`` preserves the historical
+    opted-in profile fan-out by default; set it False to install only at the
+    selected Hermes home.
     """
     if mode not in {"symlink", "wrapper"}:
         raise ValueError("mode must be 'symlink' or 'wrapper'")
@@ -1075,7 +1079,8 @@ def install_plugin(
             )
         _prepare_plugin_target(base, target, force=force)
         os.symlink(str(source), str(target))
-        _link_all_profiles(source, hermes_home_path=hermes_home_path, force=force)
+        if link_profiles:
+            _link_all_profiles(source, hermes_home_path=hermes_home_path, force=force)
         return target
 
     # Validate and fully write the replacement before removing a working wrapper.
@@ -1091,7 +1096,8 @@ def install_plugin(
         _replace_plugin_target_with_staged(target, staged)
     finally:
         shutil.rmtree(staging_parent, ignore_errors=True)
-    _link_all_profiles(target, hermes_home_path=hermes_home_path, force=force)
+    if link_profiles:
+        _link_all_profiles(target, hermes_home_path=hermes_home_path, force=force)
     return target
 
 
@@ -1273,6 +1279,13 @@ def _parser() -> argparse.ArgumentParser:
             "wrapper with the default symlink install."
         ),
     )
+    install.add_argument(
+        "--no-profile-links",
+        dest="link_profiles",
+        action="store_false",
+        default=True,
+        help="Install only at --hermes-home; do not link opted-in child profiles.",
+    )
     subparsers.add_parser(
         "uninstall",
         help="Remove Mnemosyne from Hermes' memory provider plugin directory.",
@@ -1310,6 +1323,7 @@ def run_install(
     mode: str = "symlink",
     python: str | Path | None = None,
     migrate_wrapper_to_symlink: bool = False,
+    link_profiles: bool = True,
 ) -> int:
     """Core install logic — check deps, bootstrap Hermes venv if needed, create symlink.
 
@@ -1360,6 +1374,7 @@ def run_install(
         mode=mode,
         python=python,
         migrate_wrapper_to_symlink=migrate_wrapper_to_symlink,
+        link_profiles=link_profiles,
     )
     skill_result = install_bundled_skill(
         hermes_home_path=hermes_home_path,
@@ -1417,6 +1432,7 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  Hermes Python: {hermes_python or 'not found'}")
                 print(f"  Currently installed: {'yes' if is_installed(hermes_home_path=args.hermes_home) else 'no'}")
                 print(f"  Install mode: {getattr(args, 'mode', 'symlink')}")
+                print(f"  Will link opted-in profiles: {bool(getattr(args, 'link_profiles', True))}")
                 print(f"  Skill target file: {skill.target}")
                 print(f"  Skill state: {skill.status}")
                 print(f"  Skill action: {skill_plan.message}")
@@ -1449,6 +1465,7 @@ def main(argv: list[str] | None = None) -> int:
                 mode=getattr(args, "mode", "symlink"),
                 python=getattr(args, "python", None),
                 migrate_wrapper_to_symlink=getattr(args, "migrate_wrapper_to_symlink", False),
+                link_profiles=getattr(args, "link_profiles", True),
             )
 
         if command == "uninstall":

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -46,6 +47,16 @@ class _WrapperMetadata:
     python: Path | None = None
     site_packages: Path | None = None
     error: str | None = None
+
+
+@dataclass(frozen=True)
+class _ProfileLinkSnapshot:
+    """Identity of a recognized profile symlink at discovery time."""
+
+    path: Path
+    link_target: str
+    device: int
+    inode: int
 
 
 @dataclass(frozen=True)
@@ -252,6 +263,51 @@ def _provider_init_is_valid(init_file: Path) -> bool:
     try:
         source = init_file.read_text(errors="replace")
         return "register_memory_provider" in source or "MnemosyneMemoryProvider" in source
+    except Exception:
+        return False
+
+
+def _provider_init_is_mnemosyne(init_file: Path) -> bool:
+    """Return whether a plugin has installer-owned Mnemosyne identity markers."""
+    try:
+        plugin_yaml = init_file.with_name("plugin.yaml").read_text(errors="replace")
+        if not re.search(
+            r"^\s*name:\s*['\"]?hermes-mnemosyne['\"]?\s*$",
+            plugin_yaml,
+            flags=re.MULTILINE,
+        ):
+            return False
+
+        wrapper_manifest = init_file.with_name("mnemosyne-wrapper.json")
+        if wrapper_manifest.is_file():
+            metadata = _wrapper_metadata(init_file.parent, init_file)
+            return (
+                metadata.error is None
+                and metadata.python is not None
+                and metadata.site_packages is not None
+            )
+
+        source = init_file.read_text(errors="replace")
+        legacy_python, legacy_site = _extract_wrapper_metadata(init_file)
+        if (
+            legacy_python is not None
+            and legacy_python.is_absolute()
+            and legacy_site is not None
+            and legacy_site.is_absolute()
+            and re.search(
+                r"^from\s+mnemosyne_hermes\s+import\s+\*(?:\s+#.*)?$",
+                source,
+                flags=re.MULTILINE,
+            )
+        ):
+            return True
+        return bool(
+            re.search(
+                r"^class\s+MnemosyneMemoryProvider(?:\s*[:(])",
+                source,
+                flags=re.MULTILINE,
+            )
+        )
     except Exception:
         return False
 
@@ -731,6 +787,21 @@ def _profile_links_preference_path(hermes_home_path: str | Path | None = None) -
     return base / "plugins" / ".mnemosyne-profile-links.json"
 
 
+def _atomic_write_profile_links_preference(path: Path, payload: bytes) -> None:
+    """Replace the profile-link preference without truncating an existing file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.staging-", dir=path.parent
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        temporary.write_bytes(payload)
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
 def _write_profile_links_preference(
     enabled: bool,
     *,
@@ -738,8 +809,16 @@ def _write_profile_links_preference(
 ) -> None:
     """Persist the selected profile-link behavior for later upgrades."""
     path = _profile_links_preference_path(hermes_home_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"link_profiles": enabled}) + "\n", encoding="utf-8")
+    payload = (json.dumps({"link_profiles": enabled}) + "\n").encode("utf-8")
+    _atomic_write_profile_links_preference(path, payload)
+
+
+def _restore_profile_links_preference(path: Path, previous: bytes | None) -> None:
+    """Restore a preference snapshot after a failed plugin replacement."""
+    if previous is None:
+        path.unlink(missing_ok=True)
+        return
+    _atomic_write_profile_links_preference(path, previous)
 
 
 def profile_links_enabled(*, hermes_home_path: str | Path | None = None) -> bool:
@@ -804,38 +883,143 @@ def _verify_links(*, hermes_home_path: str | Path | None = None) -> bool:
     return all_ok
 
 
-def _unlink_all_profiles(
+def _snapshot_profile_link(path: Path) -> _ProfileLinkSnapshot | None:
+    """Capture one stable symlink identity, or None if it changes while read."""
+    try:
+        before = path.lstat()
+        if not stat.S_ISLNK(before.st_mode):
+            return None
+        link_target = os.readlink(path)
+        after = path.lstat()
+    except OSError:
+        return None
+    if (
+        not stat.S_ISLNK(after.st_mode)
+        or before.st_dev != after.st_dev
+        or before.st_ino != after.st_ino
+    ):
+        return None
+    return _ProfileLinkSnapshot(
+        path=path,
+        link_target=link_target,
+        device=after.st_dev,
+        inode=after.st_ino,
+    )
+
+
+def _same_profile_link_identity(
+    left: _ProfileLinkSnapshot, right: _ProfileLinkSnapshot
+) -> bool:
+    """Return whether two snapshots identify the same symlink object."""
+    return (
+        left.link_target == right.link_target
+        and left.device == right.device
+        and left.inode == right.inode
+    )
+
+
+def _recognized_profile_links(
     *,
     hermes_home_path: str | Path | None = None,
     recognized_targets: tuple[Path, ...] = (),
-) -> None:
-    """Remove profile links that resolve to a recognized Mnemosyne target.
+) -> list[_ProfileLinkSnapshot]:
+    """Return profile links that currently resolve to a recognized target.
 
-    Links are removed even if the profile no longer opts in, but unrelated
-    links and real directories are left untouched.
+    Profiles are considered even if they no longer opt in, but unrelated links
+    and real directories are ignored.
     """
     base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
     profiles_dir = base / "profiles"
     if not profiles_dir.is_dir():
-        return
+        return []
     recognized = {_resolve_package_dir().resolve()}
     for target in recognized_targets:
         try:
             recognized.add(target.resolve())
         except OSError:
             continue
+    links: list[_ProfileLinkSnapshot] = []
     for child in sorted(profiles_dir.iterdir()):
         if child.is_symlink():
             continue
         target = child / "plugins" / PLUGIN_NAME
-        if not target.is_symlink():
+        before = _snapshot_profile_link(target)
+        if before is None:
             continue
         try:
-            if target.resolve() in recognized:
-                target.unlink()
-                print(f"  Removed profile link: {target}")
+            resolved = target.resolve()
         except OSError:
             continue
+        after = _snapshot_profile_link(target)
+        if (
+            after is not None
+            and _same_profile_link_identity(before, after)
+            and resolved in recognized
+        ):
+            links.append(after)
+    return links
+
+
+def _unlink_profile_links(links: list[_ProfileLinkSnapshot]) -> None:
+    """Quarantine each candidate, then remove only the snapshotted symlink."""
+    for snapshot in links:
+        target = snapshot.path
+        if _snapshot_profile_link(target) is None:
+            continue
+        quarantine_parent: Path | None = None
+        quarantined: Path | None = None
+        moved = False
+        try:
+            quarantine_parent = Path(
+                tempfile.mkdtemp(prefix=f".{target.name}.unlink-", dir=target.parent)
+            )
+            quarantined = quarantine_parent / target.name
+            target.replace(quarantined)
+            moved = True
+            quarantined_snapshot = _snapshot_profile_link(quarantined)
+            if quarantined_snapshot is not None and _same_profile_link_identity(
+                snapshot, quarantined_snapshot
+            ):
+                quarantined.unlink()
+                moved = False
+                print(f"  Removed profile link: {target}")
+            elif not target.is_symlink() and not target.exists():
+                quarantined.replace(target)
+                moved = False
+        except OSError:
+            pass
+        finally:
+            if moved and quarantined is not None:
+                try:
+                    if not target.is_symlink() and not target.exists():
+                        quarantined.replace(target)
+                        moved = False
+                except OSError:
+                    pass
+            if moved and quarantined is not None:
+                print(
+                    f"  Profile entry changed during cleanup; preserved at: {quarantined}",
+                    file=sys.stderr,
+                )
+            if quarantine_parent is not None:
+                try:
+                    quarantine_parent.rmdir()
+                except OSError:
+                    pass
+
+
+def _unlink_all_profiles(
+    *,
+    hermes_home_path: str | Path | None = None,
+    recognized_targets: tuple[Path, ...] = (),
+) -> None:
+    """Remove profile links that resolve to a recognized Mnemosyne target."""
+    _unlink_profile_links(
+        _recognized_profile_links(
+            hermes_home_path=hermes_home_path,
+            recognized_targets=recognized_targets,
+        )
+    )
 
 
 def _prepare_plugin_target(
@@ -1124,17 +1308,55 @@ def install_plugin(
             "Re-run with --migrate-wrapper-to-symlink --force to migrate intentionally."
         )
 
+    recognized_profile_targets = [source]
+    # Preserve a validated previous provider target before --force replaces it.
+    if _provider_init_is_mnemosyne(target / "__init__.py"):
+        try:
+            recognized_profile_targets.append(target.resolve())
+        except OSError:
+            pass
+        wrapper_metadata = _wrapper_metadata(target, target / "__init__.py")
+        if wrapper_metadata.error is None and wrapper_metadata.site_packages is not None:
+            recognized_profile_targets.append(
+                wrapper_metadata.site_packages / "mnemosyne_hermes"
+            )
+    profile_links_to_unlink = (
+        _recognized_profile_links(
+            hermes_home_path=hermes_home_path,
+            recognized_targets=tuple(recognized_profile_targets),
+        )
+        if not link_profiles
+        else []
+    )
+    preference_path = _profile_links_preference_path(hermes_home_path)
+    try:
+        previous_preference = preference_path.read_bytes()
+    except FileNotFoundError:
+        previous_preference = None
+
     if mode == "symlink":
         if migrate_wrapper_to_symlink and _is_wrapper_plugin_target(target):
             print(
                 "  ⚠ Migrating existing Mnemosyne wrapper to a symlink; "
                 "the wrapper's selected Python will no longer be used."
             )
-        _prepare_plugin_target(base, target, force=force)
-        os.symlink(str(source), str(target))
+        _write_profile_links_preference(link_profiles, hermes_home_path=hermes_home_path)
+        try:
+            _prepare_plugin_target(base, target, force=force)
+            os.symlink(str(source), str(target))
+        except Exception:
+            try:
+                _restore_profile_links_preference(preference_path, previous_preference)
+            except OSError:
+                print(
+                    f"⚠ Profile-link preference rollback failed; inspect: {preference_path}",
+                    file=sys.stderr,
+                )
+            raise
         if link_profiles:
             _link_all_profiles(source, hermes_home_path=hermes_home_path, force=force)
-        _write_profile_links_preference(link_profiles, hermes_home_path=hermes_home_path)
+        else:
+            _unlink_profile_links(profile_links_to_unlink)
         return target
 
     # Validate and fully write the replacement before removing a working wrapper.
@@ -1144,15 +1366,29 @@ def install_plugin(
     target.parent.mkdir(parents=True, exist_ok=True)
     staging_parent = Path(tempfile.mkdtemp(prefix=f".{target.name}.staging-", dir=target.parent))
     staged = staging_parent / target.name
+    preference_written = False
     try:
         _write_wrapper_plugin(staged, python=wrapper_python, site_packages=site_packages)
+        _write_profile_links_preference(link_profiles, hermes_home_path=hermes_home_path)
+        preference_written = True
         _prepare_plugin_target(base, target, force=force, remove_target=False)
         _replace_plugin_target_with_staged(target, staged)
+    except Exception:
+        if preference_written:
+            try:
+                _restore_profile_links_preference(preference_path, previous_preference)
+            except OSError:
+                print(
+                    f"⚠ Profile-link preference rollback failed; inspect: {preference_path}",
+                    file=sys.stderr,
+                )
+        raise
     finally:
         shutil.rmtree(staging_parent, ignore_errors=True)
     if link_profiles:
         _link_all_profiles(target, hermes_home_path=hermes_home_path, force=force)
-    _write_profile_links_preference(link_profiles, hermes_home_path=hermes_home_path)
+    else:
+        _unlink_profile_links(profile_links_to_unlink)
     return target
 
 

--- a/integrations/hermes/src/mnemosyne_hermes/upgrade.py
+++ b/integrations/hermes/src/mnemosyne_hermes/upgrade.py
@@ -119,14 +119,17 @@ def upgrade_command(args=None) -> int:
     from mnemosyne_hermes.install import plugin_state, profile_links_enabled
 
     existing_plugin = plugin_state(hermes_home_path=hermes_home_path)
+    link_profiles = profile_links_enabled(hermes_home_path=hermes_home_path)
+    install_command = "mnemosyne-hermes install --force"
+    if not link_profiles:
+        install_command += " --no-profile-links"
     if existing_plugin.status == "invalid_wrapper":
         print("⚠ Cannot safely upgrade an invalid Mnemosyne wrapper.")
         print(f"  {existing_plugin.message}")
-        print("  Repair it with: mnemosyne-hermes install --force --mode wrapper")
+        print(f"  Repair it with: {install_command} --mode wrapper")
         return 1
     install_mode = "wrapper" if existing_plugin.mode == "wrapper" else "symlink"
     wrapper_python = existing_plugin.wrapper_python if install_mode == "wrapper" else None
-    link_profiles = profile_links_enabled(hermes_home_path=hermes_home_path)
 
     method = detect_install_method()
     current_ver = get_current_version()
@@ -143,7 +146,7 @@ def upgrade_command(args=None) -> int:
         print("    uv tool upgrade mnemosyne-hermes")
         print("    pip install --upgrade mnemosyne-hermes[all]")
         print("\n  After upgrading, re-register the plugin:")
-        print("    mnemosyne-hermes install --force")
+        print(f"    {install_command}")
         return 1
 
     # Check available version (best-effort)
@@ -160,7 +163,7 @@ def upgrade_command(args=None) -> int:
     if dry_run:
         method_name = {"pipx": "pipx upgrade", "uv-tool": "uv tool upgrade", "pip": "pip install --upgrade"}.get(method, method)
         print(f"\n  Would run: {method_name} mnemosyne-hermes")
-        print("  Would run: mnemosyne-hermes install --force")
+        print(f"  Would run: {install_command}")
         print(f"  Plugin symlink target: {Path(hermes_home_path or '~/.hermes').expanduser() / 'plugins' / 'mnemosyne'}")
         return 0
 
@@ -194,11 +197,11 @@ def upgrade_command(args=None) -> int:
         )
         if result_code != 0:
             print("  ⚠ Re-registration had issues (see output above).")
-            print("  Run manually: mnemosyne-hermes install --force")
+            print(f"  Run manually: {install_command}")
             return 1
     except Exception as e:
         print(f"  ⚠ Could not auto-run install step: {e}")
-        print("  Run manually: mnemosyne-hermes install --force")
+        print(f"  Run manually: {install_command}")
         return 1
 
     print("\n✓ Upgrade complete!")

--- a/integrations/hermes/src/mnemosyne_hermes/upgrade.py
+++ b/integrations/hermes/src/mnemosyne_hermes/upgrade.py
@@ -116,7 +116,7 @@ def upgrade_command(args=None) -> int:
     """
     dry_run = getattr(args, "dry_run", False) if args else False
     hermes_home_path = getattr(args, "hermes_home", None) if args else None
-    from mnemosyne_hermes.install import plugin_state
+    from mnemosyne_hermes.install import plugin_state, profile_links_enabled
 
     existing_plugin = plugin_state(hermes_home_path=hermes_home_path)
     if existing_plugin.status == "invalid_wrapper":
@@ -126,6 +126,7 @@ def upgrade_command(args=None) -> int:
         return 1
     install_mode = "wrapper" if existing_plugin.mode == "wrapper" else "symlink"
     wrapper_python = existing_plugin.wrapper_python if install_mode == "wrapper" else None
+    link_profiles = profile_links_enabled(hermes_home_path=hermes_home_path)
 
     method = detect_install_method()
     current_ver = get_current_version()
@@ -189,6 +190,7 @@ def upgrade_command(args=None) -> int:
             hermes_home_path=hermes_home_path,
             mode=install_mode,
             python=wrapper_python,
+            link_profiles=link_profiles,
         )
         if result_code != 0:
             print("  ⚠ Re-registration had issues (see output above).")

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -54,6 +54,22 @@ def test_only_opted_in_profile_gets_link(tmp_path):
     assert not (profile_b / "plugins" / "mnemosyne").exists()
 
 
+def test_wrapper_install_root_only_does_not_link_opted_in_child_profile(tmp_path):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+
+    target = install_plugin(
+        hermes_home_path=tmp_path,
+        mode="wrapper",
+        python=sys.executable,
+        link_profiles=False,
+    )
+
+    assert target == tmp_path / "plugins" / "mnemosyne"
+    assert target.is_dir() and not target.is_symlink()
+    assert not (child / "plugins" / "mnemosyne").exists()
+
+
 def test_rerun_is_idempotent(tmp_path):
     _skip_on_windows()
     profile_a = _make_profile(tmp_path, "alice", "mnemosyne")

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -70,6 +70,41 @@ def test_wrapper_install_root_only_does_not_link_opted_in_child_profile(tmp_path
     assert not (child / "plugins" / "mnemosyne").exists()
 
 
+def test_root_only_install_does_not_remove_existing_child_profile_link(tmp_path):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    install_plugin(hermes_home_path=tmp_path)
+    child_link = child / "plugins" / "mnemosyne"
+
+    install_plugin(
+        hermes_home_path=tmp_path,
+        mode="wrapper",
+        python=sys.executable,
+        force=True,
+        link_profiles=False,
+    )
+
+    assert child_link.is_symlink()
+
+
+def test_profile_links_enabled_reflects_existing_root_profile_links(tmp_path):
+    _skip_on_windows()
+    _make_profile(tmp_path, "child", "mnemosyne")
+
+    install_plugin(hermes_home_path=tmp_path)
+
+    assert install_mod.profile_links_enabled(hermes_home_path=tmp_path) is True
+
+
+def test_profile_links_enabled_is_false_for_root_only_install(tmp_path):
+    _skip_on_windows()
+    _make_profile(tmp_path, "child", "mnemosyne")
+
+    install_plugin(hermes_home_path=tmp_path, link_profiles=False)
+
+    assert install_mod.profile_links_enabled(hermes_home_path=tmp_path) is False
+
+
 def test_rerun_is_idempotent(tmp_path):
     _skip_on_windows()
     profile_a = _make_profile(tmp_path, "alice", "mnemosyne")

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -70,21 +70,252 @@ def test_wrapper_install_root_only_does_not_link_opted_in_child_profile(tmp_path
     assert not (child / "plugins" / "mnemosyne").exists()
 
 
-def test_root_only_install_does_not_remove_existing_child_profile_link(tmp_path):
+@pytest.mark.parametrize(
+    ("initial_mode", "root_only_mode"),
+    [
+        ("symlink", "symlink"),
+        ("wrapper", "wrapper"),
+        ("symlink", "wrapper"),
+        ("wrapper", "symlink"),
+    ],
+)
+def test_root_only_transition_removes_only_recognized_profile_links(
+    tmp_path, initial_mode, root_only_mode
+):
     _skip_on_windows()
     child = _make_profile(tmp_path, "child", "mnemosyne")
-    install_plugin(hermes_home_path=tmp_path)
+    foreign_profile = _make_profile(tmp_path, "foreign", "mnemosyne")
+    directory_profile = _make_profile(tmp_path, "directory", "mnemosyne")
+    initial_kwargs = {"hermes_home_path": tmp_path, "mode": initial_mode}
+    if initial_mode == "wrapper":
+        initial_kwargs["python"] = sys.executable
+    install_plugin(**initial_kwargs)
+
     child_link = child / "plugins" / "mnemosyne"
+    foreign_link = foreign_profile / "plugins" / "mnemosyne"
+    if initial_mode == "symlink":
+        previous_source = tmp_path / "previous-mnemosyne-package"
+        previous_source.mkdir()
+        (previous_source / "__init__.py").write_text(
+            "class MnemosyneMemoryProvider:\n    pass\n", encoding="utf-8"
+        )
+        (previous_source / "plugin.yaml").write_text(
+            "name: hermes-mnemosyne\n", encoding="utf-8"
+        )
+        root_link = tmp_path / "plugins" / "mnemosyne"
+        root_link.unlink()
+        os.symlink(str(previous_source), str(root_link))
+        child_link.unlink()
+        os.symlink(str(previous_source), str(child_link))
+    foreign_target = tmp_path / "foreign-provider"
+    foreign_target.mkdir()
+    foreign_link.unlink()
+    os.symlink(str(foreign_target), str(foreign_link))
+    directory_target = directory_profile / "plugins" / "mnemosyne"
+    directory_target.unlink()
+    directory_target.mkdir()
+    marker = directory_target / "foreign.txt"
+    marker.write_text("keep", encoding="utf-8")
+
+    root_only_kwargs = {
+        "hermes_home_path": tmp_path,
+        "mode": root_only_mode,
+        "force": True,
+        "link_profiles": False,
+    }
+    if root_only_mode == "wrapper":
+        root_only_kwargs["python"] = sys.executable
+    elif initial_mode == "wrapper":
+        root_only_kwargs["migrate_wrapper_to_symlink"] = True
+    install_plugin(**root_only_kwargs)
+
+    assert not child_link.is_symlink() and not child_link.exists()
+    assert foreign_link.is_symlink()
+    assert foreign_link.resolve() == foreign_target.resolve()
+    assert directory_target.is_dir()
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_root_only_cleanup_preserves_link_repointed_after_snapshot(tmp_path, monkeypatch):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
+    child_link = child / "plugins" / "mnemosyne"
+    foreign_target = tmp_path / "foreign-provider"
+    foreign_target.mkdir()
+    original_swap = install_mod._replace_plugin_target_with_staged
+
+    def swap_then_repoint(target, staged):
+        original_swap(target, staged)
+        child_link.unlink()
+        child_link.symlink_to(foreign_target, target_is_directory=True)
+
+    monkeypatch.setattr(install_mod, "_replace_plugin_target_with_staged", swap_then_repoint)
 
     install_plugin(
         hermes_home_path=tmp_path,
+        force=True,
         mode="wrapper",
         python=sys.executable,
+        link_profiles=False,
+    )
+
+    assert child_link.is_symlink()
+    assert child_link.resolve() == foreign_target.resolve()
+
+
+def test_profile_link_snapshot_rejects_repoint_during_classification(tmp_path, monkeypatch):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    target = install_plugin(hermes_home_path=tmp_path)
+    child_link = child / "plugins" / "mnemosyne"
+    foreign_target = tmp_path / "foreign-provider"
+    foreign_target.mkdir()
+    original_resolve = Path.resolve
+    repointed = False
+
+    def resolve_then_repoint(self, *args, **kwargs):
+        nonlocal repointed
+        resolved = original_resolve(self, *args, **kwargs)
+        if self == child_link and not repointed:
+            repointed = True
+            child_link.unlink()
+            child_link.symlink_to(foreign_target, target_is_directory=True)
+        return resolved
+
+    monkeypatch.setattr(Path, "resolve", resolve_then_repoint)
+
+    snapshots = install_mod._recognized_profile_links(
+        hermes_home_path=tmp_path,
+        recognized_targets=(target,),
+    )
+
+    assert snapshots == []
+    assert child_link.is_symlink()
+    assert child_link.resolve() == foreign_target.resolve()
+
+
+def test_profile_link_cleanup_restores_repointed_quarantined_link(tmp_path, monkeypatch):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    target = install_plugin(hermes_home_path=tmp_path)
+    child_link = child / "plugins" / "mnemosyne"
+    snapshots = install_mod._recognized_profile_links(
+        hermes_home_path=tmp_path,
+        recognized_targets=(target,),
+    )
+    foreign_target = tmp_path / "foreign-provider"
+    foreign_target.mkdir()
+    original_replace = Path.replace
+    repointed = False
+
+    def repoint_before_quarantine(self, destination):
+        nonlocal repointed
+        if self == child_link and not repointed:
+            repointed = True
+            child_link.unlink()
+            child_link.symlink_to(foreign_target, target_is_directory=True)
+        return original_replace(self, destination)
+
+    monkeypatch.setattr(Path, "replace", repoint_before_quarantine)
+
+    install_mod._unlink_profile_links(snapshots)
+
+    assert child_link.is_symlink()
+    assert child_link.resolve() == foreign_target.resolve()
+
+
+def test_profile_link_cleanup_restores_directory_replacing_snapshot(tmp_path, monkeypatch):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    target = install_plugin(hermes_home_path=tmp_path)
+    child_link = child / "plugins" / "mnemosyne"
+    snapshots = install_mod._recognized_profile_links(
+        hermes_home_path=tmp_path,
+        recognized_targets=(target,),
+    )
+    original_replace = Path.replace
+    replaced = False
+
+    def replace_with_directory_before_quarantine(self, destination):
+        nonlocal replaced
+        if self == child_link and not replaced:
+            replaced = True
+            child_link.unlink()
+            child_link.mkdir()
+            (child_link / "keep.txt").write_text("keep", encoding="utf-8")
+        return original_replace(self, destination)
+
+    monkeypatch.setattr(Path, "replace", replace_with_directory_before_quarantine)
+
+    install_mod._unlink_profile_links(snapshots)
+
+    assert child_link.is_dir() and not child_link.is_symlink()
+    assert (child_link / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_root_only_transition_keeps_links_to_foreign_hermes_provider(tmp_path):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    foreign_provider = tmp_path / "foreign-provider"
+    foreign_provider.mkdir()
+    (foreign_provider / "__init__.py").write_text(
+        "# Compatibility note: MnemosyneMemoryProvider is not defined here.\n"
+        "def register_memory_provider():\n    return None\n",
+        encoding="utf-8",
+    )
+    (foreign_provider / "plugin.yaml").write_text(
+        "name: foreign-memory-provider\n",
+        encoding="utf-8",
+    )
+    root_link = tmp_path / "plugins" / "mnemosyne"
+    root_link.parent.mkdir(parents=True)
+    os.symlink(str(foreign_provider), str(root_link))
+    child_link = child / "plugins" / "mnemosyne"
+    child_link.parent.mkdir(parents=True)
+    os.symlink(str(root_link), str(child_link))
+    original_child_target = child_link.readlink()
+
+    install_plugin(
+        hermes_home_path=tmp_path,
         force=True,
         link_profiles=False,
     )
 
     assert child_link.is_symlink()
+    assert child_link.readlink() == original_child_target
+
+
+def test_root_only_transition_removes_legacy_wrapper_profile_link(tmp_path):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    legacy_site = tmp_path / "legacy-site-packages"
+    legacy_package = legacy_site / "mnemosyne_hermes"
+    legacy_package.mkdir(parents=True)
+    root_plugin = tmp_path / "plugins" / "mnemosyne"
+    root_plugin.mkdir(parents=True)
+    (root_plugin / "__init__.py").write_text(
+        f"_PYTHON = {sys.executable!r}\n"
+        f"_SITE = {str(legacy_site)!r}\n"
+        "from mnemosyne_hermes import *  # noqa: F401,F403,E402\n",
+        encoding="utf-8",
+    )
+    (root_plugin / "plugin.yaml").write_text(
+        "name: hermes-mnemosyne\n",
+        encoding="utf-8",
+    )
+    child_link = child / "plugins" / "mnemosyne"
+    child_link.parent.mkdir(parents=True)
+    os.symlink(str(legacy_package), str(child_link))
+
+    install_plugin(
+        hermes_home_path=tmp_path,
+        force=True,
+        link_profiles=False,
+        migrate_wrapper_to_symlink=True,
+    )
+
+    assert not child_link.is_symlink() and not child_link.exists()
 
 
 def test_profile_links_preference_preserves_default_when_profiles_are_added_later(tmp_path):
@@ -251,6 +482,78 @@ def test_forced_wrapper_refresh_preflights_before_preserving_existing_wrapper_li
     assert foreign_link.is_symlink() and foreign_link.resolve() == foreign.resolve()
 
 
+def test_failed_root_only_wrapper_refresh_preserves_target_links_and_preference(tmp_path):
+    _skip_on_windows()
+    selected = _make_profile(tmp_path, "alice", "mnemosyne")
+    target = install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
+    selected_link = selected / "plugins" / "mnemosyne"
+    original_init = (target / "__init__.py").read_bytes()
+    preference = install_mod._profile_links_preference_path(tmp_path)
+    original_preference = preference.read_bytes()
+
+    with pytest.raises(FileNotFoundError, match="Python interpreter not found"):
+        install_plugin(
+            hermes_home_path=tmp_path,
+            force=True,
+            mode="wrapper",
+            python=tmp_path / "missing-python",
+            link_profiles=False,
+        )
+
+    assert target.is_dir() and not target.is_symlink()
+    assert (target / "__init__.py").read_bytes() == original_init
+    assert selected_link.is_symlink() and selected_link.resolve() == target.resolve()
+    assert preference.read_bytes() == original_preference
+    assert install_mod.profile_links_enabled(hermes_home_path=tmp_path) is True
+
+
+def test_root_only_wrapper_refresh_preference_failure_preserves_target_and_links(
+    tmp_path, monkeypatch
+):
+    _skip_on_windows()
+    selected = _make_profile(tmp_path, "alice", "mnemosyne")
+    foreign_profile = _make_profile(tmp_path, "bob", "mnemosyne")
+    real_profile = _make_profile(tmp_path, "carol", "mnemosyne")
+    target = install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
+    selected_link = selected / "plugins" / "mnemosyne"
+    foreign_link = foreign_profile / "plugins" / "mnemosyne"
+    foreign_link.unlink()
+    foreign_target = tmp_path / "foreign-plugin"
+    foreign_target.mkdir()
+    foreign_link.symlink_to(foreign_target, target_is_directory=True)
+    real_plugin = real_profile / "plugins" / "mnemosyne"
+    real_plugin.unlink()
+    real_plugin.mkdir()
+    marker = real_plugin / "keep.txt"
+    marker.write_text("foreign directory", encoding="utf-8")
+    original_init = (target / "__init__.py").read_bytes()
+    original_inode = target.stat().st_ino
+    preference = install_mod._profile_links_preference_path(tmp_path)
+    original_preference = preference.read_bytes()
+
+    def fail_preference_write(*args, **kwargs):
+        raise OSError("preference write failed")
+
+    monkeypatch.setattr(install_mod, "_write_profile_links_preference", fail_preference_write)
+
+    with pytest.raises(OSError, match="preference write failed"):
+        install_plugin(
+            hermes_home_path=tmp_path,
+            force=True,
+            mode="wrapper",
+            python=sys.executable,
+            link_profiles=False,
+        )
+
+    assert target.is_dir() and not target.is_symlink()
+    assert target.stat().st_ino == original_inode
+    assert (target / "__init__.py").read_bytes() == original_init
+    assert selected_link.is_symlink() and selected_link.resolve() == target.resolve()
+    assert foreign_link.is_symlink() and foreign_link.resolve() == foreign_target.resolve()
+    assert marker.read_text(encoding="utf-8") == "foreign directory"
+    assert preference.read_bytes() == original_preference
+
+
 def test_force_wrapper_refresh_replaces_wrapper_and_keeps_selected_profile_link(tmp_path):
     _skip_on_windows()
     profile = _make_profile(tmp_path, "alice", "mnemosyne")
@@ -349,6 +652,8 @@ def test_failed_wrapper_swap_restores_wrapper_and_profile_link(tmp_path, monkeyp
     target = install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
     profile_link = profile / "plugins" / "mnemosyne"
     original_init = (target / "__init__.py").read_bytes()
+    preference = install_mod._profile_links_preference_path(tmp_path)
+    original_preference = preference.read_bytes()
     original_replace = Path.replace
 
     def fail_staged_swap(self, destination):
@@ -364,12 +669,15 @@ def test_failed_wrapper_swap_restores_wrapper_and_profile_link(tmp_path, monkeyp
             force=True,
             mode="wrapper",
             python=sys.executable,
+            link_profiles=False,
         )
 
     assert target.is_dir() and not target.is_symlink()
     assert (target / "__init__.py").read_bytes() == original_init
     assert profile_link.is_symlink()
     assert profile_link.resolve() == target.resolve()
+    assert preference.read_bytes() == original_preference
+    assert install_mod.profile_links_enabled(hermes_home_path=tmp_path) is True
 
 
 def test_wrapper_preflight_and_bootstrap_support_real_pep660_editable_install(tmp_path):

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -87,11 +87,11 @@ def test_root_only_install_does_not_remove_existing_child_profile_link(tmp_path)
     assert child_link.is_symlink()
 
 
-def test_profile_links_enabled_reflects_existing_root_profile_links(tmp_path):
+def test_profile_links_preference_preserves_default_when_profiles_are_added_later(tmp_path):
     _skip_on_windows()
-    _make_profile(tmp_path, "child", "mnemosyne")
 
     install_plugin(hermes_home_path=tmp_path)
+    _make_profile(tmp_path, "child", "mnemosyne")
 
     assert install_mod.profile_links_enabled(hermes_home_path=tmp_path) is True
 

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -93,20 +93,6 @@ def test_root_only_transition_removes_only_recognized_profile_links(
 
     child_link = child / "plugins" / "mnemosyne"
     foreign_link = foreign_profile / "plugins" / "mnemosyne"
-    if initial_mode == "symlink":
-        previous_source = tmp_path / "previous-mnemosyne-package"
-        previous_source.mkdir()
-        (previous_source / "__init__.py").write_text(
-            "class MnemosyneMemoryProvider:\n    pass\n", encoding="utf-8"
-        )
-        (previous_source / "plugin.yaml").write_text(
-            "name: hermes-mnemosyne\n", encoding="utf-8"
-        )
-        root_link = tmp_path / "plugins" / "mnemosyne"
-        root_link.unlink()
-        os.symlink(str(previous_source), str(root_link))
-        child_link.unlink()
-        os.symlink(str(previous_source), str(child_link))
     foreign_target = tmp_path / "foreign-provider"
     foreign_target.mkdir()
     foreign_link.unlink()
@@ -162,6 +148,131 @@ def test_root_only_cleanup_preserves_link_repointed_after_snapshot(tmp_path, mon
 
     assert child_link.is_symlink()
     assert child_link.resolve() == foreign_target.resolve()
+
+
+def test_root_only_transition_preserves_compatible_foreign_provider_link(tmp_path):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    foreign_provider = tmp_path / "foreign-provider"
+    foreign_provider.mkdir()
+    (foreign_provider / "__init__.py").write_text(
+        "class MnemosyneMemoryProvider:\n    pass\n",
+        encoding="utf-8",
+    )
+    (foreign_provider / "plugin.yaml").write_text(
+        "name: hermes-mnemosyne\n",
+        encoding="utf-8",
+    )
+    root_link = tmp_path / "plugins" / "mnemosyne"
+    root_link.parent.mkdir(parents=True)
+    root_link.symlink_to(foreign_provider, target_is_directory=True)
+    child_link = child / "plugins" / "mnemosyne"
+    child_link.parent.mkdir(parents=True)
+    child_link.symlink_to(foreign_provider, target_is_directory=True)
+
+    install_plugin(
+        hermes_home_path=tmp_path,
+        force=True,
+        link_profiles=False,
+    )
+
+    assert child_link.is_symlink()
+    assert child_link.resolve() == foreign_provider.resolve()
+
+
+def test_root_only_cleanup_rename_failure_restores_preference(tmp_path, monkeypatch):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    install_plugin(hermes_home_path=tmp_path)
+    child_link = child / "plugins" / "mnemosyne"
+    preference = install_mod._profile_links_preference_path(tmp_path)
+    original_replace = Path.replace
+
+    def deny_profile_quarantine(self, target):
+        if self == child_link:
+            raise PermissionError("profile quarantine denied")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", deny_profile_quarantine)
+
+    with pytest.raises(PermissionError, match="profile quarantine denied"):
+        install_plugin(
+            hermes_home_path=tmp_path,
+            force=True,
+            link_profiles=False,
+        )
+
+    assert child_link.is_symlink()
+    assert install_mod.profile_links_enabled(hermes_home_path=tmp_path) is True
+    assert preference.read_text(encoding="utf-8") == '{"link_profiles": true}\n'
+
+
+def test_root_only_cleanup_failure_restores_effective_legacy_preference(
+    tmp_path, monkeypatch
+):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    install_plugin(hermes_home_path=tmp_path)
+    child_link = child / "plugins" / "mnemosyne"
+    preference = install_mod._profile_links_preference_path(tmp_path)
+    preference.unlink()
+    assert install_mod.profile_links_enabled(hermes_home_path=tmp_path) is True
+    original_replace = Path.replace
+
+    def deny_profile_quarantine(self, target):
+        if self == child_link:
+            raise PermissionError("profile quarantine denied")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", deny_profile_quarantine)
+
+    with pytest.raises(PermissionError, match="profile quarantine denied"):
+        install_plugin(
+            hermes_home_path=tmp_path,
+            mode="wrapper",
+            python=sys.executable,
+            force=True,
+            link_profiles=False,
+        )
+
+    assert child_link.is_symlink()
+    assert install_mod.profile_links_enabled(hermes_home_path=tmp_path) is True
+    assert preference.read_text(encoding="utf-8") == '{"link_profiles": true}\n'
+
+
+def test_root_only_cleanup_failure_remains_primary_when_preference_rollback_fails(
+    tmp_path, monkeypatch, capsys
+):
+    _skip_on_windows()
+    child = _make_profile(tmp_path, "child", "mnemosyne")
+    install_plugin(hermes_home_path=tmp_path)
+    child_link = child / "plugins" / "mnemosyne"
+    original_replace = Path.replace
+
+    def deny_profile_quarantine(self, target):
+        if self == child_link:
+            raise PermissionError("profile quarantine denied")
+        return original_replace(self, target)
+
+    def fail_preference_rollback(*args, **kwargs):
+        raise OSError("preference rollback denied")
+
+    monkeypatch.setattr(Path, "replace", deny_profile_quarantine)
+    monkeypatch.setattr(
+        install_mod,
+        "_restore_profile_links_preference",
+        fail_preference_rollback,
+    )
+
+    with pytest.raises(PermissionError, match="profile quarantine denied"):
+        install_plugin(
+            hermes_home_path=tmp_path,
+            force=True,
+            link_profiles=False,
+        )
+
+    assert child_link.is_symlink()
+    assert "Profile-link preference rollback failed" in capsys.readouterr().err
 
 
 def test_profile_link_snapshot_rejects_repoint_during_classification(tmp_path, monkeypatch):

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -106,6 +106,36 @@ def test_install_dry_run_reports_skill_action_without_writing(tmp_path, capsys, 
     assert not install.skill_target_file(tmp_path).exists()
 
 
+def test_install_dry_run_reports_when_profile_links_are_disabled(tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr(install, "_find_hermes_python", lambda: None)
+
+    rc = install.main(
+        ["--hermes-home", str(tmp_path), "install", "--no-profile-links", "--dry-run"]
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Will link opted-in profiles: False" in out
+
+
+def test_install_cli_passes_no_profile_links_to_installer(tmp_path, monkeypatch):
+    received = {}
+
+    def fake_run_install(**kwargs):
+        received.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(install, "run_install", fake_run_install)
+
+    rc = install.main(
+        ["--hermes-home", str(tmp_path), "install", "--no-profile-links"]
+    )
+
+    assert rc == 0
+    assert received["hermes_home_path"] == str(tmp_path)
+    assert received["link_profiles"] is False
+
+
 def test_status_reports_skill_state(tmp_path, capsys, monkeypatch):
     target = tmp_path / "plugins" / "mnemosyne"
     target.mkdir(parents=True)

--- a/integrations/hermes/tests/test_upgrade_wrapper.py
+++ b/integrations/hermes/tests/test_upgrade_wrapper.py
@@ -82,6 +82,50 @@ def test_upgrade_preserves_root_only_profile_link_preference(monkeypatch, tmp_pa
     assert calls[0]["link_profiles"] is False
 
 
+def test_upgrade_preserves_default_profile_links_when_profile_is_added_later(monkeypatch, tmp_path):
+    install.install_plugin(hermes_home_path=tmp_path)
+    child = tmp_path / "profiles" / "child"
+    child.mkdir(parents=True)
+    (child / "config.yaml").write_text("memory:\n  provider: mnemosyne\n", encoding="utf-8")
+    state = install.PluginState(
+        status="installed",
+        installed=True,
+        target=tmp_path / "plugins" / "mnemosyne",
+        message="installed",
+        mode="symlink",
+    )
+    calls = []
+    monkeypatch.setattr(upgrade, "detect_install_method", lambda: "pip")
+    monkeypatch.setattr(upgrade, "get_current_version", lambda: "0.5.0")
+    monkeypatch.setattr(upgrade, "get_current_core_version", lambda: "3.11.1")
+    monkeypatch.setattr(upgrade, "check_available_version", lambda method: "0.5.1")
+    monkeypatch.setattr(upgrade, "run_upgrade_command", lambda method, capture: (0, ""))
+    monkeypatch.setattr(install, "plugin_state", lambda **kwargs: state)
+    monkeypatch.setattr(install, "run_install", lambda **kwargs: calls.append(kwargs) or 0)
+
+    assert upgrade.upgrade_command(SimpleNamespace(hermes_home=str(tmp_path))) == 0
+    assert calls[0]["link_profiles"] is True
+
+
+def test_upgrade_messages_preserve_root_only_profile_link_preference(monkeypatch, tmp_path, capsys):
+    state = install.PluginState(
+        status="installed",
+        installed=True,
+        target=tmp_path / "plugins" / "mnemosyne",
+        message="installed",
+        mode="symlink",
+    )
+    monkeypatch.setattr(upgrade, "detect_install_method", lambda: "pip")
+    monkeypatch.setattr(upgrade, "get_current_version", lambda: "0.5.0")
+    monkeypatch.setattr(upgrade, "get_current_core_version", lambda: "3.11.1")
+    monkeypatch.setattr(upgrade, "check_available_version", lambda method: "0.5.1")
+    monkeypatch.setattr(install, "plugin_state", lambda **kwargs: state)
+    monkeypatch.setattr(install, "profile_links_enabled", lambda **kwargs: False)
+
+    assert upgrade.upgrade_command(SimpleNamespace(hermes_home=str(tmp_path), dry_run=True)) == 0
+    assert "mnemosyne-hermes install --force --no-profile-links" in capsys.readouterr().out
+
+
 def test_upgrade_stops_before_package_upgrade_for_invalid_wrapper(monkeypatch, tmp_path, capsys):
     state = install.PluginState(
         status="invalid_wrapper",

--- a/integrations/hermes/tests/test_upgrade_wrapper.py
+++ b/integrations/hermes/tests/test_upgrade_wrapper.py
@@ -40,6 +40,7 @@ def test_upgrade_reregisters_with_existing_wrapper_mode_and_interpreter(
     monkeypatch.setattr(upgrade, "check_available_version", lambda method: "0.5.1")
     monkeypatch.setattr(upgrade, "run_upgrade_command", lambda method, capture: (0, ""))
     monkeypatch.setattr(install, "plugin_state", lambda **kwargs: state)
+    monkeypatch.setattr(install, "profile_links_enabled", lambda **kwargs: True)
     monkeypatch.setattr(
         install,
         "run_install",
@@ -53,8 +54,32 @@ def test_upgrade_reregisters_with_existing_wrapper_mode_and_interpreter(
             "hermes_home_path": str(tmp_path),
             "mode": expected_mode,
             "python": expected_python,
+            "link_profiles": True,
         }
     ]
+
+
+def test_upgrade_preserves_root_only_profile_link_preference(monkeypatch, tmp_path):
+    state = install.PluginState(
+        status="installed",
+        installed=True,
+        target=tmp_path / "plugins" / "mnemosyne",
+        message="installed",
+        mode="wrapper",
+        wrapper_python=Path("/selected/venv/bin/python"),
+    )
+    calls = []
+    monkeypatch.setattr(upgrade, "detect_install_method", lambda: "pip")
+    monkeypatch.setattr(upgrade, "get_current_version", lambda: "0.5.0")
+    monkeypatch.setattr(upgrade, "get_current_core_version", lambda: "3.11.1")
+    monkeypatch.setattr(upgrade, "check_available_version", lambda method: "0.5.1")
+    monkeypatch.setattr(upgrade, "run_upgrade_command", lambda method, capture: (0, ""))
+    monkeypatch.setattr(install, "plugin_state", lambda **kwargs: state)
+    monkeypatch.setattr(install, "profile_links_enabled", lambda **kwargs: False)
+    monkeypatch.setattr(install, "run_install", lambda **kwargs: calls.append(kwargs) or 0)
+
+    assert upgrade.upgrade_command(SimpleNamespace(hermes_home=str(tmp_path))) == 0
+    assert calls[0]["link_profiles"] is False
 
 
 def test_upgrade_stops_before_package_upgrade_for_invalid_wrapper(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- add a backward-compatible `link_profiles` installer option
- add `mnemosyne-hermes install --no-profile-links` for root-only installs
- prevent a root/default Hermes home from linking opted-in child profiles when explicitly requested

## Why
A root Hermes home can contain `profiles/`; the existing installer traverses those profiles even when the caller intends to install only the root provider. This flag makes that scope explicit while preserving existing fan-out behavior by default.

## Validation
- `uv run python -m pytest tests/test_install_hermes.py tests/test_install_status.py -q`
- result: 35 passed
- added regression coverage for root wrapper isolation and dry-run reporting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds root-only Hermes plugin installation support.

- Adds backward-compatible `link_profiles` options to installer APIs.
- Adds the `mnemosyne-hermes install --no-profile-links` CLI flag.
- Persists the profile-link preference per Hermes home.
- Preserves the preference during upgrades and recovery.
- Preserves profile fan-out by default.
- Adds coverage for root-only installation, dry-run output, and upgrade behavior.
- Validation passed: 93 integration tests.

## Architectural impact

- **Agent integration:** Improves Hermes installation control through the Python API and CLI. MCP integration is unchanged.
- **Privacy:** Reduces unintended plugin exposure across Hermes profiles.
- **Local-first design:** Preserved. The change manages local plugin directories and preferences. It adds no remote service or sync behavior.
- **Core memory architecture:** No changes to working, episodic, or BEAM memory.
- **Retrieval and consolidation:** No changes.
- **Veracity system and sync layer:** No changes.
- **Benchmark methodology:** No changes.
- **Maintainability:** Preserves existing defaults and retains root-only preferences across upgrades.

This is the right call for Hermes profile isolation. It prevents new root-level installations from linking into opted-in child profiles while preserving existing default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->