### PR TITLE
fix: harden Hermes automatic prefetch relevance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
@@ -188,8 +190,11 @@ jobs:
           print('embedding model cached')
           "
 
-      - name: Run tests
-        run: pytest tests/ integrations/hermes/tests/test_wrapper_bootstrap.py integrations/hermes/tests/test_canonical_tools.py -v --tb=short
+      - name: Run core tests
+        run: pytest tests/ -v --tb=short
+
+      - name: Run Hermes integration tests
+        run: pytest integrations/hermes/tests/ -v --tb=short
 
   build:
     runs-on: ubuntu-latest

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -153,8 +153,8 @@ No required config. Everything defaults to `~/.mnemosyne/`. Optional overrides:
 | `MNEMOSYNE_PREFETCH_MIN_DISTINCTIVE_TOKENS` | `2` | Shared non-generic terms required for automatic prefetch injection |
 | `MNEMOSYNE_PREFETCH_MIN_QUERY_COVERAGE` | `0.30` | Minimum fraction of non-generic query terms covered by a prefetched memory |
 | `MNEMOSYNE_PREFETCH_CANONICAL_RARE_TOKEN_MAX_FREQUENCY` | `1` | Maximum canonical document frequency that permits a one-token match (`0` disables the exception) |
-| `MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS` | built-in generic-token set | Complete replacement for the canonical generic-token set |
-| `MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS` | _(empty)_ | Extra owner/deployment terms added to the configured generic-token set |
+| `MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS` | path-specific built-in canonical set | Complete replacement for the canonical generic-token set used by automatic and explicit canonical lookup; does not affect working/episodic prefetch |
+| `MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS` | _(empty)_ | Extra owner/deployment terms added to automatic canonical prefetch only |
 | `MNEMOSYNE_DEFAULT_SCOPE` | `session` | Default scope for remember (`global` enables cross-session immediate recall) |
 
 Or in `~/.hermes/config.yaml`:

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -150,6 +150,11 @@ No required config. Everything defaults to `~/.mnemosyne/`. Optional overrides:
 | `MNEMOSYNE_SYNC_TURN_ASSISTANT_LIMIT` | `800` | Assistant content truncation in `sync_turn()` (`0` = no limit) |
 | `MNEMOSYNE_FACT_RECALL_ENABLED` | `false` | Merge LLM-extracted facts into standard recall |
 | `MNEMOSYNE_PREFETCH_CONTENT_CHARS` | `0` | Per-memory prefetch content cap (`0` = full content) |
+| `MNEMOSYNE_PREFETCH_MIN_DISTINCTIVE_TOKENS` | `2` | Shared non-generic terms required for automatic prefetch injection |
+| `MNEMOSYNE_PREFETCH_MIN_QUERY_COVERAGE` | `0.30` | Minimum fraction of non-generic query terms covered by a prefetched memory |
+| `MNEMOSYNE_PREFETCH_CANONICAL_RARE_TOKEN_MAX_FREQUENCY` | `1` | Maximum canonical document frequency that permits a one-token match (`0` disables the exception) |
+| `MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS` | built-in generic-token set | Complete replacement for the canonical generic-token set |
+| `MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS` | _(empty)_ | Extra owner/deployment terms added to the configured generic-token set |
 | `MNEMOSYNE_DEFAULT_SCOPE` | `session` | Default scope for remember (`global` enables cross-session immediate recall) |
 
 Or in `~/.hermes/config.yaml`:

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -291,18 +291,25 @@ def _parse_token_set_env(key: str, default: Set[str]) -> Set[str]:
     return tokens or set(default)
 
 
-# Generic schema/system labels do not, by themselves, prove a canonical fact is
-# relevant to a turn. Deployments can replace this list with
-# MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS or extend the effective list with
-# MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS.
-_PREFETCH_CANONICAL_GENERIC_TOKEN_DEFAULTS = {
+# Generic schema/system labels do not, by themselves, prove a memory is
+# relevant to a turn. This fixed set governs ordinary working/episodic
+# automatic prefetch; canonical-specific deployment tuning must not alter that
+# established path.
+_PREFETCH_LEXICAL_GENERIC_TOKENS = {
     "user", "owner", "assistant", "agent", "system", "profile", "identity", "default",
     "preference", "preferences", "recommendation", "recommendations",
 }
 
-# Explicit recall keeps the pre-hardening generic-token contract. The extra
-# preference/recommendation terms and prefetch environment tuning below are
-# intentionally limited to silent automatic context injection.
+# Canonical automatic prefetch starts from the same conservative defaults, but
+# deployments can replace this list with
+# MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS or extend the effective list with
+# MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS.
+_PREFETCH_CANONICAL_GENERIC_TOKEN_DEFAULTS = set(_PREFETCH_LEXICAL_GENERIC_TOKENS)
+
+# Explicit recall keeps the pre-hardening default generic-token contract while
+# continuing to honor the established canonical replacement variable. The new
+# preference/recommendation defaults and additive tuning remain limited to
+# silent automatic context injection.
 _CANONICAL_RECALL_GENERIC_TOKENS = {
     "user", "owner", "assistant", "agent", "system", "profile", "identity", "default",
 }
@@ -318,6 +325,14 @@ def _prefetch_canonical_generic_tokens() -> Set[str]:
         set(),
     )
     return configured | extras
+
+
+def _canonical_recall_generic_tokens() -> Set[str]:
+    """Return the historical configured token set for explicit canonical recall."""
+    return _parse_token_set_env(
+        "MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS",
+        _CANONICAL_RECALL_GENERIC_TOKENS,
+    )
 
 
 def _is_low_quality_prefetch(content: str) -> bool:
@@ -363,7 +378,7 @@ def _canonical_recall_rows(store: Any, owner_id: str, query: str, *, limit: int 
         rows = store.list(owner_id)
     except Exception:
         return []
-    generic_tokens = _CANONICAL_RECALL_GENERIC_TOKENS
+    generic_tokens = _canonical_recall_generic_tokens()
     candidates: List[Dict[str, Any]] = []
     for row in rows:
         body = str(row.get("body") or "").strip()
@@ -531,7 +546,7 @@ def _prefetch_adjusted_score(row: Dict[str, Any]) -> float:
 
 def _prefetch_has_distinctive_lexical_evidence(query: str, content: str) -> bool:
     """Require multiple shared topical terms with meaningful query coverage."""
-    generic_tokens = _prefetch_canonical_generic_tokens()
+    generic_tokens = _PREFETCH_LEXICAL_GENERIC_TOKENS
     query_tokens = _prefetch_tokens(query) - generic_tokens
     overlap = query_tokens & _prefetch_tokens(content)
     return (

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -228,7 +228,7 @@ _PREFETCH_RAW_SOURCES = {"conversation"}
 _PREFETCH_DISTILLED_SOURCES = {
     "preference", "correction", "fact", "identity", "insight", "sleep_consolidation",
 }
-_PREFETCH_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_./:-]*", re.IGNORECASE)
+_PREFETCH_TOKEN_RE = re.compile(r"[^\W_][\w./:-]*", re.IGNORECASE | re.UNICODE)
 _PREFETCH_DEDUP_STOPWORDS = _PREFETCH_FRAGMENT_STOPWORDS | frozenset({
     "about", "after", "before", "because", "could", "from", "have", "into",
     "like", "more", "need", "needs", "than", "them", "they", "want", "wants",
@@ -355,9 +355,21 @@ def _strip_prefetch_prefix(content: str) -> str:
     return c
 
 
+def _is_prefetch_cjk_char(char: str) -> bool:
+    """Match the CJK ranges supported by the core lexical recall path."""
+    return (
+        "\u4e00" <= char <= "\u9fff"
+        or "\u3040" <= char <= "\u30ff"
+        or "\uac00" <= char <= "\ud7af"
+    )
+
+
 def _prefetch_tokens(content: str) -> Set[str]:
     c = _strip_prefetch_prefix(content).lower()
-    tokens: Set[str] = set()
+    # Core recall scores spaceless CJK text by character overlap. Preserve that
+    # evidence in the stricter automatic-prefetch gate instead of discarding an
+    # already-relevant result merely because the adapter's word regex is ASCII.
+    tokens: Set[str] = {char for char in c if _is_prefetch_cjk_char(char)}
     for token in _PREFETCH_TOKEN_RE.findall(c):
         # Keep internal URL/path separators, but trim sentence punctuation so
         # canonical facts ending in "branding." still match query token

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -300,6 +300,13 @@ _PREFETCH_CANONICAL_GENERIC_TOKEN_DEFAULTS = {
     "preference", "preferences", "recommendation", "recommendations",
 }
 
+# Explicit recall keeps the pre-hardening generic-token contract. The extra
+# preference/recommendation terms and prefetch environment tuning below are
+# intentionally limited to silent automatic context injection.
+_CANONICAL_RECALL_GENERIC_TOKENS = {
+    "user", "owner", "assistant", "agent", "system", "profile", "identity", "default",
+}
+
 
 def _prefetch_canonical_generic_tokens() -> Set[str]:
     configured = _parse_token_set_env(
@@ -356,7 +363,7 @@ def _canonical_recall_rows(store: Any, owner_id: str, query: str, *, limit: int 
         rows = store.list(owner_id)
     except Exception:
         return []
-    generic_tokens = _prefetch_canonical_generic_tokens()
+    generic_tokens = _CANONICAL_RECALL_GENERIC_TOKENS
     candidates: List[Dict[str, Any]] = []
     for row in rows:
         body = str(row.get("body") or "").strip()

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -233,6 +234,45 @@ _PREFETCH_DEDUP_STOPWORDS = _PREFETCH_FRAGMENT_STOPWORDS | frozenset({
     "like", "more", "need", "needs", "than", "them", "they", "want", "wants",
     "when", "where", "which", "while", "would", "yourself",
 })
+
+
+def _parse_bounded_int_env(key: str, default: int, minimum: int) -> int:
+    raw = os.environ.get(key, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except ValueError:
+        logger.warning("Invalid %s=%r; using %s", key, raw, default)
+        return default
+
+
+def _parse_unit_float_env(key: str, default: float) -> float:
+    raw = os.environ.get(key, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+        if not math.isfinite(value):
+            raise ValueError("value must be finite")
+        return min(1.0, max(0.0, value))
+    except ValueError:
+        logger.warning("Invalid %s=%r; using %s", key, raw, default)
+        return default
+
+
+def _prefetch_min_distinctive_tokens() -> int:
+    return _parse_bounded_int_env("MNEMOSYNE_PREFETCH_MIN_DISTINCTIVE_TOKENS", 2, 1)
+
+
+def _prefetch_min_query_coverage() -> float:
+    return _parse_unit_float_env("MNEMOSYNE_PREFETCH_MIN_QUERY_COVERAGE", 0.30)
+
+
+def _prefetch_canonical_rare_token_max_frequency() -> int:
+    return _parse_bounded_int_env("MNEMOSYNE_PREFETCH_CANONICAL_RARE_TOKEN_MAX_FREQUENCY", 1, 0)
+
+
 def _parse_token_set_env(key: str, default: Set[str]) -> Set[str]:
     """Read a comma/space-separated token set from env.
 
@@ -252,18 +292,25 @@ def _parse_token_set_env(key: str, default: Set[str]) -> Set[str]:
 
 
 # Generic schema/system labels do not, by themselves, prove a canonical fact is
-# relevant to a turn. Deployments can extend this list with local owner/assistant
-# names using MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS.
+# relevant to a turn. Deployments can replace this list with
+# MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS or extend the effective list with
+# MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS.
 _PREFETCH_CANONICAL_GENERIC_TOKEN_DEFAULTS = {
-    "user", "owner", "assistant", "agent", "system", "profile", "identity", "default"
+    "user", "owner", "assistant", "agent", "system", "profile", "identity", "default",
+    "preference", "preferences", "recommendation", "recommendations",
 }
 
 
 def _prefetch_canonical_generic_tokens() -> Set[str]:
-    return _parse_token_set_env(
+    configured = _parse_token_set_env(
         "MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS",
         _PREFETCH_CANONICAL_GENERIC_TOKEN_DEFAULTS,
     )
+    extras = _parse_token_set_env(
+        "MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS",
+        set(),
+    )
+    return configured | extras
 
 
 def _is_low_quality_prefetch(content: str) -> bool:
@@ -300,13 +347,8 @@ def _prefetch_tokens(content: str) -> Set[str]:
     return tokens
 
 
-def _canonical_prefetch_rows(store: Any, owner_id: str, query: str, *, limit: int = 3) -> List[Dict[str, Any]]:
-    """Return canonical facts relevant enough for automatic memory-context injection.
-
-    Canonical rows are small, owner-scoped, and single-source-of-truth, so a
-    lightweight lexical pass over current slots is enough and avoids LLM/reranker
-    cost. Importance cannot rescue a row here; it must share query terms.
-    """
+def _canonical_recall_rows(store: Any, owner_id: str, query: str, *, limit: int = 3) -> List[Dict[str, Any]]:
+    """Return canonical facts using the established explicit-recall contract."""
     query_tokens = _prefetch_tokens(query)
     if not query_tokens:
         return []
@@ -314,24 +356,17 @@ def _canonical_prefetch_rows(store: Any, owner_id: str, query: str, *, limit: in
         rows = store.list(owner_id)
     except Exception:
         return []
+    generic_tokens = _prefetch_canonical_generic_tokens()
     candidates: List[Dict[str, Any]] = []
     for row in rows:
         body = str(row.get("body") or "").strip()
         if not body:
             continue
-        # Score canonical relevance from the fact body itself. Category/name
-        # labels such as "identity" or "profile" are schema metadata; counting
-        # them as topical evidence made generic identity slots inject into
-        # unrelated professional-identity questions.
         row_tokens = _prefetch_tokens(body)
         overlap = query_tokens & row_tokens
-        generic_tokens = _prefetch_canonical_generic_tokens()
         distinctive_overlap = overlap - generic_tokens
         if not distinctive_overlap:
             continue
-        # One distinctive token can be enough for canonical slots such as
-        # profile URLs; broad queries need a little more coverage. Generic
-        # owner/system words do not count toward the minimum overlap.
         coverage = len(overlap) / max(len(query_tokens), 1)
         distinctive_coverage = len(distinctive_overlap) / max(len(query_tokens - generic_tokens), 1)
         if len(distinctive_overlap) < 2 and max(coverage, distinctive_coverage) < 0.30:
@@ -350,7 +385,96 @@ def _canonical_prefetch_rows(store: Any, owner_id: str, query: str, *, limit: in
             "canonical_category": row.get("category"),
             "canonical_name": row.get("name"),
         })
+    candidates.sort(
+        key=lambda r: (float(r.get("score") or 0.0), float(r.get("keyword_score") or 0.0)),
+        reverse=True,
+    )
+    return candidates[:limit]
+
+
+def _canonical_prefetch_rows(store: Any, owner_id: str, query: str, *, limit: int = 3) -> List[Dict[str, Any]]:
+    """Return canonical facts relevant enough for automatic memory-context injection.
+
+    Canonical rows are small, owner-scoped, and single-source-of-truth, so a
+    lightweight lexical pass over current slots is enough and avoids LLM/reranker
+    cost. Importance cannot rescue a row here; it must share query terms.
+    """
+    query_tokens = _prefetch_tokens(query)
+    if not query_tokens:
+        return []
+    try:
+        rows = store.list(owner_id)
+    except Exception:
+        return []
+    generic_tokens = _prefetch_canonical_generic_tokens()
+    tokenized_rows: List[tuple[Dict[str, Any], str, Set[str]]] = []
+    token_document_frequency: Dict[str, int] = {}
+    for row in rows:
+        body = str(row.get("body") or "").strip()
+        if not body:
+            continue
+        # Score canonical relevance from the fact body itself. Category/name
+        # labels such as "identity" or "profile" are schema metadata; counting
+        # them as topical evidence made generic identity slots inject into
+        # unrelated professional-identity questions.
+        row_tokens = _prefetch_tokens(body)
+        tokenized_rows.append((row, body, row_tokens))
+        for token in row_tokens - generic_tokens:
+            token_document_frequency[token] = token_document_frequency.get(token, 0) + 1
+
+    # A single lexical overlap is useful only when the token is genuinely rare
+    # across the owner's canonical surface. Otherwise broad words such as
+    # "approval", "family", or a local owner's name can inject several
+    # unrelated high-trust facts and crowd out precise episodic recall.
+    rare_document_frequency = _prefetch_canonical_rare_token_max_frequency()
+    minimum_overlap = _prefetch_min_distinctive_tokens()
+    minimum_coverage = _prefetch_min_query_coverage()
+    candidates: List[Dict[str, Any]] = []
+    for row, body, row_tokens in tokenized_rows:
+        overlap = query_tokens & row_tokens
+        distinctive_overlap = overlap - generic_tokens
+        if not distinctive_overlap:
+            continue
+        # One distinctive token can be enough for canonical slots such as
+        # profile URLs; broad queries need a little more coverage. Generic
+        # owner/system words do not count toward the minimum overlap.
+        coverage = len(overlap) / max(len(query_tokens), 1)
+        distinctive_coverage = len(distinctive_overlap) / max(len(query_tokens - generic_tokens), 1)
+        if len(distinctive_overlap) == 1:
+            only_token = next(iter(distinctive_overlap))
+            if (
+                max(coverage, distinctive_coverage) < minimum_coverage
+                or token_document_frequency.get(only_token, 0) > rare_document_frequency
+            ):
+                continue
+        elif len(distinctive_overlap) < minimum_overlap:
+            continue
+        score = min(1.0, 0.72 + coverage * 0.24 + min(len(overlap), 3) * 0.03)
+        candidates.append({
+            "content": body,
+            "source": f"canonical:{row.get('category') or 'fact'}",
+            "timestamp": row.get("valid_from") or row.get("created_at") or "",
+            "importance": 0.95,
+            "score": score,
+            "keyword_score": max(0.35, coverage),
+            "fact_match": True,
+            "trust_tier": "CANONICAL",
+            "tier": "canonical",
+            "canonical_category": row.get("category"),
+            "canonical_name": row.get("name"),
+            "_prefetch_overlap_count": len(distinctive_overlap),
+        })
+    # When one fact has materially stronger lexical evidence, do not let
+    # weaker one-token candidates ride alongside it merely because their lone
+    # token happens to be unique in a small canonical collection.
+    if any(int(r.get("_prefetch_overlap_count") or 0) >= minimum_overlap for r in candidates):
+        candidates = [
+            r for r in candidates
+            if int(r.get("_prefetch_overlap_count") or 0) >= minimum_overlap
+        ]
     candidates.sort(key=lambda r: (float(r.get("score") or 0.0), float(r.get("keyword_score") or 0.0)), reverse=True)
+    for candidate in candidates:
+        candidate.pop("_prefetch_overlap_count", None)
     return candidates[:limit]
 
 
@@ -396,6 +520,17 @@ def _prefetch_adjusted_score(row: Dict[str, Any]) -> float:
     signal = _prefetch_topic_signal(row)
     importance = min(max(float(row.get("importance") or 0.0), 0.0), 1.0)
     return (score * 0.65 + signal * 0.35 + importance * 0.05) * _prefetch_source_quality(row)
+
+
+def _prefetch_has_distinctive_lexical_evidence(query: str, content: str) -> bool:
+    """Require multiple shared topical terms with meaningful query coverage."""
+    generic_tokens = _prefetch_canonical_generic_tokens()
+    query_tokens = _prefetch_tokens(query) - generic_tokens
+    overlap = query_tokens & _prefetch_tokens(content)
+    return (
+        len(overlap) >= _prefetch_min_distinctive_tokens()
+        and (len(overlap) / max(len(query_tokens), 1)) >= _prefetch_min_query_coverage()
+    )
 
 
 def _semantic_dedup_prefetch(rows: List[Dict[str, Any]], threshold: float = 0.72) -> List[Dict[str, Any]]:
@@ -1263,6 +1398,13 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                     continue
                 if _prefetch_source_quality(r) <= 0:
                     continue
+                # Silent context injection is deliberately more conservative
+                # than explicit recall. One broad shared word (for example
+                # "coffee", "light", or "preference") is not enough evidence
+                # to inject a high-importance but unrelated memory. Explicit
+                # mnemosyne_recall remains available for semantic exploration.
+                if not _prefetch_has_distinctive_lexical_evidence(query, r.get("content", "")):
+                    continue
                 signal = _prefetch_topic_signal(r)
                 score = float(r.get("score") or 0.0)
                 importance = float(r.get("importance") or 0.0)
@@ -1784,7 +1926,7 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 from mnemosyne.core.canonical import CanonicalStore
                 store = CanonicalStore(db_path=self._beam.db_path, conn=self._beam.conn)
                 self._beam.canonical = store
-            canonical_rows = _canonical_prefetch_rows(store, self._canonical_owner(), query, limit=max(2, min(top_k, 5)))
+            canonical_rows = _canonical_recall_rows(store, self._canonical_owner(), query, limit=max(2, min(top_k, 5)))
         except Exception:
             canonical_rows = []
         if canonical_rows:

--- a/integrations/hermes/tests/test_prefetch_hardening.py
+++ b/integrations/hermes/tests/test_prefetch_hardening.py
@@ -113,6 +113,22 @@ def test_prefetch_requires_two_distinctive_lexical_terms(monkeypatch):
     assert "Cedar Bakery" in bakery
 
 
+def test_canonical_generic_override_does_not_change_normal_prefetch(monkeypatch):
+    monkeypatch.setenv(
+        "MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS",
+        "cedar,bakery",
+    )
+    p = _provider([
+        {"content": "SampleOwner prefers Cedar Bakery over Harbor Bakery.", "source": "preference",
+         "timestamp": "2026-06-11T09:01:00Z", "importance": 0.9, "score": 0.8,
+         "keyword_score": 0.8, "trust_tier": "STATED"},
+    ])
+
+    block = p.prefetch("Cedar Bakery preference")
+
+    assert "Cedar Bakery" in block
+
+
 def test_prefetch_generic_token_configuration_replaces_defaults(monkeypatch):
     monkeypatch.setenv("MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS", "sampleowner,assistant")
 
@@ -253,6 +269,25 @@ def test_explicit_recall_does_not_apply_prefetch_specific_generic_tokens():
     ))
 
     assert [row["canonical_name"] for row in response["results"]] == ["selection-lens"]
+
+
+def test_explicit_recall_honors_configured_canonical_generic_tokens(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS", "sampleowner")
+    p = _provider([])
+    p._beam.canonical = FakeCanonicalStore([
+        {
+            "name": "budget-lens",
+            "body": "SampleOwner budget approach.",
+            "category": "model:user",
+        },
+    ])
+
+    response = json.loads(p.handle_tool_call(
+        "mnemosyne_recall",
+        {"query": "SampleOwner", "limit": 5},
+    ))
+
+    assert response["results"] == []
 
 
 def test_canonical_prefetch_can_disable_single_token_exception(monkeypatch):

--- a/integrations/hermes/tests/test_prefetch_hardening.py
+++ b/integrations/hermes/tests/test_prefetch_hardening.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
-from mnemosyne_hermes import MnemosyneMemoryProvider
+import json
+
+import pytest
+
+from mnemosyne_hermes import (
+    MnemosyneMemoryProvider,
+    _canonical_prefetch_rows,
+    _prefetch_canonical_generic_tokens,
+    _prefetch_min_query_coverage,
+)
 
 
 class FakeBeam:
@@ -10,12 +19,38 @@ class FakeBeam:
         self.results = results or []
         self.writes = []
 
-    def recall(self, **kwargs):
+    def recall(self, *args, **kwargs):
+        self.last_args = args
         self.last_kwargs = kwargs
         return self.results
 
     def remember(self, **kwargs):
         self.writes.append(kwargs)
+
+
+class FakeCanonicalStore:
+    def __init__(self, rows_or_owners):
+        if isinstance(rows_or_owners, dict):
+            self.rows_by_owner = rows_or_owners
+        else:
+            self.rows_by_owner = {"default": rows_or_owners}
+        self.requested_owner_ids = []
+
+    def list(self, owner_id):
+        self.requested_owner_ids.append(owner_id)
+        return self.rows_by_owner.get(owner_id, [])
+
+
+@pytest.fixture(autouse=True)
+def clear_prefetch_configuration(monkeypatch):
+    for key in (
+        "MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS",
+        "MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS",
+        "MNEMOSYNE_PREFETCH_MIN_DISTINCTIVE_TOKENS",
+        "MNEMOSYNE_PREFETCH_MIN_QUERY_COVERAGE",
+        "MNEMOSYNE_PREFETCH_CANONICAL_RARE_TOKEN_MAX_FREQUENCY",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
 def _provider(results):
@@ -57,6 +92,67 @@ def test_prefetch_requires_topic_signal_not_importance_only():
     assert "minecraft watcher" not in block
 
 
+def test_prefetch_requires_two_distinctive_lexical_terms(monkeypatch):
+    monkeypatch.setenv(
+        "MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS",
+        "sampleowner,assistant",
+    )
+    p = _provider([
+        {"content": "A lightweight workflow unrelated to tea.", "source": "workflow",
+         "timestamp": "2026-06-11T09:00:00Z", "importance": 0.95, "score": 0.9,
+         "keyword_score": 0.5, "trust_tier": "STATED"},
+        {"content": "SampleOwner prefers Cedar Bakery over Harbor Bakery.", "source": "preference",
+         "timestamp": "2026-06-11T09:01:00Z", "importance": 0.9, "score": 0.8,
+         "keyword_score": 0.8, "trust_tier": "STATED"},
+    ])
+
+    tea = p.prefetch("tea preference jasmine oolong floral citrus clear infusion")
+    bakery = p.prefetch("Cedar Bakery preference")
+
+    assert tea == ""
+    assert "Cedar Bakery" in bakery
+
+
+def test_prefetch_generic_token_configuration_replaces_defaults(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS", "sampleowner,assistant")
+
+    tokens = _prefetch_canonical_generic_tokens()
+
+    assert tokens == {"sampleowner", "assistant"}
+
+
+def test_prefetch_extra_generic_token_configuration_is_additive(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS", "sampleowner,assistant")
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS", "local,ownername")
+
+    tokens = _prefetch_canonical_generic_tokens()
+
+    assert tokens == {"sampleowner", "assistant", "local", "ownername"}
+
+
+def test_prefetch_lexical_thresholds_are_configurable(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_MIN_DISTINCTIVE_TOKENS", "1")
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_MIN_QUERY_COVERAGE", "0.10")
+    p = _provider([
+        {"content": "A lightweight workflow unrelated to tea.", "source": "workflow",
+         "timestamp": "2026-06-11T09:00:00Z", "importance": 0.95, "score": 0.9,
+         "keyword_score": 0.5, "trust_tier": "STATED"},
+    ])
+
+    block = p.prefetch("tea floral jasmine clear infusion")
+
+    assert "lightweight workflow" in block
+
+
+def test_prefetch_nonfinite_query_coverage_uses_conservative_default(monkeypatch, caplog):
+    for value in ("NaN", "inf", "-inf"):
+        monkeypatch.setenv("MNEMOSYNE_PREFETCH_MIN_QUERY_COVERAGE", value)
+
+        assert _prefetch_min_query_coverage() == 0.30
+
+    assert caplog.text.count("MNEMOSYNE_PREFETCH_MIN_QUERY_COVERAGE") == 3
+
+
 def test_sync_roles_can_disable_assistant_autosave():
     p = MnemosyneMemoryProvider()
     p._beam = FakeBeam()
@@ -68,3 +164,108 @@ def test_sync_roles_can_disable_assistant_autosave():
     written = [w["content"] for w in p._beam.writes]
     assert any(c.startswith("[USER]") for c in written)
     assert not any(c.startswith("[ASSISTANT]") for c in written)
+
+
+def test_canonical_prefetch_rejects_common_single_token_matches(monkeypatch):
+    monkeypatch.setenv(
+        "MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS",
+        "user,owner,assistant,agent,system,profile,identity,default,sampleowner,prefers,preference",
+    )
+    store = FakeCanonicalStore([
+        {"name": "tea", "body": "SampleOwner likes fragrant jasmine tea.", "category": "model:user"},
+        {"name": "unrelated-a", "body": "SampleOwner studies orbital mechanics.", "category": "model:user"},
+        {"name": "unrelated-b", "body": "SampleOwner collects antique maps.", "category": "model:user"},
+    ])
+
+    rows = _canonical_prefetch_rows(store, "default", "SampleOwner tea preference")
+
+    assert [row["canonical_name"] for row in rows] == ["tea"]
+
+
+def test_canonical_prefetch_allows_rare_single_token_and_two_token_matches(monkeypatch):
+    monkeypatch.delenv("MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS", raising=False)
+    store = FakeCanonicalStore([
+        {"name": "archive", "body": "Archive boundaries apply to expired records.", "category": "model:user"},
+        {"name": "archive-noise", "body": "External indexes require archiving.", "category": "model:workflow"},
+        {"name": "geology", "body": "Caldrin catalogs basalt formations.", "category": "model:user"},
+        {"name": "other", "body": "Copper alloys resist corrosion.", "category": "model:user"},
+    ])
+
+    archive = _canonical_prefetch_rows(store, "default", "archive boundaries")
+    caldrin = _canonical_prefetch_rows(store, "default", "Caldrin research lens")
+
+    assert [row["canonical_name"] for row in archive] == ["archive"]
+    assert [row["canonical_name"] for row in caldrin] == ["geology"]
+
+
+def test_canonical_prefetch_rarity_is_scoped_to_requested_owner(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_CANONICAL_RARE_TOKEN_MAX_FREQUENCY", "1")
+    store = FakeCanonicalStore({
+        "default": [
+            {"name": "geology", "body": "Caldrin catalogs basalt formations.", "category": "model:user"},
+        ],
+        "other-owner": [
+            {"name": "geology-a", "body": "Caldrin catalogs basalt formations.", "category": "model:user"},
+            {"name": "geology-b", "body": "Caldrin studies coastal erosion.", "category": "model:user"},
+        ],
+    })
+
+    default_rows = _canonical_prefetch_rows(store, "default", "Caldrin research lens")
+    other_rows = _canonical_prefetch_rows(store, "other-owner", "Caldrin research lens")
+
+    assert store.requested_owner_ids == ["default", "other-owner"]
+    assert [row["canonical_name"] for row in default_rows] == ["geology"]
+    assert other_rows == []
+
+
+def test_explicit_recall_preserves_broad_canonical_merge():
+    p = _provider([])
+    p._beam.canonical = FakeCanonicalStore([
+        {"name": "geology-a", "body": "Caldrin catalogs basalt formations.", "category": "model:user"},
+        {"name": "geology-b", "body": "Caldrin studies coastal erosion.", "category": "model:user"},
+    ])
+
+    response = json.loads(p.handle_tool_call(
+        "mnemosyne_recall",
+        {"query": "Caldrin research lens", "limit": 5},
+    ))
+
+    assert p._beam.last_args == ("Caldrin research lens",)
+    assert {row["canonical_name"] for row in response["results"]} == {"geology-a", "geology-b"}
+
+
+def test_canonical_prefetch_can_disable_single_token_exception(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_CANONICAL_RARE_TOKEN_MAX_FREQUENCY", "0")
+    store = FakeCanonicalStore([
+        {"name": "geology", "body": "Caldrin catalogs basalt formations.", "category": "model:user"},
+    ])
+
+    rows = _canonical_prefetch_rows(store, "default", "Caldrin research lens")
+
+    assert rows == []
+
+
+def test_canonical_prefetch_keeps_singleton_coverage_guard_when_minimum_is_one(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_MIN_DISTINCTIVE_TOKENS", "1")
+    store = FakeCanonicalStore([
+        {"name": "geology", "body": "Caldrin catalogs basalt formations.", "category": "model:user"},
+    ])
+
+    rows = _canonical_prefetch_rows(
+        store,
+        "default",
+        "Caldrin research archive survey analysis history",
+    )
+
+    assert rows == []
+
+
+def test_canonical_prefetch_respects_higher_distinctive_token_minimum(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_MIN_DISTINCTIVE_TOKENS", "3")
+    store = FakeCanonicalStore([
+        {"name": "tea", "body": "Fragrant jasmine tea is preferred.", "category": "model:user"},
+    ])
+
+    rows = _canonical_prefetch_rows(store, "default", "fragrant jasmine soup")
+
+    assert rows == []

--- a/integrations/hermes/tests/test_prefetch_hardening.py
+++ b/integrations/hermes/tests/test_prefetch_hardening.py
@@ -290,6 +290,25 @@ def test_explicit_recall_honors_configured_canonical_generic_tokens(monkeypatch)
     assert response["results"] == []
 
 
+def test_explicit_recall_override_can_include_prefetch_specific_generic_token(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS", "recommendations")
+    p = _provider([])
+    p._beam.canonical = FakeCanonicalStore([
+        {
+            "name": "selection-lens",
+            "body": "SampleOwner recommendations emphasize reliability.",
+            "category": "model:user",
+        },
+    ])
+
+    response = json.loads(p.handle_tool_call(
+        "mnemosyne_recall",
+        {"query": "recommendations", "limit": 5},
+    ))
+
+    assert response["results"] == []
+
+
 def test_canonical_prefetch_can_disable_single_token_exception(monkeypatch):
     monkeypatch.setenv("MNEMOSYNE_PREFETCH_CANONICAL_RARE_TOKEN_MAX_FREQUENCY", "0")
     store = FakeCanonicalStore([

--- a/integrations/hermes/tests/test_prefetch_hardening.py
+++ b/integrations/hermes/tests/test_prefetch_hardening.py
@@ -234,6 +234,27 @@ def test_explicit_recall_preserves_broad_canonical_merge():
     assert {row["canonical_name"] for row in response["results"]} == {"geology-a", "geology-b"}
 
 
+def test_explicit_recall_does_not_apply_prefetch_specific_generic_tokens():
+    p = _provider([])
+    store = FakeCanonicalStore([
+        {
+            "name": "selection-lens",
+            "body": "SampleOwner recommendations emphasize reliability.",
+            "category": "model:user",
+        },
+    ])
+    p._beam.canonical = store
+
+    assert _canonical_prefetch_rows(store, "default", "recommendations") == []
+
+    response = json.loads(p.handle_tool_call(
+        "mnemosyne_recall",
+        {"query": "recommendations", "limit": 5},
+    ))
+
+    assert [row["canonical_name"] for row in response["results"]] == ["selection-lens"]
+
+
 def test_canonical_prefetch_can_disable_single_token_exception(monkeypatch):
     monkeypatch.setenv("MNEMOSYNE_PREFETCH_CANONICAL_RARE_TOKEN_MAX_FREQUENCY", "0")
     store = FakeCanonicalStore([

--- a/integrations/hermes/tests/test_prefetch_hardening.py
+++ b/integrations/hermes/tests/test_prefetch_hardening.py
@@ -113,6 +113,42 @@ def test_prefetch_requires_two_distinctive_lexical_terms(monkeypatch):
     assert "Cedar Bakery" in bakery
 
 
+def test_prefetch_supports_cjk_lexical_evidence():
+    p = _provider([
+        {
+            "content": "東京では静かな喫茶店を好む。",
+            "source": "preference",
+            "timestamp": "2026-08-08T00:00:00Z",
+            "importance": 0.9,
+            "score": 0.8,
+            "keyword_score": 0.8,
+            "trust_tier": "STATED",
+        },
+    ])
+
+    block = p.prefetch("東京で静かな喫茶店を探している")
+
+    assert "静かな喫茶店" in block
+
+
+def test_prefetch_supports_cyrillic_lexical_evidence():
+    p = _provider([
+        {
+            "content": "Пользователь предпочитает тёмную резервную копию.",
+            "source": "preference",
+            "timestamp": "2026-08-08T00:00:00Z",
+            "importance": 0.9,
+            "score": 0.8,
+            "keyword_score": 0.8,
+            "trust_tier": "STATED",
+        },
+    ])
+
+    block = p.prefetch("Найди тёмную резервную копию")
+
+    assert "тёмную резервную копию" in block
+
+
 def test_canonical_generic_override_does_not_change_normal_prefetch(monkeypatch):
     monkeypatch.setenv(
         "MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS",


### PR DESCRIPTION
## Summary

Hermes automatic context prefetch can silently inject irrelevant high-importance memories when a query and memory share only one broad lexical term.

Fixes #615.

This change:

- preserves `MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS` replacement semantics and adds a separate additive configuration for deployment-specific tokens;
- requires configurable distinctive lexical evidence before silent working-memory injection;
- scores canonical candidates using distinctive overlap, query coverage, and per-owner canonical document frequency;
- permits a one-token canonical match only when it meets both the configured coverage threshold and rare-token frequency limit;
- prefers stronger multi-token canonical candidates over weaker singleton candidates;
- rejects non-finite query-coverage configuration and falls back to the conservative default;
- adds the Hermes integration suite to the repository CI test matrix;
- leaves explicit `mnemosyne_recall` behavior unchanged.

## Configuration

- `MNEMOSYNE_PREFETCH_MIN_DISTINCTIVE_TOKENS` (default `2`, minimum `1`)
- `MNEMOSYNE_PREFETCH_MIN_QUERY_COVERAGE` (default `0.30`, clamped to `[0.0, 1.0]`)
- `MNEMOSYNE_PREFETCH_CANONICAL_RARE_TOKEN_MAX_FREQUENCY` (default `1`, minimum `0`; `0` disables the singleton exception)
- `MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS` replaces the built-in generic-token set when configured.
- `MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS` adds deployment-specific tokens to the effective generic-token set.

These thresholds apply only to silent automatic prefetch injection. Explicit recall remains available for broader semantic exploration.

## Regression coverage

Tests cover:

- rejecting irrelevant automatic injection based on one broad shared term;
- preserving a valid multi-term `Cedar Bakery` match;
- preserving replacement semantics for the existing generic-token configuration;
- adding deployment-specific generic tokens through the separate additive configuration;
- rejecting common singleton canonical matches;
- allowing a rare singleton synthetic `Caldrin` match and proving rarity is scoped to the requested owner;
- allowing a valid two-token `archive boundaries` match;
- disabling singleton canonical matches through the rare-token frequency setting;
- keeping singleton coverage and rarity safeguards active when the minimum distinctive-token setting is `1`;
- respecting a higher configured distinctive-token minimum.
- treating `NaN` and infinite query-coverage values as invalid.
- preserving broad canonical merging through the public `mnemosyne_recall` tool while applying the stricter filter only to silent prefetch.

## Verification

```text
MNEMOSYNE_NO_EMBEDDINGS=1 uv run --frozen pytest -q integrations/hermes/tests/test_prefetch_hardening.py
15 passed

MNEMOSYNE_NO_EMBEDDINGS=1 uv run --python 3.13 --frozen pytest -q integrations/hermes/tests
114 passed

MNEMOSYNE_NO_EMBEDDINGS=1 uv run --frozen pytest -q \
  tests/test_prefetch_profiles.py \
  tests/test_prefetch_identity_always_inject.py \
  tests/test_hermes_memory_provider_thread_isolation.py \
  tests/test_model_refresh_stress.py \
  tests/test_prefetch_low_quality.py \
  tests/test_prefetch_content_truncation.py
43 passed

uv run --frozen ruff check integrations/hermes/src/mnemosyne_hermes/__init__.py integrations/hermes/tests/test_prefetch_hardening.py --select E9,F63,F7,F82
All checks passed

CI workflow validation
pytest tests/ -v --tb=short
pytest integrations/hermes/tests/ -v --tb=short
Hermes regression suite runs in a separate pytest process in every Python matrix job

git diff --check
passed

uv build --out-dir <temporary-directory>
uvx --from twine twine check <temporary-directory>/*
wheel and sdist built; both passed
```

A repository-wide run also exposed the existing `tests/test_mnemosyne_stats.py::test_performance` timing threshold on this host (18.4s versus the fixed 5s limit). The unchanged `upstream/main` tree fails the same test at 19.0s, so this is baseline/environment behavior outside this integration-only diff.

## Release metadata

No version, manifest, generated-documentation, or changelog release material is included. Those updates belong to the project's separate release-preparation workflow; open PR #588 independently owns the existing `0.5.0` packaged-manifest parity fix.

**AI Assistance:** The implementation, regression tests, and initial analysis were prepared with AI agents.