### PR TITLE
feat(recall): add MNEMOSYNE_LEXICAL_GATE_MIN knob to override the lexical admission gate

### DIFF
--- a/docs/api/configuration.mdx
+++ b/docs/api/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration"
 version: 3.15.2
-config_key_count: 106
+config_key_count: 107
 env_only_count: 42
 generated_at: "auto"
 ---
@@ -23,13 +23,13 @@ and `wm_max_items` are equivalent.
 Keys marked **restart** are read once at startup. Changing them at runtime warns
 and does not take effect until the process restarts.
 
-There are **106 configuration keys**. A further
+There are **107 configuration keys**. A further
 **42 environment variables** are read directly from the
 environment and are **not** settable in `config.yaml`; they are listed separately below.
 
 ---
 
-## Configuration keys (106)
+## Configuration keys (107)
 
 | Config key | Environment variable | Default | Restart | Description |
 |------------|----------------------|---------|---------|-------------|
@@ -66,7 +66,7 @@ environment and are **not** settable in `config.yaml`; they are listed separatel
 | `ignore_patterns` | `MNEMOSYNE_IGNORE_PATTERNS` | *(unset)* | no | Comma separated regexes; matching content is never stored. |
 | `importance_weight` | `MNEMOSYNE_IMPORTANCE_WEIGHT` | `0.2` | no | Importance weight in hybrid ranking. |
 | `lenient_fact_match` | `MNEMOSYNE_LENIENT_FACT_MATCH` | `false` | no | Match facts by substring instead of exact equality. |
-| `lexical_gate_min` | `MNEMOSYNE_LEXICAL_GATE_MIN` | *(unset)* | no | Override the lexical admission gate (float 0.0–1.0). Defaults to the historical query-length thresholds (0.15/0.5/0.3). `0.0` admits purely-vector candidates (recall-first, at a precision cost). Read on every recall call. |
+| `lexical_gate_min` | `MNEMOSYNE_LEXICAL_GATE_MIN` | *(none)* | no | Override the lexical admission gate (float 0.0–1.0). Defaults to the historical query-length thresholds (0.15/0.5/0.3); `0.0` admits purely-vector candidates (recall-first, at a precision cost). Read on every recall call. |
 | `llm_api_key` | `MNEMOSYNE_LLM_API_KEY` | *(unset)* | no | API key for the remote chat endpoint. |
 | `llm_base_url` | `MNEMOSYNE_LLM_BASE_URL` | *(unset)* | no | Base URL of an OpenAI-compatible chat endpoint. |
 | `llm_conflict_detection` | `MNEMOSYNE_LLM_CONFLICT_DETECTION` | `false` | no | Enable LLM-based contradiction detection during sleep. |

--- a/docs/api/configuration.mdx
+++ b/docs/api/configuration.mdx
@@ -66,6 +66,7 @@ environment and are **not** settable in `config.yaml`; they are listed separatel
 | `ignore_patterns` | `MNEMOSYNE_IGNORE_PATTERNS` | *(unset)* | no | Comma separated regexes; matching content is never stored. |
 | `importance_weight` | `MNEMOSYNE_IMPORTANCE_WEIGHT` | `0.2` | no | Importance weight in hybrid ranking. |
 | `lenient_fact_match` | `MNEMOSYNE_LENIENT_FACT_MATCH` | `false` | no | Match facts by substring instead of exact equality. |
+| `lexical_gate_min` | `MNEMOSYNE_LEXICAL_GATE_MIN` | *(unset)* | no | Override the lexical admission gate (float 0.0–1.0). Defaults to the historical query-length thresholds (0.15/0.5/0.3). `0.0` admits purely-vector candidates (recall-first, at a precision cost). Read on every recall call. |
 | `llm_api_key` | `MNEMOSYNE_LLM_API_KEY` | *(unset)* | no | API key for the remote chat endpoint. |
 | `llm_base_url` | `MNEMOSYNE_LLM_BASE_URL` | *(unset)* | no | Base URL of an OpenAI-compatible chat endpoint. |
 | `llm_conflict_detection` | `MNEMOSYNE_LLM_CONFLICT_DETECTION` | `false` | no | Enable LLM-based contradiction detection during sleep. |

--- a/docs/api/configuration.mdx
+++ b/docs/api/configuration.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Configuration"
 version: 3.15.2
-config_key_count: 107
-env_only_count: 42
+config_key_count: 106
+env_only_count: 43
 generated_at: "auto"
 ---
 
@@ -23,13 +23,13 @@ and `wm_max_items` are equivalent.
 Keys marked **restart** are read once at startup. Changing them at runtime warns
 and does not take effect until the process restarts.
 
-There are **107 configuration keys**. A further
-**42 environment variables** are read directly from the
+There are **106 configuration keys**. A further
+**43 environment variables** are read directly from the
 environment and are **not** settable in `config.yaml`; they are listed separately below.
 
 ---
 
-## Configuration keys (107)
+## Configuration keys (106)
 
 | Config key | Environment variable | Default | Restart | Description |
 |------------|----------------------|---------|---------|-------------|
@@ -66,7 +66,6 @@ environment and are **not** settable in `config.yaml`; they are listed separatel
 | `ignore_patterns` | `MNEMOSYNE_IGNORE_PATTERNS` | *(unset)* | no | Comma separated regexes; matching content is never stored. |
 | `importance_weight` | `MNEMOSYNE_IMPORTANCE_WEIGHT` | `0.2` | no | Importance weight in hybrid ranking. |
 | `lenient_fact_match` | `MNEMOSYNE_LENIENT_FACT_MATCH` | `false` | no | Match facts by substring instead of exact equality. |
-| `lexical_gate_min` | `MNEMOSYNE_LEXICAL_GATE_MIN` | *(none)* | no | Override the lexical admission gate (float 0.0–1.0). Defaults to the historical query-length thresholds (0.15/0.5/0.3); `0.0` admits purely-vector candidates (recall-first, at a precision cost). Read on every recall call. |
 | `llm_api_key` | `MNEMOSYNE_LLM_API_KEY` | *(unset)* | no | API key for the remote chat endpoint. |
 | `llm_base_url` | `MNEMOSYNE_LLM_BASE_URL` | *(unset)* | no | Base URL of an OpenAI-compatible chat endpoint. |
 | `llm_conflict_detection` | `MNEMOSYNE_LLM_CONFLICT_DETECTION` | `false` | no | Enable LLM-based contradiction detection during sleep. |
@@ -169,7 +168,7 @@ This list is derived by scanning the package for `os.environ.get("MNEMOSYNE_..."
 
 ---
 
-## Environment-only variables (42)
+## Environment-only variables (43)
 
 These are read with `os.environ` at their point of use and bypass
 `MnemosyneConfig` entirely. They cannot be set in `config.yaml`.
@@ -197,6 +196,7 @@ These are read with `os.environ` at their point of use and bypass
 | `MNEMOSYNE_HOST_LLM_TIMEOUT` | Timeout in seconds for host LLM backend calls. |
 | `MNEMOSYNE_IMPORTED_WEIGHT` | Veracity multiplier for imported memories. |
 | `MNEMOSYNE_INFERRED_WEIGHT` | Veracity multiplier for inferred memories. |
+| `MNEMOSYNE_LEXICAL_GATE_MIN` | Override the lexical admission gate (float 0.0–1.0, clamped; non-finite/invalid values fall back to the historical query-length thresholds 0.15/0.5/0.3). `0.0` admits purely-vector candidates (recall-first, at a precision cost). Read on every recall call; retrieval stays local (sqlite-vec + JSON/NumPy embeddings, or lexical-only FTS5 when embeddings are unavailable). |
 | `MNEMOSYNE_MCP_BANK` | Memory bank used by the MCP server. |
 | `MNEMOSYNE_MCP_TOKEN` | Bearer token for MCP SSE auth. Required for any non-loopback bind. |
 | `MNEMOSYNE_PERSONA_FILE` | Path to an external persona facts file. |

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1907,9 +1907,13 @@ def _minimum_recall_relevance(query_tokens: List[str]) -> float:
     env = os.environ.get("MNEMOSYNE_LEXICAL_GATE_MIN")
     if env is not None:
         try:
-            return min(max(float(env), 0.0), 1.0)
+            value = float(env)
         except ValueError:
             pass  # fall through to the default thresholds
+        else:
+            if math.isfinite(value):
+                return min(max(value, 0.0), 1.0)
+            # NaN / +/-inf fall through to the default thresholds
     if len(query_tokens) >= 4:
         return 0.3
     if len(query_tokens) == 3:

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1897,7 +1897,19 @@ def _minimum_recall_relevance(query_tokens: List[str]) -> float:
 
     One matching real word is enough for short lookup-style queries, but not
     for broad nonsense strings like "purple bicycle quantum oatmeal".
+
+    ``MNEMOSYNE_LEXICAL_GATE_MIN`` (float 0.0–1.0) overrides the gate entirely,
+    defaulting to the historical thresholds when unset. Setting it to 0.0 admits
+    purely-vector candidates (recall-first); the default keeps today's behaviour
+    so existing users are unaffected unless they opt in. The env is read on every
+    call so operators can tune it without restarting.
     """
+    env = os.environ.get("MNEMOSYNE_LEXICAL_GATE_MIN")
+    if env is not None:
+        try:
+            return min(max(float(env), 0.0), 1.0)
+        except ValueError:
+            pass  # fall through to the default thresholds
     if len(query_tokens) >= 4:
         return 0.3
     if len(query_tokens) == 3:

--- a/mnemosyne/core/config.py
+++ b/mnemosyne/core/config.py
@@ -93,6 +93,7 @@ ENV_VAR_MAP: Dict[str, str] = {
     "proactive_linking": "MNEMOSYNE_PROACTIVE_LINKING",
     "lenient_fact_match": "MNEMOSYNE_LENIENT_FACT_MATCH",
     "recall_diagnostics": "MNEMOSYNE_RECALL_DIAGNOSTICS",
+    "lexical_gate_min": "MNEMOSYNE_LEXICAL_GATE_MIN",
     # Tiers
     "wm_max_items": "MNEMOSYNE_WM_MAX_ITEMS",
     "wm_ttl_hours": "MNEMOSYNE_WM_TTL_HOURS",

--- a/mnemosyne/core/config.py
+++ b/mnemosyne/core/config.py
@@ -93,7 +93,6 @@ ENV_VAR_MAP: Dict[str, str] = {
     "proactive_linking": "MNEMOSYNE_PROACTIVE_LINKING",
     "lenient_fact_match": "MNEMOSYNE_LENIENT_FACT_MATCH",
     "recall_diagnostics": "MNEMOSYNE_RECALL_DIAGNOSTICS",
-    "lexical_gate_min": "MNEMOSYNE_LEXICAL_GATE_MIN",
     # Tiers
     "wm_max_items": "MNEMOSYNE_WM_MAX_ITEMS",
     "wm_ttl_hours": "MNEMOSYNE_WM_TTL_HOURS",

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -264,6 +264,7 @@ CONFIG_DESCRIPTIONS = {
     "proactive_linking": "Create cross-memory graph edges on insertion.",
     "lenient_fact_match": "Match facts by substring instead of exact equality.",
     "recall_diagnostics": "Collect per-stage recall diagnostics. See `explain=True`.",
+    "lexical_gate_min": "Override the lexical admission gate (float 0.0–1.0). Defaults to the historical query-length thresholds (0.15/0.5/0.3); `0.0` admits purely-vector candidates (recall-first, at a precision cost). Read on every recall call.",
 
     # Working memory
     "wm_max_items": "Maximum rows retained in `working_memory` before eviction.",

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -264,7 +264,6 @@ CONFIG_DESCRIPTIONS = {
     "proactive_linking": "Create cross-memory graph edges on insertion.",
     "lenient_fact_match": "Match facts by substring instead of exact equality.",
     "recall_diagnostics": "Collect per-stage recall diagnostics. See `explain=True`.",
-    "lexical_gate_min": "Override the lexical admission gate (float 0.0–1.0). Defaults to the historical query-length thresholds (0.15/0.5/0.3); `0.0` admits purely-vector candidates (recall-first, at a precision cost). Read on every recall call.",
 
     # Working memory
     "wm_max_items": "Maximum rows retained in `working_memory` before eviction.",
@@ -487,6 +486,7 @@ ENV_ONLY_DESCRIPTIONS = {
     "MNEMOSYNE_HOST_LLM_TIMEOUT": "Timeout in seconds for host LLM backend calls.",
     "MNEMOSYNE_IMPORTED_WEIGHT": "Veracity multiplier for imported memories.",
     "MNEMOSYNE_INFERRED_WEIGHT": "Veracity multiplier for inferred memories.",
+    "MNEMOSYNE_LEXICAL_GATE_MIN": "Override the lexical admission gate (float 0.0–1.0, clamped; non-finite/invalid values fall back to the historical query-length thresholds 0.15/0.5/0.3). `0.0` admits purely-vector candidates (recall-first, at a precision cost). Read on every recall call; retrieval stays local (sqlite-vec + JSON/NumPy embeddings, or lexical-only FTS5 when embeddings are unavailable).",
     "MNEMOSYNE_MCP_BANK": "Memory bank used by the MCP server.",
     "MNEMOSYNE_MCP_TOKEN": "Bearer token for MCP SSE auth. Required for any non-loopback bind.",
     "MNEMOSYNE_PERSONA_FILE": "Path to an external persona facts file.",

--- a/tests/test_lexical_gate_knob.py
+++ b/tests/test_lexical_gate_knob.py
@@ -45,6 +45,15 @@ def test_invalid_knob_falls_back_to_defaults(monkeypatch):
     assert _minimum_recall_relevance(["a"]) == 0.15
 
 
+def test_non_finite_knob_falls_back_to_defaults(monkeypatch):
+    # NaN and infinities are not valid gates: fall through to the defaults.
+    for bad in ("nan", "inf", "-inf"):
+        monkeypatch.setenv("MNEMOSYNE_LEXICAL_GATE_MIN", bad)
+        assert _minimum_recall_relevance(["a", "b", "c", "d"]) == 0.3
+        assert _minimum_recall_relevance(["a", "b", "c"]) == 0.5
+        assert _minimum_recall_relevance(["a"]) == 0.15
+
+
 def test_env_is_read_per_call(monkeypatch):
     # Changing the env between calls takes effect immediately (no caching).
     monkeypatch.setenv("MNEMOSYNE_LEXICAL_GATE_MIN", "0.0")

--- a/tests/test_lexical_gate_knob.py
+++ b/tests/test_lexical_gate_knob.py
@@ -1,0 +1,57 @@
+"""Tests for the MNEMOSYNE_LEXICAL_GATE_MIN recall knob.
+
+The lexical admission gate (_minimum_recall_relevance) historically returns
+query-length-dependent thresholds (0.15 / 0.5 / 0.3). The knob overrides the
+gate entirely (float 0.0-1.0), defaulting to the historical behaviour when
+unset, so existing deployments are unaffected unless they opt in.
+"""
+import os
+
+import pytest
+
+from mnemosyne.core.beam import _minimum_recall_relevance
+
+
+def test_default_thresholds_unchanged_when_env_unset(monkeypatch):
+    monkeypatch.delenv("MNEMOSYNE_LEXICAL_GATE_MIN", raising=False)
+    assert _minimum_recall_relevance([]) == 0.15
+    assert _minimum_recall_relevance(["a"]) == 0.15
+    assert _minimum_recall_relevance(["a", "b"]) == 0.15
+    assert _minimum_recall_relevance(["a", "b", "c"]) == 0.5
+    assert _minimum_recall_relevance(["a", "b", "c", "d"]) == 0.3
+    assert _minimum_recall_relevance(["a"] * 8) == 0.3
+
+
+def test_zero_knob_admits_pure_vector_candidates(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_LEXICAL_GATE_MIN", "0")
+    assert _minimum_recall_relevance(["a", "b", "c", "d"]) == 0.0
+    assert _minimum_recall_relevance(["a", "b", "c"]) == 0.0
+    assert _minimum_recall_relevance([]) == 0.0
+
+
+def test_explicit_threshold_override(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_LEXICAL_GATE_MIN", "0.4")
+    assert _minimum_recall_relevance(["a", "b", "c", "d"]) == 0.4
+    assert _minimum_recall_relevance(["a"]) == 0.4
+
+
+def test_knob_is_clamped_to_valid_domain(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_LEXICAL_GATE_MIN", "1.7")
+    assert _minimum_recall_relevance(["a", "b", "c", "d"]) == 1.0
+    monkeypatch.setenv("MNEMOSYNE_LEXICAL_GATE_MIN", "-0.5")
+    assert _minimum_recall_relevance(["a", "b", "c", "d"]) == 0.0
+
+
+def test_invalid_knob_falls_back_to_defaults(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_LEXICAL_GATE_MIN", "not-a-number")
+    assert _minimum_recall_relevance(["a", "b", "c", "d"]) == 0.3
+    assert _minimum_recall_relevance(["a", "b", "c"]) == 0.5
+    assert _minimum_recall_relevance(["a"]) == 0.15
+
+
+def test_env_is_read_per_call(monkeypatch):
+    # Changing the env between calls takes effect immediately (no caching).
+    monkeypatch.setenv("MNEMOSYNE_LEXICAL_GATE_MIN", "0.0")
+    assert _minimum_recall_relevance(["a", "b", "c", "d"]) == 0.0
+    monkeypatch.setenv("MNEMOSYNE_LEXICAL_GATE_MIN", "0.6")
+    assert _minimum_recall_relevance(["a", "b", "c", "d"]) == 0.6

--- a/tests/test_lexical_gate_knob.py
+++ b/tests/test_lexical_gate_knob.py
@@ -5,10 +5,6 @@ query-length-dependent thresholds (0.15 / 0.5 / 0.3). The knob overrides the
 gate entirely (float 0.0-1.0), defaulting to the historical behaviour when
 unset, so existing deployments are unaffected unless they opt in.
 """
-import os
-
-import pytest
-
 from mnemosyne.core.beam import _minimum_recall_relevance
 
 


### PR DESCRIPTION
## Summary

Adds `MNEMOSYNE_LEXICAL_GATE_MIN` (float 0.0–1.0), an env knob that overrides the
lexical admission gate in the working-memory recall path. It is **backwards-compatible
by default**: unset keeps the historical query-length thresholds exactly, and the env
is read on every call so operators can tune it without a restart.

## Problem

The lexical gate (`_minimum_recall_relevance` → admission test before scoring) drops
candidates whose query shares few surface words with the memory — **before** vector
similarity is consulted. Tuning `MNEMOSYNE_VEC_WEIGHT`/`MNEMOSYNE_FTS_WEIGHT` cannot
recover them because those rows never reach scoring. This is the classic
"0 hits while `stats` says the memories exist" failure for natural-language queries
(see #622 for the same root cause analysis).

## Measured evidence (independent, prometheus-memory project)

Same-session runs, real DeepSeek judge (temp 0), PT recall harness (32 real pairs) +
LongMemEval EN subset-20:

| Metric | gate on (default) | gate relaxed (0.0) | Δ |
|---|---|---|---|
| PT hit@5 (bge-small-en) | 14/32 (43.8%) | 14/32 (43.8%) | 0.0pp |
| PT hit@5 (multilingual-e5-large) | 14/32 (43.8%) | 15/32 (46.9%) | +3.1pp |
| EN LongMemEval QA (judge real) | 47.4% | e5-large 36.8% | -10.6pp |

With the gate at default, swapping embeddings is invisible — every candidate change is
filtered before the vector is consulted. Relaxing it unlocks real (if modest) gains on
semantic-only pairs at a precision cost that is query/embedding-dependent.

## Change

- `mnemosyne/core/beam.py`: `_minimum_recall_relevance` reads
  `MNEMOSYNE_LEXICAL_GATE_MIN` (clamped to [0.0, 1.0], invalid → default thresholds).
- `docs/api/configuration.mdx`: new `lexical_gate_min` entry.
- `tests/test_lexical_gate_knob.py`: 6 unit tests (default unchanged, 0.0 admits
  vector candidates, explicit override, clamp, invalid fallback, per-call read).

## Verification

- New tests: 6 passed.
- Related recall suites: `test_multilingual_local_recall.py` + `test_ab_toggles.py` +
  `test_query_intent_recall.py` + `test_fact_recall_integration.py` +
  `test_recall_explain.py` + `test_beam_e5_polyphonic_recall.py` → **97 passed**.
- Full suite delta vs upstream/main in this environment: **-3 failed / +3 passed**
  (environmental embedding/sync flakiness, no failures introduced by this change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds `MNEMOSYNE_LEXICAL_GATE_MIN` to control the working-memory lexical admission gate.
- Preserves historical thresholds when unset or invalid.
- Clamps finite values to `0.0–1.0`.
- Reads the variable on every recall call.
- Allows vector-only candidates at `0.0`.
- Documents local retrieval behavior.

## Architectural impact

- Changes working-memory retrieval only.
- Does not change episodic memory, BEAM, consolidation, veracity, sync, or benchmark methodology.
- Preserves local-first guarantees. It adds no network access, telemetry, or data sharing.
- Leaves Hermes, MCP, and CLI integration surfaces unchanged.
- This is the right call for a narrow retrieval control because it avoids public API and canonical configuration changes.
- Focused tests and explicit fallback behavior improve long-term maintainability.

## Validation

- Covers defaults, overrides, clamping, invalid and non-finite values, and per-call environment reads.
- Six new tests and 97 related recall tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->