### PR TITLE
feat(cli): report core and Hermes versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Added
 
+- **CLI version reporting (#642).** `mnemosyne --version` / `mnemosyne version` and `mnemosyne-hermes --version` / `mnemosyne-hermes version` report installed distribution versions without initializing Mnemosyne data. `hermes mnemosyne version` now reports both core and Hermes-provider versions.
 - **Embedding dimension in doctor diagnostics.** `collect_runtime_diagnostics` (surfaced by `mnemosyne doctor`) now reports the resolved `embeddings_dim` alongside `embeddings_model`, so operators can confirm their `MNEMOSYNE_EMBEDDING_DIM` / model-table resolution without inspecting a traceback. Complements the fail-loud unknown-model resolver (#521); the version bump is deferred to that PR to avoid a duplicate bump.
 
 ### Fixed

--- a/hermes_memory_provider/cli.py
+++ b/hermes_memory_provider/cli.py
@@ -6,6 +6,7 @@ Available via: hermes mnemosyne <subcommand>
 from __future__ import annotations
 
 import json
+import importlib.metadata
 import re
 import sys
 from pathlib import Path
@@ -58,6 +59,14 @@ if _mnemosyne_root.name == "site-packages":
     _guard_selected_site_packages_python_compatibility(_mnemosyne_root)
 if str(_mnemosyne_root) not in sys.path:
     sys.path.insert(0, str(_mnemosyne_root))
+
+
+def _distribution_version(distribution: str) -> str:
+    """Return an installed distribution version without importing package globals."""
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return "unavailable"
 
 
 def register_cli(subparser):
@@ -115,6 +124,11 @@ def mnemosyne_command(args):
         print("Usage: hermes mnemosyne {stats|sleep|version|inspect|clear|export|import}")
         return 1
 
+    if cmd == "version":
+        print(f"Mnemosyne {_distribution_version('mnemosyne-memory')}")
+        print(f"Mnemosyne Hermes {_distribution_version('mnemosyne-hermes')}")
+        return 0
+
     # Register Hermes host LLM backend so sleep uses Hermes' provider.
     # Use a try/except fallback chain: the relative import works when loaded
     # as part of the hermes_memory_provider package; the absolute import is
@@ -145,10 +159,6 @@ def mnemosyne_command(args):
         episodic = beam.get_episodic_stats()
         memoria = beam.get_memoria_stats()
         print(json.dumps({"working": working, "episodic": episodic, "memoria": memoria}, indent=2))
-
-    elif cmd == "version":
-        from mnemosyne import __version__
-        print(f"Mnemosyne v{__version__}")
 
     elif cmd == "sleep":
         dry_run = bool(getattr(args, "dry_run", False))

--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -6,6 +6,7 @@ Available via: hermes mnemosyne <subcommand>
 from __future__ import annotations
 
 import json
+import importlib.metadata
 import os
 from pathlib import Path
 
@@ -13,6 +14,14 @@ _BANK_HELP = (
     "Mnemosyne bank to operate on. Defaults to the active Hermes profile's bank "
     "when profile_isolation is enabled, otherwise the shared default bank."
 )
+
+
+def _distribution_version(distribution: str) -> str:
+    """Return an installed distribution version without importing package globals."""
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return "unavailable"
 
 
 def register_cli(subparser):
@@ -149,6 +158,11 @@ def mnemosyne_command(args):
         print("Usage: hermes mnemosyne {stats|sleep|version|inspect|clear|export|import}")
         return 1
 
+    if cmd == "version":
+        print(f"Mnemosyne {_distribution_version('mnemosyne-memory')}")
+        print(f"Mnemosyne Hermes {_distribution_version('mnemosyne-hermes')}")
+        return 0
+
     # Register Hermes host LLM backend so sleep uses Hermes' provider.
     # Use a try/except fallback chain: the relative import works when loaded
     # as part of the mnemosyne_hermes package; the absolute import is needed
@@ -211,14 +225,6 @@ def mnemosyne_command(args):
         episodic = beam.get_episodic_stats()
         memoria = beam.get_memoria_stats()
         print(json.dumps({"working": working, "episodic": episodic, "memoria": memoria}, indent=2))
-
-    elif cmd == "version":
-        from mnemosyne import __version__
-        try:
-            from mnemosyne import __author__
-            print(f"Mnemosyne {__version__} by {__author__}")
-        except ImportError:
-            print(f"Mnemosyne {__version__}")
 
     elif cmd == "sleep":
         dry_run = bool(getattr(args, "dry_run", False))

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
 import hashlib
 import importlib
 import json
@@ -1260,6 +1261,14 @@ def is_installed(*, hermes_home_path: str | Path | None = None) -> bool:
     return plugin_state(hermes_home_path=hermes_home_path).installed
 
 
+def _distribution_version(distribution: str) -> str:
+    """Return an installed distribution version without importing package globals."""
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return "unavailable"
+
+
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -1270,6 +1279,7 @@ def _parser() -> argparse.ArgumentParser:
         "--hermes-home",
         help="Hermes home directory. Defaults to HERMES_HOME or ~/.hermes.",
     )
+    parser.add_argument("--version", action="store_true", help="Show installed package versions and exit.")
 
     subparsers = parser.add_subparsers(dest="command")
 
@@ -1322,6 +1332,7 @@ def _parser() -> argparse.ArgumentParser:
         "status",
         help="Show whether Mnemosyne is installed for Hermes memory discovery.",
     )
+    subparsers.add_parser("version", help="Show installed package versions.")
     cleanup = subparsers.add_parser(
         "cleanup",
         help="Remove all traces of Mnemosyne from Hermes plugin directory (safe, never touches database).",
@@ -1427,6 +1438,10 @@ def main(argv: list[str] | None = None) -> int:
     """Run the mnemosyne-hermes installer CLI."""
     parser = _parser()
     args = parser.parse_args(argv)
+    if args.version or args.command == "version":
+        print(f"Mnemosyne {_distribution_version('mnemosyne-memory')}")
+        print(f"Mnemosyne Hermes {_distribution_version('mnemosyne-hermes')}")
+        return 0
     command = args.command or "install"
 
     try:

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -9,6 +9,7 @@ All commands use the v2 BEAM architecture (Mnemosyne/BeamMemory).
 import os
 import sys
 import json
+import importlib.metadata
 from pathlib import Path
 from typing import NoReturn
 
@@ -27,6 +28,14 @@ def _default_data_dir() -> str:
 
 
 DATA_DIR = _default_data_dir()
+
+
+def _distribution_version(distribution: str) -> str:
+    """Return an installed distribution version without importing package globals."""
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return "unavailable"
 
 
 def _fail(message: str, exit_code: int = 2) -> NoReturn:
@@ -1673,6 +1682,10 @@ COMMANDS = {
 
 def run_cli():
     """Main CLI entry point."""
+    if len(sys.argv) >= 2 and sys.argv[1] in ("--version", "version"):
+        print(f"Mnemosyne {_distribution_version('mnemosyne-memory')}")
+        return
+
     if len(sys.argv) < 2 or sys.argv[1] in ("--help", "-h", "help"):
         # Keep historical setup behavior for non-doctor CLI entry points while
         # leaving module import and the doctor path free of mkdir side effects.
@@ -1680,6 +1693,7 @@ def run_cli():
         print("Mnemosyne - Local AI Memory System\n")
         print("Usage: mnemosyne <command> [args]\n")
         print("Commands:")
+        print("  version                                Show installed version")
         print("  store <content> [source] [importance]  Store a memory")
         print("  recall <query> [top_k]                 Search memories")
         print("  update <id> <content> [importance]     Update a memory")

--- a/tests/test_cli_host_llm_standalone_loading.py
+++ b/tests/test_cli_host_llm_standalone_loading.py
@@ -81,35 +81,34 @@ def _clear_backend():
 
 
 @pytest.mark.parametrize("cli_path", CLI_COPIES, ids=[str(p.relative_to(REPO_ROOT)) for p in CLI_COPIES])
-def test_register_host_llm_reached_under_standalone_loading(fake_agent_module, cli_path):
-    """Loading cli.py via spec_from_file_location must still reach
-    register_hermes_host_llm() — the fallback import chain must succeed
-    even though the relative import fails.
-    """
+def test_register_host_llm_reached_under_standalone_loading(fake_agent_module, monkeypatch, cli_path):
+    """Standalone non-version commands must still register the host backend."""
     fake_agent_module.call_llm = MagicMock(return_value={"choices": [{"message": {"content": "ok"}}]})
 
     mod_name = f"_test_standalone_{cli_path.stem}_{hash(str(cli_path)) & 0xFFFFFFFF:x}"
     mod = _load_cli_standalone(cli_path, mod_name)
 
-    # Verify mnemosyne_command exists and is callable
     assert hasattr(mod, "mnemosyne_command"), f"{cli_path} does not define mnemosyne_command"
 
-    # Call mnemosyne_command with args that pass the early-return guard
-    # (mnemosyne_cmd must be set) but exercise a lightweight subcommand.
-    # "version" only needs to import mnemosyne.__version__ — no DB access.
-    # The registration happens before subcommand dispatch, so any valid cmd
-    # triggers it. We capture stdout to suppress the version output.
-    import argparse, io, contextlib
-    args = argparse.Namespace(mnemosyne_cmd="version")
-    with contextlib.redirect_stdout(io.StringIO()):
-        mod.mnemosyne_command(args)
+    from mnemosyne.core import beam as beam_module
 
-    # The backend should be registered — if the import fallback failed
-    # silently, this assertion fails.
+    class FakeBeam:
+        def get_working_stats(self):
+            return {}
+
+        def get_episodic_stats(self):
+            return {}
+
+        def get_memoria_stats(self):
+            return {}
+
+    monkeypatch.setattr(beam_module, "BeamMemory", lambda *_args, **_kwargs: FakeBeam())
+
+    import argparse, contextlib, io
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        mod.mnemosyne_command(argparse.Namespace(mnemosyne_cmd="stats"))
+
     backend = get_host_llm_backend()
-    assert backend is not None, (
-        f"register_hermes_host_llm() was not reached when loading {cli_path} "
-        f"via spec_from_file_location — the relative import likely failed "
-        f"silently and the fallback import was not attempted."
-    )
+    assert backend is not None
     assert backend.name == "hermes"

--- a/tests/test_issue_642_cli_versions.py
+++ b/tests/test_issue_642_cli_versions.py
@@ -1,0 +1,210 @@
+"""Regression coverage for issue #642 CLI version reporting."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INTEGRATION_SRC = REPO_ROOT / "integrations" / "hermes" / "src"
+
+
+def _run_core_version(
+    args: list[str], tmp_path: Path, *, assert_no_data_dir: bool = True
+) -> subprocess.CompletedProcess[str]:
+    data_dir = tmp_path / "data"
+    env = os.environ.copy()
+    env["MNEMOSYNE_DATA_DIR"] = str(data_dir)
+    result = subprocess.run(
+        [sys.executable, "-m", "mnemosyne.cli", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    if assert_no_data_dir:
+        assert not data_dir.exists(), "version reporting must not create the Mnemosyne data directory"
+    return result
+
+
+@pytest.mark.parametrize("args", [["--version"], ["version"]])
+def test_core_version_routes_report_distribution_metadata_without_creating_data_dir(tmp_path, args):
+    result = _run_core_version(args, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == f"Mnemosyne {importlib.metadata.version('mnemosyne-memory')}\n"
+    assert result.stderr == ""
+
+
+def test_core_help_advertises_standalone_version_command(tmp_path):
+    result = _run_core_version(["--help"], tmp_path, assert_no_data_dir=False)
+
+    assert result.returncode == 0, result.stderr
+    assert "  version                                Show installed version\n" in result.stdout
+    assert result.stderr == ""
+
+
+def _load_host_provider_cli(monkeypatch):
+    for module_name in tuple(sys.modules):
+        if module_name == "hermes_memory_provider" or module_name.startswith("hermes_memory_provider."):
+            del sys.modules[module_name]
+    from hermes_memory_provider import cli
+
+    return cli
+
+
+def _load_integration_cli(monkeypatch):
+    monkeypatch.syspath_prepend(str(INTEGRATION_SRC))
+    for module_name in tuple(sys.modules):
+        if module_name == "mnemosyne_hermes" or module_name.startswith("mnemosyne_hermes."):
+            del sys.modules[module_name]
+    from mnemosyne_hermes import cli
+
+    return cli
+
+
+def _parse_host_version_args(cli):
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command")
+    mnemosyne = commands.add_parser("mnemosyne")
+    cli.register_cli(mnemosyne)
+    return parser.parse_args(["mnemosyne", "version"])
+
+
+@pytest.mark.parametrize("loader", [_load_host_provider_cli, _load_integration_cli])
+def test_host_cli_version_dispatcher_parity_without_beam_or_optional_metadata(monkeypatch, capsys, loader):
+    """Both host CLI implementations dispatch version before bank/Beam setup."""
+    cli = loader(monkeypatch)
+
+    def fake_version(name: str) -> str:
+        if name == "mnemosyne-memory":
+            return "3.15.1"
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(cli.importlib.metadata, "version", fake_version)
+    from mnemosyne.core import beam as beam_module
+
+    monkeypatch.setattr(
+        beam_module,
+        "BeamMemory",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("version must not construct BeamMemory")),
+    )
+    if hasattr(cli, "_resolve_cli_bank"):
+        monkeypatch.setattr(cli, "_resolve_cli_bank", lambda *_args: None)
+
+    args = _parse_host_version_args(cli)
+    assert args.func(args) == 0
+    assert capsys.readouterr().out == "Mnemosyne 3.15.1\nMnemosyne Hermes unavailable\n"
+
+
+@pytest.mark.parametrize("loader", [_load_host_provider_cli, _load_integration_cli])
+def test_host_cli_version_does_not_register_or_replace_host_backend(monkeypatch, loader):
+    """Version inspection must leave the process-global host LLM registry intact."""
+    cli = loader(monkeypatch)
+    adapter = importlib.import_module(f"{cli.__package__}.hermes_llm_adapter")
+    registrations = []
+    monkeypatch.setattr(adapter, "register_hermes_host_llm", lambda: registrations.append(True))
+
+    from mnemosyne.core.llm_backends import CallableLLMBackend, get_host_llm_backend, set_host_llm_backend
+
+    sentinel = CallableLLMBackend("sentinel", lambda *_args, **_kwargs: None)
+    set_host_llm_backend(sentinel)
+    try:
+        args = _parse_host_version_args(cli)
+        assert args.func(args) == 0
+        assert registrations == []
+        assert get_host_llm_backend() is sentinel
+    finally:
+        set_host_llm_backend(None)
+
+
+def test_packaged_host_cli_version_returns_before_bank_resolution(monkeypatch, capsys):
+    """The packaged host dispatcher must not resolve a bank for ``version``."""
+    cli = _load_integration_cli(monkeypatch)
+
+    def fake_version(name: str) -> str:
+        if name == "mnemosyne-memory":
+            return "3.15.1"
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(cli.importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(
+        cli,
+        "_resolve_cli_bank",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("version must not resolve a bank")),
+    )
+
+    args = _parse_host_version_args(cli)
+    assert args.func(args) == 0
+    assert capsys.readouterr().out == "Mnemosyne 3.15.1\nMnemosyne Hermes unavailable\n"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        REPO_ROOT / "hermes_memory_provider" / "cli.py",
+        INTEGRATION_SRC / "mnemosyne_hermes" / "cli.py",
+    ],
+)
+def test_host_cli_version_paths_do_not_reference_package_version_globals(path):
+    source = path.read_text()
+    assert "__version__" not in source
+    assert "__author__" not in source
+
+
+@pytest.mark.parametrize("argv", [["--version"], ["version"]])
+def test_installer_version_routes_report_both_distributions(monkeypatch, capsys, argv):
+    _load_integration_cli(monkeypatch)
+    from mnemosyne_hermes import install
+
+    def fake_version(name: str) -> str:
+        return {"mnemosyne-memory": "3.15.1", "mnemosyne-hermes": "0.5.0"}[name]
+
+    monkeypatch.setattr(install.importlib.metadata, "version", fake_version)
+
+    assert install.main(argv) == 0
+    assert capsys.readouterr().out == "Mnemosyne 3.15.1\nMnemosyne Hermes 0.5.0\n"
+
+
+def test_hermes_provider_version_reports_both_distributions_without_opening_beam(monkeypatch, capsys):
+    cli = _load_integration_cli(monkeypatch)
+
+    def fake_version(name: str) -> str:
+        return {"mnemosyne-memory": "3.15.1", "mnemosyne-hermes": "0.5.0"}[name]
+
+    monkeypatch.setattr(cli.importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(
+        cli,
+        "_resolve_cli_bank",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("version must not initialize a bank")),
+    )
+
+    assert cli.mnemosyne_command(argparse.Namespace(mnemosyne_cmd="version")) == 0
+    assert capsys.readouterr().out == "Mnemosyne 3.15.1\nMnemosyne Hermes 0.5.0\n"
+
+
+def test_hermes_provider_version_handles_missing_optional_integration_metadata(monkeypatch, capsys):
+    cli = _load_integration_cli(monkeypatch)
+
+    def fake_version(name: str) -> str:
+        if name == "mnemosyne-memory":
+            return "3.15.1"
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(cli.importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(
+        cli,
+        "_resolve_cli_bank",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("version must not initialize a bank")),
+    )
+
+    assert cli.mnemosyne_command(argparse.Namespace(mnemosyne_cmd="version")) == 0
+    assert capsys.readouterr().out == "Mnemosyne 3.15.1\nMnemosyne Hermes unavailable\n"


### PR DESCRIPTION
## Summary
- add supported `version` and `--version` reporting for the core and Hermes integration CLIs
- report installed `mnemosyne-memory` and `mnemosyne-hermes` distribution versions through the Hermes provider CLI
- keep version inspection side-effect free: no data directory, bank, Beam memory, or host-LLM backend registration
- advertise the core version command in `mnemosyne --help`

## Tests
- `immutable-git-test-runner.sh` on `d827aadaeb698d2b9a92405ef1e6af2b3edb4ef1`: 51 passed, Ruff passed, source integrity passed
- focused regressions cover both CLI spellings, both provider mirrors, missing integration metadata, and no-state-side-effect paths

Closes #642


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds `version` and `--version` support to the core, Hermes integration, and installer CLIs.
- Reports installed `mnemosyne-memory` and `mnemosyne-hermes` versions through `importlib.metadata`.
- Handles missing optional Hermes metadata with `unavailable`.
- Keeps version inspection side-effect free. It does not create databases, initialize memory components, or register backends.
- Preserves `mnemosyne-hermes status` compatibility.
- Adds regression coverage for CLI routes, help output, metadata failures, and core-only installations.

## Architecture and local-first impact

- Core memory architecture is unchanged.
- Working, episodic, and BEAM tiers are unchanged.
- Retrieval, consolidation, veracity, synchronization, and benchmark behavior are unchanged.
- The privacy posture is unchanged. Version commands inspect local package metadata only.
- Local-first guarantees are preserved. Version commands do not access databases or remote services.
- Hermes receives clearer integration version reporting through its CLI surfaces.
- MCP behavior and discovery behavior are unchanged.
- The implementation centralizes version lookup around installed distribution metadata. This improves release accuracy and long-term maintainability.
- Using side-effect-free version paths is the right call for diagnostics and automation.
- The changelog also records embedding-dimension reporting in doctor diagnostics.
- No changes erode the local-first design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->