### PR TITLE
fix(hermes): follow wrapper-script exec target when locating Hermes Python

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -539,19 +539,16 @@ def _resolve_exec_target(raw_target: str, wrapper: Path) -> Path | None:
         return None
 
     if target.is_absolute():
-        return target
+        return target if target.is_file() else None
 
-    # Relative path such as ./bin/hermes
-    candidate = wrapper.parent / target
-    if candidate.is_file():
-        return candidate
+    if os.path.dirname(str(target)):
+        # Explicit relative path such as ./bin/hermes or ../bin/hermes.
+        candidate = wrapper.parent / target
+        return candidate if candidate.is_file() else None
 
-    # Bare command name such as hermes
+    # Bare command name such as hermes: resolve via PATH lookup.
     found = shutil.which(raw_target)
-    if found:
-        return Path(found)
-
-    return None
+    return Path(found) if found else None
 
 
 def _resolve_hermes_bin(hermes_bin: str) -> Path | None:

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -507,48 +508,117 @@ def plugin_state(*, hermes_home_path: str | Path | None = None) -> PluginState:
 _MAX_WRAPPER_READ_BYTES = 4096
 
 
-def _read_wrapper_exec_target(path: Path) -> str | None:
-    """Return the first `exec` target from a shell wrapper script, or None."""
+def _is_env_assignment(token: str) -> bool:
+    """True if the token is a plain ``NAME=value`` shell assignment."""
+    name, sep, value = token.partition("=")
+    if not sep or not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    if not all(char.isalnum() or char == "_" for char in name):
+        return False
+    # Reject command/parameter substitution we cannot evaluate.
+    return not value.startswith(("$", "`"))
+
+
+def _strip_env_prefix(tokens: list[str]) -> list[str] | None:
+    """Consume ``env`` assignments and no-arg flags, returning the command.
+
+    Returns None for any option that takes an argument (``-u NAME``, ``-C DIR``,
+    ``-S ...``) or is otherwise unrecognized, so an unfamiliar layout is rejected
+    rather than misread.
+    """
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token in ("-", "-i", "--ignore-environment"):
+            index += 1
+            continue
+        if token.startswith("-"):
+            return None
+        if _is_env_assignment(token):
+            index += 1
+            continue
+        break
+    return tokens[index:]
+
+
+def _wrapper_exec_target(path: Path) -> tuple[bool, str | None]:
+    """Inspect a launcher for an ``exec`` handoff to another program.
+
+    Returns ``(is_wrapper, target)``:
+      * ``(False, None)`` - no ``exec`` handoff; treat ``path`` as the binary.
+      * ``(True, target)`` - wrapper execs ``target`` (a path or command name).
+      * ``(True, None)``   - wrapper uses a form we will not resolve; callers
+                             must not fall back to the wrapper itself.
+
+    Supported forms (trailing ``"$@"`` and arguments ignored)::
+
+        exec /path/to/hermes "$@"
+        exec "./hermes" "$@"
+        VAR=val exec /path/to/hermes "$@"
+        exec env [VAR=val ...] /path/to/hermes "$@"
+    """
     try:
         with path.open("r", encoding="utf-8", errors="replace") as fh:
             source = fh.read(_MAX_WRAPPER_READ_BYTES)
     except (OSError, UnicodeDecodeError):
-        return None
-    # Matches shell wrappers like:
-    #   exec "/path/to/hermes" "$@"
-    #   exec /path/to/hermes "$@"
-    match = re.search(
-        r'^\s*exec\s+(?:"([^"]+)"|\'([^\']+)\'|(\S+))',
-        source,
-        flags=re.MULTILINE,
-    )
-    if not match:
-        return None
-    return next(g for g in match.groups() if g)
+        return False, None
+
+    for raw_line in source.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            tokens = shlex.split(line, comments=True)
+        except ValueError:
+            continue
+
+        index = 0
+        while index < len(tokens) and _is_env_assignment(tokens[index]):
+            index += 1
+        tokens = tokens[index:]
+        if not tokens or tokens[0] != "exec":
+            continue
+
+        # This line hands off with exec, so the wrapper is never the target.
+        rest = tokens[1:]
+        if not rest or rest[0].startswith("-"):
+            return True, None
+        if rest[0] == "env":
+            rest = _strip_env_prefix(rest[1:])
+            if not rest:
+                return True, None
+        return True, rest[0]
+
+    return False, None
 
 
 def _resolve_exec_target(raw_target: str, wrapper: Path) -> Path | None:
-    """Normalize an exec target from a wrapper script.
+    """Turn an ``exec`` target into a concrete executable path.
 
-    Absolute paths are returned as-is. Relative paths are resolved against the
-    wrapper's directory. Bare command names are resolved via PATH lookup.
+    Absolute paths are used as-is, explicit relative paths (``./hermes``,
+    ``../bin/hermes``, ``bin/hermes``) resolve against the wrapper's own
+    directory, and bare command names go through PATH. The raw target is
+    classified before ``Path`` drops a leading ``./``, so a relative launcher is
+    never shadowed by a same-named file in the process working directory.
     """
-    try:
-        target = Path(raw_target).expanduser()
-    except (OSError, RuntimeError):
-        return None
+    expanded = os.path.expanduser(raw_target)
 
-    if target.is_absolute():
-        return target if target.is_file() else None
+    if os.path.isabs(expanded):
+        candidate = Path(expanded)
+    elif os.sep in expanded or (os.altsep and os.altsep in expanded):
+        candidate = wrapper.parent / expanded
+    else:
+        found = shutil.which(expanded)
+        if not found:
+            return None
+        candidate = Path(found)
 
-    if os.path.dirname(str(target)):
-        # Explicit relative path such as ./bin/hermes or ../bin/hermes.
-        candidate = wrapper.parent / target
-        return candidate if candidate.is_file() else None
-
-    # Bare command name such as hermes: resolve via PATH lookup.
-    found = shutil.which(raw_target)
-    return Path(found) if found else None
+    return candidate if candidate.is_file() else None
 
 
 def _resolve_hermes_bin(hermes_bin: str) -> Path | None:
@@ -586,9 +656,14 @@ def _resolve_hermes_bin(hermes_bin: str) -> Path | None:
             )
             return None
 
-        exec_target = _read_wrapper_exec_target(canonical)
-        if not exec_target:
+        is_wrapper, exec_target = _wrapper_exec_target(canonical)
+        if not is_wrapper:
             return canonical
+        if exec_target is None:
+            LOGGER.debug(
+                "Hermes wrapper %r uses an unsupported exec form", hermes_bin
+            )
+            return None
 
         next_path = _resolve_exec_target(exec_target, canonical)
         if next_path is None:

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -500,6 +500,37 @@ def plugin_state(*, hermes_home_path: str | Path | None = None) -> PluginState:
         message="Plugin is installed and discoverable.",
     )
 
+def _resolve_hermes_bin(hermes_bin: str) -> Path | None:
+    """Resolve the real Hermes executable from a launcher on PATH.
+
+    If the launcher is a symlink, follow it. If it is a wrapper script that
+    execs another binary (common for PATH shims), read the exec target so the
+    Python beside the *real* Hermes binary is used rather than the python
+    beside the shim.
+    """
+    path = Path(hermes_bin)
+    if path.is_symlink():
+        return path.resolve()
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    # Matches shell wrappers like:
+    #   exec "/path/to/hermes" "$@"
+    #   exec /path/to/hermes "$@"
+    match = re.search(
+        r'^\s*exec\s+(?:"([^"]+)"|\'([^\']+)\'|(\S+))',
+        source,
+        flags=re.MULTILINE,
+    )
+    if not match:
+        return None
+    target = Path(next(g for g in match.groups() if g)).expanduser()
+    if target.is_file():
+        return target.resolve()
+    return None
+
+
 def _find_hermes_python() -> Optional[Path]:
     """Try to find Hermes' python executable for dep validation.
 
@@ -516,17 +547,19 @@ def _find_hermes_python() -> Optional[Path]:
     #    actual venv and produced "loaded but no provider instance found").
     hermes_bin = shutil.which("hermes")
     if hermes_bin:
-        # NOTE: resolve the *launcher* symlink (hermes -> venv/bin/hermes) to
-        # find the venv bin dir, but do NOT resolve the python symlink itself.
-        # A venv's bin/python is a symlink to the base interpreter; running the
-        # venv path activates the venv site-packages, running the resolved base
-        # path does NOT. Returning the resolved base interpreter would silently
-        # drop the provider deps again.
-        bin_dir = Path(hermes_bin).resolve().parent
-        for py_name in ("python", "python3"):
-            candidate = bin_dir / py_name
-            if candidate.is_file():
-                return candidate
+        resolved = _resolve_hermes_bin(hermes_bin)
+        if resolved:
+            # NOTE: resolve the *launcher* symlink (hermes -> venv/bin/hermes)
+            # to find the venv bin dir, but do NOT resolve the python symlink
+            # itself. A venv's bin/python is a symlink to the base interpreter;
+            # running the venv path activates the venv site-packages, while
+            # running the resolved base path does NOT. Returning the resolved
+            # base interpreter would silently drop the provider deps again.
+            bin_dir = resolved.parent
+            for py_name in ("python", "python3"):
+                candidate = bin_dir / py_name
+                if candidate.is_file():
+                    return candidate
 
     # 2. Check known hermes-agent checkout / install roots with a venv.
     for root in [

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -7,6 +7,7 @@ import importlib.metadata
 import hashlib
 import importlib
 import json
+import logging
 import os
 import re
 import shutil
@@ -22,6 +23,9 @@ PLUGIN_NAME = "mnemosyne"
 SKILL_NAME = "mnemosyne-memory-override"
 SKILL_CATEGORY = "memory"
 BUNDLED_SKILL_RESOURCE = ("skills", SKILL_NAME, "SKILL.md")
+
+_MAX_HERMES_BIN_DEPTH = 10
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -500,26 +504,15 @@ def plugin_state(*, hermes_home_path: str | Path | None = None) -> PluginState:
         message="Plugin is installed and discoverable.",
     )
 
-def _resolve_hermes_bin(hermes_bin: str) -> Path | None:
-    """Resolve the real Hermes executable from a launcher on PATH.
+_MAX_WRAPPER_READ_BYTES = 4096
 
-    If the launcher is a symlink, follow it. If it is a wrapper script that
-    execs another binary (common for PATH shims), read the exec target so the
-    Python beside the *real* Hermes binary is used rather than the python
-    beside the shim.
-    """
-    path = Path(hermes_bin)
-    if path.is_symlink():
-        try:
-            resolved = path.resolve()
-        except (OSError, RuntimeError):
-            return None
-        if resolved.is_file() and os.access(resolved, os.X_OK):
-            return resolved
-        return None
+
+def _read_wrapper_exec_target(path: Path) -> str | None:
+    """Return the first `exec` target from a shell wrapper script, or None."""
     try:
-        source = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            source = fh.read(_MAX_WRAPPER_READ_BYTES)
+    except (OSError, UnicodeDecodeError):
         return None
     # Matches shell wrappers like:
     #   exec "/path/to/hermes" "$@"
@@ -531,12 +524,91 @@ def _resolve_hermes_bin(hermes_bin: str) -> Path | None:
     )
     if not match:
         return None
-    target = Path(next(g for g in match.groups() if g)).expanduser()
-    if target.is_file() and os.access(target, os.X_OK):
+    return next(g for g in match.groups() if g)
+
+
+def _resolve_exec_target(raw_target: str, wrapper: Path) -> Path | None:
+    """Normalize an exec target from a wrapper script.
+
+    Absolute paths are returned as-is. Relative paths are resolved against the
+    wrapper's directory. Bare command names are resolved via PATH lookup.
+    """
+    try:
+        target = Path(raw_target).expanduser()
+    except (OSError, RuntimeError):
+        return None
+
+    if target.is_absolute():
+        return target
+
+    # Relative path such as ./bin/hermes
+    candidate = wrapper.parent / target
+    if candidate.is_file():
+        return candidate
+
+    # Bare command name such as hermes
+    found = shutil.which(raw_target)
+    if found:
+        return Path(found)
+
+    return None
+
+
+def _resolve_hermes_bin(hermes_bin: str) -> Path | None:
+    """Resolve the real Hermes executable from a launcher on PATH.
+
+    Follows symlinks and shell wrappers that `exec` another binary (common for
+    PATH shims), tracking visited paths to avoid symlink loops. A direct
+    executable that is not a wrapper is returned as well, preserving discovery
+    for pipx / package entry points.
+
+    Returns None when resolution fails or the target is not executable.
+    """
+    path = Path(hermes_bin)
+    seen: set[Path] = set()
+
+    for _ in range(_MAX_HERMES_BIN_DEPTH):
         try:
-            return target.resolve()
-        except (OSError, RuntimeError):
+            canonical = path.resolve()
+        except (OSError, RuntimeError) as exc:
+            LOGGER.debug(
+                "Failed to resolve Hermes launcher %r: %s", hermes_bin, exc
+            )
             return None
+
+        if canonical in seen:
+            LOGGER.debug("Hermes launcher %r has a symlink loop", hermes_bin)
+            return None
+        seen.add(canonical)
+
+        if not canonical.is_file() or not os.access(canonical, os.X_OK):
+            LOGGER.debug(
+                "Hermes launcher %r resolves to non-executable %r",
+                hermes_bin,
+                canonical,
+            )
+            return None
+
+        exec_target = _read_wrapper_exec_target(canonical)
+        if not exec_target:
+            return canonical
+
+        next_path = _resolve_exec_target(exec_target, canonical)
+        if next_path is None:
+            LOGGER.debug(
+                "Hermes wrapper %r execs an invalid target %r",
+                hermes_bin,
+                exec_target,
+            )
+            return None
+
+        path = next_path
+
+    LOGGER.debug(
+        "Hermes launcher %r exceeded maximum resolution depth (%d)",
+        hermes_bin,
+        _MAX_HERMES_BIN_DEPTH,
+    )
     return None
 
 
@@ -567,7 +639,7 @@ def _find_hermes_python() -> Optional[Path]:
             bin_dir = resolved.parent
             for py_name in ("python", "python3"):
                 candidate = bin_dir / py_name
-                if candidate.is_file():
+                if candidate.is_file() and os.access(candidate, os.X_OK):
                     return candidate
 
     # 2. Check known hermes-agent checkout / install roots with a venv.

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -510,7 +510,13 @@ def _resolve_hermes_bin(hermes_bin: str) -> Path | None:
     """
     path = Path(hermes_bin)
     if path.is_symlink():
-        return path.resolve()
+        try:
+            resolved = path.resolve()
+        except (OSError, RuntimeError):
+            return None
+        if resolved.is_file() and os.access(resolved, os.X_OK):
+            return resolved
+        return None
     try:
         source = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
@@ -526,8 +532,11 @@ def _resolve_hermes_bin(hermes_bin: str) -> Path | None:
     if not match:
         return None
     target = Path(next(g for g in match.groups() if g)).expanduser()
-    if target.is_file():
-        return target.resolve()
+    if target.is_file() and os.access(target, os.X_OK):
+        try:
+            return target.resolve()
+        except (OSError, RuntimeError):
+            return None
     return None
 
 

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -22,6 +22,13 @@ def _source() -> Path:
     return install_mod._resolve_package_dir()
 
 
+def _isolate_hermes_python_sources(tmp_path, monkeypatch):
+    """Patch fallback interpreter sources so tests only see the mocked hermes launcher."""
+    monkeypatch.setattr(install_mod, "hermes_home", lambda: tmp_path / "no_hermes_home")
+    monkeypatch.setattr(install_mod.sys, "prefix", install_mod.sys.base_prefix)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+
 def _make_profile(hermes_home, name, provider):
     profile = hermes_home / "profiles" / name
     profile.mkdir(parents=True)
@@ -64,11 +71,119 @@ def test_find_hermes_python_follows_wrapper_script_to_real_venv(tmp_path, monkey
     assert found == real_python
 
 
+def test_resolve_hermes_bin_returns_direct_executable_for_plain_entrypoint(
+    tmp_path, monkeypatch
+):
+    _skip_on_windows()
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    hermes = bin_dir / "hermes"
+    hermes.write_text("#!/usr/bin/env python3\nimport hermes.cli\n", encoding="utf-8")
+    hermes.chmod(0o755)
+    python = bin_dir / "python"
+    python.write_text("#!/bin/sh\n", encoding="utf-8")
+    python.chmod(0o755)
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(hermes))
+
+    assert install_mod._resolve_hermes_bin(str(hermes)) == hermes
+    assert install_mod._find_hermes_python() == python
+
+
+def test_resolve_hermes_bin_follows_symlink_to_wrapper_script_to_real_venv(
+    tmp_path, monkeypatch
+):
+    _skip_on_windows()
+
+    real_venv = tmp_path / "hermes-agent" / "venv"
+    real_bin = real_venv / "bin"
+    real_bin.mkdir(parents=True)
+    real_hermes = real_bin / "hermes"
+    real_hermes.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_hermes.chmod(0o755)
+    real_python = real_bin / "python"
+    real_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_python.chmod(0o755)
+
+    shim_dir = tmp_path / ".local" / "bin"
+    shim_dir.mkdir(parents=True)
+    shim = shim_dir / "hermes"
+    shim.write_text(
+        f'#!/usr/bin/env bash\nexec "{real_hermes}" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+
+    launcher = tmp_path / "hermes"
+    launcher.symlink_to(shim)
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(launcher))
+
+    assert install_mod._resolve_hermes_bin(str(launcher)) == real_hermes
+    assert install_mod._find_hermes_python() == real_python
+
+
+def test_resolve_hermes_bin_resolves_relative_exec_target(tmp_path, monkeypatch):
+    _skip_on_windows()
+
+    real_bin = tmp_path / "bin"
+    real_bin.mkdir(parents=True)
+    real_hermes = real_bin / "hermes"
+    real_hermes.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_hermes.chmod(0o755)
+    real_python = real_bin / "python"
+    real_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_python.chmod(0o755)
+
+    shim = tmp_path / "hermes"
+    shim.write_text(
+        '#!/usr/bin/env bash\nexec "./bin/hermes" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
+
+    assert install_mod._resolve_hermes_bin(str(shim)) == real_hermes
+    assert install_mod._find_hermes_python() == real_python
+
+
+def test_resolve_hermes_bin_resolves_bare_exec_target_via_path(tmp_path, monkeypatch):
+    _skip_on_windows()
+
+    real_bin = tmp_path / "real" / "bin"
+    real_bin.mkdir(parents=True)
+    real_hermes = real_bin / "hermes"
+    real_hermes.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_hermes.chmod(0o755)
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir(parents=True)
+    shim = shim_dir / "hermes-launcher"
+    shim.write_text(
+        '#!/usr/bin/env bash\nexec hermes "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
+    # Place the real hermes earlier on PATH so the bare exec target resolves to it.
+    monkeypatch.setenv("PATH", str(real_bin), prepend=":")
+
+    assert install_mod._resolve_hermes_bin(str(shim)) == real_hermes
+
+
 def test_resolve_hermes_bin_returns_none_for_broken_symlink(tmp_path, monkeypatch):
     _skip_on_windows()
 
     shim = tmp_path / "hermes"
     shim.symlink_to(tmp_path / "missing" / "hermes")
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
     monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
 
     assert install_mod._resolve_hermes_bin(str(shim)) is None
@@ -86,6 +201,8 @@ def test_resolve_hermes_bin_returns_none_for_non_executable_symlink_target(
 
     shim = tmp_path / "hermes"
     shim.symlink_to(real)
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
     monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
 
     assert install_mod._resolve_hermes_bin(str(shim)) is None
@@ -100,8 +217,25 @@ def test_resolve_hermes_bin_returns_none_for_symlink_loop(tmp_path, monkeypatch)
     a.symlink_to(b)
     b.symlink_to(a)
 
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
     monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(a))
     assert install_mod._resolve_hermes_bin(str(a)) is None
+
+
+def test_resolve_hermes_bin_returns_none_for_wrapper_loop(tmp_path, monkeypatch):
+    _skip_on_windows()
+
+    shim = tmp_path / "hermes"
+    shim.write_text(
+        f'#!/usr/bin/env bash\nexec "{shim}" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
+
+    assert install_mod._resolve_hermes_bin(str(shim)) is None
 
 
 def test_default_install_links_single_home(tmp_path):

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -64,6 +64,46 @@ def test_find_hermes_python_follows_wrapper_script_to_real_venv(tmp_path, monkey
     assert found == real_python
 
 
+def test_resolve_hermes_bin_returns_none_for_broken_symlink(tmp_path, monkeypatch):
+    _skip_on_windows()
+
+    shim = tmp_path / "hermes"
+    shim.symlink_to(tmp_path / "missing" / "hermes")
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
+
+    assert install_mod._resolve_hermes_bin(str(shim)) is None
+    assert install_mod._find_hermes_python() is None
+
+
+def test_resolve_hermes_bin_returns_none_for_non_executable_symlink_target(
+    tmp_path, monkeypatch
+):
+    _skip_on_windows()
+
+    real = tmp_path / "real_hermes"
+    real.write_text("#!/bin/sh\n", encoding="utf-8")
+    real.chmod(0o644)
+
+    shim = tmp_path / "hermes"
+    shim.symlink_to(real)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
+
+    assert install_mod._resolve_hermes_bin(str(shim)) is None
+    assert install_mod._find_hermes_python() is None
+
+
+def test_resolve_hermes_bin_returns_none_for_symlink_loop(tmp_path, monkeypatch):
+    _skip_on_windows()
+
+    a = tmp_path / "hermes_a"
+    b = tmp_path / "hermes_b"
+    a.symlink_to(b)
+    b.symlink_to(a)
+
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(a))
+    assert install_mod._resolve_hermes_bin(str(a)) is None
+
+
 def test_default_install_links_single_home(tmp_path):
     _skip_on_windows()
 

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -170,11 +170,19 @@ def test_resolve_hermes_bin_resolves_bare_exec_target_via_path(tmp_path, monkeyp
     )
     shim.chmod(0o755)
 
+    # Decoy executable next to the wrapper. A bare command name must NOT be
+    # resolved relative to the wrapper directory; it should use PATH.
+    decoy = shim_dir / "hermes"
+    decoy.write_text("#!/bin/sh\n", encoding="utf-8")
+    decoy.chmod(0o755)
+
     _isolate_hermes_python_sources(tmp_path, monkeypatch)
     # Place the real hermes earlier on PATH so the bare exec target resolves to it.
     monkeypatch.setenv("PATH", str(real_bin), prepend=":")
 
-    assert install_mod._resolve_hermes_bin(str(shim)) == real_hermes
+    result = install_mod._resolve_hermes_bin(str(shim))
+    assert result == real_hermes
+    assert result != decoy
 
 
 def test_resolve_hermes_bin_returns_none_for_broken_symlink(tmp_path, monkeypatch):

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -246,6 +246,140 @@ def test_resolve_hermes_bin_returns_none_for_wrapper_loop(tmp_path, monkeypatch)
     assert install_mod._resolve_hermes_bin(str(shim)) is None
 
 
+def test_resolve_hermes_bin_ignores_cwd_decoy_for_dot_slash_target(
+    tmp_path, monkeypatch
+):
+    """`exec ./hermes-real` must resolve beside the wrapper, not a CWD decoy."""
+    _skip_on_windows()
+
+    real_bin = tmp_path / "bin"
+    real_bin.mkdir(parents=True)
+    shim = real_bin / "hermes"
+    shim.write_text(
+        '#!/usr/bin/env bash\nexec ./hermes-real "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    real_hermes = real_bin / "hermes-real"
+    real_hermes.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_hermes.chmod(0o755)
+    real_python = real_bin / "python"
+    real_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_python.chmod(0o755)
+
+    # A same-named decoy in the process working directory must not win.
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    decoy_hermes = cwd / "hermes-real"
+    decoy_hermes.write_text("#!/bin/sh\n", encoding="utf-8")
+    decoy_hermes.chmod(0o755)
+    decoy_python = cwd / "python"
+    decoy_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    decoy_python.chmod(0o755)
+    monkeypatch.chdir(cwd)
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
+
+    assert install_mod._resolve_hermes_bin(str(shim)) == real_hermes
+    assert install_mod._find_hermes_python() == real_python
+
+
+def test_resolve_hermes_bin_follows_env_prefix_exec_target(tmp_path, monkeypatch):
+    """`exec env FOO=bar /real/hermes` must resolve to the real binary, not env."""
+    _skip_on_windows()
+
+    real_bin = tmp_path / "real" / "bin"
+    real_bin.mkdir(parents=True)
+    real_hermes = real_bin / "hermes"
+    real_hermes.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_hermes.chmod(0o755)
+    real_python = real_bin / "python"
+    real_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_python.chmod(0o755)
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    shim = shim_dir / "hermes"
+    shim.write_text(
+        f'#!/usr/bin/env bash\nexec env FOO=bar "{real_hermes}" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    # Decoy python beside the wrapper: proves we did not stop at the wrapper.
+    decoy_python = shim_dir / "python"
+    decoy_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    decoy_python.chmod(0o755)
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
+
+    assert install_mod._resolve_hermes_bin(str(shim)) == real_hermes
+    assert install_mod._find_hermes_python() == real_python
+
+
+def test_resolve_hermes_bin_follows_pre_exec_assignment_target(tmp_path, monkeypatch):
+    """`FOO=bar exec /real/hermes` must resolve to the real binary."""
+    _skip_on_windows()
+
+    real_bin = tmp_path / "real" / "bin"
+    real_bin.mkdir(parents=True)
+    real_hermes = real_bin / "hermes"
+    real_hermes.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_hermes.chmod(0o755)
+    real_python = real_bin / "python"
+    real_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_python.chmod(0o755)
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    shim = shim_dir / "hermes"
+    shim.write_text(
+        f'#!/usr/bin/env bash\nFOO=bar exec "{real_hermes}" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    decoy_python = shim_dir / "python"
+    decoy_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    decoy_python.chmod(0o755)
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
+
+    assert install_mod._resolve_hermes_bin(str(shim)) == real_hermes
+    assert install_mod._find_hermes_python() == real_python
+
+
+def test_resolve_hermes_bin_rejects_unsupported_env_option(tmp_path, monkeypatch):
+    """`exec env -u FOO ...` takes an argument we will not parse, so it is unresolved."""
+    _skip_on_windows()
+
+    real_bin = tmp_path / "real" / "bin"
+    real_bin.mkdir(parents=True)
+    real_hermes = real_bin / "hermes"
+    real_hermes.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_hermes.chmod(0o755)
+
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    shim = shim_dir / "hermes"
+    shim.write_text(
+        f'#!/usr/bin/env bash\nexec env -u FOO "{real_hermes}" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    # A decoy python beside the wrapper must NOT be selected via a fallback.
+    decoy_python = shim_dir / "python"
+    decoy_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    decoy_python.chmod(0o755)
+
+    _isolate_hermes_python_sources(tmp_path, monkeypatch)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
+
+    assert install_mod._resolve_hermes_bin(str(shim)) is None
+    assert install_mod._find_hermes_python() is None
+
+
 def test_default_install_links_single_home(tmp_path):
     _skip_on_windows()
 

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -31,6 +31,39 @@ def _make_profile(hermes_home, name, provider):
     return profile
 
 
+def test_find_hermes_python_follows_wrapper_script_to_real_venv(tmp_path, monkeypatch):
+    """A PATH shim that execs the real Hermes binary must not pick a stray python beside the shim."""
+    # Real Hermes venv layout.
+    real_venv = tmp_path / "hermes-agent" / "venv"
+    real_bin = real_venv / "bin"
+    real_bin.mkdir(parents=True)
+    real_hermes = real_bin / "hermes"
+    real_hermes.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_hermes.chmod(0o755)
+    real_python = real_bin / "python"
+    real_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_python.chmod(0o755)
+
+    # PATH shim in ~/.local/bin that execs the real Hermes binary.
+    shim_dir = tmp_path / ".local" / "bin"
+    shim_dir.mkdir(parents=True)
+    shim = shim_dir / "hermes"
+    shim.write_text(
+        f'#!/usr/bin/env bash\nexec "{real_hermes}" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+
+    # A decoy python next to the shim: this is the bug case.
+    decoy_python = shim_dir / "python"
+    decoy_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    decoy_python.chmod(0o755)
+
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _bin: str(shim))
+    found = install_mod._find_hermes_python()
+    assert found == real_python
+
+
 def test_default_install_links_single_home(tmp_path):
     _skip_on_windows()
 


### PR DESCRIPTION
Closes #618

When `hermes` on PATH is a shell wrapper that `exec`s the real Hermes binary (instead of being a symlink to it), `_find_hermes_python()` resolved the wrapper's own directory and picked a stray `python` next to the shim, causing the installer to bootstrap into the wrong environment.

Changes:
- Added `_resolve_hermes_bin()` which follows the `exec` target of wrapper scripts and falls back to symlink resolution otherwise.
- `_find_hermes_python()` now uses the resolved real Hermes binary to locate the venv `python` sibling.
- Added a regression test covering a PATH shim with a decoy `python` beside it.

This keeps the PATH probe working for pipx/pip-installed launchers while avoiding the wrong interpreter reported in #618.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates Hermes Python discovery to resolve symlink and shell-wrapper launchers.
- Resolves relative and `PATH`-based `exec` targets.
- Rejects broken, non-executable, invalid, and looping targets.
- Selects the virtual-environment Python beside the resolved Hermes binary.
- Adds regression tests for launcher chains and decoy Python executables.

## Architecture impact

- **Core memory architecture:** No changes to working, episodic, or BEAM memory.
- **Retrieval and consolidation:** No changes.
- **Veracity system and sync layer:** No changes.
- **Privacy and local-first guarantees:** Preserved. The change adds no network, telemetry, or remote execution behavior.
- **Agent integration surfaces:** Improves Hermes installer reliability. MCP and CLI behavior are unchanged.
- **Maintainability:** Centralizes bounded launcher resolution and validates targets before interpreter selection. This is the right call because installation logic now uses the actual Hermes binary instead of an unrelated Python beside a wrapper.
- **Benchmark methodology:** No changes.
- **Local-first risks:** None identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->