### PR TITLE
chore(hermes): prepare 0.6.0 standalone release

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,10 +1,11 @@
 #!/bin/bash
-# Mnemosyne pre-push hook — validates tags against __version__ and SemVer rules.
+# Mnemosyne pre-push hook — validates release tags against their package version.
 # Install: git config core.hooksPath .githooks
 
 set -euo pipefail
 
-VERSION_FILE="mnemosyne/__init__.py"
+CORE_VERSION_FILE="mnemosyne/__init__.py"
+HERMES_PROJECT_FILE="integrations/hermes/pyproject.toml"
 
 # Only run during tag pushes
 refs=()
@@ -18,17 +19,104 @@ if [ ${#refs[@]} -eq 0 ]; then
     exit 0
 fi
 
-# Parse version from __init__.py
-if [ ! -f "$VERSION_FILE" ]; then
-    echo "ERROR: $VERSION_FILE not found. Run from repo root."
-    exit 1
-fi
+core_version() {
+    if [ ! -f "$CORE_VERSION_FILE" ]; then
+        echo "ERROR: $CORE_VERSION_FILE not found. Run from repo root."
+        exit 1
+    fi
 
-pkg_version=$(grep -E "^__version__\s*=" "$VERSION_FILE" | sed -E "s/__version__\s*=\s*['\"]([^'\"]+)['\"].*/\1/")
-if [ -z "$pkg_version" ]; then
-    echo "ERROR: Could not extract __version__ from $VERSION_FILE"
-    exit 1
-fi
+    local version
+    version=$(grep -E "^__version__\s*=" "$CORE_VERSION_FILE" | sed -E "s/__version__\s*=\s*['\"]([^'\"]+)['\"].*/\1/")
+    if [ -z "$version" ]; then
+        echo "ERROR: Could not extract __version__ from $CORE_VERSION_FILE"
+        exit 1
+    fi
+    printf '%s\n' "$version"
+}
+
+hermes_version() {
+    if [ ! -f "$HERMES_PROJECT_FILE" ]; then
+        echo "ERROR: $HERMES_PROJECT_FILE not found. Run from repo root."
+        exit 1
+    fi
+
+    python3 - "$HERMES_PROJECT_FILE" <<'PY'
+import re
+import sys
+
+
+path = sys.argv[1]
+section = None
+seen_project = False
+versions = []
+header = re.compile(r"^\[([^]]+)\]\s*(?:#.*)?$")
+assignment = re.compile(r"^version\s*=\s*(.*?)\s*$")
+static_string = re.compile(r"^(?:\"([^\"\n]*)\"|'([^'\n]*)')\s*(?:#.*)?$")
+
+try:
+    with open(path, encoding="utf-8") as project_file:
+        for line_number, raw_line in enumerate(project_file, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            table = header.match(line)
+            if table:
+                section = table.group(1)
+                if section == "project":
+                    seen_project = True
+                continue
+
+            if section != "project":
+                continue
+
+            version_field = assignment.match(line)
+            if not version_field:
+                continue
+
+            value = static_string.match(version_field.group(1))
+            if not value:
+                raise ValueError(
+                    "[project].version on line {} must be a non-empty static string".format(
+                        line_number
+                    )
+                )
+            version = value.group(1) if value.group(1) is not None else value.group(2)
+            if not version:
+                raise ValueError(
+                    "[project].version on line {} must be a non-empty static string".format(
+                        line_number
+                    )
+                )
+            versions.append(version)
+except (OSError, UnicodeError, ValueError) as error:
+    print("ERROR: Could not read [project].version from {}: {}".format(path, error), file=sys.stderr)
+    raise SystemExit(1)
+
+if not seen_project:
+    print(
+        "ERROR: Could not read [project].version from {}: [project] section is missing".format(path),
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+if not versions:
+    print(
+        "ERROR: Could not read [project].version from {}: version field is missing".format(path),
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+if len(versions) > 1:
+    detail = "conflicting" if len(set(versions)) > 1 else "duplicate"
+    print(
+        "ERROR: Could not read [project].version from {}: {} version fields".format(
+            path, detail
+        ),
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+print(versions[0])
+PY
+}
 
 for tag in "${refs[@]}"; do
     # Validate format: vMAJOR.MINOR.PATCH
@@ -39,38 +127,39 @@ for tag in "${refs[@]}"; do
         exit 1
     fi
 
-    # Strip 'v' prefix for comparison
     tag_version="${tag#v}"
+    if [[ "$tag" == v0.* ]]; then
+        version_file="$HERMES_PROJECT_FILE"
+        pkg_version=$(hermes_version)
+        tag_namespace='v0.* standalone'
+        latest_existing=$(git tag --list 'v0.*' --sort=-v:refname 2>/dev/null | head -1 || echo "")
+    else
+        version_file="$CORE_VERSION_FILE"
+        pkg_version=$(core_version)
+        tag_namespace='core (non-v0)'
+        latest_existing=$(git tag --list 'v[1-9]*' --sort=-v:refname 2>/dev/null | head -1 || echo "")
+    fi
 
-    # Must match __version__
     if [ "$tag_version" != "$pkg_version" ]; then
-        echo "ERROR: Tag version '$tag_version' does not match __version__ in $VERSION_FILE"
-        echo "  Tag:         $tag"
-        echo "  __version__: $pkg_version"
+        echo "ERROR: Tag version '$tag_version' does not match the release version in $version_file"
+        echo "  Tag:     $tag"
+        echo "  Version: $pkg_version"
         echo ""
-        echo "  Fix: Update mnemosyne/__init__.py or use the correct tag."
+        echo "  Fix: Update the package version or use the correct tag."
         exit 1
     fi
 
-    # Extract components
-    major=$(echo "$tag_version" | cut -d. -f1)
-    minor=$(echo "$tag_version" | cut -d. -f2)
-    patch=$(echo "$tag_version" | cut -d. -f3)
-
-    # Check that the tag isn't backtracking (new tag must be >= all existing tags)
-    # Uses git tag sorting (version sort, so v3.1.9 < v3.1.10)
-    latest_existing=$(git tag --sort=-v:refname 2>/dev/null | head -1 || echo "")
+    # Compare only releases in the selected package namespace.
     if [ -n "$latest_existing" ]; then
         latest_ver="${latest_existing#v}"
-        # Only compare if the new tag would go backwards
         if [ "$(printf '%s\n' "$tag_version" "$latest_ver" | sort -V | head -1)" = "$tag_version" ] && [ "$tag_version" != "$latest_ver" ]; then
-            echo "ERROR: Tag '$tag_version' is behind existing tag '$latest_ver'"
-            echo "  New tag must be greater than the latest existing tag."
+            echo "ERROR: Tag '$tag_version' is behind existing $tag_namespace tag '$latest_existing'"
+            echo "  New tag must be greater than the latest existing tag in that namespace."
             exit 1
         fi
     fi
 
-    echo "✓ Tag '$tag' matches __version__ ('$pkg_version')"
+    echo "✓ Tag '$tag' matches the release version ('$pkg_version') in $version_file"
 done
 
 exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,26 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Validate standalone tag version
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+
+          tag = os.environ["RELEASE_TAG"]
+          expected = tag.removeprefix("v")
+          with open("pyproject.toml", "rb") as project_file:
+              version = tomllib.load(project_file)["project"]["version"]
+          if version != expected:
+              raise SystemExit(
+                  f"Standalone tag {tag!r} does not match "
+                  f"integrations/hermes/pyproject.toml [project].version {version!r}"
+              )
+          print(f"Validated standalone tag {tag} against package version {version}")
+          PY
+
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,13 @@
 # Releasing Mnemosyne
 
-> **Use `scripts/release.py`.** A release touches three repositories and
-> several places that will not tell you when they are wrong. Doing it by
-> hand is how `__version__` reached 3.15.1 with no tag, `CHANGELOG` grew a
-> dated `[3.15.0]` heading for a version that never shipped, the docs hero
-> read 3.14.0, and the marketing site's release card read 3.15.0. Four
-> surfaces, three answers.
+> **Core `mnemosyne-memory` releases use `scripts/release.py`.** It is not
+> for the standalone `mnemosyne-hermes` distribution, which has its own
+> `0.x` version and release gate below. A core release touches three
+> repositories and several places that will not tell you when they are wrong.
+> Doing it by hand is how `__version__` reached 3.15.1 with no tag,
+> `CHANGELOG` grew a dated `[3.15.0]` heading for a version that never
+> shipped, the docs hero read 3.14.0, and the marketing site's release card
+> read 3.15.0. Four surfaces, three answers.
 >
 > ```bash
 > python3 scripts/release.py check 3.16.0      # what is not ready
@@ -22,6 +24,9 @@
 | | `CHANGELOG.md`, `[Unreleased]` promoted to a dated section | `prepare` |
 | | `hermes_memory_provider/plugin.yaml` `version` | `prepare` |
 | | `docs/api/*.mdx` regenerated so they carry the new version | `prepare` |
+| `mnemosyne` standalone Hermes package | `integrations/hermes/pyproject.toml` `[project].version` | prepared with the packaged manifest |
+| | `integrations/hermes/plugin.yaml` source plugin manifest `version` | must exactly equal the standalone distribution version, runtime version, and packaged `integrations/hermes/src/mnemosyne_hermes/plugin.yaml` |
+| | `integrations/hermes/src/mnemosyne_hermes/plugin.yaml` `version` | must exactly match the standalone distribution |
 | `mnemosyne-docs` | `version.txt`, which drives the landing hero | `prepare` |
 | | `content/api/tool-schema.mdx` | `prepare`, via the docs generator |
 | `mnemosyne-website` | `public/llms.txt` "Latest stable" | `prepare` |
@@ -74,7 +79,31 @@ Mnemosyne follows **strict SemVer** (MAJOR.MINOR.PATCH).
 
 Release on main branch only. No release branches for older minors (yet).
 
-## Release Process
+### Standalone Hermes package releases
+
+`mnemosyne-hermes` is a separate `0.x` distribution. Its release version is
+the static `[project].version` in `integrations/hermes/pyproject.toml`; the
+packaged `src/mnemosyne_hermes/plugin.yaml` must carry exactly the same value.
+`integrations/hermes/plugin.yaml` must exactly equal that standalone
+distribution version, the runtime version, and the packaged manifest version.
+
+The `v0.*` tag path intentionally selects only
+`build-and-release-hermes` in `.github/workflows/release.yml`; the core release
+job explicitly excludes it. Do not change that routing for a routine standalone
+release.
+
+AJ owns release authority for this package. A contributor may prepare and test
+the version bump, but AJ performs the tag, GitHub Release, and PyPI publication.
+Before AJ does so, verify the intended `v<standalone-version>` tag maps to
+the standalone version (for example, `0.6.0` maps to `v0.6.0`). The pre-push
+hook and the standalone workflow job both verify that tag against
+`integrations/hermes/pyproject.toml` `[project].version` before build or
+publication; `v0.*` tags are compared only with prior standalone `v0.*` tags.
+The workflow then builds from `integrations/hermes`. After the workflow
+completes, verify both the GitHub release assets and the `mnemosyne-hermes`
+PyPI project show that exact version.
+
+## Core Release Process
 
 ### 1. Bump the version
 
@@ -112,11 +141,14 @@ The auto-generated notes from `generate_release_notes: true` are a starting poin
 
 ## Git Hook (auto-enforced)
 
-A pre-push hook in <code>.githooks/pre-push</code> validates:
+A pre-push hook in <code>.githooks/pre-push</code> validates each pushed tag:
 
 1. Tag format: `vMAJOR.MINOR.PATCH` (e.g. `v3.1.2`, not `v3.1` or `v3.1.2-beta`)
-2. Tag matches <code>__version__</code> in <code>mnemosyne/__init__.py</code> (without the `v`)
-3. Major bumps cannot skip the minor/patch sequence (no `v3.1.2 → v4.0.0` without a prior 3.x.y release — this prevents accidental jumps)
+2. A `v0.*` standalone tag matches `[project].version` in
+   <code>integrations/hermes/pyproject.toml</code>; other tags match
+   <code>__version__</code> in <code>mnemosyne/__init__.py</code> (without `v`)
+3. Each tag is monotonic only within its own namespace: `v0.*` standalone tags
+   or non-`v0` core tags, respectively
 
 Install with:
 

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-mnemosyne
-version: 0.5.0
+version: 0.6.0
 description: "Native local memory for Hermes - SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, and temporal triples. Zero cloud. Zero latency. Pipx-installable via `pipx install mnemosyne-hermes`."
 author: Abdias J
 pip_dependencies:

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mnemosyne-hermes"
-version = "0.5.0"
+version = "0.6.0"
 description = "Mnemosyne memory provider for Hermes Agent — local-first, zero-cloud memory"
 readme = "README.md"
 license = "MIT"

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -134,7 +134,7 @@ except Exception as _persona_import_exc:  # pragma: no cover - graceful import f
         def _with_persona_block(self, base: str) -> str:
             return base
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/hermes/src/mnemosyne_hermes/plugin.yaml
+++ b/integrations/hermes/src/mnemosyne_hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-mnemosyne
-version: 0.5.0
+version: 0.6.0
 description: "Native local memory for Hermes — SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, temporal triples, and bidirectional sync with optional client-side encryption. Zero cloud. Zero latency."
 author: Abdias J
 provides_tools:

--- a/tests/test_plugin_manifest_versions.py
+++ b/tests/test_plugin_manifest_versions.py
@@ -1,6 +1,12 @@
 """Prevent static Hermes plugin manifests from drifting from their packages."""
 
 import re
+import shutil
+import subprocess
+import sys
+import zipfile
+from email import policy
+from email.parser import BytesParser
 from pathlib import Path
 
 import yaml
@@ -27,6 +33,16 @@ def _manifest_version(path: Path) -> str:
     return version
 
 
+def _project_version(path: Path) -> str:
+    match = re.search(
+        r'^version\s*=\s*["\']([^"\']+)["\']$',
+        path.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    assert match, f"missing static project version in {path}"
+    return match.group(1)
+
+
 def _source_manifest_paths() -> set[Path]:
     generated_roots = {".git", ".venv", "venv", "env", "build", "dist"}
     return {
@@ -37,6 +53,53 @@ def _source_manifest_paths() -> set[Path]:
             for part in path.relative_to(ROOT).parts
         )
     }
+
+
+def _build_standalone_wheel(hermes_root: Path, tmp_path: Path) -> Path:
+    build_root = tmp_path / "hermes"
+    shutil.copytree(
+        hermes_root,
+        build_root,
+        ignore=shutil.ignore_patterns("build", "dist", "*.egg-info", "__pycache__"),
+    )
+    wheel_dir = tmp_path / "wheels"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            "--no-deps",
+            "--wheel-dir",
+            str(wheel_dir),
+            ".",
+        ],
+        cwd=build_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    wheels = list(wheel_dir.glob("*.whl"))
+    assert len(wheels) == 1, f"expected one standalone wheel, found {wheels}"
+    return wheels[0]
+
+
+def _wheel_metadata(archive: zipfile.ZipFile) -> bytes:
+    metadata_paths = [
+        path for path in archive.namelist() if path.endswith(".dist-info/METADATA")
+    ]
+    assert len(metadata_paths) == 1, (
+        f"expected one wheel METADATA file, found {metadata_paths}"
+    )
+    return archive.read(metadata_paths[0])
+
+
+def _manifest_version_from_wheel(archive: zipfile.ZipFile, path: str) -> str:
+    manifest = yaml.safe_load(archive.read(path))
+    assert isinstance(manifest, dict), f"invalid packaged plugin manifest in {path}"
+    version = manifest.get("version")
+    assert isinstance(version, str), f"missing packaged manifest version in {path}"
+    return version
 
 
 def test_all_plugin_manifests_have_an_explicit_version_contract():
@@ -64,9 +127,9 @@ def test_package_metadata_uses_the_same_version_contract():
         re.MULTILINE,
     )
 
-    hermes_project = (
-        ROOT / "integrations" / "hermes" / "pyproject.toml"
-    ).read_text(encoding="utf-8")
+    hermes_project = (ROOT / "integrations" / "hermes" / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
     hermes_version = _assignment_version(
         ROOT / "integrations" / "hermes" / "src" / "mnemosyne_hermes" / "__init__.py"
     )
@@ -75,3 +138,35 @@ def test_package_metadata_uses_the_same_version_contract():
         hermes_project,
         re.MULTILINE,
     )
+
+
+def test_standalone_hermes_release_source_surfaces_are_ready_for_0_6_0():
+    hermes_root = ROOT / "integrations" / "hermes"
+    distribution_version = _project_version(hermes_root / "pyproject.toml")
+    runtime_version = _assignment_version(
+        hermes_root / "src" / "mnemosyne_hermes" / "__init__.py"
+    )
+    source_manifest_version = _manifest_version(hermes_root / "plugin.yaml")
+    packaged_manifest_version = _manifest_version(
+        hermes_root / "src" / "mnemosyne_hermes" / "plugin.yaml"
+    )
+
+    assert distribution_version == "0.6.0"
+    assert runtime_version == distribution_version
+    assert source_manifest_version == distribution_version
+    assert packaged_manifest_version == distribution_version
+
+
+def test_standalone_hermes_release_wheel_is_ready_for_0_6_0(tmp_path):
+    wheel = _build_standalone_wheel(ROOT / "integrations" / "hermes", tmp_path)
+
+    with zipfile.ZipFile(wheel) as archive:
+        metadata = BytesParser(policy=policy.default).parsebytes(
+            _wheel_metadata(archive)
+        )
+        manifest_path = "mnemosyne_hermes/plugin.yaml"
+
+        assert manifest_path in archive.namelist()
+        assert metadata["Name"] == "mnemosyne-hermes"
+        assert metadata["Version"] == "0.6.0"
+        assert _manifest_version_from_wheel(archive, manifest_path) == "0.6.0"

--- a/tests/test_release_gates.py
+++ b/tests/test_release_gates.py
@@ -1,0 +1,155 @@
+"""Regression coverage for standalone and core release tag gates."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / ".githooks" / "pre-push"
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+PYTHON310 = shutil.which("python3.10")
+
+
+def _tag_push(tag: str) -> str:
+    return f"refs/tags/{tag} deadbeef refs/tags/{tag} {'0' * 40}\n"
+
+
+def _run_hook(
+    repo: Path, *tags: str, python310: str | None = None, tmp_path: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = None
+    if python310 is not None:
+        assert tmp_path is not None
+        python_bin = tmp_path / "python-bin"
+        python_bin.mkdir(parents=True)
+        (python_bin / "python3").symlink_to(python310)
+        env = {"HOME": str(tmp_path / "home"), "LC_ALL": "C", "PATH": f"{python_bin}:/usr/bin:/bin"}
+
+    return subprocess.run(
+        ["/usr/bin/bash", ".githooks/pre-push"],
+        cwd=repo,
+        input="".join(_tag_push(tag) for tag in tags),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def _release_repo(
+    tmp_path: Path,
+    standalone_version: str = "0.6.0",
+    *,
+    high_standalone_tag: bool = False,
+    project_toml: str | None = None,
+) -> Path:
+    repo = tmp_path / "release-repo"
+    (repo / ".githooks").mkdir(parents=True)
+    (repo / "mnemosyne").mkdir()
+    (repo / "integrations" / "hermes").mkdir(parents=True)
+    shutil.copy2(HOOK, repo / ".githooks" / "pre-push")
+    (repo / "mnemosyne" / "__init__.py").write_text('__version__ = "3.16.0"\n')
+    (repo / "integrations" / "hermes" / "pyproject.toml").write_text(
+        project_toml
+        or "[project]\nname = \"mnemosyne-hermes\"\n" f"version = \"{standalone_version}\"\n"
+    )
+    commands = [
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "release-gate@example.test"],
+        ["git", "config", "user.name", "Release Gate"],
+        ["git", "add", "."],
+        ["git", "commit", "-qm", "fixture"],
+        ["git", "tag", "v3.15.1"],
+        ["git", "tag", "v0.5.0"],
+    ]
+    if high_standalone_tag:
+        commands.append(["git", "tag", "v0.999.0"])
+    for command in commands:
+        subprocess.run(command, cwd=repo, check=True)
+    return repo
+
+
+def test_standalone_0_6_0_tag_succeeds_against_actual_repo_state():
+    result = _run_hook(ROOT, "v0.6.0")
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "integrations/hermes/pyproject.toml" in result.stdout
+
+
+@pytest.mark.skipif(PYTHON310 is None, reason="python3.10 is unavailable for hook compatibility coverage")
+def test_standalone_0_6_0_tag_succeeds_with_python_3_10(tmp_path):
+    result = _run_hook(ROOT, "v0.6.0", python310=PYTHON310, tmp_path=tmp_path)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "ModuleNotFoundError" not in result.stderr
+
+
+def test_hook_keeps_standalone_and_core_namespaces_independent(tmp_path):
+    repo = _release_repo(tmp_path)
+
+    mixed_result = _run_hook(repo, "v0.6.0", "v3.16.0")
+    assert mixed_result.returncode == 0, mixed_result.stderr + mixed_result.stdout
+    assert "v0.6.0" in mixed_result.stdout
+    assert "v3.16.0" in mixed_result.stdout
+
+    high_standalone_repo = _release_repo(tmp_path / "high", high_standalone_tag=True)
+    core_result = _run_hook(high_standalone_repo, "v3.16.0")
+    assert core_result.returncode == 0, core_result.stderr + core_result.stdout
+
+
+def test_hook_rejects_mismatched_standalone_tag_before_release(tmp_path):
+    repo = _release_repo(tmp_path, standalone_version="0.6.0")
+
+    result = _run_hook(repo, "v0.7.0")
+
+    assert result.returncode != 0
+    assert "does not match the release version" in result.stdout
+    assert "integrations/hermes/pyproject.toml" in result.stdout
+
+
+@pytest.mark.skipif(PYTHON310 is None, reason="python3.10 is unavailable for hook compatibility coverage")
+def test_hook_rejects_mismatched_standalone_tag_with_python_3_10(tmp_path):
+    repo = _release_repo(tmp_path, standalone_version="0.6.0")
+
+    result = _run_hook(repo, "v0.7.0", python310=PYTHON310, tmp_path=tmp_path / "run")
+
+    assert result.returncode != 0
+    assert "does not match the release version" in result.stdout
+    assert "ModuleNotFoundError" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("project_toml", "error"),
+    [
+        ('[build-system]\nrequires = []\n', "[project] section is missing"),
+        ('[project]\nname = "mnemosyne-hermes"\n', "version field is missing"),
+        ('[project]\nversion = 0.6\n', "must be a non-empty static string"),
+        ('[project]\nversion = "0.6.0"\nversion = "0.6.0"\n', "duplicate version fields"),
+        ('[project]\nversion = "0.6.0"\nversion = "0.7.0"\n', "conflicting version fields"),
+    ],
+)
+def test_hook_rejects_invalid_static_project_version(tmp_path, project_toml, error):
+    repo = _release_repo(tmp_path, project_toml=project_toml)
+
+    result = _run_hook(repo, "v0.6.0")
+
+    assert result.returncode != 0
+    assert error in result.stderr
+
+
+def test_standalone_workflow_has_tomllib_tag_version_gate_before_build():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    job = workflow.split("  build-and-release-hermes:", maxsplit=1)[1]
+
+    assert "- name: Validate standalone tag version" in job
+    assert "RELEASE_TAG: ${{ github.ref_name }}" in job
+    assert "import tomllib" in job
+    assert 'tomllib.load(project_file)["project"]["version"]' in job
+    assert 'expected = tag.removeprefix("v")' in job
+    assert "if version != expected:" in job
+    assert job.index("- name: Validate standalone tag version") < job.index("- name: Build package")


### PR DESCRIPTION
## Summary

Prepares the standalone `mnemosyne-hermes` **0.6.0** release after the package remained at 0.5.0 while current provider and wrapper fixes accumulated on `main`.

- aligns the standalone distribution, runtime, source-manifest, and packaged-manifest versions;
- adds version-parity and built-artifact regression coverage;
- makes the pre-push tag gate namespace-aware: `v0.*` validates the standalone package while Core tags retain their Core validation;
- adds a fail-closed standalone tag-to-package-version check before the Hermes release job can build or publish;
- documents the standalone release path separately from Core-only `scripts/release.py`.

## Safety / scope

- No tag, GitHub Release, or PyPI publication is performed by this PR.
- The standalone pre-push path is tested on Python 3.10 and 3.13; the GitHub release job pins Python 3.11 for its `tomllib` check.
- Core versions, CHANGELOG, runtime behavior, migration/legacy integration, and release routing are unchanged.

## Verification

- focused release-gate and manifest tests: 14 passed;
- actual hook success/mismatch, mixed-tag, namespace-isolation, and Python 3.10 coverage;
- standalone wheel metadata and packaged `plugin.yaml` checked at 0.6.0;
- immutable archive verification passed.

## Maintainer handoff

This addresses the release-preparation and guard gaps tracked by #631. The final release act remains AJ-owned: review/merge this PR, then choose the release timing and create/push `v0.6.0`; the workflow will validate the tag before publishing. Please do not close #631 until the GitHub Release and PyPI `mnemosyne-hermes 0.6.0` artifact are verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prepares `mnemosyne-hermes` version `0.6.0`.
- Aligns package, runtime, source-manifest, and packaged-manifest versions.
- Adds version-parity and built-artifact regression tests.
- Adds namespace-aware tag validation for core and Hermes releases.
- Adds fail-closed tag-to-package-version validation to the release workflow.
- Documents the standalone Hermes release process.

## Architecture and integration impact

- Core memory architecture is unchanged.
- Tiered memory, retrieval, consolidation, veracity, synchronization, and benchmark methodology are unchanged.
- Hermes runtime behavior is unchanged.
- MCP and CLI surfaces are unchanged.
- The PR adds release safeguards around the Hermes integration without changing its interface.

## Privacy and local-first impact

- Privacy posture is unchanged.
- Local-first guarantees are preserved.
- The PR adds no telemetry, publication, synchronization, or routing behavior.

## Maintainability

- Version-parity tests reduce drift between Hermes package and plugin manifests.
- Release-gate tests cover malformed versions, mismatched tags, Python 3.10 compatibility, namespace isolation, and workflow validation order.
- Separate release documentation clarifies version surfaces and maintainer-controlled publication.
- Fail-closed validation and independent tag namespaces are the right call for preventing incorrect standalone releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->