### PR TITLE
fix(beam): invalidate cache after forgetting memory

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4371,7 +4371,10 @@ class BeamMemory:
                     "DELETE FROM annotations WHERE memory_id = ?", (memory_id,)
                 )
                 cursor.execute("DELETE FROM memory_embeddings WHERE memory_id = ?", (memory_id,))
-        return wm_rows > 0
+        forgotten = wm_rows > 0
+        if forgotten:
+            self._invalidate_query_cache()
+        return forgotten
 
     # ------------------------------------------------------------------
     # Episodic Memory

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -114,7 +114,7 @@ def test_successful_forget_working_clears_persisted_enhanced_recall_cache(
         beam_module, "resolve_beam_runtime", lambda: SimpleNamespace(cross_session=False)
     )
     db_path = tmp_path / "memories.db"
-    memory = fresh = None
+    memory = forgetter = fresh = None
     try:
         memory = BeamMemory(session_id="session-a", db_path=db_path)
         memory_id = memory.remember("issue 553 forget cache sentinel", source="test")
@@ -128,19 +128,33 @@ def test_successful_forget_working_clears_persisted_enhanced_recall_cache(
 
         assert memory.forget_working("missing-memory") is False
         assert memory._query_cache.stats()["version"] == cache_version
-        assert memory.forget_working(memory_id) is True
-        assert memory._query_cache.stats()["version"] == cache_version + 1
-        assert memory_id not in {
-            result["id"] for result in _call(memory, "issue 553 forget cache sentinel", top_k=3)
+
+        local_id = memory.remember("issue 553 local-cache forget sentinel", source="test")
+        _call(memory, "issue 553 local-cache forget sentinel", top_k=3)
+        local_version = memory._query_cache.stats()["version"]
+        assert memory.forget_working(local_id) is True
+        assert memory._query_cache.stats()["version"] == local_version + 1
+        assert local_id not in {
+            result["id"]
+            for result in _call(memory, "issue 553 local-cache forget sentinel", top_k=3)
         }
+
+        forgetter = BeamMemory(session_id="session-a", db_path=db_path)
+        assert not hasattr(forgetter, "_query_cache")
+        assert forgetter.forget_working(memory_id) is True
 
         fresh = BeamMemory(session_id="session-a", db_path=db_path)
         assert memory_id not in {
             result["id"] for result in _call(fresh, "issue 553 forget cache sentinel", top_k=3)
         }
     finally:
-        _close_memory(fresh)
-        _close_memory(memory)
+        try:
+            _close_memory(fresh)
+        finally:
+            try:
+                _close_memory(forgetter)
+            finally:
+                _close_memory(memory)
 
 
 def test_failed_cross_session_forget_keeps_cache_and_memory(
@@ -166,6 +180,7 @@ def test_failed_cross_session_forget_keeps_cache_and_memory(
         cache_version = other._query_cache.stats()["version"]
         assert other.forget_working(memory_id) is False
         assert other._query_cache.stats()["version"] == cache_version
+        assert owner.get(memory_id) is not None
         assert memory_id in {
             row["id"] for row in _call(owner, "issue 553 private forget sentinel", top_k=3)
         }

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -105,6 +105,75 @@ def test_successful_invalidate_clears_persisted_enhanced_recall_cache(monkeypatc
             _close_memory(memory)
 
 
+def test_successful_forget_working_clears_persisted_enhanced_recall_cache(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "1")
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    monkeypatch.setattr(
+        beam_module, "resolve_beam_runtime", lambda: SimpleNamespace(cross_session=False)
+    )
+    db_path = tmp_path / "memories.db"
+    memory = fresh = None
+    try:
+        memory = BeamMemory(session_id="session-a", db_path=db_path)
+        memory_id = memory.remember("issue 553 forget cache sentinel", source="test")
+        warm = _call(memory, "issue 553 forget cache sentinel", top_k=3)
+        assert memory_id in {result["id"] for result in warm}
+        assert memory._query_cache is not None
+        warm_cache_stats = memory._query_cache.stats()
+        assert _call(memory, "issue 553 forget cache sentinel", top_k=3) == warm
+        assert memory._query_cache.stats()["hits"] == warm_cache_stats["hits"] + 1
+        cache_version = memory._query_cache.stats()["version"]
+
+        assert memory.forget_working("missing-memory") is False
+        assert memory._query_cache.stats()["version"] == cache_version
+        assert memory.forget_working(memory_id) is True
+        assert memory._query_cache.stats()["version"] == cache_version + 1
+        assert memory_id not in {
+            result["id"] for result in _call(memory, "issue 553 forget cache sentinel", top_k=3)
+        }
+
+        fresh = BeamMemory(session_id="session-a", db_path=db_path)
+        assert memory_id not in {
+            result["id"] for result in _call(fresh, "issue 553 forget cache sentinel", top_k=3)
+        }
+    finally:
+        _close_memory(fresh)
+        _close_memory(memory)
+
+
+def test_failed_cross_session_forget_keeps_cache_and_memory(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "1")
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    monkeypatch.setattr(
+        beam_module, "resolve_beam_runtime", lambda: SimpleNamespace(cross_session=False)
+    )
+    owner = other = None
+    try:
+        db_path = tmp_path / "memories.db"
+        owner = BeamMemory(session_id="session-a", db_path=db_path)
+        memory_id = owner.remember("issue 553 private forget sentinel", source="test")
+        assert memory_id in {
+            row["id"] for row in _call(owner, "issue 553 private forget sentinel", top_k=3)
+        }
+
+        other = BeamMemory(session_id="session-b", db_path=db_path)
+        _call(other, "issue 553 private forget sentinel", top_k=3)
+        assert other._query_cache is not None
+        cache_version = other._query_cache.stats()["version"]
+        assert other.forget_working(memory_id) is False
+        assert other._query_cache.stats()["version"] == cache_version
+        assert memory_id in {
+            row["id"] for row in _call(owner, "issue 553 private forget sentinel", top_k=3)
+        }
+    finally:
+        _close_memory(other)
+        _close_memory(owner)
+
+
 def test_invalidate_without_local_query_cache_clears_persisted_enhanced_recall_cache(
     monkeypatch, tmp_path: Path
 ):

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -130,7 +130,8 @@ def test_successful_forget_working_clears_persisted_enhanced_recall_cache(
         assert memory._query_cache.stats()["version"] == cache_version
 
         local_id = memory.remember("issue 553 local-cache forget sentinel", source="test")
-        _call(memory, "issue 553 local-cache forget sentinel", top_k=3)
+        local_warm = _call(memory, "issue 553 local-cache forget sentinel", top_k=3)
+        assert local_id in {result["id"] for result in local_warm}
         local_version = memory._query_cache.stats()["version"]
         assert memory.forget_working(local_id) is True
         assert memory._query_cache.stats()["version"] == local_version + 1
@@ -175,11 +176,16 @@ def test_failed_cross_session_forget_keeps_cache_and_memory(
         }
 
         other = BeamMemory(session_id="session-b", db_path=db_path)
-        _call(other, "issue 553 private forget sentinel", top_k=3)
+        other_warm = _call(other, "issue 553 private forget sentinel", top_k=3)
+        assert memory_id not in {result["id"] for result in other_warm}
         assert other._query_cache is not None
         cache_version = other._query_cache.stats()["version"]
         assert other.forget_working(memory_id) is False
         assert other._query_cache.stats()["version"] == cache_version
+        assert memory_id not in {
+            result["id"]
+            for result in _call(other, "issue 553 private forget sentinel", top_k=3)
+        }
         assert owner.get(memory_id) is not None
         assert memory_id in {
             row["id"] for row in _call(owner, "issue 553 private forget sentinel", top_k=3)


### PR DESCRIPTION
Fixes #553.

Invalidate the Enhanced Recall cache only after `forget_working()` successfully commits its authorized delete and cascades.

Regression covers cached deletion, persisted-cache invalidation for a fresh instance, and no cache-version bump for a missing id.

Tests: `MNEMOSYNE_NO_EMBEDDINGS=1 .venv/bin/python -m pytest -q tests/test_enhanced_recall_cache.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- `forget_working()` now invalidates the Enhanced Recall cache only after an authorized deletion succeeds.
- Missing or unauthorized IDs do not change the cache version.
- Regression tests cover cached results, database reopening, missing IDs, and cross-session ownership.

## Architectural impact

- Keeps working-memory deletion and retrieval cache state consistent.
- Prevents deleted memories from appearing in later cached requests.
- Preserves local-first behavior through the existing BeamMemory/SQLite path.
- Improves privacy by removing stale deleted data from local retrieval results.
- Does not change episodic memory, BEAM memory, retrieval strategies, consolidation, veracity, sync, or benchmark methodology.
- Does not change Hermes, MCP, or CLI integration surfaces.
- Uses mutation-success invalidation, which is the right call for correctness and maintainability.
- The change does not erode local-first design or introduce external dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->