### PR TITLE
test(beam): cover successful vector reindex mapping

### DIFF
--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -209,6 +209,96 @@ def test_reindex_real_commits_deferred_working_batches_before_next_embedding(tmp
     assert not beam.conn.in_transaction
 
 
+def test_reindex_success_rebuilds_exact_source_vectors_and_recalls_target(tmp_path, monkeypatch):
+    """A deterministic core rebuild maps every derived vector back to its source row."""
+    import json
+    import numpy as np
+    import mnemosyne.core.beam as beam_module
+
+    beam = BeamMemory(session_id="reindex-success", db_path=str(tmp_path / "memory.db"))
+    conn = beam.conn
+    if not beam_module._vec_available(conn) or not beam_module._wm_vec_available(conn):
+        pytest.skip("sqlite-vec vec_episodes and vec_working tables unavailable in this build")
+    if beam_module._mib is None:
+        pytest.skip("binary episodic vector writer unavailable in this build")
+
+    working_sources = {
+        "wm-orchid": "working source orchid signal",
+        "wm-copper": "working source copper signal",
+    }
+    episodic_sources = {
+        "ep-harbor": "episodic source harbor signal",
+        "ep-forest": "episodic source forest signal",
+    }
+    source_vectors = {}
+    for position, text in enumerate((*working_sources.values(), *episodic_sources.values())):
+        vector = [-1.0] * E.EMBEDDING_DIM
+        vector[position] = 1.0
+        source_vectors[text] = vector
+
+    for memory_id, content in working_sources.items():
+        conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (memory_id, content, "test", "2026-01-01T00:00:00", "reindex-success"),
+        )
+        conn.execute(
+            "INSERT INTO memory_embeddings (memory_id, embedding_json, model) VALUES (?, ?, ?)",
+            (memory_id, "[99.0]", "stale-model"),
+        )
+    for memory_id, content in episodic_sources.items():
+        conn.execute(
+            "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, importance) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (memory_id, content, "test", "2026-01-01T00:00:00", "reindex-success", 0.5),
+        )
+    conn.commit()
+
+    monkeypatch.setattr(E, "available", lambda: True)
+    monkeypatch.setattr(E, "embed", lambda contents: [source_vectors[text] for text in contents])
+    monkeypatch.setattr(E, "embed_query", lambda text: np.asarray(source_vectors[text], dtype=np.float32))
+
+    result = reindex_vectors(conn, batch_size=1)
+
+    assert result["status"] == "reindexed"
+    assert result["working_memory_reindexed"] == len(working_sources)
+    assert result["episodic_memory_reindexed"] == len(episodic_sources)
+
+    embedding_rows = {
+        row["memory_id"]: json.loads(row["embedding_json"])
+        for row in conn.execute(
+            "SELECT memory_id, embedding_json FROM memory_embeddings ORDER BY memory_id"
+        )
+    }
+    assert embedding_rows == {
+        memory_id: source_vectors[content] for memory_id, content in working_sources.items()
+    }
+
+    working_rowids = dict(conn.execute("SELECT id, rowid FROM working_memory"))
+    episodic_rowids = dict(conn.execute("SELECT id, rowid FROM episodic_memory"))
+    assert {row[0] for row in conn.execute("SELECT rowid FROM vec_working")} == set(working_rowids.values())
+    assert {row[0] for row in conn.execute("SELECT rowid FROM vec_episodes")} == set(episodic_rowids.values())
+
+    for memory_id, content in working_sources.items():
+        matches = beam_module._wm_vec_search_sqlite(
+            conn, np.asarray(source_vectors[content], dtype=np.float32), k=1, where_sql="1=1"
+        )
+        assert matches[0]["id"] == memory_id
+    for memory_id, content in episodic_sources.items():
+        matches = beam_module._vec_search(conn, source_vectors[content], k=1)
+        assert matches[0]["rowid"] == episodic_rowids[memory_id]
+
+    binary_rows = dict(conn.execute("SELECT id, binary_vector FROM episodic_memory"))
+    assert binary_rows == {
+        memory_id: beam_module._mib(np.asarray(source_vectors[content]))
+        for memory_id, content in episodic_sources.items()
+    }
+
+    target_id, target_content = next(iter(episodic_sources.items()))
+    recalled = beam.recall(target_content, top_k=5)
+    assert any(row["id"] == target_id for row in recalled)
+
+
 def test_reindex_rebuilds_all_vector_stores_at_active_dim():
     if not E.available():
         import pytest  # type: ignore

--- a/tests/test_reindex_vectors.py
+++ b/tests/test_reindex_vectors.py
@@ -235,6 +235,8 @@ def test_reindex_success_rebuilds_exact_source_vectors_and_recalls_target(tmp_pa
         vector = [-1.0] * E.EMBEDDING_DIM
         vector[position] = 1.0
         source_vectors[text] = vector
+    target_id, target_content = next(iter(episodic_sources.items()))
+    probe = "unrelated recall probe"
 
     for memory_id, content in working_sources.items():
         conn.execute(
@@ -256,7 +258,11 @@ def test_reindex_success_rebuilds_exact_source_vectors_and_recalls_target(tmp_pa
 
     monkeypatch.setattr(E, "available", lambda: True)
     monkeypatch.setattr(E, "embed", lambda contents: [source_vectors[text] for text in contents])
-    monkeypatch.setattr(E, "embed_query", lambda text: np.asarray(source_vectors[text], dtype=np.float32))
+    monkeypatch.setattr(
+        E,
+        "embed_query",
+        lambda text: np.asarray(source_vectors[target_content if text == probe else text], dtype=np.float32),
+    )
 
     result = reindex_vectors(conn, batch_size=1)
 
@@ -294,9 +300,8 @@ def test_reindex_success_rebuilds_exact_source_vectors_and_recalls_target(tmp_pa
         for memory_id, content in episodic_sources.items()
     }
 
-    target_id, target_content = next(iter(episodic_sources.items()))
-    recalled = beam.recall(target_content, top_k=5)
-    assert any(row["id"] == target_id for row in recalled)
+    recalled = beam.recall(probe, top_k=5)
+    assert recalled[0]["id"] == target_id
 
 
 def test_reindex_rebuilds_all_vector_stores_at_active_dim():


### PR DESCRIPTION
## Summary

Adds deterministic core success-path coverage for `reindex_vectors()`. The fake embedder gives each seeded working and episodic source row a distinct predictable vector.

The test verifies the rebuilt `memory_embeddings`, `vec_working`, `vec_episodes`, episodic `binary_vector`, and an episodic recall smoke.

Closes #605.

## Why this boundary

This covers the successful rebuild contract added alongside #603 without changing production behavior.

## Non-goals

No provider/MCP parity, configuration or migration changes, reindex refactor, benchmark, consolidation, or cross-session coverage.

## Verification

- `MNEMOSYNE_NO_EMBEDDINGS=1 pytest -q tests/test_reindex_vectors.py` → `14 passed, 1 skipped`
- `MNEMOSYNE_NO_EMBEDDINGS=1 pytest -q tests/test_reindex_vectors.py tests/test_beam.py tests/test_diagnose_optional_deps.py` → `124 passed, 2 skipped`
- Focused Python 3.13 run of the new test: `1 passed`
- Ruff and `git diff --check` clean

Release note: not required. This is test-only coverage with no user-visible runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds deterministic integration coverage for `reindex_vectors()`.
- Verifies rebuilt working-memory and episodic vectors match the exact source rows.
- Verifies episodic `binary_vector` refresh and successful episodic recall.
- Skips when required local vector backends are unavailable.

## Architectural Impact

- **Tiered memory:** Validates working and episodic memory reindexing. It does not change BEAM behavior.
- **Retrieval:** Adds a recall smoke test for rebuilt episodic vectors.
- **Consolidation, veracity, and sync:** No changes.
- **Hermes, MCP, and CLI:** No integration-surface changes.
- **Privacy and local-first design:** The test uses a fake embedder and existing local backends. It adds no provider calls, configuration, or external data flow.
- **Maintainability:** Establishes a deterministic contract for `reindex_vectors()` and protects vector-table consistency. This is the right call for preventing silent reindex regressions.
- **Benchmark methodology:** No benchmark changes.
- **Production behavior:** No implementation, migration, or configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->