### PR TITLE
test(repair): avoid brittle process fd count assertion

### DIFF
--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -667,7 +667,11 @@ def test_sidecar_created_after_preflight_is_rejected_before_inode_binding(tmp_pa
     journal_bytes = b"sidecar created after the initial preflight check"
     before = _hash(db_path)
     backup = tmp_path / "must-not-exist.sqlite"
-    fd_before = len(os.listdir("/proc/self/fd"))
+    fd_targets_before = {
+        os.readlink(f"/proc/self/fd/{fd}")
+        for fd in os.listdir("/proc/self/fd")
+        if os.path.exists(f"/proc/self/fd/{fd}")
+    }
     real_gate = repair._verify_report_gate
 
     def create_sidecar_after_preflight(*args, conn=None, **kwargs):
@@ -693,10 +697,15 @@ def test_sidecar_created_after_preflight_is_rejected_before_inode_binding(tmp_pa
     assert journal.read_bytes() == journal_bytes
     assert not backup.exists()
     assert not list(tmp_path.glob(".mnemosyne-repair-*"))
-    # Other tests and the runner may close inherited descriptors while this
-    # test executes.  The repair path must not leak a new descriptor, but an
-    # exact process-wide count is not stable enough to assert here.
-    assert len(os.listdir("/proc/self/fd")) <= fd_before
+    fd_targets_after = {
+        os.readlink(f"/proc/self/fd/{fd}")
+        for fd in os.listdir("/proc/self/fd")
+        if os.path.exists(f"/proc/self/fd/{fd}")
+    }
+    leaked_targets = {
+        target for target in fd_targets_after - fd_targets_before if str(tmp_path) in target
+    }
+    assert not leaked_targets
 
 
 def test_backup_parent_swap_cannot_redirect_fd_anchored_backup(tmp_path, monkeypatch):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from collections import Counter
 from pathlib import Path
 import sqlite3
 import subprocess
@@ -28,6 +29,17 @@ RAW_SECRET = "repair-output-private-secret-79d1"  # nosec - redaction fixture
 RAW_CONTENT = "Only the hidden cobalt-archive content may contain this phrase."
 RAW_EMBEDDING = "[0.125, 0.875]"
 RAW_BLOB_HEX = "DEADBEEF"
+
+
+def _fd_target_counts() -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for fd in os.listdir("/proc/self/fd"):
+        try:
+            target = os.readlink(f"/proc/self/fd/{fd}")
+        except OSError:
+            continue
+        counts[target] += 1
+    return counts
 
 
 def _create_db(path: Path, *, with_vector_cache: bool = False) -> None:
@@ -667,11 +679,7 @@ def test_sidecar_created_after_preflight_is_rejected_before_inode_binding(tmp_pa
     journal_bytes = b"sidecar created after the initial preflight check"
     before = _hash(db_path)
     backup = tmp_path / "must-not-exist.sqlite"
-    fd_targets_before = {
-        os.readlink(f"/proc/self/fd/{fd}")
-        for fd in os.listdir("/proc/self/fd")
-        if os.path.exists(f"/proc/self/fd/{fd}")
-    }
+    fd_targets_before = _fd_target_counts()
     real_gate = repair._verify_report_gate
 
     def create_sidecar_after_preflight(*args, conn=None, **kwargs):
@@ -697,15 +705,55 @@ def test_sidecar_created_after_preflight_is_rejected_before_inode_binding(tmp_pa
     assert journal.read_bytes() == journal_bytes
     assert not backup.exists()
     assert not list(tmp_path.glob(".mnemosyne-repair-*"))
-    fd_targets_after = {
-        os.readlink(f"/proc/self/fd/{fd}")
-        for fd in os.listdir("/proc/self/fd")
-        if os.path.exists(f"/proc/self/fd/{fd}")
-    }
-    leaked_targets = {
-        target for target in fd_targets_after - fd_targets_before if str(tmp_path) in target
-    }
+    fd_targets_after = _fd_target_counts()
+    leaked_targets = (fd_targets_after - fd_targets_before)
+    leaked_targets = Counter(
+        {target: count for target, count in leaked_targets.items() if str(tmp_path) in target}
+    )
     assert not leaked_targets
+
+
+def test_sidecar_rejection_detects_duplicate_repair_fd(tmp_path, monkeypatch):
+    """Descriptor accounting catches a leaked FD for an already-open target."""
+
+    db_path = tmp_path / "memory.db"
+    _create_db(db_path)
+    _insert_memory(db_path, "selected")
+    report_path = _write_manifest(db_path, tmp_path)
+    journal = db_path.with_name(db_path.name + "-journal")
+    journal.write_bytes(b"sidecar")
+    backup = tmp_path / "must-not-exist.sqlite"
+    existing_fd = os.open(db_path, os.O_RDONLY)
+    leaked_fd = None
+    real_gate = repair._verify_report_gate
+
+    def leak_fd_after_gate(*args, conn=None, **kwargs):
+        nonlocal leaked_fd
+        result = real_gate(*args, conn=conn, **kwargs)
+        if conn is None:
+            leaked_fd = os.open(db_path, os.O_RDONLY)
+        return result
+
+    monkeypatch.setattr(repair, "_verify_report_gate", leak_fd_after_gate)
+    before = _fd_target_counts()
+    try:
+        with pytest.raises(RepairError, match="sidecars prevent"):
+            run_repair(
+                db_path=db_path,
+                bank_name="default",
+                report_path=report_path,
+                selections=["working_memory:selected"],
+                action="expire",
+                apply=True,
+                backup_path=backup,
+            )
+
+        delta = _fd_target_counts() - before
+        assert delta[str(db_path)] == 1
+    finally:
+        os.close(existing_fd)
+        if leaked_fd is not None:
+            os.close(leaked_fd)
 
 
 def test_backup_parent_swap_cannot_redirect_fd_anchored_backup(tmp_path, monkeypatch):

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -740,6 +740,7 @@ def test_sidecar_rejection_detects_duplicate_repair_fd(tmp_path, monkeypatch):
     existing_fd = os.open(db_path, os.O_RDONLY)
     leaked_fd = None
     real_gate = repair._verify_report_gate
+    db_before = _hash(db_path)
 
     def leak_fd_after_gate(*args, conn=None, **kwargs):
         nonlocal leaked_fd
@@ -763,6 +764,8 @@ def test_sidecar_rejection_detects_duplicate_repair_fd(tmp_path, monkeypatch):
                 backup_path=backup,
             )
 
+        assert not backup.exists()
+        assert _hash(db_path) == db_before
         delta = _fd_target_counts() - before
         assert delta[str(db_path)] == 1
     finally:

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -42,6 +42,21 @@ def _fd_target_counts() -> Counter[str]:
     return counts
 
 
+def test_fd_target_counts_ignores_disappearing_descriptors(monkeypatch):
+    """A descriptor vanishing during /proc enumeration does not abort the snapshot."""
+
+    monkeypatch.setattr(os, "listdir", lambda _path: ["3", "4"])
+
+    def readlink(path: str) -> str:
+        if path.endswith("/3"):
+            raise FileNotFoundError(path)
+        return "/tmp/memory.db"
+
+    monkeypatch.setattr(os, "readlink", readlink)
+
+    assert _fd_target_counts() == Counter({"/tmp/memory.db": 1})
+
+
 def _create_db(path: Path, *, with_vector_cache: bool = False) -> None:
     conn = sqlite3.connect(path)
     conn.executescript(

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -736,7 +736,6 @@ def test_sidecar_rejection_detects_duplicate_repair_fd(tmp_path, monkeypatch):
     _insert_memory(db_path, "selected")
     report_path = _write_manifest(db_path, tmp_path)
     journal = db_path.with_name(db_path.name + "-journal")
-    journal.write_bytes(b"sidecar")
     backup = tmp_path / "must-not-exist.sqlite"
     existing_fd = os.open(db_path, os.O_RDONLY)
     leaked_fd = None
@@ -747,6 +746,7 @@ def test_sidecar_rejection_detects_duplicate_repair_fd(tmp_path, monkeypatch):
         result = real_gate(*args, conn=conn, **kwargs)
         if conn is None:
             leaked_fd = os.open(db_path, os.O_RDONLY)
+            journal.write_bytes(b"sidecar")
         return result
 
     monkeypatch.setattr(repair, "_verify_report_gate", leak_fd_after_gate)

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -693,7 +693,10 @@ def test_sidecar_created_after_preflight_is_rejected_before_inode_binding(tmp_pa
     assert journal.read_bytes() == journal_bytes
     assert not backup.exists()
     assert not list(tmp_path.glob(".mnemosyne-repair-*"))
-    assert len(os.listdir("/proc/self/fd")) == fd_before
+    # Other tests and the runner may close inherited descriptors while this
+    # test executes.  The repair path must not leak a new descriptor, but an
+    # exact process-wide count is not stable enough to assert here.
+    assert len(os.listdir("/proc/self/fd")) <= fd_before
 
 
 def test_backup_parent_swap_cannot_redirect_fd_anchored_backup(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- keep the repair sidecar test focused on descriptor leaks introduced by the repair path
- allow unrelated runner descriptors to close while the test executes

## Validation
- `python -m pytest tests/test_repair.py -q` — 18 skipped on Windows because `/proc/self/fd` is unavailable
- `python -m ruff check tests/test_repair.py` — passed
- `git diff --check` — passed

The Linux CI failure showed the process-wide descriptor count changing from 140 to 27, so exact equality is not a stable invariant. The assertion now rejects only a count increase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `tests/test_repair.py` to detect file descriptor leaks in the repair path.
- Added `_fd_target_counts()` to count `/proc/self/fd` symlink targets.
- Added regression coverage for duplicate descriptors that target the same resource.
- Added coverage for descriptor entries that disappear during enumeration.
- The test rejects descriptor increases caused by repair.
- The test allows unrelated process descriptors to close.

## Architecture and Maintainability

- No changes affect working, episodic, or BEAM memory tiers.
- No changes affect retrieval, consolidation, veracity, sync, privacy, local-first guarantees, Hermes, MCP, or CLI integration.
- Counter-based snapshots detect duplicate resource descriptors and reduce test brittleness.
- `OSError` handling improves resilience during `/proc` enumeration.
- The focused regression tests improve long-term repair-path maintainability.
- Validation passed with `pytest`, `ruff`, and `git diff --check`.
- Eighteen tests are skipped on Windows because `/proc/self/fd` is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->