### PR TITLE
docs: add changelog entry for #603

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
-- **Vector rebuilds no longer report false success (#603).** Reindexing and `vec_working` repair now fail explicitly when embedding batches, derived-vector writes, or final coverage checks are incomplete. `mnemosyne diagnose --repair-vec-working` returns a non-zero exit code when a requested repair fails.
+- **Vector rebuild failures are now reported explicitly (#603).** Reindexing fails on incomplete embedding batches or derived-vector write failures. `vec_working` repair also fails when its final coverage check remains incomplete. `mnemosyne diagnose --repair-vec-working` returns a non-zero exit code when a requested repair fails.
 - **Persona token-cap truncation (#621).** `render_persona_markdown` now skips oversized topic sections and continues evaluating later sections, so smaller persona sections that still fit within the approximate token cap are retained.
 - **`degrade_batch` now honors `config.yaml` at the BEAM consumer (#482).** Episodic degradation resolves `degrade_batch` as `config.yaml > MNEMOSYNE_DEGRADE_BATCH > 100` once per complete degradation pass. Reloaded YAML applies to the next pass without changing the candidate limits of a running pass.
 - **BEAM recall weights now honor `config.yaml` at runtime (#482).** `vec_weight`, `fts_weight`, and `importance_weight` now resolve as `config.yaml > MNEMOSYNE_*_WEIGHT > defaults` in direct and Hermes-provider recall paths. Reloaded weights apply to the next request, and enhanced recall cache entries are isolated by the effective weight snapshot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Vector rebuilds no longer report false success (#603).** Reindexing and `vec_working` repair now fail explicitly when embedding batches, derived-vector writes, or final coverage checks are incomplete. `mnemosyne diagnose --repair-vec-working` returns a non-zero exit code when a requested repair fails.
 - **Persona token-cap truncation (#621).** `render_persona_markdown` now skips oversized topic sections and continues evaluating later sections, so smaller persona sections that still fit within the approximate token cap are retained.
 - **`degrade_batch` now honors `config.yaml` at the BEAM consumer (#482).** Episodic degradation resolves `degrade_batch` as `config.yaml > MNEMOSYNE_DEGRADE_BATCH > 100` once per complete degradation pass. Reloaded YAML applies to the next pass without changing the candidate limits of a running pass.
 - **BEAM recall weights now honor `config.yaml` at runtime (#482).** `vec_weight`, `fts_weight`, and `importance_weight` now resolve as `config.yaml > MNEMOSYNE_*_WEIGHT > defaults` in direct and Hermes-provider recall paths. Reloaded weights apply to the next request, and enhanced recall cache entries are isolated by the effective weight snapshot.


### PR DESCRIPTION
## Summary

Adds the missing `[Unreleased]` changelog entry for merged #603.

## Why this path

`CHANGELOG.md` is the release-note surface, and #603 changed user-visible reindex and repair failure reporting. This records the already-merged behavior without changing implementation or release versioning.

## Non-goals

No code changes, tests, version bump, or changes to release process.

## Why not a version bump

Release versioning remains release-owner work. This PR only restores the missing Unreleased note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds the missing `[Unreleased]` entry for vector rebuild reliability fixes.
- Documents failure reporting for incomplete embedding batches, vector writes, and coverage checks during reindexing and `vec_working` repair.
- Documents non-zero exit behavior for `mnemosyne diagnose --repair-vec-working` when repair fails.

## Architecture and maintainability impact

- Improves observability for working-memory vector repair and reindex operations.
- Does not change tiered memory, retrieval, consolidation, veracity, sync, or benchmark behavior.
- Does not change Hermes, MCP, or CLI integration surfaces beyond documenting existing CLI failure behavior.
- Preserves local-first and privacy guarantees. No runtime, data-flow, or dependency changes are included.
- Adding the entry is the right call for long-term maintainability because it records user-visible reliability behavior without expanding the code or release scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->