### PR TITLE
docs(hermes): explain direct import dry run

### DIFF
--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -312,6 +312,16 @@ mnemosyne doctor --bank default --format both
 mnemosyne repair --report mnemosyne-doctor.json --select working_memory:<ID> --dry-run
 ```
 
+### Preflight a direct JSON file import
+
+Before importing a JSON file directly through the Hermes provider, run:
+
+```bash
+hermes mnemosyne import --input <backup.json> --dry-run
+```
+
+This dry run validates the file and reports the import counts using a disposable database clone. It writes neither the active database nor provider audit data. Run the same command without `--dry-run` to perform the side-effecting import.
+
 ## Data Location
 
 By default, data is stored under:


### PR DESCRIPTION
Documents the #540 safe direct-file import preflight.

```bash
hermes mnemosyne import --input <backup.json> --dry-run
```

The dry run validates and counts against a disposable database clone, without writing the active database or provider audit data.

Docs only; no runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Documents `hermes mnemosyne import --input <backup.json> --dry-run`.
- The dry run validates and counts imports in a disposable database clone.
- The dry run does not modify the active database or provider audit data.
- The command performs the import only when `--dry-run` is omitted.

## Architectural impact

- Mnemosyne’s working, episodic, and BEAM memory tiers are unchanged.
- Retrieval, consolidation, veracity, sync, and benchmark systems are unchanged.
- The Hermes CLI integration surface gains documented safe preflight behavior.
- MCP and other agent integration surfaces are unchanged.
- The documented workflow strengthens local-first guarantees and privacy by preventing preflight writes to active data and audit records.
- The disposable clone is the right call for safe direct-file import validation.
- The change improves maintainability through explicit operational documentation.
- No runtime behavior or local-first design is eroded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->