### PR TITLE
fix(hermes): preserve wrapper installs safely

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -306,7 +306,7 @@ pip install --upgrade mnemosyne-memory==3.11.0
 
 No manual migration. Sync role default changed to `["user"]` — if you
 want assistant-turn autosave, set `memory.mnemosyne.sync_roles:
-`["user", "assistant"]` in `config.yaml`.
+["user", "assistant"]` in `config.yaml`.
 
 ### Updating a Hermes wrapper install
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -163,6 +163,11 @@ For the new plugin features:
 
 ```bash
 pipx install "mnemosyne-hermes[all]"
+```
+
+For existing symlink installs only:
+
+```bash
 mnemosyne-hermes install --force
 ```
 
@@ -301,7 +306,28 @@ pip install --upgrade mnemosyne-memory==3.11.0
 
 No manual migration. Sync role default changed to `["user"]` — if you
 want assistant-turn autosave, set `memory.mnemosyne.sync_roles:
-["user", "assistant"]` in `config.yaml`.
+`["user", "assistant"]` in `config.yaml`.
+
+### Updating a Hermes wrapper install
+
+For a persistent wrapper (the Docker/read-only deployment path), keep wrapper
+mode and name the Python environment that contains the selected package:
+
+```bash
+mnemosyne-hermes install --mode wrapper --python /path/to/venv/bin/python --force
+```
+
+`--force` refreshes a wrapper only after that Python can resolve its
+site-packages and import `mnemosyne_hermes`; an invalid `--python` leaves the
+existing wrapper and opted-in profile links in place. To intentionally replace
+a wrapper with the historical symlink install, acknowledge the mode change:
+
+```bash
+mnemosyne-hermes install --force --migrate-wrapper-to-symlink
+```
+
+That migration stops using the wrapper's selected Python. The installer warns
+before making the change; without the explicit flag it refuses the replacement.
 
 ---
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -27,6 +27,32 @@ Already on v3.0.0? See [Upgrading to v3.0.0](#upgrading-to-v300-memoria-architec
 
 ---
 
+## Current / Unreleased — Hermes wrapper install safety
+
+### Updating a Hermes wrapper install
+
+For a persistent wrapper (the Docker/read-only deployment path), keep wrapper
+mode and name the Python environment that contains the selected package:
+
+```bash
+mnemosyne-hermes install --mode wrapper --python /path/to/venv/bin/python --force
+```
+
+`--force` refreshes a wrapper only after that Python can resolve its
+site-packages and import `mnemosyne_hermes`; an invalid `--python` leaves the
+existing wrapper and opted-in profile links in place. Editable installs in the
+selected environment are supported. To intentionally replace a wrapper with
+the historical symlink install, acknowledge the mode change:
+
+```bash
+mnemosyne-hermes install --mode symlink --force --migrate-wrapper-to-symlink
+```
+
+That migration stops using the wrapper's selected Python. The installer warns
+before making the change; without the explicit flag it refuses the replacement.
+
+---
+
 ## PEP 668: externally-managed-environment on Debian / Ubuntu
 
 Debian 13 (and Ubuntu 24.04+) ship Python with PEP 668 protection.
@@ -307,29 +333,6 @@ pip install --upgrade mnemosyne-memory==3.11.0
 No manual migration. Sync role default changed to `["user"]` — if you
 want assistant-turn autosave, set `memory.mnemosyne.sync_roles:
 ["user", "assistant"]` in `config.yaml`.
-
-### Updating a Hermes wrapper install
-
-For a persistent wrapper (the Docker/read-only deployment path), keep wrapper
-mode and name the Python environment that contains the selected package:
-
-```bash
-mnemosyne-hermes install --mode wrapper --python /path/to/venv/bin/python --force
-```
-
-`--force` refreshes a wrapper only after that Python can resolve its
-site-packages and import `mnemosyne_hermes`; an invalid `--python` leaves the
-existing wrapper and opted-in profile links in place. To intentionally replace
-a wrapper with the historical symlink install, acknowledge the mode change:
-
-```bash
-mnemosyne-hermes install --force --migrate-wrapper-to-symlink
-```
-
-That migration stops using the wrapper's selected Python. The installer warns
-before making the change; without the explicit flag it refuses the replacement.
-
----
 
 ## Upgrading to v3.6.0 — Canonical Facts + API Embedding Fallback
 

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -323,24 +323,26 @@ def _check_wrapper_import(
     site_packages: Path, python: Path | None = None
 ) -> tuple[bool, str | None, bool]:
     """Return import success, error text, and whether the runtime is invalid."""
-    if not site_packages.exists():
+    if not site_packages.is_dir():
         return False, f"site-packages target missing: {site_packages}", False
     runner = python or Path(sys.executable)
     if not runner.is_file():
         return False, f"wrapper Python missing: {runner}", True
     if not os.access(runner, os.X_OK):
         return False, f"wrapper Python is not executable: {runner}", True
-    package_init = site_packages / "mnemosyne_hermes" / "__init__.py"
-    if not package_init.is_file():
-        return False, f"mnemosyne_hermes package missing from selected site-packages: {site_packages}", False
     code = (
+        "import site\n"
         "import sys\n"
         "from pathlib import Path\n"
-        f"sys.path.insert(0, {str(site_packages)!r})\n"
-        f"expected = Path({str(package_init)!r}).resolve()\n"
+        f"selected_site = Path({str(site_packages)!r}).resolve()\n"
+        "site.addsitedir(str(selected_site))\n"
         "import mnemosyne_hermes\n"
-        "actual = Path(mnemosyne_hermes.__file__).resolve()\n"
-        "assert actual == expected, f'package origin mismatch: {actual} != {expected}'\n"
+        "origin = getattr(mnemosyne_hermes, '__file__', None)\n"
+        "if not origin:\n"
+        "    raise SystemExit('mnemosyne_hermes package has no file origin')\n"
+        "actual = Path(origin).resolve()\n"
+        "if not actual.is_file():\n"
+        "    raise SystemExit(f'mnemosyne_hermes package origin is not a file: {actual}')\n"
         + "print(getattr(mnemosyne_hermes, '__version__', 'unknown'))\n"
     )
     try:
@@ -349,7 +351,16 @@ def _check_wrapper_import(
             capture_output=True,
             text=True,
             timeout=10,
-            env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+            # -S and a selected site directory isolate imports from the runner's
+            # ambient site/user directories. Filtering PYTHONPATH prevents a
+            # caller-controlled package shadowing that contract; filtering
+            # PYTHONOPTIMIZE keeps assertion elision from changing probe behavior.
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if key not in {"PYTHONPATH", "PYTHONOPTIMIZE"}
+            },
+            cwd=site_packages,
         )
     except OSError as exc:
         return False, f"could not run wrapper Python {runner}: {exc}", True
@@ -859,7 +870,10 @@ def _replace_plugin_target_with_staged(target: Path, staged: Path) -> None:
             except OSError:
                 # Preserve the failed swap as the primary exception. Keeping the
                 # backup is safer than masking it with a rollback cleanup error.
-                pass
+                print(
+                    f"⚠ Wrapper rollback failed; previous plugin retained at: {previous}",
+                    file=sys.stderr,
+                )
             else:
                 restored_previous = True
         if restored_previous and previous_parent is not None:
@@ -906,6 +920,7 @@ import importlib
 import json
 import os
 from pathlib import Path
+import site as site_module
 import sys
 
 
@@ -938,6 +953,12 @@ def activate() -> dict[str, object]:
     package_init = package_root / "__init__.py"
     expected_root = package_root.resolve() if package_init.is_file() else None
     site = str(site_path)
+    while site in sys.path:
+        sys.path.remove(site)
+    # Process .pth files from the selected runtime as well as direct packages.
+    # Setuptools' PEP 660 editable installs use a .pth-installed finder, so a
+    # bare sys.path insertion would make a valid selected environment fail.
+    site_module.addsitedir(site)
     while site in sys.path:
         sys.path.remove(site)
     sys.path.insert(0, site)
@@ -1020,9 +1041,9 @@ def install_plugin(
     """Install the Mnemosyne provider into Hermes' user plugin directory.
 
     ``mode='symlink'`` keeps the historical behavior. ``mode='wrapper'``
-    creates a real persistent plugin directory containing a tiny shim that adds
-    the selected interpreter's site-packages path to ``sys.path`` and imports
-    ``mnemosyne_hermes`` from there.
+    creates a real persistent plugin directory containing a tiny shim that
+    activates the selected interpreter's site-packages (including editable
+    install ``.pth`` files) and imports ``mnemosyne_hermes`` from there.
     """
     if mode not in {"symlink", "wrapper"}:
         raise ValueError("mode must be 'symlink' or 'wrapper'")
@@ -1248,8 +1269,8 @@ def _parser() -> argparse.ArgumentParser:
         "--migrate-wrapper-to-symlink",
         action="store_true",
         help=(
-            "With --force, intentionally replace an existing wrapper with the "
-            "default symlink install."
+            "With --mode symlink and --force, intentionally replace an existing "
+            "wrapper with the default symlink install."
         ),
     )
     subparsers.add_parser(

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -346,13 +346,16 @@ def _check_wrapper_import(
         f"expected_site = Path({str(site_packages)!r}).resolve()\n"
         "try:\n"
         "    dist = importlib.metadata.distribution('mnemosyne-hermes')\n"
-        "except importlib.metadata.PackageNotFoundError as exc:\n"
-        "    raise RuntimeError(\n"
+        "except importlib.metadata.PackageNotFoundError:\n"
+        "    sys.exit(\n"
         "        f'mnemosyne_hermes package missing from selected site-packages: {expected_site}'\n"
-        "    ) from exc\n"
-        "assert Path(dist.locate_file('')).resolve() == expected_site, (\n"
-        "    f'mnemosyne_hermes package missing from selected site-packages: {expected_site}'\n"
-        ")\n"
+        "    )\n"
+        "dist_root = Path(dist.locate_file('')).resolve()\n"
+        "runtime_paths = {Path(path).resolve() for path in sys.path if path}\n"
+        "if dist_root not in runtime_paths:\n"
+        "    sys.exit(\n"
+        "        f'mnemosyne_hermes distribution is not on selected Python sys.path: {dist_root}'\n"
+        "    )\n"
         "import mnemosyne_hermes\n"
         + origin_check
         + "print(getattr(mnemosyne_hermes, '__version__', 'unknown'))\n"
@@ -363,7 +366,7 @@ def _check_wrapper_import(
             capture_output=True,
             text=True,
             timeout=10,
-            env={**os.environ, "PYTHONPATH": "", "PYTHONNOUSERSITE": "1"},
+            env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
         )
     except OSError as exc:
         return False, f"could not run wrapper Python {runner}: {exc}", True
@@ -866,10 +869,21 @@ def _replace_plugin_target_with_staged(target: Path, staged: Path) -> None:
     try:
         staged.replace(target)
     except Exception:
+        restored_previous = False
         if previous is not None and not target.exists() and not target.is_symlink():
-            previous.replace(target)
-        if previous_parent is not None:
-            previous_parent.rmdir()
+            try:
+                previous.replace(target)
+            except OSError:
+                # Preserve the failed swap as the primary exception. Keeping the
+                # backup is safer than masking it with a rollback cleanup error.
+                pass
+            else:
+                restored_previous = True
+        if restored_previous and previous_parent is not None:
+            try:
+                previous_parent.rmdir()
+            except OSError:
+                pass
         raise
     else:
         if previous is not None:
@@ -1370,6 +1384,12 @@ def main(argv: list[str] | None = None) -> int:
             hermes_python = _find_hermes_python()
             target = plugin_target_dir(args.hermes_home)
             if getattr(args, "dry_run", False):
+                refuses_wrapper_migration = (
+                    getattr(args, "mode", "symlink") == "symlink"
+                    and getattr(args, "force", False)
+                    and _is_wrapper_plugin_target(target)
+                    and not getattr(args, "migrate_wrapper_to_symlink", False)
+                )
                 skill = skill_state(hermes_home_path=args.hermes_home)
                 skill_plan = install_bundled_skill(
                     hermes_home_path=args.hermes_home,
@@ -1391,9 +1411,14 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  Will force: {bool(getattr(args, 'force', False))}")
                 if getattr(args, "migrate_wrapper_to_symlink", False):
                     print("  Will allow wrapper-to-symlink migration: yes")
+                if refuses_wrapper_migration:
+                    print(
+                        "  Will refuse to replace the existing wrapper without "
+                        "--migrate-wrapper-to-symlink."
+                    )
                 if hermes_python:
                     print(f"  Will bootstrap: {not getattr(args, 'no_bootstrap', False)}")
-                return 0
+                return 1 if refuses_wrapper_migration else 0
 
             return run_install(
                 force=getattr(args, "force", False),

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
@@ -338,11 +339,23 @@ def _check_wrapper_import(
             "assert actual == expected, f'package origin mismatch: {actual} != {expected}'; "
         )
     code = (
-        "import sys; from pathlib import Path; "
-        f"sys.path.insert(0, {str(site_packages)!r}); "
-        "import mnemosyne_hermes; "
+        "import importlib.metadata\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        f"sys.path.insert(0, {str(site_packages)!r})\n"
+        f"expected_site = Path({str(site_packages)!r}).resolve()\n"
+        "try:\n"
+        "    dist = importlib.metadata.distribution('mnemosyne-hermes')\n"
+        "except importlib.metadata.PackageNotFoundError as exc:\n"
+        "    raise RuntimeError(\n"
+        "        f'mnemosyne_hermes package missing from selected site-packages: {expected_site}'\n"
+        "    ) from exc\n"
+        "assert Path(dist.locate_file('')).resolve() == expected_site, (\n"
+        "    f'mnemosyne_hermes package missing from selected site-packages: {expected_site}'\n"
+        ")\n"
+        "import mnemosyne_hermes\n"
         + origin_check
-        + "print(getattr(mnemosyne_hermes, '__version__', 'unknown'))"
+        + "print(getattr(mnemosyne_hermes, '__version__', 'unknown'))\n"
     )
     try:
         result = subprocess.run(
@@ -350,6 +363,7 @@ def _check_wrapper_import(
             capture_output=True,
             text=True,
             timeout=10,
+            env={**os.environ, "PYTHONPATH": "", "PYTHONNOUSERSITE": "1"},
         )
     except OSError as exc:
         return False, f"could not run wrapper Python {runner}: {exc}", True
@@ -774,8 +788,10 @@ def _unlink_all_profiles(
             continue
 
 
-def _prepare_plugin_target(base: Path, target: Path, *, force: bool) -> None:
-    """Migrate legacy plugin names and remove an existing target when forced."""
+def _prepare_plugin_target(
+    base: Path, target: Path, *, force: bool, remove_target: bool = True
+) -> None:
+    """Migrate legacy names and, optionally, remove an existing plugin target."""
     old_plugin_dir = base / "plugins" / "hermes-mnemosyne"
     if old_plugin_dir.is_symlink() or old_plugin_dir.exists():
         if old_plugin_dir.is_symlink() or os.path.islink(str(old_plugin_dir)):
@@ -800,14 +816,71 @@ def _prepare_plugin_target(base: Path, target: Path, *, force: bool) -> None:
             raise FileExistsError(
                 f"{target} already exists. Re-run with --force to replace it."
             )
-        if target.is_symlink():
-            target.unlink()
-        elif target.is_dir():
-            shutil.rmtree(target)
-        else:
-            target.unlink()
+        if remove_target:
+            if target.is_symlink():
+                target.unlink()
+            elif target.is_dir():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
 
     target.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _is_wrapper_plugin_target(target: Path) -> bool:
+    """Return whether ``target`` is a generated Mnemosyne wrapper directory."""
+    if target.is_symlink() or not target.is_dir():
+        return False
+    if (target / "mnemosyne-wrapper.json").exists():
+        return True
+    python, site_packages = _extract_wrapper_metadata(target / "__init__.py")
+    return python is not None or site_packages is not None
+
+
+def _validated_wrapper_environment(
+    python: str | Path | None,
+) -> tuple[Path, Path]:
+    """Validate the selected wrapper runtime before touching an installed plugin."""
+    wrapper_python = Path(python).expanduser() if python else Path(sys.executable)
+    if not wrapper_python.is_file():
+        raise FileNotFoundError(f"Python interpreter not found: {wrapper_python}")
+    site_packages = _site_packages_for_python(wrapper_python)
+    import_ok, import_error, _invalid_runtime = _check_wrapper_import(site_packages, wrapper_python)
+    if not import_ok:
+        raise RuntimeError(
+            f"Selected Python environment cannot import mnemosyne_hermes: {import_error}"
+        )
+    return wrapper_python, site_packages
+
+
+def _replace_plugin_target_with_staged(target: Path, staged: Path) -> None:
+    """Swap a fully written wrapper into place, restoring the old target on error."""
+    previous: Path | None = None
+    previous_parent: Path | None = None
+    if target.is_symlink() or target.exists():
+        previous_parent = Path(
+            tempfile.mkdtemp(prefix=f".{target.name}.previous-", dir=target.parent)
+        )
+        previous = previous_parent / target.name
+        target.replace(previous)
+    try:
+        staged.replace(target)
+    except Exception:
+        if previous is not None and not target.exists() and not target.is_symlink():
+            previous.replace(target)
+        if previous_parent is not None:
+            previous_parent.rmdir()
+        raise
+    else:
+        if previous is not None:
+            if previous.is_symlink():
+                previous.unlink()
+            elif previous.is_dir():
+                shutil.rmtree(previous)
+            else:
+                previous.unlink()
+        if previous_parent is not None:
+            previous_parent.rmdir()
 
 
 def _write_wrapper_plugin(target: Path, *, python: Path, site_packages: Path) -> None:
@@ -939,6 +1012,7 @@ def install_plugin(
     force: bool = False,
     mode: str = "symlink",
     python: str | Path | None = None,
+    migrate_wrapper_to_symlink: bool = False,
 ) -> Path:
     """Install the Mnemosyne provider into Hermes' user plugin directory.
 
@@ -949,6 +1023,8 @@ def install_plugin(
     """
     if mode not in {"symlink", "wrapper"}:
         raise ValueError("mode must be 'symlink' or 'wrapper'")
+    if migrate_wrapper_to_symlink and (mode != "symlink" or not force):
+        raise ValueError("migrate_wrapper_to_symlink requires mode='symlink' and force=True")
 
     source = _resolve_package_dir()
     if not source.is_dir():
@@ -956,24 +1032,41 @@ def install_plugin(
 
     base = Path(hermes_home_path).expanduser() if hermes_home_path else hermes_home()
     target = plugin_target_dir(hermes_home_path)
-    _prepare_plugin_target(base, target, force=force)
+    if (
+        mode == "symlink"
+        and force
+        and _is_wrapper_plugin_target(target)
+        and not migrate_wrapper_to_symlink
+    ):
+        raise RuntimeError(
+            "Refusing to replace an existing wrapper with a symlink. "
+            "Re-run with --migrate-wrapper-to-symlink --force to migrate intentionally."
+        )
 
     if mode == "symlink":
+        if migrate_wrapper_to_symlink and _is_wrapper_plugin_target(target):
+            print(
+                "  ⚠ Migrating existing Mnemosyne wrapper to a symlink; "
+                "the wrapper's selected Python will no longer be used."
+            )
+        _prepare_plugin_target(base, target, force=force)
         os.symlink(str(source), str(target))
         _link_all_profiles(source, hermes_home_path=hermes_home_path, force=force)
         return target
 
-    wrapper_python = Path(python).expanduser() if python else Path(sys.executable)
-    if not wrapper_python.is_file():
-        raise FileNotFoundError(f"Python interpreter not found: {wrapper_python}")
-    site_packages = _site_packages_for_python(wrapper_python)
-    import_ok, import_error, _invalid_runtime = _check_wrapper_import(site_packages, wrapper_python)
-    if not import_ok:
-        raise RuntimeError(
-            "Selected Python environment cannot import mnemosyne_hermes: "
-            f"{import_error}"
-        )
-    _write_wrapper_plugin(target, python=wrapper_python, site_packages=site_packages)
+    # Validate and fully write the replacement before removing a working wrapper.
+    # In particular, a bad --python or a selected environment missing this package
+    # must leave the existing wrapper and every profile link untouched.
+    wrapper_python, site_packages = _validated_wrapper_environment(python)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staging_parent = Path(tempfile.mkdtemp(prefix=f".{target.name}.staging-", dir=target.parent))
+    staged = staging_parent / target.name
+    try:
+        _write_wrapper_plugin(staged, python=wrapper_python, site_packages=site_packages)
+        _prepare_plugin_target(base, target, force=force, remove_target=False)
+        _replace_plugin_target_with_staged(target, staged)
+    finally:
+        shutil.rmtree(staging_parent, ignore_errors=True)
     _link_all_profiles(target, hermes_home_path=hermes_home_path, force=force)
     return target
 
@@ -1148,6 +1241,14 @@ def _parser() -> argparse.ArgumentParser:
         dest="python",
         help="Python interpreter whose site-packages the wrapper should import from.",
     )
+    install.add_argument(
+        "--migrate-wrapper-to-symlink",
+        action="store_true",
+        help=(
+            "With --force, intentionally replace an existing wrapper with the "
+            "default symlink install."
+        ),
+    )
     subparsers.add_parser(
         "uninstall",
         help="Remove Mnemosyne from Hermes' memory provider plugin directory.",
@@ -1184,6 +1285,7 @@ def run_install(
     no_bootstrap: bool = False,
     mode: str = "symlink",
     python: str | Path | None = None,
+    migrate_wrapper_to_symlink: bool = False,
 ) -> int:
     """Core install logic — check deps, bootstrap Hermes venv if needed, create symlink.
 
@@ -1233,6 +1335,7 @@ def run_install(
         force=force,
         mode=mode,
         python=python,
+        migrate_wrapper_to_symlink=migrate_wrapper_to_symlink,
     )
     skill_result = install_bundled_skill(
         hermes_home_path=hermes_home_path,
@@ -1286,6 +1389,8 @@ def main(argv: list[str] | None = None) -> int:
                     if wrapper_python.is_file():
                         print(f"  Wrapper site-packages: {_site_packages_for_python(wrapper_python)}")
                 print(f"  Will force: {bool(getattr(args, 'force', False))}")
+                if getattr(args, "migrate_wrapper_to_symlink", False):
+                    print("  Will allow wrapper-to-symlink migration: yes")
                 if hermes_python:
                     print(f"  Will bootstrap: {not getattr(args, 'no_bootstrap', False)}")
                 return 0
@@ -1296,6 +1401,7 @@ def main(argv: list[str] | None = None) -> int:
                 no_bootstrap=getattr(args, "no_bootstrap", False),
                 mode=getattr(args, "mode", "symlink"),
                 python=getattr(args, "python", None),
+                migrate_wrapper_to_symlink=getattr(args, "migrate_wrapper_to_symlink", False),
             )
 
         if command == "uninstall":

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -331,38 +331,21 @@ def _check_wrapper_import(
     if not os.access(runner, os.X_OK):
         return False, f"wrapper Python is not executable: {runner}", True
     package_init = site_packages / "mnemosyne_hermes" / "__init__.py"
-    origin_check = ""
-    if package_init.is_file():
-        origin_check = (
-            f"expected = Path({str(package_init)!r}).resolve(); "
-            "actual = Path(mnemosyne_hermes.__file__).resolve(); "
-            "assert actual == expected, f'package origin mismatch: {actual} != {expected}'; "
-        )
+    if not package_init.is_file():
+        return False, f"mnemosyne_hermes package missing from selected site-packages: {site_packages}", False
     code = (
-        "import importlib.metadata\n"
         "import sys\n"
         "from pathlib import Path\n"
         f"sys.path.insert(0, {str(site_packages)!r})\n"
-        f"expected_site = Path({str(site_packages)!r}).resolve()\n"
-        "try:\n"
-        "    dist = importlib.metadata.distribution('mnemosyne-hermes')\n"
-        "except importlib.metadata.PackageNotFoundError:\n"
-        "    sys.exit(\n"
-        "        f'mnemosyne_hermes package missing from selected site-packages: {expected_site}'\n"
-        "    )\n"
-        "dist_root = Path(dist.locate_file('')).resolve()\n"
-        "runtime_paths = {Path(path).resolve() for path in sys.path if path}\n"
-        "if dist_root not in runtime_paths:\n"
-        "    sys.exit(\n"
-        "        f'mnemosyne_hermes distribution is not on selected Python sys.path: {dist_root}'\n"
-        "    )\n"
+        f"expected = Path({str(package_init)!r}).resolve()\n"
         "import mnemosyne_hermes\n"
-        + origin_check
+        "actual = Path(mnemosyne_hermes.__file__).resolve()\n"
+        "assert actual == expected, f'package origin mismatch: {actual} != {expected}'\n"
         + "print(getattr(mnemosyne_hermes, '__version__', 'unknown'))\n"
     )
     try:
         result = subprocess.run(
-            [str(runner), "-c", code],
+            [str(runner), "-S", "-c", code],
             capture_output=True,
             text=True,
             timeout=10,
@@ -887,14 +870,20 @@ def _replace_plugin_target_with_staged(target: Path, staged: Path) -> None:
         raise
     else:
         if previous is not None:
-            if previous.is_symlink():
-                previous.unlink()
-            elif previous.is_dir():
-                shutil.rmtree(previous)
-            else:
-                previous.unlink()
+            try:
+                if previous.is_symlink():
+                    previous.unlink()
+                elif previous.is_dir():
+                    shutil.rmtree(previous)
+                else:
+                    previous.unlink()
+            except OSError:
+                pass
         if previous_parent is not None:
-            previous_parent.rmdir()
+            try:
+                previous_parent.rmdir()
+            except OSError:
+                pass
 
 
 def _write_wrapper_plugin(target: Path, *, python: Path, site_packages: Path) -> None:
@@ -1384,6 +1373,13 @@ def main(argv: list[str] | None = None) -> int:
             hermes_python = _find_hermes_python()
             target = plugin_target_dir(args.hermes_home)
             if getattr(args, "dry_run", False):
+                invalid_wrapper_migration_args = (
+                    getattr(args, "migrate_wrapper_to_symlink", False)
+                    and (
+                        getattr(args, "mode", "symlink") != "symlink"
+                        or not getattr(args, "force", False)
+                    )
+                )
                 refuses_wrapper_migration = (
                     getattr(args, "mode", "symlink") == "symlink"
                     and getattr(args, "force", False)
@@ -1411,6 +1407,11 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  Will force: {bool(getattr(args, 'force', False))}")
                 if getattr(args, "migrate_wrapper_to_symlink", False):
                     print("  Will allow wrapper-to-symlink migration: yes")
+                if invalid_wrapper_migration_args:
+                    print(
+                        "  Will refuse --migrate-wrapper-to-symlink unless "
+                        "--mode symlink and --force are both set."
+                    )
                 if refuses_wrapper_migration:
                     print(
                         "  Will refuse to replace the existing wrapper without "
@@ -1418,7 +1419,7 @@ def main(argv: list[str] | None = None) -> int:
                     )
                 if hermes_python:
                     print(f"  Will bootstrap: {not getattr(args, 'no_bootstrap', False)}")
-                return 1 if refuses_wrapper_migration else 0
+                return 1 if invalid_wrapper_migration_args or refuses_wrapper_migration else 0
 
             return run_install(
                 force=getattr(args, "force", False),

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -217,6 +217,48 @@ def test_force_wrapper_refresh_replaces_wrapper_and_keeps_selected_profile_link(
     assert target.stat().st_ino != old_inode
     assert install_mod.plugin_state(hermes_home_path=tmp_path).mode == "wrapper"
     assert (profile / "plugins" / "mnemosyne").resolve() == target.resolve()
+    assert not list(target.parent.glob(".mnemosyne.previous-*"))
+
+
+def test_force_wrapper_refresh_replaces_existing_symlink_and_keeps_profile_link(tmp_path):
+    _skip_on_windows()
+    profile = _make_profile(tmp_path, "alice", "mnemosyne")
+    target = install_plugin(hermes_home_path=tmp_path)
+    assert target.is_symlink()
+
+    refreshed = install_plugin(
+        hermes_home_path=tmp_path,
+        force=True,
+        mode="wrapper",
+        python=sys.executable,
+    )
+
+    assert refreshed == target
+    assert target.is_dir() and not target.is_symlink()
+    assert (profile / "plugins" / "mnemosyne").resolve() == target.resolve()
+
+
+def test_wrapper_refresh_ignores_post_swap_backup_cleanup_error(tmp_path, monkeypatch):
+    _skip_on_windows()
+    target = install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
+    original_rmtree = install_mod.shutil.rmtree
+
+    def fail_backup_cleanup(path, *args, **kwargs):
+        if Path(path).parent.name.startswith(".mnemosyne.previous-"):
+            raise OSError("backup cleanup failed")
+        return original_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(install_mod.shutil, "rmtree", fail_backup_cleanup)
+
+    refreshed = install_plugin(
+        hermes_home_path=tmp_path,
+        force=True,
+        mode="wrapper",
+        python=sys.executable,
+    )
+
+    assert refreshed == target
+    assert target.is_dir() and not target.is_symlink()
 
 
 def test_failed_wrapper_swap_restores_wrapper_and_profile_link(tmp_path, monkeypatch):

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
 import venv
 from pathlib import Path
@@ -185,7 +186,7 @@ def test_forced_wrapper_refresh_preflights_before_preserving_existing_wrapper_li
     else:
         environment = tmp_path / "unavailable-environment"
         venv.EnvBuilder(with_pip=False).create(environment)
-        with pytest.raises(RuntimeError, match="package missing from selected site-packages"):
+        with pytest.raises(RuntimeError, match="Selected Python environment cannot import"):
             install_plugin(
                 hermes_home_path=tmp_path,
                 force=True,
@@ -261,6 +262,36 @@ def test_wrapper_refresh_ignores_post_swap_backup_cleanup_error(tmp_path, monkey
     assert target.is_dir() and not target.is_symlink()
 
 
+def test_failed_wrapper_rollback_reports_retained_backup_path(tmp_path, monkeypatch, capsys):
+    _skip_on_windows()
+    target = install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
+    original_replace = Path.replace
+
+    def fail_swap_and_rollback(self, destination):
+        if self.parent.name.startswith(".mnemosyne.staging-"):
+            raise OSError("staged swap failed")
+        if self.parent.name.startswith(".mnemosyne.previous-"):
+            raise OSError("rollback failed")
+        return original_replace(self, destination)
+
+    monkeypatch.setattr(Path, "replace", fail_swap_and_rollback)
+
+    with pytest.raises(OSError, match="staged swap failed"):
+        install_plugin(
+            hermes_home_path=tmp_path,
+            force=True,
+            mode="wrapper",
+            python=sys.executable,
+        )
+
+    error = capsys.readouterr().err
+    assert "Wrapper rollback failed; previous plugin retained at:" in error
+    backup = Path(error.rsplit(": ", 1)[1].strip())
+    assert backup.name == target.name
+    assert backup.parent.name.startswith(".mnemosyne.previous-")
+    assert backup.is_dir()
+
+
 def test_failed_wrapper_swap_restores_wrapper_and_profile_link(tmp_path, monkeypatch):
     _skip_on_windows()
     profile = _make_profile(tmp_path, "alice", "mnemosyne")
@@ -288,6 +319,53 @@ def test_failed_wrapper_swap_restores_wrapper_and_profile_link(tmp_path, monkeyp
     assert (target / "__init__.py").read_bytes() == original_init
     assert profile_link.is_symlink()
     assert profile_link.resolve() == target.resolve()
+
+
+def test_wrapper_preflight_and_bootstrap_support_real_pep660_editable_install(tmp_path):
+    _skip_on_windows()
+    environment = tmp_path / "editable-environment"
+    venv.EnvBuilder(with_pip=True).create(environment)
+    python = environment / "bin" / "python"
+    project = _source().parent.parent
+    install_result = subprocess.run(
+        [str(python), "-m", "pip", "install", "--no-deps", "-e", str(project)],
+        capture_output=True,
+        text=True,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    site_packages = install_mod._site_packages_for_python(python)
+    assert not (site_packages / "mnemosyne_hermes").exists()
+    assert install_mod._check_wrapper_import(site_packages, python) == (True, None, False)
+
+    wrapper = tmp_path / "hermes-home" / "plugins" / "mnemosyne"
+    install_mod._write_wrapper_plugin(wrapper, python=python, site_packages=site_packages)
+    expected_source = _source().resolve()
+    code = f"""
+import importlib.util
+import sys
+from pathlib import Path
+
+wrapper = Path({str(wrapper)!r})
+spec = importlib.util.spec_from_file_location(
+    'standalone_mnemosyne_bootstrap', wrapper / '_mnemosyne_bootstrap.py'
+)
+bootstrap = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bootstrap)
+bootstrap.activate()
+import mnemosyne_hermes
+assert Path(mnemosyne_hermes.__file__).resolve().parent == Path({str(expected_source)!r})
+assert sys.path[0] == {str(site_packages.resolve())!r}
+"""
+    result = subprocess.run(
+        [str(python), "-S", "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize(

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 import pytest
-
 from mnemosyne_hermes import install as install_mod
 from mnemosyne_hermes.install import install_plugin
 
@@ -16,7 +16,7 @@ def _skip_on_windows() -> None:
         pytest.skip("POSIX symlink test")
 
 
-def _source() -> "object":
+def _source() -> Path:
     return install_mod._resolve_package_dir()
 
 
@@ -121,6 +121,102 @@ def test_wrapper_profile_links_point_to_base_wrapper_and_uninstall_leaves_foreig
     assert not wrapper_link.is_symlink() and not wrapper_link.exists()
     assert foreign_link.is_symlink()
     assert foreign_link.resolve() == foreign.resolve()
+
+
+def test_force_symlink_install_refuses_to_replace_wrapper_without_migration_flag(tmp_path):
+    _skip_on_windows()
+    profile = _make_profile(tmp_path, "alice", "mnemosyne")
+    target = install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
+    profile_link = profile / "plugins" / "mnemosyne"
+    original_init = (target / "__init__.py").read_bytes()
+
+    with pytest.raises(RuntimeError, match="migrate-wrapper-to-symlink"):
+        install_plugin(hermes_home_path=tmp_path, force=True)
+
+    assert target.is_dir() and not target.is_symlink()
+    assert (target / "__init__.py").read_bytes() == original_init
+    assert profile_link.is_symlink()
+    assert profile_link.resolve() == target.resolve()
+
+
+def test_explicit_force_migration_replaces_wrapper_with_symlink_and_warns(tmp_path, capsys):
+    _skip_on_windows()
+    profile = _make_profile(tmp_path, "alice", "mnemosyne")
+    target = install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
+
+    migrated = install_plugin(
+        hermes_home_path=tmp_path,
+        force=True,
+        migrate_wrapper_to_symlink=True,
+    )
+
+    assert migrated == target
+    assert target.is_symlink()
+    assert target.resolve() == Path(_source()).resolve()
+    assert (profile / "plugins" / "mnemosyne").resolve() == Path(_source()).resolve()
+    assert "Migrating existing Mnemosyne wrapper to a symlink" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("failure", ("missing_python", "unavailable_package"))
+def test_forced_wrapper_refresh_preflights_before_preserving_existing_wrapper_links(
+    tmp_path, monkeypatch, failure
+):
+    _skip_on_windows()
+    selected = _make_profile(tmp_path, "alice", "mnemosyne")
+    unselected = _make_profile(tmp_path, "bob", "honcho")
+    foreign = tmp_path / "foreign-provider"
+    foreign.mkdir()
+    foreign_link = unselected / "plugins" / "mnemosyne"
+    foreign_link.parent.mkdir(parents=True)
+    os.symlink(str(foreign), str(foreign_link))
+    target = install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
+    selected_link = selected / "plugins" / "mnemosyne"
+    original_init = (target / "__init__.py").read_bytes()
+
+    if failure == "missing_python":
+        with pytest.raises(FileNotFoundError, match="Python interpreter not found"):
+            install_plugin(
+                hermes_home_path=tmp_path,
+                force=True,
+                mode="wrapper",
+                python=tmp_path / "missing-python",
+            )
+    else:
+        empty_site = tmp_path / "empty-site-packages"
+        empty_site.mkdir()
+        monkeypatch.setattr(install_mod, "_site_packages_for_python", lambda _python: empty_site)
+        with pytest.raises(RuntimeError, match="package missing from selected site-packages"):
+            install_plugin(
+                hermes_home_path=tmp_path,
+                force=True,
+                mode="wrapper",
+                python=sys.executable,
+            )
+
+    assert target.is_dir() and not target.is_symlink()
+    assert (target / "__init__.py").read_bytes() == original_init
+    assert selected_link.is_symlink() and selected_link.resolve() == target.resolve()
+    assert foreign_link.is_symlink() and foreign_link.resolve() == foreign.resolve()
+
+
+def test_force_wrapper_refresh_replaces_wrapper_and_keeps_selected_profile_link(tmp_path):
+    _skip_on_windows()
+    profile = _make_profile(tmp_path, "alice", "mnemosyne")
+    target = install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
+    old_inode = target.stat().st_ino
+
+    refreshed = install_plugin(
+        hermes_home_path=tmp_path,
+        force=True,
+        mode="wrapper",
+        python=sys.executable,
+    )
+
+    assert refreshed == target
+    assert target.is_dir() and not target.is_symlink()
+    assert target.stat().st_ino != old_inode
+    assert install_mod.plugin_state(hermes_home_path=tmp_path).mode == "wrapper"
+    assert (profile / "plugins" / "mnemosyne").resolve() == target.resolve()
 
 
 def test_link_profile_returns_none_on_symlink_error(tmp_path, monkeypatch):

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import venv
 from pathlib import Path
 
 import pytest
@@ -159,7 +160,7 @@ def test_explicit_force_migration_replaces_wrapper_with_symlink_and_warns(tmp_pa
 
 @pytest.mark.parametrize("failure", ("missing_python", "unavailable_package"))
 def test_forced_wrapper_refresh_preflights_before_preserving_existing_wrapper_links(
-    tmp_path, monkeypatch, failure
+    tmp_path, failure
 ):
     _skip_on_windows()
     selected = _make_profile(tmp_path, "alice", "mnemosyne")
@@ -182,15 +183,14 @@ def test_forced_wrapper_refresh_preflights_before_preserving_existing_wrapper_li
                 python=tmp_path / "missing-python",
             )
     else:
-        empty_site = tmp_path / "empty-site-packages"
-        empty_site.mkdir()
-        monkeypatch.setattr(install_mod, "_site_packages_for_python", lambda _python: empty_site)
+        environment = tmp_path / "unavailable-environment"
+        venv.EnvBuilder(with_pip=False).create(environment)
         with pytest.raises(RuntimeError, match="package missing from selected site-packages"):
             install_plugin(
                 hermes_home_path=tmp_path,
                 force=True,
                 mode="wrapper",
-                python=sys.executable,
+                python=environment / "bin" / "python",
             )
 
     assert target.is_dir() and not target.is_symlink()
@@ -217,6 +217,52 @@ def test_force_wrapper_refresh_replaces_wrapper_and_keeps_selected_profile_link(
     assert target.stat().st_ino != old_inode
     assert install_mod.plugin_state(hermes_home_path=tmp_path).mode == "wrapper"
     assert (profile / "plugins" / "mnemosyne").resolve() == target.resolve()
+
+
+def test_failed_wrapper_swap_restores_wrapper_and_profile_link(tmp_path, monkeypatch):
+    _skip_on_windows()
+    profile = _make_profile(tmp_path, "alice", "mnemosyne")
+    target = install_plugin(hermes_home_path=tmp_path, mode="wrapper", python=sys.executable)
+    profile_link = profile / "plugins" / "mnemosyne"
+    original_init = (target / "__init__.py").read_bytes()
+    original_replace = Path.replace
+
+    def fail_staged_swap(self, destination):
+        if self.parent.name.startswith(".mnemosyne.staging-"):
+            raise OSError("staged swap failed")
+        return original_replace(self, destination)
+
+    monkeypatch.setattr(Path, "replace", fail_staged_swap)
+
+    with pytest.raises(OSError, match="staged swap failed"):
+        install_plugin(
+            hermes_home_path=tmp_path,
+            force=True,
+            mode="wrapper",
+            python=sys.executable,
+        )
+
+    assert target.is_dir() and not target.is_symlink()
+    assert (target / "__init__.py").read_bytes() == original_init
+    assert profile_link.is_symlink()
+    assert profile_link.resolve() == target.resolve()
+
+
+@pytest.mark.parametrize(
+    ("force", "mode"),
+    [
+        (False, "symlink"),
+        (True, "wrapper"),
+    ],
+)
+def test_migrate_wrapper_to_symlink_rejects_invalid_flag_combinations(tmp_path, force, mode):
+    with pytest.raises(ValueError, match="migrate_wrapper_to_symlink requires"):
+        install_plugin(
+            hermes_home_path=tmp_path,
+            force=force,
+            mode=mode,
+            migrate_wrapper_to_symlink=True,
+        )
 
 
 def test_link_profile_returns_none_on_symlink_error(tmp_path, monkeypatch):

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -310,6 +310,29 @@ def test_check_wrapper_import_returns_error_when_interpreter_cannot_launch(tmp_p
     assert invalid_runtime is True
 
 
+def test_check_wrapper_import_uses_selected_runtime_paths_without_disabling_user_site(
+    monkeypatch,
+):
+    site_packages = install._site_packages_for_python(Path(sys.executable))
+    observed = {}
+
+    def successful_probe(command, **kwargs):
+        observed["command"] = command
+        observed["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(command, 0, "ok\n", "")
+
+    monkeypatch.setattr(install.subprocess, "run", successful_probe)
+
+    ok, error, invalid_runtime = install._check_wrapper_import(site_packages, Path(sys.executable))
+
+    assert ok is True
+    assert error is None
+    assert invalid_runtime is False
+    assert "PYTHONPATH" not in observed["env"]
+    assert "PYTHONNOUSERSITE" not in observed["env"]
+    assert "if dist_root not in runtime_paths" in observed["command"][2]
+
+
 def test_plugin_state_classifies_timed_out_wrapper_import_as_stale(tmp_path, monkeypatch):
     target = tmp_path / "plugins" / "mnemosyne"
     site_packages = install._site_packages_for_python(Path(sys.executable))
@@ -361,6 +384,8 @@ def test_install_plugin_rejects_unknown_mode(tmp_path):
 
 
 def test_cli_requires_explicit_flag_to_migrate_wrapper_to_symlink(tmp_path, monkeypatch, capsys):
+    if sys.platform.startswith("win32"):
+        pytest.skip("POSIX symlink test")
     target = install.install_plugin(
         hermes_home_path=tmp_path,
         mode="wrapper",
@@ -393,3 +418,24 @@ def test_cli_requires_explicit_flag_to_migrate_wrapper_to_symlink(tmp_path, monk
     assert migrated == 0
     assert target.is_symlink()
     assert "Migrating existing Mnemosyne wrapper to a symlink" in capsys.readouterr().out
+
+
+def test_dry_run_reports_refused_wrapper_migration(tmp_path, monkeypatch, capsys):
+    if sys.platform.startswith("win32"):
+        pytest.skip("POSIX symlink test")
+    target = install.install_plugin(
+        hermes_home_path=tmp_path,
+        mode="wrapper",
+        python=sys.executable,
+    )
+    original_init = (target / "__init__.py").read_bytes()
+    monkeypatch.setattr(install, "_find_hermes_python", lambda: None)
+
+    rc = install.main(
+        ["--hermes-home", str(tmp_path), "install", "--force", "--dry-run", "--no-bootstrap"]
+    )
+
+    assert rc == 1
+    assert "Will refuse to replace the existing wrapper" in capsys.readouterr().out
+    assert target.is_dir() and not target.is_symlink()
+    assert (target / "__init__.py").read_bytes() == original_init

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -317,6 +317,9 @@ def test_check_wrapper_import_returns_error_when_interpreter_cannot_launch(tmp_p
 def test_check_wrapper_import_isolates_selected_site_from_pythonpath(monkeypatch):
     site_packages = install._site_packages_for_python(Path(sys.executable))
     observed = {}
+    monkeypatch.setenv("PYTHONPATH", "/untrusted/pythonpath")
+    monkeypatch.setenv("PYTHONOPTIMIZE", "2")
+    monkeypatch.setenv("PYTHONNOUSERSITE", "1")
 
     def successful_probe(command, **kwargs):
         observed["command"] = command
@@ -331,9 +334,11 @@ def test_check_wrapper_import_isolates_selected_site_from_pythonpath(monkeypatch
     assert error is None
     assert invalid_runtime is False
     assert "PYTHONPATH" not in observed["env"]
-    assert "PYTHONNOUSERSITE" not in observed["env"]
+    assert "PYTHONOPTIMIZE" not in observed["env"]
+    assert observed["env"]["PYTHONNOUSERSITE"] == "1"
     assert observed["command"][1] == "-S"
-    assert "actual == expected" in observed["command"][3]
+    assert "site.addsitedir" in observed["command"][3]
+    assert "assert " not in observed["command"][3]
 
 
 def test_check_wrapper_import_accepts_direct_package_without_dist_metadata(tmp_path):
@@ -466,3 +471,11 @@ def test_dry_run_rejects_invalid_wrapper_migration_flag_combination(tmp_path, mo
 
     assert rc == 1
     assert "unless --mode symlink and --force are both set" in capsys.readouterr().out
+
+
+def test_install_help_describes_required_wrapper_migration_flags(capsys):
+    with pytest.raises(SystemExit, match="0"):
+        install.main(["install", "--help"])
+
+    help_text = capsys.readouterr().out
+    assert "With --mode symlink and --force" in help_text

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -298,6 +298,10 @@ def test_plugin_state_reports_non_executable_wrapper_interpreter_without_raising
 
 
 def test_check_wrapper_import_returns_error_when_interpreter_cannot_launch(tmp_path, monkeypatch):
+    package = tmp_path / "mnemosyne_hermes"
+    package.mkdir()
+    (package / "__init__.py").write_text("__version__ = 'test'\n", encoding="utf-8")
+
     def raise_permission_error(*args, **kwargs):
         raise PermissionError("permission denied")
 
@@ -310,9 +314,7 @@ def test_check_wrapper_import_returns_error_when_interpreter_cannot_launch(tmp_p
     assert invalid_runtime is True
 
 
-def test_check_wrapper_import_uses_selected_runtime_paths_without_disabling_user_site(
-    monkeypatch,
-):
+def test_check_wrapper_import_isolates_selected_site_from_pythonpath(monkeypatch):
     site_packages = install._site_packages_for_python(Path(sys.executable))
     observed = {}
 
@@ -330,7 +332,21 @@ def test_check_wrapper_import_uses_selected_runtime_paths_without_disabling_user
     assert invalid_runtime is False
     assert "PYTHONPATH" not in observed["env"]
     assert "PYTHONNOUSERSITE" not in observed["env"]
-    assert "if dist_root not in runtime_paths" in observed["command"][2]
+    assert observed["command"][1] == "-S"
+    assert "actual == expected" in observed["command"][3]
+
+
+def test_check_wrapper_import_accepts_direct_package_without_dist_metadata(tmp_path):
+    site_packages = tmp_path / "site-packages"
+    package = site_packages / "mnemosyne_hermes"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("__version__ = 'test'\n", encoding="utf-8")
+
+    ok, error, invalid_runtime = install._check_wrapper_import(site_packages, Path(sys.executable))
+
+    assert ok is True
+    assert error is None
+    assert invalid_runtime is False
 
 
 def test_plugin_state_classifies_timed_out_wrapper_import_as_stale(tmp_path, monkeypatch):
@@ -439,3 +455,14 @@ def test_dry_run_reports_refused_wrapper_migration(tmp_path, monkeypatch, capsys
     assert "Will refuse to replace the existing wrapper" in capsys.readouterr().out
     assert target.is_dir() and not target.is_symlink()
     assert (target / "__init__.py").read_bytes() == original_init
+
+
+def test_dry_run_rejects_invalid_wrapper_migration_flag_combination(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(install, "_find_hermes_python", lambda: None)
+
+    rc = install.main(
+        ["--hermes-home", str(tmp_path), "install", "--dry-run", "--migrate-wrapper-to-symlink"]
+    )
+
+    assert rc == 1
+    assert "unless --mode symlink and --force are both set" in capsys.readouterr().out

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -7,7 +7,6 @@ import sys
 from pathlib import Path
 
 import pytest
-
 from mnemosyne_hermes import install
 
 
@@ -359,3 +358,38 @@ def test_install_plugin_rejects_unknown_mode(tmp_path):
         assert "mode must be" in str(exc)
     else:
         raise AssertionError("install_plugin should reject unknown modes")
+
+
+def test_cli_requires_explicit_flag_to_migrate_wrapper_to_symlink(tmp_path, monkeypatch, capsys):
+    target = install.install_plugin(
+        hermes_home_path=tmp_path,
+        mode="wrapper",
+        python=sys.executable,
+    )
+    original_init = (target / "__init__.py").read_bytes()
+    monkeypatch.setattr(install, "check_mnemosyne_core", lambda: True)
+    monkeypatch.setattr(install, "_find_hermes_python", lambda: None)
+
+    rejected = install.main(
+        ["--hermes-home", str(tmp_path), "install", "--force", "--no-bootstrap"]
+    )
+
+    assert rejected == 1
+    assert target.is_dir() and not target.is_symlink()
+    assert (target / "__init__.py").read_bytes() == original_init
+    assert "migrate-wrapper-to-symlink" in capsys.readouterr().err
+
+    migrated = install.main(
+        [
+            "--hermes-home",
+            str(tmp_path),
+            "install",
+            "--force",
+            "--no-bootstrap",
+            "--migrate-wrapper-to-symlink",
+        ]
+    )
+
+    assert migrated == 0
+    assert target.is_symlink()
+    assert "Migrating existing Mnemosyne wrapper to a symlink" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- reject accidental forced wrapper-to-symlink downgrades unless explicitly requested
- validate and stage wrapper refreshes before replacing a working install
- document safe wrapper update commands

## Why this path
Wrapper mode is the Docker-safe integration path. A generic forced symlink install could otherwise remove its import bootstrap and leave profile links resolving to the package directory.

## Non-goals
- remove legacy fresh symlink installs
- remove automatic opted-in profile links
- change the `upgrade` path, which already preserves wrapper mode

## Verification
- 54 focused wrapper/install tests
- 99 Hermes integration tests
- ruff, py_compile, docs span/fence checks, git diff --check
- independent high-reasoning review: no blockers

Why not simply switch the default mode? That would break the documented legacy mutable-environment path. This keeps it while making a wrapper downgrade explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents accidental migration from Hermes wrapper installs to symlink installs.
- Requires `--migrate-wrapper-to-symlink --force` for explicit migration.
- Validates wrapper imports with an isolated Python interpreter before changes.
- Stages wrapper replacements and uses atomic swap and rollback handling.
- Preserves the working wrapper when validation or replacement fails.
- Documents safe commands for persistent Hermes wrapper updates.

## Architectural impact

- **Core memory architecture:** No changes to working, episodic, or BEAM memory tiers.
- **Retrieval and consolidation:** No changes.
- **Veracity system:** No changes.
- **Sync layer:** No changes.
- **Local-first posture:** Preserved. Hermes remains a Docker-safe local integration path. The installer adds no remote services or data flows.
- **Privacy posture:** Preserved. The changes affect local installation safety only.
- **Agent integration:** Hermes installation, programmatic APIs, and CLI flows gain safer validation and explicit migration controls. MCP and other CLI integrations are unchanged.
- **Maintainability:** Improved through isolated preflight checks, editable-wrapper support, staged replacement, rollback handling, explicit API flags, and focused regression tests.
- **Benchmark methodology:** No changes.

## Architectural assessment

This is the right call for installation safety. It preserves existing wrapper deployments and prevents failed updates from replacing working installations. It also preserves legacy fresh symlink installs and explicit profile links.

The PR does not erode the local-first design. It does not change memory behavior, retrieval, synchronization, privacy boundaries, agent data flows, or benchmark methodology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->