### PR TITLE
docs(cli): explain rebuild repair exit codes

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -33,7 +33,9 @@ The three flags on `sleep` are parsed but undocumented in the built-in help. `--
 | `verify` | `verify [db_path] [--quick]`. Integrity check |
 | `reindex` | `reindex [--model NAME] [--dry-run] [--yes] [--no-backup]`. Re-embeds everything and rebuilds the sqlite-vec tables |
 
-`reindex` is the recovery path for a vector dimension mismatch. It is synchronous, backs up first unless told otherwise, and prompts unless `--yes`.
+`reindex` is the recovery path for a vector dimension mismatch. It is synchronous, backs up first unless told otherwise, and prompts unless `--yes`. Its `--dry-run` option prints a rebuild plan without writing.
+
+For automation, do not treat a non-zero exit from a non-dry-run `mnemosyne reindex` as success: it means the vector rebuild did not complete. Likewise, non-dry-run `mnemosyne diagnose --repair-vec-working` exits non-zero unless the requested repair reaches `repaired`; its `--dry-run` mode reports what it would repair without writing.
 
 `doctor` and `repair` are the only commands that do not create the data directory as a side effect.
 


### PR DESCRIPTION
Documents the #603 automation contract.

- Non-dry-run `reindex` non-zero means rebuild incomplete.
- Non-dry-run `diagnose --repair-vec-working` succeeds only when repair reaches `repaired`.
- Keeps dry-run wording limited to non-writing behavior.

Docs only; no runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Documents exit-code behavior for non-dry-run `reindex` and `diagnose --repair-vec-working`.
- Clarifies that dry-run commands do not write data.
- Does not change tiered memory, retrieval, consolidation, veracity, sync, privacy, local-first guarantees, or Hermes, MCP, and CLI runtime behavior.
- Improves the CLI contract and long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->