### PR TITLE
fix(hermes-provider): advertise shared_* tools in plugin.yaml manifest

### DIFF
--- a/hermes_memory_provider/plugin.yaml
+++ b/hermes_memory_provider/plugin.yaml
@@ -34,6 +34,10 @@ provides_tools:
   - mnemosyne_persona_list
   - mnemosyne_persona_reinforce
   - mnemosyne_triple_end
+  - mnemosyne_shared_remember
+  - mnemosyne_shared_recall
+  - mnemosyne_shared_forget
+  - mnemosyne_shared_stats
 provides_hooks:
   - pre_llm_call
   - on_session_start


### PR DESCRIPTION
## Summary

`plugin.yaml:provides_tools` listed 31 tools but omitted the four `mnemosyne_shared_*` tools that are defined as schemas in `__init__.py` (lines 622-668) and returned by `get_tool_schemas()`.

While the runtime tool dispatcher (`memory_manager.py:442`) iterates `provider.get_tool_schemas()` and DID expose these tools to the model, this created a silent discrepancy between the code-defined tool surface and the manifest-declared tool surface. Registry consumers that read only `provides_tools` (e.g. `_get_plugin_toolset_key`, `hermes tools` CLI) would not see the shared tools.

## Change

+4 lines to `hermes_memory_provider/plugin.yaml`:

```yaml
  - mnemosyne_shared_remember
  - mnemosyne_shared_recall
  - mnemosyne_shared_forget
  - mnemosyne_shared_stats
```

## Why this is a fix, not just a manifest update

- 4 tools are advertised in the system prompt ("Use mnemosyne_shared_* tools for manual shared surface CRUD") but their toolset key would not resolve from the manifest.
- Other consumers reading only `provides_tools` (e.g. toolset-key lookups, plugin metadata consumers) would not see these tools.
- This is a real silent-failure class: code-defined vs manifest-declared tool drift.

## Surfaced during

Hermes self-audit 2026-08-07 (`~/.hermes/wiki/audits/hermes-self-audit-2026-08-07.md`, with two-opinion NVIDIA NIM cross-model review). The shared_* tools were functional at runtime but their manifest gap is a real consumer-side failure mode.

## Test plan

- No code change — manifest only.
- Re-run `hermes plugins list` on consumer side to confirm shared_* tools appear.
- Verify `_get_plugin_toolset_key` returns the expected toolset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds four existing Mnemosyne shared-memory tools to `hermes_memory_provider/plugin.yaml`.
- Enables Hermes manifest-based discovery, toolset-key lookup, and `hermes tools` CLI visibility.
- Does not change tiered memory, retrieval, consolidation, veracity, sync, privacy, or local-first behavior.
- Does not change MCP integration or benchmark methodology.
- Improves maintainability by keeping the plugin manifest aligned with runtime tool exposure.
- This is the right call for agent integration because it fixes metadata drift without changing core memory behavior or weakening local-first guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->