### PR TITLE
test(hermes): cover invalidate audit metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
           "
 
       - name: Run tests
-        run: pytest tests/ integrations/hermes/tests/test_wrapper_bootstrap.py -v --tb=short
+        run: pytest tests/ integrations/hermes/tests/test_wrapper_bootstrap.py integrations/hermes/tests/test_canonical_tools.py -v --tb=short
 
   build:
     runs-on: ubuntu-latest

--- a/integrations/hermes/tests/test_canonical_tools.py
+++ b/integrations/hermes/tests/test_canonical_tools.py
@@ -154,7 +154,16 @@ def test_invalidate_reports_not_found_when_no_row_matched(tmp_path):
         ))
         assert result["status"] == "memory_not_found"
         assert result["memory_id"] == "missing-memory-id"
-        assert audit_events[0][0] == "invalidate"
-        assert audit_events[0][1]["metadata"] == {"invalidated": False}
+        assert audit_events == [
+            (
+                "invalidate",
+                {
+                    "memory_id": "missing-memory-id",
+                    "bank": "private",
+                    "source_tool": "mnemosyne_invalidate",
+                    "metadata": {"invalidated": False},
+                },
+            ),
+        ]
     finally:
         _close(provider)

--- a/integrations/hermes/tests/test_canonical_tools.py
+++ b/integrations/hermes/tests/test_canonical_tools.py
@@ -165,5 +165,6 @@ def test_invalidate_reports_not_found_when_no_row_matched(tmp_path):
                 },
             ),
         ]
+        assert audit_events[0][1]["metadata"]["invalidated"] is False
     finally:
         _close(provider)

--- a/integrations/hermes/tests/test_canonical_tools.py
+++ b/integrations/hermes/tests/test_canonical_tools.py
@@ -144,6 +144,9 @@ def test_active_adapter_exposes_canonical_tool_schemas():
 def test_invalidate_reports_not_found_when_no_row_matched(tmp_path):
     provider = _provider(tmp_path, profile="profile_a")
     try:
+        audit_events = []
+        provider._audit_event = lambda action, **kwargs: audit_events.append((action, kwargs))
+
         assert provider._beam.invalidate("missing-memory-id") is False
         result = json.loads(provider.handle_tool_call(
             "mnemosyne_invalidate",
@@ -151,5 +154,7 @@ def test_invalidate_reports_not_found_when_no_row_matched(tmp_path):
         ))
         assert result["status"] == "memory_not_found"
         assert result["memory_id"] == "missing-memory-id"
+        assert audit_events[0][0] == "invalidate"
+        assert audit_events[0][1]["metadata"] == {"invalidated": False}
     finally:
         _close(provider)


### PR DESCRIPTION
## Summary
- extends the missing-ID Hermes invalidate regression with the exact audit event contract
- runs the focused Hermes canonical-tools test in the standard CI matrix

## Validation
- `pytest integrations/hermes/tests/test_canonical_tools.py::test_invalidate_reports_not_found_when_no_row_matched -q`
- `pytest integrations/hermes/tests/test_wrapper_bootstrap.py integrations/hermes/tests/test_canonical_tools.py -v --tb=short`

Closes #613


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds regression coverage for Hermes `mnemosyne_invalidate` audit metadata when no memory ID matches.
- Verifies the `invalidate` action and `metadata["invalidated"] is False`.
- Adds the Hermes canonical-tools test to the standard CI matrix.

## Architecture and scope

- Makes no production changes.
- Does not change tiered memory, retrieval, consolidation, veracity, or sync behavior.
- Preserves local-first behavior and existing privacy boundaries.
- Strengthens the Hermes agent integration audit contract.
- Does not change MCP, CLI, or other agent integration surfaces.
- Improves maintainability by protecting missing-memory behavior with focused regression coverage.
- Adds no benchmark methodology changes.

## Validation

- Runs the focused Hermes canonical-tools test in CI.
- Retains coverage for Hermes wrapper bootstrap and canonical-tools test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->