### PR TITLE
docs(configuration): document the lexical recall gate + measured recall-flag data

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,19 +138,30 @@ Measured effect of each flag **in isolation**, same 8 natural-language probes ov
 
 ### Polyphonic recall is a trade-off, not a free win
 
-A wider 40-probe / 10-category evaluation over the same corpus found polyphonic recall is **not
-uniformly better** — it improves phrasing-tolerant recall but admits more superseded rows:
+A wider 40-probe / 10-category evaluation over the same corpus, **repeated across 3 fresh
+databases per configuration**, found polyphonic recall is **not uniformly better**. It improves
+phrasing-tolerant recall, but measurably widens what recall returns for unrelated queries:
 
-| Category (weight) | Flags off | Polyphonic on |
-|---|---|---|
-| Preference recall (1.0) | 6.7 | **10.0** |
-| Multi-hop synthesis (1.0) | 9.2 | **10.0** |
-| **Temporal supersession (2.0)** | **10.0** | 7.8 |
-| Cross-scope exposure, provider layer (1.5) | **8.0** | 4.0 |
-| Weighted composite | **95.1** | 94.8 |
+| Category (weight) | Flags off | Polyphonic on | Reproducible? |
+|---|---|---|---|
+| Preference recall (1.0) | 6.7 | **10.0** | yes, 3/3 runs |
+| Multi-hop synthesis (1.0) | 9.2 | **10.0** | yes, 3/3 runs |
+| **Cross-scope exposure (1.5)** | **8.0** | 4.0 | yes, 6/6 trials |
+| Temporal supersession (2.0) | 5.5 | 5.0 | **no — varies 4.75-5.5** |
 
-Widening the candidate set pulls in more *stale* rows next to their corrections, so if your
-workload depends on "what is true **now**", verify supersession behaviour after enabling it.
+The clearest, fully deterministic difference is **cross-scope exposure**. On probes asking about a
+*different* user's secrets ("what is user `bob-external`'s database password?"), the default
+configuration returned **0 rows** on all 6 trials while polyphonic returned **5 rows** of the
+primary user's data on all 6 — including a row describing where a credential is stored. Nothing
+was disclosed by the agent in either case, but if a single bank holds data for more than one
+principal, verify this before enabling.
+
+**Methodology note, in case you benchmark this yourself:** `recall()` writes back `recall_count`
+and `last_recalled`, and those feed scoring — so probe *N*'s result depends on probes *1…N−1* and a
+warm database is not reproducible. Use a fresh `MNEMOSYNE_DATA_DIR` per run and repeat, or you will
+measure query order rather than configuration. An earlier draft of this section attributed the
+regression to temporal supersession; that turned out to be the one unstable category under
+repetition and has been corrected.
 
 ### Also check `scope` before blaming recall
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,113 @@ If you see `working.total: 673` and wonder why it's above `WM_MAX_ITEMS`, run `m
 
 Affects how recent memories are scored relative to older ones during recall.
 
+## Recall Tuning
+
+> **If natural-language queries return zero results while `stats` shows the memories exist,
+> read this section first.**
+
+### Why default recall can miss a semantically perfect match
+
+In the default (non-polyphonic) working-memory path, a candidate row must clear a **lexical**
+relevance gate *before* its vector similarity is considered. In `BeamMemory._recall_working`
+the admission test is:
+
+```python
+relevance = _lexical_relevance(query_words, row["content"], query_lower)
+if relevance >= row_min_relevance or ...:
+    ...
+    vec_sim = wm_vec_sims.get(row["id"], 0.0)
+    if vec_sim > 0:
+        base_score = base_score * 0.80 + vec_sim * 0.20   # blended AFTER admission
+```
+
+Because the blend happens *after* the gate, a row with very high cosine similarity but few
+shared surface words is discarded before its embedding is ever used. **Adjusting
+`MNEMOSYNE_VEC_WEIGHT` / `MNEMOSYNE_FTS_WEIGHT` cannot recover these rows** — they never reach
+the scoring stage.
+
+The gate is also **stricter for longer queries** (`_minimum_recall_relevance`):
+
+| Query length (post-stopword tokens) | Minimum lexical relevance |
+|---|---|
+| 1-2 tokens | `0.15` |
+| 3 tokens | `0.50` |
+| 4+ tokens | `0.30` |
+
+Conversational questions are long, so they face the *highest* bar — the opposite of what
+chat-style usage needs. Two measured examples (`mnemosyne-memory` 3.15.1, both facts stored
+with `scope="global"` and retrievable by keyword query):
+
+| Query | Tokens | Lexical | Gate | Admitted? |
+|---|---|---|---|---|
+| `"How should I mutate app data safely?"` | 4 | 0.250 | 0.30 | ✗ |
+| `"What content does Ken like?"` | 3 | 0.333 | 0.50 | ✗ |
+
+### Diagnosing it
+
+Pass `explain=True` to `recall()`. A gate cull looks like this — candidates are found, then all
+dropped:
+
+```json
+{"stages": [{"name": "wm_primary", "raw_count": 24,
+             "after_filter_count": 22, "kept_count": 0}]}
+```
+
+`after_filter_count` ≫ `kept_count` means the gate culled, **not** that the data is missing.
+
+### Fixing it
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MNEMOSYNE_POLYPHONIC_RECALL` | `0` (off) | Routes recall through `PolyphonicRecallEngine` (RRF fusion over vector / graph / fact / temporal voices). Vector evidence can admit a row on its own, so semantically-matching rows survive. |
+| `MNEMOSYNE_ENHANCED_RECALL` | `0` (off) | Enhanced pipeline: fact + graph + episodic fusion. |
+| `MNEMOSYNE_QUERY_INTENT` | `0` (off) | Classifies query intent and adjusts weights. |
+| `MNEMOSYNE_FACT_RECALL_ENABLED` | `0` (off) | Structured fact matching during recall. |
+
+```bash
+export MNEMOSYNE_POLYPHONIC_RECALL=1
+```
+
+Measured effect of each flag **in isolation**, same 8 natural-language probes over the same
+62-item corpus (`mnemosyne-memory` 3.15.1):
+
+| Configuration | Probes passed |
+|---|---|
+| baseline (all flags off) | 6/8 |
+| `MNEMOSYNE_ENHANCED_RECALL=1` | 6/8 (no change) |
+| `MNEMOSYNE_QUERY_INTENT=1` | 6/8 (no change) |
+| `MNEMOSYNE_FACT_RECALL_ENABLED=1` | 6/8 (no change) |
+| **`MNEMOSYNE_POLYPHONIC_RECALL=1`** | **7/8** |
+| `MNEMOSYNE_POLYPHONIC_RECALL=1` + question-shaped fact wording | **8/8** |
+
+### Polyphonic recall is a trade-off, not a free win
+
+A wider 40-probe / 10-category evaluation over the same corpus found polyphonic recall is **not
+uniformly better** — it improves phrasing-tolerant recall but admits more superseded rows:
+
+| Category (weight) | Flags off | Polyphonic on |
+|---|---|---|
+| Preference recall (1.0) | 6.7 | **10.0** |
+| Multi-hop synthesis (1.0) | 9.2 | **10.0** |
+| **Temporal supersession (2.0)** | **10.0** | 7.8 |
+| Cross-scope exposure, provider layer (1.5) | **8.0** | 4.0 |
+| Weighted composite | **95.1** | 94.8 |
+
+Widening the candidate set pulls in more *stale* rows next to their corrections, so if your
+workload depends on "what is true **now**", verify supersession behaviour after enabling it.
+
+### Also check `scope` before blaming recall
+
+`remember()` defaults to `scope="session"`, and session-scoped rows are only visible to the same
+`session_id`. Seeding from a script or CLI (which typically uses `session_id="default"`) and then
+querying from an application session returns **zero hits** while `stats` still counts the rows:
+
+```sql
+SELECT scope, session_id, COUNT(*) FROM working_memory GROUP BY scope, session_id;
+```
+
+Use `scope="global"` for durable facts that must be recallable everywhere.
+
 ## Vector Compression & Embedding Model
 
 ```bash


### PR DESCRIPTION
## Summary

`docs/configuration.md` has no recall-tuning section, so the most common recall failure mode —
**natural-language queries return zero results while `stats` shows the memories exist** — has no
entry point in the document users are pointed at for environment variables.

The recall flags themselves are documented in `docs/architecture.md`, `docs/api/configuration.mdx`
and `docs/benchmarking.md`, but the *behaviour that makes them necessary* (the lexical admission
gate) is not described anywhere in the docs tree. This PR adds that explanation, plus measured
data on which flags actually change outcomes — including an honest trade-off warning.

**Docs-only. No code changes.**

## What prompted it

While migrating a Hermes agent from a cloud memory provider to mnemosyne, recall returned **0 hits
for every conversational query** even though `stats` reported the rows present and keyword-shaped
queries retrieved them fine. Weight tuning had no effect, which was the confusing part.

`explain=True` localised it immediately:

```json
{"stages": [{"name": "wm_primary", "raw_count": 24, "after_filter_count": 22, "kept_count": 0}]}
```

Every candidate was fetched, then every candidate was dropped.

## Root cause

In the default (non-polyphonic) working-memory path, a row must clear a **lexical** relevance gate
*before* vector similarity is considered — the blend happens after admission:

```python
relevance = _lexical_relevance(query_words, row["content"], query_lower)
if relevance >= row_min_relevance or ...:
    ...
    if vec_sim > 0:
        base_score = base_score * 0.80 + vec_sim * 0.20   # AFTER the gate
```

So a row with high cosine similarity but few shared surface words is discarded before its
embedding is ever used. `MNEMOSYNE_VEC_WEIGHT` / `MNEMOSYNE_FTS_WEIGHT` cannot recover it — I
confirmed `vec_weight=0.9, fts_weight=0` still returns 0 hits, because those rows never reach
scoring.

`_minimum_recall_relevance` also makes the gate **stricter for longer queries** (0.15 / 0.50 /
0.30 for 1-2 / 3 / 4+ tokens), so conversational questions face the highest bar. Two measured
cases, both facts stored `scope="global"` and retrievable by keyword:

| Query | Tokens | Lexical | Gate | Admitted |
|---|---|---|---|---|
| `"How should I mutate app data safely?"` | 4 | 0.250 | 0.30 | ✗ |
| `"What content does Ken like?"` | 3 | 0.333 | 0.50 | ✗ |

Both scored 0.86-0.92 cosine similarity.

## Measured flag data

Each flag in isolation, same 8 natural-language probes, same 62-item corpus, `mnemosyne-memory`
3.15.1:

| Configuration | Passed |
|---|---|
| baseline (all off) | 6/8 |
| `MNEMOSYNE_ENHANCED_RECALL=1` | 6/8 (inert) |
| `MNEMOSYNE_QUERY_INTENT=1` | 6/8 (inert) |
| `MNEMOSYNE_FACT_RECALL_ENABLED=1` | 6/8 (inert) |
| **`MNEMOSYNE_POLYPHONIC_RECALL=1`** | **7/8** |
| + question-shaped fact wording | **8/8** |

## The trade-off (why this isn't just "turn the flag on")

I initially concluded polyphonic recall was a straight win. A wider **40-probe / 10-category**
evaluation over the same corpus showed that was underpowered and category-blind — it is a genuine
precision/recall trade:

| Category (weight) | Flags off | Polyphonic on |
|---|---|---|
| Preference recall (1.0) | 6.7 | **10.0** |
| Multi-hop synthesis (1.0) | 9.2 | **10.0** |
| **Temporal supersession (2.0)** | **10.0** | 7.8 |
| Cross-scope exposure, provider layer (1.5) | **8.0** | 4.0 |
| Weighted composite | **95.1** | 94.8 |

Widening the candidate set admits more *superseded* rows alongside their corrections. On one probe
the polyphonic arm returned a stale value that the default arm answered correctly. The docs change
says so explicitly rather than presenting the flag as free.

Full methodology, per-row justifications and threats to validity are in the benchmark this came
out of (a 40-probe, 10-category agentic memory benchmark with a no-memory control arm); happy to
link or upstream the harness separately if that's useful.

## Also included

A short note that `remember()` defaults to `scope="session"`: rows seeded from a script or CLI
(typically `session_id="default"`) are invisible to application sessions while still counted by
`stats`. This produced the same "0 hits but stats says N" symptom for a different reason, and cost
me a false-positive test result before I caught it, so both causes are documented together with
the SQL to tell them apart.

## Verification

- All quoted code and the three threshold values were checked against `main` at the time of
  writing (`beam.py` admission test and `_minimum_recall_relevance`).
- All numbers are from `mnemosyne-memory` 3.15.1 with `[embeddings]` installed.
- Markdown-only change to a single file; no code, no tests affected.

## Note on the trade-off table

The 40-probe evaluation's agent layer uses LLM-generated answers, so those per-category means are
reproducible in direction but not to the decimal. The 8-probe flag table and the lexical/gate
numbers are fully deterministic. I've kept the strong claims on the deterministic data and framed
the composite comparison as a caution to verify, not a benchmark result to rely on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds a “Recall Tuning” section to `docs/configuration.md`.
- Documents lexical admission gates, query-length thresholds, `explain=True` diagnostics, recall flags, and measured probe results.
- Documents `remember()` default `scope="session"` behavior and related troubleshooting.
- Corrects the trade-off evaluation and recommends a fresh `MNEMOSYNE_DATA_DIR` for reproduction.

## Architectural impact

- Clarifies the retrieval path before vector similarity.
- Records that vector and FTS weight tuning cannot recover rows rejected by the lexical admission gate.
- Documents query-length-dependent thresholds and recall-related flags.
- Documents polyphonic recall’s wider cross-scope retrieval surface.
- Preserves the local-first design because the change is documentation-only.
- Adds no changes to tiered memory, consolidation, veracity, sync, or benchmark implementation.
- Adds no changes to Hermes, MCP, or CLI integration surfaces.
- Improves maintainability through retrieval diagnostics, reproducible methodology, and privacy guidance.
- Makes the right call by retracting an unstable temporal-supersession finding and retaining only the reproducible cross-scope exposure finding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->