### PR TITLE
fix(beam): fail loudly on incomplete vector rebuilds

### DIFF
--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -285,6 +285,13 @@ def cmd_diagnose(args):
 
         if repair_vec_working:
             print("\n  vec_working repair requested")
+            repair_failed = any(
+                entry.get("check") == "vec_working_repair_status"
+                and str(entry.get("status", "")).upper() == "ERROR"
+                for entry in result.get("entries", [])
+            )
+            if repair_failed and not dry_run:
+                _fail("vec_working repair failed; inspect diagnostics above", exit_code=1)
 
         if fix_mode or (dry_run and not repair_vec_working):
             print("\n--- Auto-fix ---")

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -285,12 +285,15 @@ def cmd_diagnose(args):
 
         if repair_vec_working:
             print("\n  vec_working repair requested")
-            repair_failed = any(
-                entry.get("check") == "vec_working_repair_status"
-                and str(entry.get("status", "")).upper() == "ERROR"
+            repair_statuses = [
+                entry.get("status")
                 for entry in result.get("entries", [])
+                if entry.get("check") == "vec_working_repair_status"
+            ]
+            repair_succeeded = bool(repair_statuses) and all(
+                status == "repaired" for status in repair_statuses
             )
-            if repair_failed and not dry_run:
+            if not dry_run and not repair_succeeded:
                 _fail("vec_working repair failed; inspect diagnostics above", exit_code=1)
 
         if fix_mode or (dry_run and not repair_vec_working):

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2515,6 +2515,13 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
     def _count(sql: str) -> int:
         return int(conn.execute(sql).fetchone()[0])
 
+    def _commit_reindex_writes() -> None:
+        """Commit a rebuild boundary even when BEAM normally defers commits."""
+        if isinstance(conn, _BeamConnection):
+            conn._real_commit()
+        else:
+            conn.commit()
+
     def _embed_chunk(store: str, chunk) -> Any:
         try:
             vectors = _embeddings.embed([row["content"] for row in chunk])
@@ -2602,7 +2609,7 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
             conn.execute(
                 f"CREATE VIRTUAL TABLE {table} USING vec0(embedding {vec_type}[{target_dim}])"
             )
-        conn.commit()
+        _commit_reindex_writes()
 
     # 2) Working memory -> memory_embeddings (+ vec_working), via the shared write
     #    helper so the float-JSON and sqlite-vec stores stay consistent.
@@ -2619,7 +2626,7 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
                 conn, r["id"], np.asarray(vec).tolist(), commit_vec=False, strict_vec=True
             )
             wm_done += 1
-        conn.commit()
+        _commit_reindex_writes()
         if progress:
             progress("working_memory", wm_done, wm_total)
 
@@ -2644,7 +2651,7 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
                     (_mib(arr), rowid),
                 )
             ep_done += 1
-        conn.commit()
+        _commit_reindex_writes()
         if progress:
             progress("episodic_memory", ep_done, ep_total)
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2550,6 +2550,10 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
                     f"expected {target_dim}"
                 )
             for value in values:
+                if isinstance(value, (str, bytes)):
+                    raise RuntimeError(
+                        f"{store} embedding vector {index} is not a convertible numeric vector"
+                    )
                 if isinstance(value, (list, tuple)) or getattr(value, "ndim", 0) != 0:
                     raise RuntimeError(
                         f"{store} embedding vector {index} must be one-dimensional"

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2458,17 +2458,24 @@ def repair_vec_working(conn: sqlite3.Connection, *, dry_run: bool = False) -> Di
     result["after"] = vec_working_coverage(conn)
     if result.get("status") != "error":
         after = result["after"]
-        coverage_error = after.get("error") or after.get("missing_vec_working_rows_error")
+        coverage_errors = {
+            key: value
+            for key, value in after.items()
+            if key == "error" or key.endswith("_error")
+        }
         unresolved = after.get("missing_vec_working_rows")
         if (
             after.get("status") not in {"complete", "no_vectors", "empty"}
             or after.get("vec_working_available") is not True
-            or coverage_error
+            or coverage_errors
             or unresolved != 0
         ):
             result["status"] = "error"
-            if coverage_error:
-                result["error"] = f"vec_working repair coverage unavailable: {coverage_error}"
+            if coverage_errors:
+                details = "; ".join(
+                    f"{key}: {value}" for key, value in coverage_errors.items()
+                )
+                result["error"] = f"vec_working repair coverage unavailable: {details}"
             elif unresolved is None:
                 result["error"] = "vec_working repair coverage unavailable"
             else:
@@ -2526,6 +2533,37 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
                 f"{store} embedding batch returned {vector_count} embeddings "
                 f"for {len(chunk)} source rows"
             )
+        for index, vector in enumerate(vectors):
+            if isinstance(vector, (str, bytes)) or getattr(vector, "ndim", 1) != 1:
+                raise RuntimeError(
+                    f"{store} embedding vector {index} must be one-dimensional"
+                )
+            try:
+                values = list(vector)
+            except TypeError as exc:
+                raise RuntimeError(
+                    f"{store} embedding vector {index} is not a convertible numeric vector"
+                ) from exc
+            if len(values) != target_dim:
+                raise RuntimeError(
+                    f"{store} embedding vector {index} has dimension {len(values)}; "
+                    f"expected {target_dim}"
+                )
+            for value in values:
+                if isinstance(value, (list, tuple)) or getattr(value, "ndim", 0) != 0:
+                    raise RuntimeError(
+                        f"{store} embedding vector {index} must be one-dimensional"
+                    )
+                try:
+                    numeric_value = float(value)
+                except (TypeError, ValueError, OverflowError) as exc:
+                    raise RuntimeError(
+                        f"{store} embedding vector {index} is not a convertible numeric vector"
+                    ) from exc
+                if not math.isfinite(numeric_value):
+                    raise RuntimeError(
+                        f"{store} embedding vector {index} must contain only finite values"
+                    )
         return vectors
 
     wm_total = _count("SELECT COUNT(*) FROM working_memory "
@@ -2547,6 +2585,10 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
 
     if not _embeddings.available():
         raise RuntimeError("Embedding model unavailable; cannot reindex vectors.")
+    if ep_total and not vec_ok and _mib is None:
+        raise RuntimeError(
+            "episodic_memory vector backend unavailable; cannot reindex episodic vectors."
+        )
 
     # 1) Recreate the sqlite-vec tables at the active dimension. vec_facts has no
     #    writer yet but is recreated so its declared dim can't mismatch a query.

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2461,7 +2461,7 @@ def repair_vec_working(conn: sqlite3.Connection, *, dry_run: bool = False) -> Di
         coverage_error = after.get("error") or after.get("missing_vec_working_rows_error")
         unresolved = after.get("missing_vec_working_rows")
         if (
-            after.get("status") != "complete"
+            after.get("status") not in {"complete", "no_vectors", "empty"}
             or after.get("vec_working_available") is not True
             or coverage_error
             or unresolved != 0

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2288,7 +2288,8 @@ def _wm_vec_delete(conn: sqlite3.Connection, memory_id: str) -> None:
     conn.execute("DELETE FROM vec_working WHERE rowid = ?", (rowid,))
 
 
-def _store_working_embedding(conn: sqlite3.Connection, memory_id: str, embedding: List[float], *, commit_vec: bool = True) -> None:
+def _store_working_embedding(conn: sqlite3.Connection, memory_id: str, embedding: List[float], *,
+                             commit_vec: bool = True, strict_vec: bool = False) -> None:
     """Store working-memory embedding in fallback and sqlite-vec stores.
 
     ``memory_embeddings`` remains the compatibility/fallback store. When the
@@ -2310,6 +2311,8 @@ def _store_working_embedding(conn: sqlite3.Connection, memory_id: str, embedding
     try:
         _wm_vec_upsert(conn, memory_id, embedding, commit=commit_vec)
     except Exception as exc:
+        if strict_vec:
+            raise
         logger.warning(
             "vec_working upsert failed for '%s' (%s): %s",
             memory_id, type(exc).__name__, exc,
@@ -2320,27 +2323,18 @@ def _backfill_vec_working_from_memory_embeddings(conn: sqlite3.Connection) -> in
     """Idempotently mirror fallback working embeddings into vec_working."""
     if not _wm_vec_available(conn) or np is None:
         return 0
-    try:
-        rows = conn.execute("""
-            SELECT wm.id, wm.rowid, me.embedding_json
-            FROM working_memory wm
-            JOIN memory_embeddings me ON me.memory_id = wm.id
-            LEFT JOIN vec_working vw ON vw.rowid = wm.rowid
-            WHERE vw.rowid IS NULL
-        """).fetchall()
-    except Exception:
-        return 0
+    rows = conn.execute("""
+        SELECT wm.id, wm.rowid, me.embedding_json
+        FROM working_memory wm
+        JOIN memory_embeddings me ON me.memory_id = wm.id
+        LEFT JOIN vec_working vw ON vw.rowid = wm.rowid
+        WHERE vw.rowid IS NULL
+    """).fetchall()
     inserted = 0
     for row in rows:
-        try:
-            embedding = json.loads(row["embedding_json"])
-            _vec_table_insert(conn, "vec_working", int(row["rowid"]), embedding)
-            inserted += 1
-        except Exception as exc:
-            logger.warning(
-                "vec_working backfill skipped '%s' (%s): %s",
-                row["id"], type(exc).__name__, exc,
-            )
+        embedding = json.loads(row["embedding_json"])
+        _vec_table_insert(conn, "vec_working", int(row["rowid"]), embedding)
+        inserted += 1
     return inserted
 
 
@@ -2458,11 +2452,29 @@ def repair_vec_working(conn: sqlite3.Connection, *, dry_run: bool = False) -> Di
     try:
         result["inserted"] = _backfill_vec_working_from_memory_embeddings(conn)
         conn.commit()
-        result["status"] = "repaired"
     except Exception as exc:
         result["status"] = "error"
         result["error"] = f"{type(exc).__name__}: {exc}"
     result["after"] = vec_working_coverage(conn)
+    if result.get("status") != "error":
+        after = result["after"]
+        coverage_error = after.get("error") or after.get("missing_vec_working_rows_error")
+        unresolved = after.get("missing_vec_working_rows")
+        if (
+            after.get("status") != "complete"
+            or after.get("vec_working_available") is not True
+            or coverage_error
+            or unresolved != 0
+        ):
+            result["status"] = "error"
+            if coverage_error:
+                result["error"] = f"vec_working repair coverage unavailable: {coverage_error}"
+            elif unresolved is None:
+                result["error"] = "vec_working repair coverage unavailable"
+            else:
+                result["error"] = f"vec_working repair incomplete: {unresolved} rows unresolved"
+        else:
+            result["status"] = "repaired"
     return result
 
 
@@ -2494,10 +2506,27 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
     vec_ok = _vec_available(conn)
 
     def _count(sql: str) -> int:
+        return int(conn.execute(sql).fetchone()[0])
+
+    def _embed_chunk(store: str, chunk) -> Any:
         try:
-            return int(conn.execute(sql).fetchone()[0])
-        except Exception:
-            return 0
+            vectors = _embeddings.embed([row["content"] for row in chunk])
+        except Exception as exc:
+            raise RuntimeError(
+                f"{store} embedding batch failed: {type(exc).__name__}: {exc}"
+            ) from exc
+        if vectors is None:
+            raise RuntimeError(f"{store} embedding batch returned no embeddings")
+        try:
+            vector_count = len(vectors)
+        except TypeError as exc:
+            raise RuntimeError(f"{store} embedding batch returned an invalid result") from exc
+        if vector_count != len(chunk):
+            raise RuntimeError(
+                f"{store} embedding batch returned {vector_count} embeddings "
+                f"for {len(chunk)} source rows"
+            )
+        return vectors
 
     wm_total = _count("SELECT COUNT(*) FROM working_memory "
                       "WHERE content IS NOT NULL AND length(content) > 0")
@@ -2538,11 +2567,11 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
     ).fetchall()
     for start in range(0, len(wm_rows), batch_size):
         chunk = wm_rows[start:start + batch_size]
-        vecs = _embeddings.embed([r["content"] for r in chunk])
-        if vecs is None:
-            break
+        vecs = _embed_chunk("working_memory", chunk)
         for r, vec in zip(chunk, vecs):
-            _store_working_embedding(conn, r["id"], np.asarray(vec).tolist(), commit_vec=False)
+            _store_working_embedding(
+                conn, r["id"], np.asarray(vec).tolist(), commit_vec=False, strict_vec=True
+            )
             wm_done += 1
         conn.commit()
         if progress:
@@ -2557,26 +2586,27 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
     ).fetchall()
     for start in range(0, len(ep_rows), batch_size):
         chunk = ep_rows[start:start + batch_size]
-        vecs = _embeddings.embed([r["content"] for r in chunk])
-        if vecs is None:
-            break
+        vecs = _embed_chunk("episodic_memory", chunk)
         for r, vec in zip(chunk, vecs):
             arr = np.asarray(vec)
             rowid = int(r["rowid"])
             if vec_ok:
                 _vec_table_insert(conn, "vec_episodes", rowid, arr.tolist(), commit=False)
             if _mib is not None:
-                try:
-                    conn.execute(
-                        "UPDATE episodic_memory SET binary_vector = ? WHERE rowid = ?",
-                        (_mib(arr), rowid),
-                    )
-                except Exception:
-                    pass
+                conn.execute(
+                    "UPDATE episodic_memory SET binary_vector = ? WHERE rowid = ?",
+                    (_mib(arr), rowid),
+                )
             ep_done += 1
         conn.commit()
         if progress:
             progress("episodic_memory", ep_done, ep_total)
+
+    if wm_done != wm_total or ep_done != ep_total:
+        raise RuntimeError(
+            "Reindex incomplete: processed "
+            f"{wm_done}/{wm_total} working and {ep_done}/{ep_total} episodic rows"
+        )
 
     plan["status"] = "reindexed"
     plan["working_memory_reindexed"] = wm_done

--- a/mnemosyne/diagnose.py
+++ b/mnemosyne/diagnose.py
@@ -272,7 +272,10 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False, 
             log("db", "vec_working_orphans", str(after.get("orphan_vec_working_rows", 0)))
             log("db", "working_embedding_rows", str(after.get("working_embedding_rows", 0)))
         except Exception as exc:
-            log("db", "vec_working_coverage", "ERROR", str(exc))
+            if repair_vec_working:
+                log("db", "vec_working_repair_status", "ERROR", str(exc))
+            else:
+                log("db", "vec_working_coverage", "ERROR", str(exc))
     except Exception as e:
         log("db", "stats", "ERROR", str(e))
 
@@ -299,7 +302,9 @@ def run_diagnostics(*, repair_vec_working: bool = False, dry_run: bool = False, 
         "log_path": str(log_path),
         "checks_total": len(entries),
         "checks_passed": sum(1 for e in entries if e["status"] in non_failure_statuses),
-        "checks_failed": sum(1 for e in entries if e["status"] in ("MISSING", "NO", "ERROR")),
+        "checks_failed": sum(
+            1 for e in entries if str(e["status"]).upper() in ("MISSING", "NO", "ERROR")
+        ),
         "key_findings": [],
         "fixable": [],
         "entries": entries,

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -474,6 +474,28 @@ def test_vec_working_coverage_reports_fallback_only_when_table_unavailable(temp_
     assert repair["reason"] == "vec_working unavailable"
 
 
+@pytest.mark.parametrize("terminal_status", ["no_vectors", "empty"])
+def test_vec_working_repair_accepts_no_work_terminal_states(monkeypatch, terminal_status):
+    """Empty or vectorless stores are healthy no-op repair outcomes."""
+    coverage = {
+        "vec_working_available": True,
+        "missing_vec_working_rows": 0,
+        "status": terminal_status,
+    }
+    monkeypatch.setattr(beam_module, "vec_working_coverage", lambda _conn: coverage)
+    monkeypatch.setattr(beam_module, "_backfill_vec_working_from_memory_embeddings", lambda _conn: 0)
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        result = beam_module.repair_vec_working(conn)
+    finally:
+        conn.close()
+
+    assert result["status"] == "repaired"
+    assert result["inserted"] == 0
+    assert result["after"]["status"] == terminal_status
+
+
 def test_vec_working_repair_reports_backfill_insert_failure(temp_db, monkeypatch):
     """Repair must not claim success while vec_working coverage remains partial."""
     beam = BeamMemory(session_id="vec-working-repair-failure", db_path=temp_db)

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -526,14 +526,24 @@ def test_vec_working_repair_reports_backfill_insert_failure(temp_db, monkeypatch
     assert result["after"]["missing_vec_working_rows"] == 1
 
 
-def test_vec_working_repair_reports_unavailable_coverage(monkeypatch):
-    """A failed post-repair coverage query must not be reported as repaired."""
+@pytest.mark.parametrize(
+    "coverage_error_key",
+    [
+        "missing_vec_working_rows_error",
+        "memory_embeddings_error",
+        "vec_working_rows_error",
+        "error",
+    ],
+)
+def test_vec_working_repair_reports_unavailable_coverage(monkeypatch, coverage_error_key):
+    """Any post-repair coverage error key must prevent a repaired status."""
     coverage_results = iter([
         {"vec_working_available": True, "missing_vec_working_rows": 1},
         {
             "vec_working_available": True,
             "missing_vec_working_rows": 0,
-            "missing_vec_working_rows_error": "OperationalError: vec_working unavailable",
+            "status": "complete",
+            coverage_error_key: "OperationalError: coverage unavailable",
         },
     ])
     monkeypatch.setattr(beam_module, "vec_working_coverage", lambda _conn: next(coverage_results))
@@ -546,6 +556,7 @@ def test_vec_working_repair_reports_unavailable_coverage(monkeypatch):
     result = beam_module.repair_vec_working(_Connection())
 
     assert result["status"] == "error"
+    assert coverage_error_key in result["error"]
     assert "coverage unavailable" in result["error"]
 
 

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -474,6 +474,81 @@ def test_vec_working_coverage_reports_fallback_only_when_table_unavailable(temp_
     assert repair["reason"] == "vec_working unavailable"
 
 
+def test_vec_working_repair_reports_backfill_insert_failure(temp_db, monkeypatch):
+    """Repair must not claim success while vec_working coverage remains partial."""
+    beam = BeamMemory(session_id="vec-working-repair-failure", db_path=temp_db)
+    beam.conn.execute("CREATE TABLE vec_working (rowid INTEGER PRIMARY KEY, embedding TEXT)")
+    beam.conn.execute(
+        "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("unrepaired", "working source", "test", "2026-01-01T00:00:00", "vec-working-repair-failure"),
+    )
+    beam.conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+        ("unrepaired", "[0.1, 0.2]", "test"),
+    )
+    beam.conn.commit()
+    monkeypatch.setattr(beam_module, "_wm_vec_available", lambda _conn: True)
+    monkeypatch.setattr(beam_module, "np", object())
+    monkeypatch.setattr(
+        beam_module,
+        "_vec_table_insert",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("vec insert failed")),
+    )
+
+    result = beam_module.repair_vec_working(beam.conn)
+
+    assert result["status"] == "error"
+    assert "vec insert failed" in result["error"]
+    assert result["after"]["missing_vec_working_rows"] == 1
+
+
+def test_vec_working_repair_reports_unavailable_coverage(monkeypatch):
+    """A failed post-repair coverage query must not be reported as repaired."""
+    coverage_results = iter([
+        {"vec_working_available": True, "missing_vec_working_rows": 1},
+        {
+            "vec_working_available": True,
+            "missing_vec_working_rows": 0,
+            "missing_vec_working_rows_error": "OperationalError: vec_working unavailable",
+        },
+    ])
+    monkeypatch.setattr(beam_module, "vec_working_coverage", lambda _conn: next(coverage_results))
+    monkeypatch.setattr(beam_module, "_backfill_vec_working_from_memory_embeddings", lambda _conn: 1)
+
+    class _Connection:
+        def commit(self):
+            pass
+
+    result = beam_module.repair_vec_working(_Connection())
+
+    assert result["status"] == "error"
+    assert "coverage unavailable" in result["error"]
+
+
+def test_vec_working_repair_requires_complete_available_postcheck(monkeypatch):
+    """A post-repair coverage error with a default zero count is not success."""
+    coverage_results = iter([
+        {"vec_working_available": True, "missing_vec_working_rows": 1},
+        {
+            "vec_working_available": False,
+            "missing_vec_working_rows": 0,
+            "status": "error",
+            "error": "vec_working table missing",
+        },
+    ])
+    monkeypatch.setattr(beam_module, "vec_working_coverage", lambda _conn: next(coverage_results))
+    monkeypatch.setattr(beam_module, "_backfill_vec_working_from_memory_embeddings", lambda _conn: 1)
+
+    class _Connection:
+        def commit(self):
+            pass
+
+    result = beam_module.repair_vec_working(_Connection())
+
+    assert result["status"] == "error"
+    assert "coverage unavailable" in result["error"]
+
 
 class TestFactAnnotationMatching:
     def test_strict_fact_match_ignores_stopword_only_matches(self, monkeypatch):

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -477,6 +477,7 @@ def test_vec_working_coverage_reports_fallback_only_when_table_unavailable(temp_
 def test_vec_working_repair_reports_backfill_insert_failure(temp_db, monkeypatch):
     """Repair must not claim success while vec_working coverage remains partial."""
     beam = BeamMemory(session_id="vec-working-repair-failure", db_path=temp_db)
+    beam.conn.execute("DROP TABLE IF EXISTS vec_working")
     beam.conn.execute("CREATE TABLE vec_working (rowid INTEGER PRIMARY KEY, embedding TEXT)")
     beam.conn.execute(
         "INSERT INTO working_memory (id, content, source, timestamp, session_id) "

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -1,8 +1,9 @@
 import sqlite3
 
-import mnemosyne
+import pytest
 
-from mnemosyne import diagnose
+import mnemosyne
+from mnemosyne import cli, diagnose
 from mnemosyne.core.beam import BeamMemory
 from mnemosyne.core.memory import init_db
 
@@ -149,3 +150,21 @@ def test_diagnose_reports_memory_orphans_without_mutating_rows(tmp_path, monkeyp
     assert _entry(summary, "orphan_memory_id_overlap")["status"] == "1"
     assert _entry(summary, "hygiene_noise_scanned")["status"] == "3"
     assert _entry(summary, "hygiene_noise_candidates")["status"] == "0"
+
+
+def test_cli_diagnose_repair_failure_is_a_process_failure(monkeypatch):
+    monkeypatch.setattr(
+        diagnose,
+        "run_diagnostics",
+        lambda **_kwargs: {
+            "checks_passed": 1,
+            "checks_total": 2,
+            "key_findings": ["vec_working repair error: inserted 0 rows"],
+            "entries": [{"check": "vec_working_repair_status", "status": "error"}],
+        },
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        cli.cmd_diagnose(["--repair-vec-working"])
+
+    assert raised.value.code == 1

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -38,6 +38,29 @@ def test_diagnose_treats_ctransformers_as_optional(tmp_path, monkeypatch):
     assert ctransformers["status"] not in {"MISSING", "ERROR"}
 
 
+def test_run_diagnostics_counts_lowercase_error_status(tmp_path, monkeypatch):
+    """Summary failures include lowercase statuses emitted by diagnostics."""
+    monkeypatch.setattr(diagnose, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr(
+        diagnose,
+        "collect_runtime_diagnostics",
+        lambda: {
+            "checks": [
+                {"category": "test", "check": "lowercase_error", "status": "error", "detail": ""},
+            ]
+        },
+    )
+
+    summary = diagnose.run_diagnostics()
+
+    assert _entry(summary, "lowercase_error")["status"] == "error"
+    assert summary["checks_failed"] == sum(
+        str(entry["status"]).upper() in {"MISSING", "NO", "ERROR"}
+        for entry in summary["entries"]
+    )
+
+
 def test_diagnose_vector_guidance_uses_valid_sleep_actions(tmp_path, monkeypatch):
     monkeypatch.setattr(diagnose, "LOG_DIR", tmp_path / "logs")
     monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -152,15 +152,19 @@ def test_diagnose_reports_memory_orphans_without_mutating_rows(tmp_path, monkeyp
     assert _entry(summary, "hygiene_noise_candidates")["status"] == "0"
 
 
-def test_cli_diagnose_repair_failure_is_a_process_failure(monkeypatch):
+@pytest.mark.parametrize("repair_status", ["error", "skipped", None])
+def test_cli_diagnose_unsuccessful_repair_is_a_process_failure(monkeypatch, repair_status):
+    entry = {"check": "vec_working_repair_status"}
+    if repair_status is not None:
+        entry["status"] = repair_status
     monkeypatch.setattr(
         diagnose,
         "run_diagnostics",
         lambda **_kwargs: {
             "checks_passed": 1,
             "checks_total": 2,
-            "key_findings": ["vec_working repair error: inserted 0 rows"],
-            "entries": [{"check": "vec_working_repair_status", "status": "error"}],
+            "key_findings": ["vec_working repair did not complete"],
+            "entries": [entry],
         },
     )
 
@@ -168,3 +172,18 @@ def test_cli_diagnose_repair_failure_is_a_process_failure(monkeypatch):
         cli.cmd_diagnose(["--repair-vec-working"])
 
     assert raised.value.code == 1
+
+
+def test_cli_diagnose_skipped_repair_dry_run_does_not_exit(monkeypatch):
+    monkeypatch.setattr(
+        diagnose,
+        "run_diagnostics",
+        lambda **_kwargs: {
+            "checks_passed": 1,
+            "checks_total": 2,
+            "key_findings": ["vec_working repair skipped"],
+            "entries": [{"check": "vec_working_repair_status", "status": "skipped"}],
+        },
+    )
+
+    cli.cmd_diagnose(["--repair-vec-working", "--dry-run"])

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -152,38 +152,69 @@ def test_diagnose_reports_memory_orphans_without_mutating_rows(tmp_path, monkeyp
     assert _entry(summary, "hygiene_noise_candidates")["status"] == "0"
 
 
-@pytest.mark.parametrize("repair_status", ["error", "skipped", None])
-def test_cli_diagnose_unsuccessful_repair_is_a_process_failure(monkeypatch, repair_status):
-    entry = {"check": "vec_working_repair_status"}
-    if repair_status is not None:
-        entry["status"] = repair_status
-    monkeypatch.setattr(
-        diagnose,
-        "run_diagnostics",
-        lambda **_kwargs: {
+@pytest.mark.parametrize(
+    "repair_statuses", [["error"], ["skipped"], [None], ["repaired", "error"]]
+)
+def test_cli_diagnose_unsuccessful_repair_is_a_process_failure(monkeypatch, repair_statuses):
+    entries = []
+    for repair_status in repair_statuses:
+        entry = {"check": "vec_working_repair_status"}
+        if repair_status is not None:
+            entry["status"] = repair_status
+        entries.append(entry)
+    run_diagnostics_calls = []
+
+    def run_diagnostics(**kwargs):
+        run_diagnostics_calls.append(kwargs)
+        return {
             "checks_passed": 1,
             "checks_total": 2,
             "key_findings": ["vec_working repair did not complete"],
-            "entries": [entry],
-        },
-    )
+            "entries": entries,
+        }
+
+    monkeypatch.setattr(diagnose, "run_diagnostics", run_diagnostics)
 
     with pytest.raises(SystemExit) as raised:
         cli.cmd_diagnose(["--repair-vec-working"])
 
     assert raised.value.code == 1
+    assert run_diagnostics_calls == [{"repair_vec_working": True, "dry_run": False}]
+
+
+def test_cli_diagnose_repaired_vec_working_succeeds(monkeypatch):
+    run_diagnostics_calls = []
+
+    def run_diagnostics(**kwargs):
+        run_diagnostics_calls.append(kwargs)
+        return {
+            "checks_passed": 2,
+            "checks_total": 2,
+            "key_findings": [],
+            "entries": [{"check": "vec_working_repair_status", "status": "repaired"}],
+        }
+
+    monkeypatch.setattr(diagnose, "run_diagnostics", run_diagnostics)
+
+    cli.cmd_diagnose(["--repair-vec-working"])
+
+    assert run_diagnostics_calls == [{"repair_vec_working": True, "dry_run": False}]
 
 
 def test_cli_diagnose_skipped_repair_dry_run_does_not_exit(monkeypatch):
-    monkeypatch.setattr(
-        diagnose,
-        "run_diagnostics",
-        lambda **_kwargs: {
+    run_diagnostics_calls = []
+
+    def run_diagnostics(**kwargs):
+        run_diagnostics_calls.append(kwargs)
+        return {
             "checks_passed": 1,
             "checks_total": 2,
             "key_findings": ["vec_working repair skipped"],
             "entries": [{"check": "vec_working_repair_status", "status": "skipped"}],
-        },
-    )
+        }
+
+    monkeypatch.setattr(diagnose, "run_diagnostics", run_diagnostics)
 
     cli.cmd_diagnose(["--repair-vec-working", "--dry-run"])
+
+    assert run_diagnostics_calls == [{"repair_vec_working": True, "dry_run": True}]

--- a/tests/test_diagnose_optional_deps.py
+++ b/tests/test_diagnose_optional_deps.py
@@ -153,7 +153,7 @@ def test_diagnose_reports_memory_orphans_without_mutating_rows(tmp_path, monkeyp
 
 
 @pytest.mark.parametrize(
-    "repair_statuses", [["error"], ["skipped"], [None], ["repaired", "error"]]
+    "repair_statuses", [["error"], ["skipped"], [None], ["repaired", "error"], []]
 )
 def test_cli_diagnose_unsuccessful_repair_is_a_process_failure(monkeypatch, repair_statuses):
     entries = []

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -69,6 +69,69 @@ def test_reindex_rejects_failed_or_partial_embedding_batches(tmp_path, monkeypat
         reindex_vectors(beam.conn)
 
 
+@pytest.mark.parametrize(
+    ("invalid_vector", "reason"),
+    [
+        (["not-a-number"] * E.EMBEDDING_DIM, "convertible numeric"),
+        ([[0.1]] * E.EMBEDDING_DIM, "one-dimensional"),
+        ([float("nan")] * E.EMBEDDING_DIM, "finite values"),
+        ([0.1] * (E.EMBEDDING_DIM - 1), "expected"),
+    ],
+)
+def test_reindex_rejects_invalid_individual_embedding_vectors(
+    tmp_path, monkeypatch, invalid_vector, reason
+):
+    """Each vector must be numeric, 1-D, finite, and at the active dimension."""
+    beam = _reindex_fixture_beam(tmp_path, working=1)
+    monkeypatch.setattr(E, "available", lambda: True)
+    monkeypatch.setattr(E, "embed", lambda _contents: [invalid_vector])
+
+    with pytest.raises(
+        RuntimeError, match=rf"working_memory embedding vector 0.*{reason}"
+    ):
+        reindex_vectors(beam.conn)
+
+
+def test_reindex_requires_episodic_vector_backend_before_writes(tmp_path, monkeypatch):
+    """Episodic rows cannot be counted as reindexed without a writable backend."""
+    beam = _reindex_fixture_beam(tmp_path, episodic=1)
+    embed_calls = []
+    monkeypatch.setattr(E, "available", lambda: True)
+    monkeypatch.setattr(E, "embed", lambda contents: embed_calls.append(contents))
+    monkeypatch.setattr("mnemosyne.core.beam._vec_available", lambda _conn: False)
+    monkeypatch.setattr("mnemosyne.core.beam._mib", None)
+
+    with pytest.raises(RuntimeError, match="episodic_memory vector backend unavailable"):
+        reindex_vectors(beam.conn)
+
+    assert embed_calls == []
+
+
+def test_reindex_rejects_invalid_later_episodic_batch(tmp_path, monkeypatch):
+    """A later invalid episodic batch must fail before it is counted as written."""
+    beam = _reindex_fixture_beam(tmp_path, episodic=2)
+    responses = iter([
+        [[0.1] * E.EMBEDDING_DIM],
+        [[float("nan")] * E.EMBEDDING_DIM],
+    ])
+    calls = []
+    monkeypatch.setattr(E, "available", lambda: True)
+
+    def embed(contents):
+        calls.append(contents)
+        return next(responses)
+
+    monkeypatch.setattr(E, "embed", embed)
+    monkeypatch.setattr("mnemosyne.core.beam.np", _NumpyStub())
+    monkeypatch.setattr("mnemosyne.core.beam._vec_available", lambda _conn: False)
+    monkeypatch.setattr("mnemosyne.core.beam._mib", lambda _array: b"vector")
+
+    with pytest.raises(RuntimeError, match="episodic_memory embedding vector 0.*finite values"):
+        reindex_vectors(beam.conn, batch_size=1)
+
+    assert len(calls) == 2
+
+
 def test_reindex_does_not_mask_episodic_binary_vector_write_failure(tmp_path, monkeypatch):
     """A binary-vector update failure after a destructive rebuild must fail loudly."""
     beam = _reindex_fixture_beam(tmp_path, episodic=1)

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -93,6 +93,16 @@ def test_reindex_rejects_invalid_individual_embedding_vectors(
         reindex_vectors(beam.conn)
 
 
+def test_reindex_rejects_numeric_string_embedding_vector(tmp_path, monkeypatch):
+    """Numeric-looking strings must not be persisted as JSON string vectors."""
+    beam = _reindex_fixture_beam(tmp_path, working=1)
+    monkeypatch.setattr(E, "available", lambda: True)
+    monkeypatch.setattr(E, "embed", lambda _contents: [["0.1"] * E.EMBEDDING_DIM])
+
+    with pytest.raises(RuntimeError, match="working_memory embedding vector 0.*convertible numeric"):
+        reindex_vectors(beam.conn)
+
+
 def test_reindex_requires_episodic_vector_backend_before_writes(tmp_path, monkeypatch):
     """Episodic rows cannot be counted as reindexed without a writable backend."""
     beam = _reindex_fixture_beam(tmp_path, episodic=1)

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -56,9 +56,16 @@ def test_reindex_does_not_mask_episodic_binary_vector_write_failure(tmp_path, mo
     beam = _reindex_fixture_beam(tmp_path, episodic=1)
     monkeypatch.setattr(E, "available", lambda: True)
     monkeypatch.setattr(E, "embed", lambda contents: [[0.1] * E.EMBEDDING_DIM for _ in contents])
+    class _Array:
+        def __init__(self, vector):
+            self.vector = vector
+
+        def tolist(self):
+            return self.vector
+
     monkeypatch.setattr(
         "mnemosyne.core.beam.np",
-        type("_Numpy", (), {"asarray": staticmethod(lambda vector: vector)})(),
+        type("_Numpy", (), {"asarray": staticmethod(_Array)})(),
     )
     monkeypatch.setattr("mnemosyne.core.beam._mib", lambda _array: b"vector")
     beam.conn.execute(

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from mnemosyne.core.beam import BeamMemory, reindex_vectors, _effective_vec_type
 import mnemosyne.core.embeddings as E
 
@@ -18,6 +20,54 @@ import mnemosyne.core.embeddings as E
 def _ddl(conn, table):
     row = conn.execute("SELECT sql FROM sqlite_master WHERE name = ?", (table,)).fetchone()
     return row[0] if row and row[0] else ""
+
+
+def _reindex_fixture_beam(tmp_path, *, working=0, episodic=0):
+    beam = BeamMemory(session_id="reindex-failure", db_path=str(tmp_path / "m.db"))
+    for index in range(working):
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (f"wm-{index}", f"working source {index}", "test", "2026-01-01T00:00:00", "reindex-failure"),
+        )
+    for index in range(episodic):
+        beam.conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, importance) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (f"ep-{index}", f"episodic source {index}", "test", "2026-01-01T00:00:00", "reindex-failure", 0.5),
+        )
+    beam.conn.commit()
+    return beam
+
+
+@pytest.mark.parametrize("batch_response", [None, [[0.1] * 384]])
+def test_reindex_rejects_failed_or_partial_embedding_batches(tmp_path, monkeypatch, batch_response):
+    """A failed or short embedding batch must never yield a reindexed result."""
+    beam = _reindex_fixture_beam(tmp_path, working=2)
+    monkeypatch.setattr(E, "available", lambda: True)
+    monkeypatch.setattr(E, "embed", lambda _contents: batch_response)
+
+    with pytest.raises(RuntimeError, match="working_memory embedding batch"):
+        reindex_vectors(beam.conn)
+
+
+def test_reindex_does_not_mask_episodic_binary_vector_write_failure(tmp_path, monkeypatch):
+    """A binary-vector update failure after a destructive rebuild must fail loudly."""
+    beam = _reindex_fixture_beam(tmp_path, episodic=1)
+    monkeypatch.setattr(E, "available", lambda: True)
+    monkeypatch.setattr(E, "embed", lambda contents: [[0.1] * E.EMBEDDING_DIM for _ in contents])
+    monkeypatch.setattr(
+        "mnemosyne.core.beam.np",
+        type("_Numpy", (), {"asarray": staticmethod(lambda vector: vector)})(),
+    )
+    monkeypatch.setattr("mnemosyne.core.beam._mib", lambda _array: b"vector")
+    beam.conn.execute(
+        "CREATE TRIGGER fail_binary_vector BEFORE UPDATE OF binary_vector ON episodic_memory "
+        "BEGIN SELECT RAISE(ABORT, 'binary vector write failed'); END"
+    )
+
+    with pytest.raises(Exception, match="binary vector write failed"):
+        reindex_vectors(beam.conn)
 
 
 def test_reindex_rebuilds_all_vector_stores_at_active_dim():

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -70,19 +70,20 @@ def test_reindex_rejects_failed_or_partial_embedding_batches(tmp_path, monkeypat
 
 
 @pytest.mark.parametrize(
-    ("invalid_vector", "reason"),
+    ("invalid_vector_factory", "reason"),
     [
-        (["not-a-number"] * E.EMBEDDING_DIM, "convertible numeric"),
-        ([[0.1]] * E.EMBEDDING_DIM, "one-dimensional"),
-        ([float("nan")] * E.EMBEDDING_DIM, "finite values"),
-        ([0.1] * (E.EMBEDDING_DIM - 1), "expected"),
+        (lambda: ["not-a-number"] * E.EMBEDDING_DIM, "convertible numeric"),
+        (lambda: [[0.1]] * E.EMBEDDING_DIM, "one-dimensional"),
+        (lambda: [float("nan")] * E.EMBEDDING_DIM, "finite values"),
+        (lambda: [0.1] * (E.EMBEDDING_DIM - 1), "expected"),
     ],
 )
 def test_reindex_rejects_invalid_individual_embedding_vectors(
-    tmp_path, monkeypatch, invalid_vector, reason
+    tmp_path, monkeypatch, invalid_vector_factory, reason
 ):
     """Each vector must be numeric, 1-D, finite, and at the active dimension."""
     beam = _reindex_fixture_beam(tmp_path, working=1)
+    invalid_vector = invalid_vector_factory()
     monkeypatch.setattr(E, "available", lambda: True)
     monkeypatch.setattr(E, "embed", lambda _contents: [invalid_vector])
 

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -178,6 +178,36 @@ def test_reindex_does_not_mask_working_vec_write_failure(tmp_path, monkeypatch):
         reindex_vectors(beam.conn)
 
 
+def test_reindex_real_commits_deferred_working_batches_before_next_embedding(tmp_path, monkeypatch):
+    """Deferred BEAM writes must be committed before the next embedding request."""
+    beam = _reindex_fixture_beam(tmp_path, working=2)
+    observed_transactions = []
+    real_commits = []
+    original_real_commit = type(beam.conn)._real_commit
+
+    def record_real_commit(conn):
+        real_commits.append(conn.in_transaction)
+        return original_real_commit(conn)
+
+    def embed(contents):
+        observed_transactions.append(beam.conn.in_transaction)
+        return [[0.1] * E.EMBEDDING_DIM for _ in contents]
+
+    monkeypatch.setattr(type(beam.conn), "_real_commit", record_real_commit)
+    monkeypatch.setattr(E, "available", lambda: True)
+    monkeypatch.setattr(E, "embed", embed)
+    monkeypatch.setattr("mnemosyne.core.beam.np", _NumpyStub())
+    monkeypatch.setattr("mnemosyne.core.beam._vec_available", lambda _conn: False)
+    beam.conn._defer_commit = True
+
+    result = reindex_vectors(beam.conn, batch_size=1)
+
+    assert result["working_memory_reindexed"] == 2
+    assert observed_transactions == [False, False]
+    assert real_commits == [True, True]
+    assert not beam.conn.in_transaction
+
+
 def test_reindex_rebuilds_all_vector_stores_at_active_dim():
     if not E.available():
         import pytest  # type: ignore

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -8,6 +8,7 @@ working. Also checks that --dry-run writes nothing.
 """
 from __future__ import annotations
 
+import sqlite3
 import tempfile
 from pathlib import Path
 
@@ -15,6 +16,20 @@ import pytest
 
 from mnemosyne.core.beam import BeamMemory, reindex_vectors, _effective_vec_type
 import mnemosyne.core.embeddings as E
+
+
+class _Array:
+    def __init__(self, vector):
+        self.vector = vector
+
+    def tolist(self):
+        return self.vector
+
+
+class _NumpyStub:
+    float32 = object()
+    asarray = staticmethod(_Array)
+    array = staticmethod(lambda vector, dtype=None: _Array(vector))
 
 
 def _ddl(conn, table):
@@ -40,7 +55,10 @@ def _reindex_fixture_beam(tmp_path, *, working=0, episodic=0):
     return beam
 
 
-@pytest.mark.parametrize("batch_response", [None, [[0.1] * 384]])
+@pytest.mark.parametrize(
+    "batch_response",
+    [None, [[0.1] * 384], [[0.1] * 384, [0.1] * 384, [0.1] * 384]],
+)
 def test_reindex_rejects_failed_or_partial_embedding_batches(tmp_path, monkeypatch, batch_response):
     """A failed or short embedding batch must never yield a reindexed result."""
     beam = _reindex_fixture_beam(tmp_path, working=2)
@@ -56,24 +74,29 @@ def test_reindex_does_not_mask_episodic_binary_vector_write_failure(tmp_path, mo
     beam = _reindex_fixture_beam(tmp_path, episodic=1)
     monkeypatch.setattr(E, "available", lambda: True)
     monkeypatch.setattr(E, "embed", lambda contents: [[0.1] * E.EMBEDDING_DIM for _ in contents])
-    class _Array:
-        def __init__(self, vector):
-            self.vector = vector
-
-        def tolist(self):
-            return self.vector
-
-    monkeypatch.setattr(
-        "mnemosyne.core.beam.np",
-        type("_Numpy", (), {"asarray": staticmethod(_Array)})(),
-    )
+    monkeypatch.setattr("mnemosyne.core.beam.np", _NumpyStub())
     monkeypatch.setattr("mnemosyne.core.beam._mib", lambda _array: b"vector")
     beam.conn.execute(
         "CREATE TRIGGER fail_binary_vector BEFORE UPDATE OF binary_vector ON episodic_memory "
         "BEGIN SELECT RAISE(ABORT, 'binary vector write failed'); END"
     )
 
-    with pytest.raises(Exception, match="binary vector write failed"):
+    with pytest.raises(sqlite3.IntegrityError, match="binary vector write failed"):
+        reindex_vectors(beam.conn)
+
+
+def test_reindex_does_not_mask_working_embedding_write_failure(tmp_path, monkeypatch):
+    """A strict working-vector write failure after a destructive rebuild must fail loudly."""
+    beam = _reindex_fixture_beam(tmp_path, working=1)
+    monkeypatch.setattr(E, "available", lambda: True)
+    monkeypatch.setattr(E, "embed", lambda contents: [[0.1] * E.EMBEDDING_DIM for _ in contents])
+    monkeypatch.setattr("mnemosyne.core.beam.np", _NumpyStub())
+    beam.conn.execute(
+        "CREATE TRIGGER fail_working_embedding BEFORE INSERT ON memory_embeddings "
+        "BEGIN SELECT RAISE(ABORT, 'working embedding write failed'); END"
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="working embedding write failed"):
         reindex_vectors(beam.conn)
 
 

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -85,18 +85,22 @@ def test_reindex_does_not_mask_episodic_binary_vector_write_failure(tmp_path, mo
         reindex_vectors(beam.conn)
 
 
-def test_reindex_does_not_mask_working_embedding_write_failure(tmp_path, monkeypatch):
-    """A strict working-vector write failure after a destructive rebuild must fail loudly."""
+def test_reindex_does_not_mask_working_vec_write_failure(tmp_path, monkeypatch):
+    """A strict vec_working write failure during reindex must fail loudly."""
     beam = _reindex_fixture_beam(tmp_path, working=1)
     monkeypatch.setattr(E, "available", lambda: True)
     monkeypatch.setattr(E, "embed", lambda contents: [[0.1] * E.EMBEDDING_DIM for _ in contents])
     monkeypatch.setattr("mnemosyne.core.beam.np", _NumpyStub())
-    beam.conn.execute(
-        "CREATE TRIGGER fail_working_embedding BEFORE INSERT ON memory_embeddings "
-        "BEGIN SELECT RAISE(ABORT, 'working embedding write failed'); END"
-    )
+    monkeypatch.setattr("mnemosyne.core.beam._vec_available", lambda _conn: False)
+    monkeypatch.setattr("mnemosyne.core.beam._wm_vec_available", lambda _conn: True)
 
-    with pytest.raises(sqlite3.IntegrityError, match="working embedding write failed"):
+    def fail_vec_working(_conn, table, _rowid, _embedding, **_kwargs):
+        assert table == "vec_working"
+        raise sqlite3.IntegrityError("vec_working write failed")
+
+    monkeypatch.setattr("mnemosyne.core.beam._vec_table_insert", fail_vec_working)
+
+    with pytest.raises(sqlite3.IntegrityError, match="vec_working write failed"):
         reindex_vectors(beam.conn)
 
 

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -198,6 +198,7 @@ def test_reindex_real_commits_deferred_working_batches_before_next_embedding(tmp
     monkeypatch.setattr(E, "embed", embed)
     monkeypatch.setattr("mnemosyne.core.beam.np", _NumpyStub())
     monkeypatch.setattr("mnemosyne.core.beam._vec_available", lambda _conn: False)
+    monkeypatch.setattr("mnemosyne.core.beam._wm_vec_available", lambda _conn: False)
     beam.conn._defer_commit = True
 
     result = reindex_vectors(beam.conn, batch_size=1)


### PR DESCRIPTION
## Summary

Fixes #600 by making vector reindex and explicit `vec_working` repair fail loudly instead of reporting successful completion after partial processing or a failed postcheck.

- Reject missing, short, or failed embedding batches.
- Do not swallow reindex writes to `vec_working` or episodic `binary_vector`.
- Mark `repair_vec_working()` successful only after a complete, available, zero-gap postcheck.
- Return exit code 1 from `mnemosyne diagnose --repair-vec-working` when the requested repair fails.

## Why this path

`reindex_vectors()` owns the destructive rebuild and its success status. `repair_vec_working()` owns the backfill postcondition. Keeping the checks at those boundaries prevents false successful results without changing embedding configuration ownership.

## Non-goals

This does not change YAML/environment configuration precedence, embedding model selection, migrations, session scoping, or transactional recovery semantics. A failed rebuild can retain partial derived vectors, but it cannot claim `reindexed`.

## Why not #482 here

#482 needs a separately agreed configuration and migration contract. This PR only makes the existing destructive/recovery operations report incomplete work correctly.

## Reproduction and verification

Starting state: source rows exist and a reindex embedding batch returns `None`, is short, or a derived-vector write fails.

Before: the operation could return `status: reindexed` after partial work.

After: it raises an explicit error; repair returns `status: error` unless the postcheck proves complete coverage.

Tests:

```text
MNEMOSYNE_NO_EMBEDDINGS=1 uv run --extra test pytest -q \
  tests/test_reindex_vectors.py tests/test_beam.py tests/test_diagnose_optional_deps.py
# 89 passed, 10 skipped
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Makes vector reindexing and `repair_vec_working()` fail loudly when embedding batches, vector writes, or coverage checks fail.
- Prevents successful status when working-memory or episodic vectors are missing after a rebuild.
- Returns exit code 1 from `mnemosyne diagnose --repair-vec-working` after non-dry-run failures.
- Adds regression coverage for incomplete embeddings, write failures, unavailable vector tables, and incomplete repairs.

## Architectural impact

- Strengthens vector integrity across working memory and episodic memory.
- Preserves tiered memory boundaries, BEAM behavior, retrieval strategies, consolidation, veracity, sync, and session scoping.
- Does not change benchmark methodology.
- This is the right call because incomplete derived memory cannot appear healthy.

## Integration and local-first impact

- Improves the CLI diagnostic contract.
- Does not change Hermes or MCP integration surfaces.
- Preserves Mnemosyne’s local-first guarantees and privacy posture.
- Failed rebuilds can retain partial derived vectors, but they cannot report success.

## Maintainability

- Explicit failure propagation improves operational visibility.
- Strict batch and coverage validation prevents silent data loss after embedding configuration changes.
- Regression tests protect destructive rebuild and repair paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->