### PR TITLE
fix(benchmarks): carry the #544 version regex fix to the benchmark copy

### DIFF
--- a/_benchmarks/evaluate_beam_end_to_end.py
+++ b/_benchmarks/evaluate_beam_end_to_end.py
@@ -365,7 +365,7 @@ def _extract_facts(content: str, source: str = "unknown") -> list[dict]:
     facts = []
     
     # Pattern 1: Version numbers ("Flask 2.3.1", "v0.6.2", "Python 3.11")
-    ver_matches = re.findall(r'([A-Z][a-zA-Z]+(?:\s*[A-Z][a-zA-Z]+)*)\s+v?(\d+\.\d+(?:\.\d+)?)', content)
+    ver_matches = re.findall(r'([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*)\s+v?(\d+\.\d+(?:\.\d+)?)', content)
     for name, ver in ver_matches[:3]:
         facts.append({
             "content": f"FACT version: {name.strip()} {ver}",


### PR DESCRIPTION
Closes #595. Follow-up to review item 2 on #544.

## Summary

Carry the #544 fix to the one call site it missed. `_benchmarks/evaluate_beam_end_to_end.py:368` still holds the verbatim pre-#544 pattern, whose nested `\s*` lets a contiguous letter run be partitioned into the repeated group in exponentially many ways.

## Why this path

Identical reasoning to #544, and deliberately the identical one-character change (`\s*` → `\s+`) rather than a different formulation: the leading `[a-zA-Z]+` is greedy, so the zero-width-separator branch never contributes a reachable name string, and each whitespace-delimited word becomes consumable exactly one way.

Not hoisted to a module constant here. `beam.py` got `_VERSION_STRING_RE` because the pattern sits on a hot path called per `remember()`; this is a one-shot `re.findall` in a benchmark helper, and hoisting it would be scope the file doesn't need.

## Scope

One line in `_benchmarks/`. No test added — see below. No change to `mnemosyne/`, no extraction-policy change, no general regex cleanup.

## Severity: latent, not live

Stating the bounds rather than implying a user-facing hang:

- `_benchmarks/` is excluded from the wheel (`pyproject.toml:78`), so it never ships.
- `_extract_facts` (line 359) is currently unreachable — one definition, zero call sites, verified by AST walk (0 direct, 0 attribute calls). Live ingestion goes through `beam._extraction_client.extract_facts(...)` at line 547.

This is worth landing because it is the last copy of a pattern the project has already ruled out, in a file meant to run against large public datasets — the exact way this class regresses.

## Validation

- Existing regression suite: `tests/test_version_regex_backtracking.py` — **7 passed**
- Behavioral equivalence: 200,000 random strings over letters/whitespace/digits/`v`/`.`, old vs new `findall` — **zero differences** (same method used to review #544; inputs where the old pattern hung were excluded rather than counted as agreement)
- Pathological input from the existing suite, `("AAAAAA " * 20) + "v1."` — old: still running after 5 s, killed; new: 0.376 ms
- `py_compile` passed
- Ruff: file has 37 pre-existing findings on both sides of the change; the touched line reports none, count unchanged
- `git diff --check` clean

## On test coverage

I did not add a test. `tests/test_version_regex_backtracking.py` already pins this pattern shape, and the natural guard — asserting no `\s*` variant survives anywhere in the tree — would be a repo-wide grep test, which is a broader call than this one-line fix should make unilaterally. Happy to add either that guard or a focused benchmark-module test if you'd prefer the coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `_benchmarks/evaluate_beam_end_to_end.py` to change `\s*` to `\s+` in `_extract_facts`.
- Prevents potential exponential backtracking in the benchmark regex.
- Preserves supported product names and version formats.

## Architectural impact

- No changes to working, episodic, or BEAM memory tiers.
- No changes to retrieval, consolidation, veracity, sync, privacy, local-first behavior, Hermes, MCP, or CLI integration.
- No changes to benchmark methodology beyond improving regex safety.
- The change is isolated, low risk, and improves long-term maintainability by aligning this benchmark regex with the existing fix from `#544`.
- The `_benchmarks/` directory remains excluded from the wheel.
- `_extract_facts` is currently unreachable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->