### PR TITLE
fix(hermes): reject mismatched wrapper Python runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
           "
 
       - name: Run tests
-        run: pytest tests/ -v --tb=short
+        run: pytest tests/ integrations/hermes/tests/test_wrapper_bootstrap.py -v --tb=short
 
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Hermes wrapper runtime compatibility guard (#625).** The legacy provider and newly registered persistent wrappers reject selected Mnemosyne site-packages whose virtualenv targets a different Python major/minor, or has an unreadable version, before activation/import; the error directs operators to recreate the Mnemosyne environment using Hermes' Python. Existing persistent wrapper artifacts must be force-refreshed or re-registered from a compatible Hermes-Python venv to receive this guard.
 - **Vector rebuild failures are now reported explicitly (#603).** Reindexing fails on incomplete embedding batches or derived-vector write failures. `vec_working` repair also fails when its final coverage check remains incomplete. `mnemosyne diagnose --repair-vec-working` returns a non-zero exit code when a requested repair fails.
 - **Persona token-cap truncation (#621).** `render_persona_markdown` now skips oversized topic sections and continues evaluating later sections, so smaller persona sections that still fit within the approximate token cap are retained.
 - **`degrade_batch` now honors `config.yaml` at the BEAM consumer (#482).** Episodic degradation resolves `degrade_batch` as `config.yaml > MNEMOSYNE_DEGRADE_BATCH > 100` once per complete degradation pass. Reloaded YAML applies to the next pass without changing the candidate limits of a running pass.

--- a/hermes_memory_provider/__init__.py
+++ b/hermes_memory_provider/__init__.py
@@ -66,7 +66,53 @@ def _stage_pending_write(payload: Dict[str, Any]) -> str:
     }
     (pending_dir / f"{pid}.json").write_text(json.dumps(record, indent=2))
     return pid
+
+
+def _guard_selected_site_packages_python_compatibility(selected_site_packages: Path) -> None:
+    """Reject a selected virtualenv that targets another Python minor version."""
+    selected_site_packages = selected_site_packages.resolve()
+    # Standard POSIX layouts put pyvenv.cfg three levels above site-packages
+    # (/venv/lib/pythonX/site-packages); Windows needs only two. Do not let
+    # this early bootstrap probe inspect arbitrary filesystem ancestors.
+    for candidate in (selected_site_packages, *selected_site_packages.parents[:3]):
+        config_path = candidate / "pyvenv.cfg"
+        if not config_path.exists():
+            continue
+        selected_version: tuple[int, int] | None = None
+        try:
+            config_text = config_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            config_text = ""
+        for line in config_text.splitlines():
+            name, separator, value = line.partition("=")
+            if separator and name.strip().lower() in {"version_info", "version"}:
+                match = re.search(r"(?<!\d)(\d+)\.(\d+)(?!\d)", value)
+                if match:
+                    selected_version = (int(match.group(1)), int(match.group(2)))
+                    break
+        runtime_version = sys.version_info[:2]
+        if selected_version is None or selected_version != runtime_version:
+            selected_text = (
+                f"{selected_version[0]}.{selected_version[1]}"
+                if selected_version is not None
+                else "unknown"
+            )
+            raise RuntimeError(
+                "Mnemosyne runtime Python compatibility error: "
+                f"runtime Python {runtime_version[0]}.{runtime_version[1]}; "
+                f"selected Mnemosyne environment Python {selected_text}. "
+                "Recreate the Mnemosyne environment using Hermes' Python, "
+                "then reinstall mnemosyne-hermes."
+            )
+        return
+
+
 _mnemosyne_root = Path(__file__).resolve().parent.parent
+# Legacy source-checkout providers use the repository root here. Only a
+# provider resolved directly from a virtualenv site-packages directory selects
+# an external runtime whose Python version must be checked.
+if _mnemosyne_root.name == "site-packages":
+    _guard_selected_site_packages_python_compatibility(_mnemosyne_root)
 if str(_mnemosyne_root) not in sys.path:
     sys.path.insert(0, str(_mnemosyne_root))
 

--- a/hermes_memory_provider/cli.py
+++ b/hermes_memory_provider/cli.py
@@ -6,10 +6,56 @@ Available via: hermes mnemosyne <subcommand>
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
+
+def _guard_selected_site_packages_python_compatibility(selected_site_packages: Path) -> None:
+    """Reject a selected virtualenv that targets another Python minor version."""
+    selected_site_packages = selected_site_packages.resolve()
+    # Standard POSIX layouts put pyvenv.cfg three levels above site-packages
+    # (/venv/lib/pythonX/site-packages); Windows needs only two. Do not let
+    # this early bootstrap probe inspect arbitrary filesystem ancestors.
+    for candidate in (selected_site_packages, *selected_site_packages.parents[:3]):
+        config_path = candidate / "pyvenv.cfg"
+        if not config_path.exists():
+            continue
+        selected_version: tuple[int, int] | None = None
+        try:
+            config_text = config_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            config_text = ""
+        for line in config_text.splitlines():
+            name, separator, value = line.partition("=")
+            if separator and name.strip().lower() in {"version_info", "version"}:
+                match = re.search(r"(?<!\d)(\d+)\.(\d+)(?!\d)", value)
+                if match:
+                    selected_version = (int(match.group(1)), int(match.group(2)))
+                    break
+        runtime_version = sys.version_info[:2]
+        if selected_version is None or selected_version != runtime_version:
+            selected_text = (
+                f"{selected_version[0]}.{selected_version[1]}"
+                if selected_version is not None
+                else "unknown"
+            )
+            raise RuntimeError(
+                "Mnemosyne runtime Python compatibility error: "
+                f"runtime Python {runtime_version[0]}.{runtime_version[1]}; "
+                f"selected Mnemosyne environment Python {selected_text}. "
+                "Recreate the Mnemosyne environment using Hermes' Python, "
+                "then reinstall mnemosyne-hermes."
+            )
+        return
+
+
 _mnemosyne_root = Path(__file__).resolve().parent.parent
+# Standalone source-checkout CLI discovery uses the repository root here.
+# Guard only the direct virtualenv site-packages target selected by the issue
+# path, not arbitrary source-root ancestors.
+if _mnemosyne_root.name == "site-packages":
+    _guard_selected_site_packages_python_compatibility(_mnemosyne_root)
 if str(_mnemosyne_root) not in sys.path:
     sys.path.insert(0, str(_mnemosyne_root))
 

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -568,7 +568,7 @@ def _bootstrap_hermes_venv(hermes_python: Path) -> bool:
             stderr = result.stderr.strip()[:500]
             print(f"  ⚠ Bootstrap failed: {stderr}", file=sys.stderr)
             return False
-        print(f"  ✓ mnemosyne-hermes installed into Hermes' venv")
+        print("  ✓ mnemosyne-hermes installed into Hermes' venv")
         return True
     except Exception as exc:
         print(f"  ⚠ Bootstrap failed: {exc}", file=sys.stderr)
@@ -920,8 +920,48 @@ import importlib
 import json
 import os
 from pathlib import Path
+import re
 import site as site_module
 import sys
+
+
+def _guard_selected_site_packages_python_compatibility(selected_site_packages: Path) -> None:
+    \"\"\"Reject a selected virtualenv that targets another Python minor version.\"\"\"
+    selected_site_packages = selected_site_packages.resolve()
+    # Standard POSIX layouts put pyvenv.cfg three levels above site-packages
+    # (/venv/lib/pythonX/site-packages); Windows needs only two. Do not let
+    # this early bootstrap probe inspect arbitrary filesystem ancestors.
+    for candidate in (selected_site_packages, *selected_site_packages.parents[:3]):
+        config_path = candidate / "pyvenv.cfg"
+        if not config_path.exists():
+            continue
+        selected_version = None
+        try:
+            config_text = config_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            config_text = ""
+        for line in config_text.splitlines():
+            name, separator, value = line.partition("=")
+            if separator and name.strip().lower() in {"version_info", "version"}:
+                match = re.search(r"(?<!\\d)(\\d+)\\.(\\d+)(?!\\d)", value)
+                if match:
+                    selected_version = (int(match.group(1)), int(match.group(2)))
+                    break
+        runtime_version = sys.version_info[:2]
+        if selected_version is None or selected_version != runtime_version:
+            selected_text = (
+                f"{selected_version[0]}.{selected_version[1]}"
+                if selected_version is not None
+                else "unknown"
+            )
+            raise RuntimeError(
+                "Mnemosyne runtime Python compatibility error: "
+                f"runtime Python {runtime_version[0]}.{runtime_version[1]}; "
+                f"selected Mnemosyne environment Python {selected_text}. "
+                "Recreate the Mnemosyne environment using Hermes' Python, "
+                "then reinstall mnemosyne-hermes."
+            )
+        return
 
 
 def activate() -> dict[str, object]:
@@ -949,6 +989,7 @@ def activate() -> dict[str, object]:
         raise RuntimeError("Invalid Mnemosyne wrapper Python executable")
     if not site_path.is_absolute() or not site_path.is_dir():
         raise RuntimeError("Invalid Mnemosyne wrapper site-packages target")
+    _guard_selected_site_packages_python_compatibility(site_path)
     package_root = site_path / "mnemosyne_hermes"
     package_init = package_root / "__init__.py"
     expected_root = package_root.resolve() if package_init.is_file() else None
@@ -1335,7 +1376,7 @@ def run_install(
         if hermes_core is None:
             print(f"\n  ⚠ Hermes' Python at {hermes_python} can't import mnemosyne core.")
             print(f"     mnemosyne-hermes is installed in YOUR Python ({sys.executable}),")
-            print(f"     but Hermes runs from a different venv.\n")
+            print("     but Hermes runs from a different venv.\n")
             if not no_bootstrap:
                 print("  → Attempting auto-bootstrap...")
                 if _bootstrap_hermes_venv(hermes_python):
@@ -1461,7 +1502,7 @@ def main(argv: list[str] | None = None) -> int:
             target = state.target
             installed = state.installed
             hermes_python = _find_hermes_python()
-            print(f"Status for mnemosyne-hermes plugin")
+            print("Status for mnemosyne-hermes plugin")
             print(f"  Plugin path: {target}")
             print(f"  State: {state.status}")
             print(f"  Mode: {state.mode}")
@@ -1473,18 +1514,18 @@ def main(argv: list[str] | None = None) -> int:
                     print(f"  Wrapper site-packages: {state.wrapper_site_packages}")
                     print(f"  Wrapper import: {'OK' if state.wrapper_import_ok else 'not checked'}")
                 else:
-                    print(f"  Type: directory (not symlink)")
-                print(f"  Plugin:    installed ✓")
+                    print("  Type: directory (not symlink)")
+                print("  Plugin:    installed ✓")
             elif state.status == "broken_symlink":
-                print(f"  Plugin:    broken symlink (target missing) ✗")
+                print("  Plugin:    broken symlink (target missing) ✗")
                 print(f"  Broken target: {state.link_target}")
-                print(f"  → Run: mnemosyne-hermes install --force")
+                print("  → Run: mnemosyne-hermes install --force")
             elif state.status == "stale_wrapper":
-                print(f"  Plugin:    stale wrapper target ✗")
+                print("  Plugin:    stale wrapper target ✗")
                 print(f"  Wrapper Python: {state.wrapper_python}")
                 print(f"  Wrapper site-packages: {state.wrapper_site_packages}")
                 print(f"  Import error: {state.wrapper_import_error}")
-                print(f"  → Re-run: mnemosyne-hermes install --mode wrapper --force --python <venv>/bin/python")
+                print("  → Re-run: mnemosyne-hermes install --mode wrapper --force --python <venv>/bin/python")
             else:
                 print(f"  NOT installed: {state.message}")
                 if state.link_target is not None:
@@ -1504,15 +1545,15 @@ def main(argv: list[str] | None = None) -> int:
                     _ver = _r.stdout.strip() or _r.stderr.strip()
                     print(f"  Hermes' Python: {hermes_python} ({_ver})")
                     if state.mode == "symlink" and hermes_python.resolve() != Path(sys.executable).resolve():
-                        print(f"  ⚠ Python version MISMATCH! Install and Hermes use different Python versions.")
+                        print("  ⚠ Python version MISMATCH! Install and Hermes use different Python versions.")
                         print(f"  → Run: {_ver.split()[1]}" if " " in _ver else "")
                 except Exception:
                     print(f"  Hermes' Python: {hermes_python} (unable to check version)")
             else:
-                print(f"  Hermes' Python: not found")
+                print("  Hermes' Python: not found")
             if installed and state.mode == "symlink" and hermes_python and hermes_python.resolve() != Path(sys.executable).resolve():
-                print(f"  → Hermes Python vs install Python mismatch means the symlink exists but Hermes")
-                print(f"     may not be able to import mnemosyne core. Run with --dry-run to diagnose.")
+                print("  → Hermes Python vs install Python mismatch means the symlink exists but Hermes")
+                print("     may not be able to import mnemosyne core. Run with --dry-run to diagnose.")
             return 0 if installed else 1
 
         if command == "cleanup":

--- a/integrations/hermes/tests/test_wrapper_bootstrap.py
+++ b/integrations/hermes/tests/test_wrapper_bootstrap.py
@@ -282,3 +282,146 @@ assert sys.path == before
     )
 
     assert result.returncode == 0, result.stderr
+
+
+
+@pytest.mark.parametrize("entrypoint", ["__init__.py", "cli.py"])
+@pytest.mark.parametrize(
+    "config_kind", ["same_major_different_minor", "malformed", "pyvenv_cfg_directory"]
+)
+def test_generated_wrapper_rejects_incompatible_side_venv_before_site_activation(
+    tmp_path, entrypoint, config_kind
+):
+    site_packages = tmp_path / "side-venv" / "lib" / "python-current" / "site-packages"
+    if config_kind == "same_major_different_minor":
+        selected_version = f"{sys.version_info.major}.{sys.version_info.minor + 1}"
+        config_line = f"version = {selected_version}.0"
+    else:
+        selected_version = "unknown"
+        config_line = "version_info = malformed" if config_kind == "malformed" else None
+    package = site_packages / "mnemosyne_hermes"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("SIDE_VALUE = 'selected-side-package'\n", encoding="utf-8")
+    (package / "cli.py").write_text(
+        "def register_cli(*args): return 'selected-cli'\n",
+        encoding="utf-8",
+    )
+    config_path = site_packages.parents[2] / "pyvenv.cfg"
+    if config_line is None:
+        config_path.mkdir()
+    else:
+        config_path.write_text(config_line + "\n", encoding="utf-8")
+
+    wrapper = tmp_path / "hermes-home" / "plugins" / "mnemosyne"
+    install._write_wrapper_plugin(
+        wrapper,
+        python=Path(sys.executable),
+        site_packages=site_packages,
+    )
+
+    code = f"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+wrapper = Path({str(wrapper)!r})
+site_packages = {str(site_packages.resolve())!r}
+before = list(sys.path)
+if {entrypoint!r} == '__init__.py':
+    parent = types.ModuleType('synthetic_hermes_plugins')
+    parent.__path__ = []
+    sys.modules[parent.__name__] = parent
+    name = 'synthetic_hermes_plugins.mnemosyne'
+    spec = importlib.util.spec_from_file_location(
+        name, wrapper / '__init__.py', submodule_search_locations=[str(wrapper)]
+    )
+else:
+    name = 'standalone_mnemosyne_cli'
+    spec = importlib.util.spec_from_file_location(name, wrapper / 'cli.py')
+module = importlib.util.module_from_spec(spec)
+sys.modules[name] = module
+try:
+    spec.loader.exec_module(module)
+except RuntimeError as exc:
+    message = str(exc)
+    assert 'runtime Python' in message
+    assert 'selected Mnemosyne environment Python {selected_version}' in message
+else:
+    raise AssertionError('incompatible selected virtualenv should fail activation')
+assert site_packages not in sys.path
+assert sys.path == before
+assert 'mnemosyne_hermes' not in sys.modules
+"""
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, "-I", "-c", code],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("entrypoint", ["__init__.py", "cli.py"])
+def test_generated_wrapper_accepts_matching_side_venv_version_info_for_both_entrypoints(tmp_path, entrypoint):
+    site_packages = tmp_path / "side-venv" / "lib" / "current" / "site-packages"
+    package = site_packages / "mnemosyne_hermes"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("SIDE_VALUE = 'selected-side-package'\n", encoding="utf-8")
+    (package / "cli.py").write_text(
+        "def register_cli(*args): return 'selected-cli'\n",
+        encoding="utf-8",
+    )
+    current_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro + 1}"
+    (site_packages.parents[2] / "pyvenv.cfg").write_text(
+        f"version_info = {current_version}\n",
+        encoding="utf-8",
+    )
+
+    wrapper = tmp_path / "hermes-home" / "plugins" / "mnemosyne"
+    install._write_wrapper_plugin(
+        wrapper,
+        python=Path(sys.executable),
+        site_packages=site_packages,
+    )
+
+    code = f"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+wrapper = Path({str(wrapper)!r})
+site_packages = {str(site_packages.resolve())!r}
+if {entrypoint!r} == '__init__.py':
+    parent = types.ModuleType('synthetic_hermes_plugins')
+    parent.__path__ = []
+    sys.modules[parent.__name__] = parent
+    name = 'synthetic_hermes_plugins.mnemosyne'
+    spec = importlib.util.spec_from_file_location(
+        name, wrapper / '__init__.py', submodule_search_locations=[str(wrapper)]
+    )
+else:
+    name = 'standalone_mnemosyne_cli'
+    spec = importlib.util.spec_from_file_location(name, wrapper / 'cli.py')
+module = importlib.util.module_from_spec(spec)
+sys.modules[name] = module
+spec.loader.exec_module(module)
+assert site_packages == sys.path[0]
+assert Path(sys.modules['mnemosyne_hermes'].__file__).parent == Path({str(package.resolve())!r})
+"""
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, "-I", "-c", code],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_hermes_provider_runtime_compat.py
+++ b/tests/test_hermes_provider_runtime_compat.py
@@ -1,0 +1,176 @@
+"""Regression coverage for legacy Hermes provider and CLI runtime selection."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _copy_legacy_entrypoint(tmp_path: Path, entrypoint: str) -> tuple[Path, Path]:
+    repo_root = Path(__file__).resolve().parents[1]
+    site_packages = tmp_path / "side-venv" / "lib" / "python-current" / "site-packages"
+    source = repo_root / "hermes_memory_provider" / entrypoint
+    target = site_packages / "hermes_memory_provider" / entrypoint
+    target.parent.mkdir(parents=True)
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    return site_packages, target
+
+
+def _copy_legacy_source_entrypoint(tmp_path: Path, entrypoint: str) -> tuple[Path, Path]:
+    repo_root = Path(__file__).resolve().parents[1]
+    source_root = tmp_path / "source-checkout"
+    source = repo_root / "hermes_memory_provider" / entrypoint
+    target = source_root / "hermes_memory_provider" / entrypoint
+    target.parent.mkdir(parents=True)
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    return source_root, target
+
+
+def _run_isolated(tmp_path: Path, code: str) -> None:
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, "-I", "-c", code],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def _legacy_provider_stubs() -> str:
+    """Provide only the import names needed to load the legacy provider."""
+    return """
+import types
+
+for name in (
+    'mnemosyne',
+    'mnemosyne.core',
+    'mnemosyne.core.episodic_graph',
+    'mnemosyne.core.beam',
+    'mnemosyne.batch_tool',
+    'mnemosyne.hermes_config',
+    'mnemosyne.integrations',
+    'mnemosyne.integrations.hermes_persona_prompt',
+):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    sys.modules[name] = module
+
+sys.modules['mnemosyne.core.episodic_graph'].GraphEdge = type('GraphEdge', (), {})
+sys.modules['mnemosyne.core.beam'].WORKING_MEMORY_TTL_HOURS = 1
+batch_tool = sys.modules['mnemosyne.batch_tool']
+batch_tool.BatchValidationError = Exception
+batch_tool.apply_beam_batch = lambda *args, **kwargs: None
+batch_tool.batch_validation_error_payload = lambda *args, **kwargs: None
+batch_tool.dry_run_batch = lambda *args, **kwargs: None
+batch_tool.validate_batch_operations = lambda *args, **kwargs: None
+sys.modules['mnemosyne.hermes_config'].read_hermes_config_key = lambda *args, **kwargs: None
+sys.modules['mnemosyne.integrations.hermes_persona_prompt'].HermesPersonaPromptMixin = type(
+    'HermesPersonaPromptMixin', (), {}
+)
+"""
+
+
+def _load_legacy_entrypoint_code(entrypoint: str, target: Path, site_packages: Path) -> str:
+    provider_stubs = _legacy_provider_stubs() if entrypoint == "__init__.py" else ""
+    return f"""
+import importlib.util
+import sys
+from pathlib import Path
+
+{provider_stubs}
+
+target = Path({str(target)!r})
+site_packages = {str(site_packages.resolve())!r}
+spec = importlib.util.spec_from_file_location('synthetic_legacy_{entrypoint}', target)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+assert sys.path[0] == site_packages
+"""
+
+
+@pytest.mark.parametrize("entrypoint", ["__init__.py", "cli.py"], ids=["provider", "standalone-cli"])
+@pytest.mark.parametrize(
+    "metadata_kind",
+    ["different-minor", "malformed-version-info", "pyvenv-cfg-directory"],
+)
+def test_legacy_entrypoint_rejects_incompatible_metadata_before_import_or_path_activation(
+    tmp_path, entrypoint, metadata_kind
+):
+    site_packages, target = _copy_legacy_entrypoint(tmp_path, entrypoint)
+    selected_version = f"{sys.version_info.major}.{sys.version_info.minor + 1}"
+    config_path = site_packages.parents[2] / "pyvenv.cfg"
+    expected_selected_version = selected_version
+    if metadata_kind == "different-minor":
+        config_path.write_text(f"version = {selected_version}.0\n", encoding="utf-8")
+    elif metadata_kind == "malformed-version-info":
+        config_path.write_text("version_info = not-a-version\n", encoding="utf-8")
+        expected_selected_version = "unknown"
+    else:
+        config_path.mkdir()
+        expected_selected_version = "unknown"
+
+    code = f"""
+import importlib.util
+import sys
+from pathlib import Path
+
+target = Path({str(target)!r})
+site_packages = {str(site_packages.resolve())!r}
+before = list(sys.path)
+spec = importlib.util.spec_from_file_location('synthetic_legacy_{entrypoint}', target)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+try:
+    spec.loader.exec_module(module)
+except RuntimeError as exc:
+    message = str(exc)
+    assert 'runtime Python' in message
+    assert 'selected Mnemosyne environment Python {expected_selected_version}' in message
+else:
+    raise AssertionError('incompatible selected virtualenv should fail legacy entrypoint import')
+assert site_packages not in sys.path
+assert sys.path == before
+assert 'mnemosyne' not in sys.modules
+assert not any(name.startswith('mnemosyne.') for name in sys.modules)
+"""
+    _run_isolated(tmp_path, code)
+
+
+@pytest.mark.parametrize("entrypoint", ["__init__.py", "cli.py"], ids=["provider", "standalone-cli"])
+def test_legacy_entrypoint_accepts_matching_nearby_version_info(tmp_path, entrypoint):
+    site_packages, target = _copy_legacy_entrypoint(tmp_path, entrypoint)
+    current_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro + 1}"
+    (site_packages.parents[2] / "pyvenv.cfg").write_text(
+        f"version_info = {current_version}\n", encoding="utf-8"
+    )
+
+    _run_isolated(tmp_path, _load_legacy_entrypoint_code(entrypoint, target, site_packages))
+
+
+@pytest.mark.parametrize("entrypoint", ["__init__.py", "cli.py"], ids=["provider", "standalone-cli"])
+def test_legacy_entrypoint_accepts_missing_nearby_pyvenv_cfg(tmp_path, entrypoint):
+    site_packages, target = _copy_legacy_entrypoint(tmp_path, entrypoint)
+    # A config beyond the standard venv ancestors must not turn a no-config
+    # selected environment into a compatibility failure.
+    (site_packages.parents[3] / "pyvenv.cfg").write_text("version = 99.0.0\n", encoding="utf-8")
+
+    _run_isolated(tmp_path, _load_legacy_entrypoint_code(entrypoint, target, site_packages))
+
+
+@pytest.mark.parametrize("entrypoint", ["__init__.py", "cli.py"], ids=["provider", "standalone-cli"])
+def test_legacy_source_checkout_ignores_nearby_mismatched_pyvenv_cfg(tmp_path, entrypoint):
+    source_root, target = _copy_legacy_source_entrypoint(tmp_path, entrypoint)
+    selected_version = f"{sys.version_info.major}.{sys.version_info.minor + 1}"
+    (source_root / "pyvenv.cfg").write_text(
+        f"version = {selected_version}.0\n", encoding="utf-8"
+    )
+
+    _run_isolated(tmp_path, _load_legacy_entrypoint_code(entrypoint, target, source_root))


### PR DESCRIPTION
## Summary

Fixes #625.

- Reject a resolved legacy-provider symlink or persistent wrapper when its selected virtualenv targets a different Python major/minor than the running Hermes process.
- Fail before activating foreign site-packages, so incompatible compiled dependencies cannot silently degrade polyphonic recall.
- Exercise both legacy entrypoints and the generated persistent-wrapper entrypoints; run the wrapper bootstrap coverage in the existing CI test matrix.

## Intent and decision gate

- **Goal:** turn the confirmed silent fallback into a clear runtime load error for the affected venv-backed paths.
- **Non-goals:** no Recall/BEAM ranking change, installer discovery redesign, automatic venv repair, or package-mode migration.
- **Why this boundary:** these are the only paths that activate selected foreign site-packages before Mnemosyne imports.
- **Why not fail on all source checkouts:** a normal source checkout is not a foreign venv site-packages target and must retain existing behavior.
- **Compatibility:** only Python major/minor is compared; patch releases remain compatible. A missing nearby `pyvenv.cfg` preserves the existing fallback.
- **Existing persistent wrappers:** must be force-refreshed or re-registered from a compatible Hermes-Python venv to receive the newly generated bootstrap.

## Verification

- Archive-isolated focused matrix: `23 passed` covering wrapper bootstrap, legacy runtime compatibility, and standalone CLI loading.
- Changed Python files: `py_compile` passed.
- Fatal Ruff selector passed; pre-existing `install.py` diagnostics were baseline-compared.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Architecture and safety

- Adds Python major/minor compatibility checks to Hermes legacy providers and persistent wrappers.
- Rejects incompatible virtual environments before foreign `site-packages` activation.
- Protects BEAM and polyphonic recall from incompatible compiled dependencies.
- Does not change working, episodic, or BEAM memory tiers, retrieval, consolidation, ranking, veracity, or benchmark methodology.

## Agent surfaces

- Covers Hermes providers, generated wrappers, persistent wrappers, and standalone CLI entrypoints.
- Does not change MCP tool contracts or memory operations.
- Adds wrapper bootstrap coverage to CI.

## Privacy and local-first design

- Adds no network calls, telemetry, remote dependencies, or sync changes.
- Preserves local-first execution and the existing privacy posture.
- Does not modify the sync layer or data-handling paths.
- The change strengthens local reliability without eroding local-first design.

## Maintainability

- Applies one runtime policy across supported Hermes entrypoints.
- Reports actionable errors for mismatched or unreadable `pyvenv.cfg` metadata.
- Preserves patch-version compatibility and source-checkout fallback behavior.
- Requires existing persistent wrappers to be force-refreshed or re-registered from a compatible Hermes-Python virtual environment.
- The runtime-side guard is the right call because discovery checks cannot protect symlink-based runtime paths.
- Verification includes focused regression tests, CI coverage, compilation checks, Ruff, and `git diff --check`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->