### PR TITLE
docs(persona): clarify tier ordering and retention semantics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ generator instead.
 |---|---|
 | [Memory Hygiene](hygiene.md) | Noise scoring, the audit and clean workflow, secret detection, and how to prevent noise being stored |
 | [Configuration Profiles](profiles.md) | The eight built-in profiles, what distinguishes them, validation rules, and the `vec_type` restart trap |
-| [L3 Persona Tier](persona.md) | Always-injected behavioural facts. Includes an explicit list of what is not yet wired |
+| [L3 Persona Tier](persona.md) | Durable behavioural facts promoted into a store; prompt injection reads an opt-in `persona.md` file. Includes an explicit list of what is not yet wired |
 | [SHMR](shmr.md) | Self-harmonizing memory reasoning. Library only; nothing calls it yet |
 
 ## Reference and analysis

--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -341,7 +341,7 @@ List L3 persona facts, optionally filtered by tier and/or topic. Returns persona
 
 ### 3. `mnemosyne_persona_promote`
 
-Promote a working or episodic memory into the L3 persona tier. Persona facts are always auto-injected into the system prompt regardless of semantic relevance. Tier values: 'permanent' (never evicted, requires explicit demotion), 'long_term' (default; reinforcement-driven decay), 'working' (transient). Returns the new persona id.
+Promote a working or episodic memory into the L3 persona tier. Persona facts are always auto-injected into the system prompt regardless of semantic relevance. Tier values: 'permanent', 'long_term' (default), 'working'. Tier controls injection priority only: no automatic eviction or decay is implemented, and a fact leaves the tier only by explicit demotion. Returns the new persona id.
 
 | Parameter | Type | Required | Default |
 |-----------|------|----------|---------|

--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -341,7 +341,7 @@ List L3 persona facts, optionally filtered by tier and/or topic. Returns persona
 
 ### 3. `mnemosyne_persona_promote`
 
-Promote a working or episodic memory into the L3 persona tier. Persona facts are always auto-injected into the system prompt regardless of semantic relevance. Tier values: 'permanent', 'long_term' (default), 'working'. Tier controls injection priority only: no automatic eviction or decay is implemented, and a fact leaves the tier only by explicit demotion. Returns the new persona id.
+Promote a working or episodic memory into the L3 persona store (the memoria_persona table). Tier values: 'permanent', 'long_term' (default), 'working'. Tier is a classification label: it orders mnemosyne_persona_list output (permanent first) and affects nothing else. No automatic eviction or decay is implemented, and a fact leaves the store only by explicit demotion. Persona facts are not read by the system prompt path, which uses the opt-in persona.md file. Returns the new persona id.
 
 | Parameter | Type | Required | Default |
 |-----------|------|----------|---------|

--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -351,7 +351,7 @@ Promote a working or episodic memory into the L3 persona store (the memoria_pers
 
 ### 4. `mnemosyne_persona_reinforce`
 
-Bump the reinforcement_count and last_reinforced_at on a persona fact. Use when the persona rule was just applied -- signals 'this rule is in active use'. Reinforcement count breaks ties in injection order; it does not feed any decay logic, because none is implemented.
+Bump the reinforcement_count and last_reinforced_at on a persona fact. Use when the persona rule was just applied -- signals 'this rule is in active use'. Reinforcement count breaks ties in mnemosyne_persona_list ordering; it does not feed any decay logic, because none is implemented.
 
 | Parameter | Type | Required | Default |
 |-----------|------|----------|---------|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,7 +153,7 @@ columns without a migration step. Most DDL lives in `init_beam` in
 | `memoria_instructions` | Standing instructions extracted from conversation |
 | `memoria_preferences` | Extracted user preferences |
 | `memoria_kg` | MEMORIA knowledge-graph rows |
-| `memoria_persona` | L3 persona tier, always injected into the prompt |
+| `memoria_persona` | L3 persona store; the prompt path reads the opt-in `persona.md` file, not this table |
 
 **Self-harmonizing reasoning (SHMR)**
 

--- a/docs/persona.md
+++ b/docs/persona.md
@@ -2,9 +2,9 @@
 
 **Status:** partially wired. Read [What is not wired](#what-is-not-wired) before relying on this.
 
-The persona tier holds a small set of durable behavioural facts about the user that are injected into every prompt regardless of semantic relevance. Ordinary memories compete for a place in recall results; persona facts do not compete, they are always present.
+The persona tier holds a small set of durable behavioural facts about the user. It is a store, not a prompt channel: promotion writes a row to the `memoria_persona` table, while [prompt injection](#prompt-injection) reads the opt-in `persona.md` file and never queries the table. Promoting a fact changes nothing about your prompts until something regenerates that file.
 
-That is the whole point of the tier, and also its cost: everything here consumes prompt budget on every single turn, so the tier is meant to stay small.
+The intended role is a set of facts that are always present rather than competing for recall, and that role has a cost: anything that reaches the injected file consumes prompt budget on every turn, so the tier is meant to stay small.
 
 ---
 
@@ -32,7 +32,7 @@ Indexed on `(session_id, tier)` and `(tier, topic)`.
 
 Three values are accepted: `permanent`, `long_term` (the default on promote), and `working`.
 
-**Tier affects ordering only.** Listing sorts `permanent` before `long_term` before `working`, then by `reinforcement_count` descending. That ordering is what determines which facts survive the token cap, so tier is effectively an injection priority.
+**Tier affects `mnemosyne_persona_list` ordering only.** Listing sorts `permanent` before `long_term` before `working`, then by `reinforcement_count` descending. Nothing else consults the tier: the prompt path reads `persona.md` and never queries this table.
 
 Tier does **not** cause retention or expiry. There is no code anywhere that deletes, ages out, or reduces the confidence of a `memoria_persona` row. The only writes are insert on promote, delete on demote, and the reinforcement counter update. Descriptions elsewhere in the codebase that call `permanent` "never evicted" or `long_term` "reinforcement-driven decay" describe an intended design, not current behaviour: nothing is evicted, because no eviction exists.
 
@@ -44,7 +44,7 @@ Implemented by `PersonaAdapter` in `hermes_memory_provider/persona_adapter.py`, 
 |---|---|
 | **promote** | Reads content from `working_memory`, falling back to `episodic_memory`. Derives `topic` from `memoria_timelines` via `source_memory_id`, else `"general"`. Errors if the content is empty. Default tier `long_term`. |
 | **demote** | Not a plain delete. Inserts a tombstone into `memoria_preferences` recording `[demoted from <tier>] <content>` and the reason, then deletes the `memoria_persona` row. Both in one transaction. |
-| **list** | Optional `tier` and `topic` filters. Returns rows in injection priority order. |
+| **list** | Optional `tier` and `topic` filters. Returns rows in tier order (`permanent` first), then by `reinforcement_count` descending. |
 | **reinforce** | `reinforcement_count += 1` and `last_reinforced_at = CURRENT_TIMESTAMP`. Returns an error if the id does not exist. |
 
 Reinforcement feeds two consumers: the list ordering above, and the regeneration trigger, which uses `MAX(last_reinforced_at)` as its watermark.

--- a/hermes_memory_provider/persona_adapter.py
+++ b/hermes_memory_provider/persona_adapter.py
@@ -186,7 +186,7 @@ class PersonaAdapter:
             sql += " WHERE " + " AND ".join(clauses)
         # Custom tier ordering: permanent > long_term > working. Alphabetical
         # sort would put 'long_term' before 'permanent', which is wrong for
-        # always-on injection priority.
+        # the tier-first list ordering the tool schema documents.
         sql += (
             " ORDER BY CASE tier "
             "WHEN 'permanent' THEN 0 "

--- a/hermes_memory_provider/persona_tools.py
+++ b/hermes_memory_provider/persona_tools.py
@@ -9,11 +9,14 @@ tool dispatch surface.
 PERSONA_PROMOTE_SCHEMA = {
     "name": "mnemosyne_persona_promote",
     "description": (
-        "Promote a working or episodic memory into the L3 persona tier. "
-        "Persona facts are always auto-injected into the system prompt regardless "
-        "of semantic relevance. Tier values: 'permanent' (never evicted, requires "
-        "explicit demotion), 'long_term' (default; reinforcement-driven decay), "
-        "'working' (transient). Returns the new persona id."
+        "Promote a working or episodic memory into the L3 persona store "
+        "(the memoria_persona table). Tier values: 'permanent', 'long_term' "
+        "(default), 'working'. Tier is a classification label: it orders "
+        "mnemosyne_persona_list output (permanent first) and affects nothing "
+        "else. No automatic eviction or decay is implemented, and a fact "
+        "leaves the store only by explicit demotion. Persona facts are not "
+        "read by the system prompt path, which uses the opt-in persona.md "
+        "file. Returns the new persona id."
     ),
     "parameters": {
         "type": "object",
@@ -26,7 +29,7 @@ PERSONA_PROMOTE_SCHEMA = {
                 "type": "string",
                 "enum": ["permanent", "long_term", "working"],
                 "default": "long_term",
-                "description": "Retention tier for the promoted persona fact.",
+                "description": "Classification tier for the promoted persona fact; affects mnemosyne_persona_list ordering only.",
             },
             "reason": {
                 "type": "string",
@@ -90,7 +93,8 @@ PERSONA_REINFORCE_SCHEMA = {
     "description": (
         "Bump the reinforcement_count and last_reinforced_at on a persona fact. "
         "Use when the persona rule was just applied -- signals 'this rule is in "
-        "active use'. Reinforcement count breaks ties in injection order; it does not feed any decay logic, because none is implemented."
+        "active use'. Reinforcement count breaks ties in mnemosyne_persona_list "
+        "ordering; it does not feed any decay logic, because none is implemented."
     ),
     "parameters": {
         "type": "object",

--- a/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
+++ b/integrations/hermes/src/mnemosyne_hermes/persona_adapter.py
@@ -186,7 +186,7 @@ class PersonaAdapter:
             sql += " WHERE " + " AND ".join(clauses)
         # Custom tier ordering: permanent > long_term > working. Alphabetical
         # sort would put 'long_term' before 'permanent', which is wrong for
-        # always-on injection priority.
+        # the tier-first list ordering the tool schema documents.
         sql += (
             " ORDER BY CASE tier "
             "WHEN 'permanent' THEN 0 "

--- a/integrations/hermes/src/mnemosyne_hermes/persona_tools.py
+++ b/integrations/hermes/src/mnemosyne_hermes/persona_tools.py
@@ -9,11 +9,14 @@ tool dispatch surface.
 PERSONA_PROMOTE_SCHEMA = {
     "name": "mnemosyne_persona_promote",
     "description": (
-        "Promote a working or episodic memory into the L3 persona tier. "
-        "Persona facts are always auto-injected into the system prompt regardless "
-        "of semantic relevance. Tier values: 'permanent' (never evicted, requires "
-        "explicit demotion), 'long_term' (default; reinforcement-driven decay), "
-        "'working' (transient). Returns the new persona id."
+        "Promote a working or episodic memory into the L3 persona store "
+        "(the memoria_persona table). Tier values: 'permanent', 'long_term' "
+        "(default), 'working'. Tier is a classification label: it orders "
+        "mnemosyne_persona_list output (permanent first) and affects nothing "
+        "else. No automatic eviction or decay is implemented, and a fact "
+        "leaves the store only by explicit demotion. Persona facts are not "
+        "read by the system prompt path, which uses the opt-in persona.md "
+        "file. Returns the new persona id."
     ),
     "parameters": {
         "type": "object",
@@ -26,7 +29,7 @@ PERSONA_PROMOTE_SCHEMA = {
                 "type": "string",
                 "enum": ["permanent", "long_term", "working"],
                 "default": "long_term",
-                "description": "Retention tier for the promoted persona fact.",
+                "description": "Classification tier for the promoted persona fact; affects mnemosyne_persona_list ordering only.",
             },
             "reason": {
                 "type": "string",
@@ -90,7 +93,8 @@ PERSONA_REINFORCE_SCHEMA = {
     "description": (
         "Bump the reinforcement_count and last_reinforced_at on a persona fact. "
         "Use when the persona rule was just applied -- signals 'this rule is in "
-        "active use'. Reinforcement count breaks ties in injection order; it does not feed any decay logic, because none is implemented."
+        "active use'. Reinforcement count breaks ties in mnemosyne_persona_list "
+        "ordering; it does not feed any decay logic, because none is implemented."
     ),
     "parameters": {
         "type": "object",

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -981,11 +981,12 @@ def init_beam(db_path: Path = None):
         _add_column_if_missing(conn, table, 'source_memory_id', 'TEXT')
 
     # --- L3 Persona (v3.10.0) ---
-    # Always-on persona tier with explicit retention classification.
+    # Explicit persona store with tier classification.
     # Tier values: 'permanent', 'long_term' (default), 'working'.
-    # Tier controls injection priority only. No eviction or decay is
-    # implemented for this table: the only writes are insert on promote,
-    # delete on demote, and the reinforcement counter bump.
+    # Tier orders persona_list output and affects nothing else; the system
+    # prompt path reads the opt-in persona.md file, not this table. No
+    # eviction or decay is implemented for this table: the only writes are
+    # insert on promote, delete on demote, and the reinforcement counter bump.
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS memoria_persona (
             id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/mnemosyne/tool_schemas.py
+++ b/mnemosyne/tool_schemas.py
@@ -663,9 +663,10 @@ PERSONA_PROMOTE_SCHEMA = {
     "description": (
         "Promote a working or episodic memory into the L3 persona tier. "
         "Persona facts are always auto-injected into the system prompt regardless "
-        "of semantic relevance. Tier values: 'permanent' (never evicted, requires "
-        "explicit demotion), 'long_term' (default; reinforcement-driven decay), "
-        "'working' (transient). Returns the new persona id."
+        "of semantic relevance. Tier values: 'permanent', 'long_term' (default), "
+        "'working'. Tier controls injection priority only: no automatic eviction "
+        "or decay is implemented, and a fact leaves the tier only by explicit "
+        "demotion. Returns the new persona id."
     ),
     "parameters": {
         "type": "object",
@@ -678,7 +679,7 @@ PERSONA_PROMOTE_SCHEMA = {
                 "type": "string",
                 "enum": ["permanent", "long_term", "working"],
                 "default": "long_term",
-                "description": "Retention tier for the promoted persona fact.",
+                "description": "Injection-priority tier for the promoted persona fact.",
             },
             "reason": {
                 "type": "string",

--- a/mnemosyne/tool_schemas.py
+++ b/mnemosyne/tool_schemas.py
@@ -745,7 +745,8 @@ PERSONA_REINFORCE_SCHEMA = {
     "description": (
         "Bump the reinforcement_count and last_reinforced_at on a persona fact. "
         "Use when the persona rule was just applied -- signals 'this rule is in "
-        "active use'. Reinforcement count breaks ties in injection order; it does not feed any decay logic, because none is implemented."
+        "active use'. Reinforcement count breaks ties in mnemosyne_persona_list "
+        "ordering; it does not feed any decay logic, because none is implemented."
     ),
     "parameters": {
         "type": "object",

--- a/mnemosyne/tool_schemas.py
+++ b/mnemosyne/tool_schemas.py
@@ -661,12 +661,14 @@ SYNC_STATUS_SCHEMA = {
 PERSONA_PROMOTE_SCHEMA = {
     "name": "mnemosyne_persona_promote",
     "description": (
-        "Promote a working or episodic memory into the L3 persona tier. "
-        "Persona facts are always auto-injected into the system prompt regardless "
-        "of semantic relevance. Tier values: 'permanent', 'long_term' (default), "
-        "'working'. Tier controls injection priority only: no automatic eviction "
-        "or decay is implemented, and a fact leaves the tier only by explicit "
-        "demotion. Returns the new persona id."
+        "Promote a working or episodic memory into the L3 persona store "
+        "(the memoria_persona table). Tier values: 'permanent', 'long_term' "
+        "(default), 'working'. Tier is a classification label: it orders "
+        "mnemosyne_persona_list output (permanent first) and affects nothing "
+        "else. No automatic eviction or decay is implemented, and a fact "
+        "leaves the store only by explicit demotion. Persona facts are not "
+        "read by the system prompt path, which uses the opt-in persona.md "
+        "file. Returns the new persona id."
     ),
     "parameters": {
         "type": "object",
@@ -679,7 +681,7 @@ PERSONA_PROMOTE_SCHEMA = {
                 "type": "string",
                 "enum": ["permanent", "long_term", "working"],
                 "default": "long_term",
-                "description": "Injection-priority tier for the promoted persona fact.",
+                "description": "Classification tier for the promoted persona fact; affects mnemosyne_persona_list ordering only.",
             },
             "reason": {
                 "type": "string",

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -119,6 +119,36 @@ def test_provider_tool_schemas_match(provider_modules):
     assert _json_stable(root_tools) == _json_stable(integration_tools)
 
 
+def test_persona_schemas_match_canonical(provider_modules):
+    """The two shipped persona tool surfaces must equal the canonical schemas.
+
+    The surface-to-surface check above kept both copies in lockstep while they
+    drifted together from mnemosyne/tool_schemas.py: the provider copies kept
+    promising auto-injection, eviction, and decay after the canonical promote
+    description was corrected. Pin every persona schema to the canonical
+    definition so a wording fix cannot land in one place again.
+    """
+    from mnemosyne import tool_schemas as canonical
+
+    canonical_by_name = {
+        schema["name"]: schema
+        for schema in (
+            canonical.PERSONA_PROMOTE_SCHEMA,
+            canonical.PERSONA_DEMOTE_SCHEMA,
+            canonical.PERSONA_LIST_SCHEMA,
+            canonical.PERSONA_REINFORCE_SCHEMA,
+        )
+    }
+    for name, module in provider_modules.items():
+        surface = {
+            schema["name"]: schema
+            for schema in module.ALL_TOOL_SCHEMAS
+            if schema["name"] in canonical_by_name
+        }
+        assert set(surface) == set(canonical_by_name), name
+        assert _json_stable(surface) == _json_stable(canonical_by_name), name
+
+
 def test_provider_config_defaults_match(provider_modules):
     root_config = _config_schema(provider_modules["hermes_memory_provider"])
     integration_config = _config_schema(provider_modules["mnemosyne_hermes"])


### PR DESCRIPTION
Fixes #611.

Persona tiers are classification labels that order `mnemosyne_persona_list` output. They do not control prompt injection: the Hermes prompt path reads the opt-in `persona.md` file, not the `memoria_persona` table. No automatic eviction or decay is implemented; a fact leaves its tier only by explicit demotion. The `mnemosyne_persona_promote` schema, both Hermes tool surfaces, and several docs claimed otherwise, so this PR aligns every surface with the implemented contract.

Changes:

- `mnemosyne/tool_schemas.py`: the `persona_promote` description now names the store it writes to (`memoria_persona`) and states that tier is a classification label affecting `mnemosyne_persona_list` ordering only, with removal by explicit demotion. The `tier` parameter is described as a classification tier.
- `hermes_memory_provider/persona_tools.py` and `integrations/hermes/src/mnemosyne_hermes/persona_tools.py`: both Hermes tool surfaces carry the same canonical descriptions.
- `tests/test_hermes_provider_parity.py`: new `test_persona_schemas_match_canonical` pins all four persona schemas on both Hermes surfaces to `mnemosyne/tool_schemas.py`. The previous parity test compared the two copies only to each other, which let them drift in lockstep.
- `mnemosyne/core/beam.py` and both `persona_adapter.py` copies: comments corrected to match.
- `docs/architecture.md`, `docs/README.md`, `docs/persona.md`: the same correction in the hand-written docs.
- `docs/api/tool-schema.mdx`: regenerated from the corrected source.

Validation: `generate-docs.py` is drift-free after the change; `tests/` and `integrations/hermes/tests/` pass when run as separate pytest invocations, matching CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jYv3WkS7NKMqfZtU4zSSU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Clarifies that persona tiers classify facts and control `mnemosyne_persona_list` ordering.
- States that persona facts are not automatically injected into system prompts.
- Documents the opt-in `persona.md` path.
- Removes incorrect claims about automatic eviction, retention, or decay.
- States that removal requires explicit demotion.
- Aligns canonical and Hermes schemas, comments, persona documentation, and generated API documentation.
- Adds parity coverage to prevent schema drift.

## Architecture and integration impact

- No changes to working, episodic, or BEAM memory tiers.
- No changes to retrieval, consolidation, veracity, synchronization, or benchmark methodology.
- No changes to memory data flow or API behavior.
- Updates the Hermes tool schemas and adds parity checks for both Hermes implementations.
- MCP advertises the persona schemas, but persona tools remain unavailable for MCP calls.
- No CLI surface exists for persona tools.
- The change preserves local-first guarantees. Prompt injection reads a local, opt-in file and introduces no network access.
- The change preserves the existing privacy posture by avoiding automatic prompt injection from `memoria_persona`.
- The change improves maintainability by aligning schemas, generated documentation, comments, and tests with implementation behavior.
- Correcting injection-priority wording is the right call because `memoria_persona` is not queried on the prompt path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
