### PR TITLE
governance: add CODEOWNERS and MAINTAINERS.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Mnemosyne CODEOWNERS
+# These owners will be the default owners for everything in the repo.
+# The Project Lead has final say on core architecture (see MAINTAINERS.md).
+
+# Default: both maintainers review
+*                           @AxDSan @dplush
+
+# Core architecture (Project Lead retains final authority)
+mnemosyne/core/beam.py      @AxDSan
+mnemosyne/core/banks.py     @AxDSan
+mnemosyne/core/profiles.py  @AxDSan
+
+# Integrations and tooling (Co-Maintainer can drive)
+hermes_memory_provider/     @dplush @AxDSan
+integrations/               @dplush @AxDSan
+scripts/                    @dplush @AxDSan
+
+# Docs and tests (either can approve)
+docs/                       @AxDSan @dplush
+tests/                      @AxDSan @dplush

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,11 +68,13 @@ Mnemosyne is intentionally minimal. Every addition is weighed against these prin
 
 ### Review Process
 
-There is no formal review board. Pull requests are reviewed by the maintainer and merged when they:
+Pull requests are reviewed by the maintainers and merged when they:
 
 - Pass existing tests
 - Follow the principles above
 - Include a clear description of what changed and why
+
+See [MAINTAINERS.md](MAINTAINERS.md) for the canonical decision framework, including who has authority over which areas of the codebase.
 
 ## Areas of Interest
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,41 @@
+# Maintainers
+
+## Project Lead
+
+**Abdias J. Moya (AJ)** — [@AxDSan](https://github.com/AxDSan)
+
+- Founder and primary architect of Mnemosyne
+- Final decision-making authority on core architecture: tiered memory model, recall pipeline, storage layer
+- PyPI publishing, repository administration, and organization ownership
+- Strategic direction and commercial entity formation
+
+## Co-Maintainer
+
+**Denis Hache** — [@dplush](https://github.com/dplush)
+
+- Write access: merge PRs, push branches
+- PR approval authority on designated code areas (see CODEOWNERS)
+- Drives features, integrations, documentation, testing, and tooling
+- Co-authorship credit on releases and publications
+
+## Decision Framework
+
+| Area | Authority |
+|------|-----------|
+| Core architecture (beam, banks, profiles, recall pipeline) | AJ (final say) |
+| Features, integrations, tooling | Denis can drive independently |
+| Breaking changes to public APIs | Requires consensus (AJ + Denis) |
+| PyPI publishing / release | AJ only |
+| Repo settings / org admin | AJ only |
+| Docs, tests, CI | Either maintainer |
+
+## Governance
+
+- All contributors must sign the [CLA](CLA.md) before contributions are accepted
+- The project remains MIT licensed; the core engine is free forever
+- A Delaware C-Corporation is planned as the long-term legal entity for Mnemosyne
+- This document may be amended by mutual written agreement of both maintainers
+
+---
+
+*Last updated: 2026-08-01*


### PR DESCRIPTION
Establishes the co-maintainer governance structure following Denis Hache's appointment.

**CODEOWNERS:**
- Core architecture (beam, banks, profiles): @AxDSan has final authority
- Integrations, tooling, scripts: @dplush can drive
- Docs and tests: either maintainer can approve

**MAINTAINERS.md:**
- Documents roles, decision framework, and governance rules
- References CLA requirement and Delaware C-Corp plans
- Clear table of who has authority over what

This formalizes what was agreed in the Co-Maintainer Appointment Agreement signed 2026-07-31.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds `CODEOWNERS` and `MAINTAINERS.md` to formalize co-maintainer governance.
- Assigns core architecture authority to `@AxDSan`.
- Assigns integrations, tooling, and scripts to `@dplush`.
- Links `CONTRIBUTING.md` to `MAINTAINERS.md` as the canonical decision framework.
- Documents decision-making, CLA requirements, legal plans, authority boundaries, and the Co-Maintainer Appointment Agreement.

## Impact

- **Core memory architecture:** No changes to working, episodic, or BEAM memory.
- **Retrieval and consolidation:** No changes.
- **Veracity system and sync layer:** No changes.
- **Privacy and local-first guarantees:** No changes. The PR adds no network, storage, or data-handling behavior.
- **Agent integration surfaces:** No changes to Hermes, MCP, or CLI behavior.
- **Benchmark methodology:** No changes.
- **Long-term maintainability:** Improves ownership clarity and review routing. Separating core architecture from integrations is the right call.
- **Local-first design risk:** None identified. The PR changes governance only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->