### PR TITLE
docs: correct persona tier retention description

### DIFF
--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -341,7 +341,7 @@ List L3 persona facts, optionally filtered by tier and/or topic. Returns persona
 
 ### 3. `mnemosyne_persona_promote`
 
-Promote a working or episodic memory into the L3 persona tier. Persona facts are always auto-injected into the system prompt regardless of semantic relevance. Tier values: 'permanent' (never evicted, requires explicit demotion), 'long_term' (default; reinforcement-driven decay), 'working' (transient). Returns the new persona id.
+Promote a working or episodic memory into the L3 persona tier. Persona facts are always auto-injected into the system prompt regardless of semantic relevance. Tier values: 'permanent' (never evicted, requires explicit demotion), 'long_term' (default), 'working' (transient). Tier controls injection priority only; no persona tier is automatically evicted or decayed. Returns the new persona id.
 
 | Parameter | Type | Required | Default |
 |-----------|------|----------|---------|

--- a/mnemosyne/tool_schemas.py
+++ b/mnemosyne/tool_schemas.py
@@ -664,8 +664,9 @@ PERSONA_PROMOTE_SCHEMA = {
         "Promote a working or episodic memory into the L3 persona tier. "
         "Persona facts are always auto-injected into the system prompt regardless "
         "of semantic relevance. Tier values: 'permanent' (never evicted, requires "
-        "explicit demotion), 'long_term' (default; reinforcement-driven decay), "
-        "'working' (transient). Returns the new persona id."
+        "explicit demotion), 'long_term' (default), 'working' (transient). Tier "
+        "controls injection priority only; no persona tier is automatically evicted "
+        "or decayed. Returns the new persona id."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## What
Correct the `mnemosyne_persona_promote` schema description: persona tiers control injection priority only. The implementation has no automatic persona eviction or decay.

## Why
The previous generated API documentation stated that `long_term` uses “reinforcement-driven decay”, which contradicts the current implementation.

## Scope
- Update the schema source in `mnemosyne/tool_schemas.py`
- Regenerate `docs/api/tool-schema.mdx`

## Verification
- `python3 scripts/generate-docs.py --check`
- `pytest tests/test_tool_surface_parity.py -q` → 7 passed, 1 skipped
- `pytest tests/test_persona_adapter.py -q` → 19 passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updated `mnemosyne_persona_promote` documentation in `mnemosyne/tool_schemas.py` and `docs/api/tool-schema.mdx`.

Persona tiers now clearly control injection priority only. The documentation no longer claims that `long_term` personas use reinforcement-driven decay or automatic eviction.

## Architectural impact

- **Core memory architecture:** Clarifies persona-tier behavior without changing implementation.
- **Tiered memory:** No changes to working, episodic, or BEAM memory.
- **Retrieval and consolidation:** No changes.
- **Veracity system and sync layer:** No changes.
- **Privacy and local-first guarantees:** No changes. The PR introduces no data flow, storage, or synchronization behavior.
- **Hermes, MCP, and CLI integration:** No API behavior changes. The schema description becomes more accurate for agent integrations.
- **Maintainability:** Documentation now matches the intended tier semantics. This reduces incorrect assumptions in future integrations.
- **Benchmark methodology:** No changes.

Clarifying that tiers control injection priority only is the right call. It removes a false claim without expanding scope or weakening local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->