### PR TITLE
test(mcp): cover hygiene cleanup with legacy importance

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -822,6 +822,73 @@ class TestToolHandlers:
         assert candidate.suggested_action == "archive"
         assert candidate.content_length == 4
 
+    @pytest.mark.parametrize("importance", [2.0, -0.25])
+    def test_hygiene_audit_candidates_with_out_of_range_importance_clean_from_stored_row(
+        self, tmp_path, monkeypatch, importance
+    ):
+        """MCP audit output can be confirmed for finite legacy importance values.
+
+        Candidate importance is audit metadata: archive must preserve the
+        current stored value, not the stale value supplied by the audit.
+        """
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        stored = handle_tool_call(
+            "mnemosyne_remember",
+            {"content": "heartbeat", "source": "heartbeat", "importance": importance},
+        )
+        assert stored["status"] == "stored"
+        memory_id = stored["memory_id"]
+
+        audited = handle_tool_call(
+            "mnemosyne_hygiene_audit",
+            {"tables": ["working_memory"], "min_score": 0.0},
+        )
+        candidates = audited["report"]["candidates"]
+        assert len(candidates) == 1
+        assert candidates[0]["memory_id"] == memory_id
+        assert candidates[0]["importance"] == importance
+
+        # Simulate a legitimate intervening row update: the audit candidate
+        # remains the exact input to clean, but it must not overwrite storage.
+        mem = _create_instance(bank="default")
+        try:
+            mem.beam.conn.execute(
+                "UPDATE working_memory SET importance = ? WHERE id = ?", (0.75, memory_id)
+            )
+            mem.beam.conn.commit()
+        finally:
+            mem.beam.conn.close()
+
+        cleaned = handle_tool_call(
+            "mnemosyne_hygiene_clean",
+            {
+                "candidates_json": json.dumps(candidates),
+                "action": "archive",
+                "confirm": True,
+            },
+        )
+
+        assert cleaned["status"] == "applied"
+        assert cleaned["result"] == {
+            "deleted": 0,
+            "archived": 1,
+            "kept": 0,
+            "flagged": 0,
+            "errors": [],
+            "log_entries": 1,
+        }
+        mem = _create_instance(bank="default")
+        try:
+            row = mem.beam.conn.execute(
+                "SELECT importance, metadata_json FROM working_memory WHERE id = ?", (memory_id,)
+            ).fetchone()
+            assert row[0] == 0
+            assert json.loads(row[1])["_original_importance"] == 0.75
+        finally:
+            mem.beam.conn.close()
+
     def test_unknown_tool(self):
         """Unknown tool raises ValueError."""
         with pytest.raises(ValueError, match="Unknown tool"):


### PR DESCRIPTION
## Summary
- Adds MCP audit-to-clean coverage for finite legacy `importance` values stored outside `[0, 1]`.
- Uses the published `candidates_json` wire format and proves cleanup rereads the stored row rather than overwriting it from stale audit metadata.
## Why this path

The MCP tools already converge on the same hygiene validator as the CLI. A public MCP regression is the smallest intervention that locks the compatibility contract without changing persisted data semantics.
## Reproduction capsule

1. Store a working-memory row with `importance=2.0`.
2. Audit it via MCP, then update the stored value to `0.75`.
3. Confirm archive using the returned JSON-serialized candidates.
Expected: the row archives successfully and records `_original_importance=0.75`, not stale candidate value `2.0`.
## Non-goals

No schema migration, persisted-domain change, or validator refactor.
## Verification

`MNEMOSYNE_NO_EMBEDDINGS=1 uv run --extra test pytest tests/test_mcp_server.py -k hygiene -v --tb=short`
Result: 23 passed, 44 deselected. Verified from an immutable Git archive of this commit.

Release note: not required. This is regression-test coverage only and has no user-visible runtime change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds MCP regression coverage for cleanup of finite legacy `importance` values outside `[0, 1]`.
- Confirms cleanup rereads the current stored row instead of stale audit metadata.
- Preserves an intervening update: `importance=2.0` or `-0.25` is audited, then changed to `0.75`, and archived with `_original_importance=0.75`.
- Uses the published `candidates_json` format.
- Confirms archive cleanup resets active `importance` to `0` and reports one archived row.

## Architectural impact

- **Core memory architecture:** Test-only change. No changes to working, episodic, or BEAM memory tiers.
- **Retrieval and consolidation:** No changes.
- **Veracity system:** Strengthens MCP regression coverage for hygiene auditing and archive cleaning.
- **Privacy and local-first guarantees:** No impact. The PR adds no data flow, schema, or persistence changes. It does not erode local-first design.
- **Agent integration:** Improves MCP verification only. Hermes and CLI behavior remain unchanged.
- **Sync layer:** No changes.
- **Maintainability:** Protects current memory state from stale audit metadata. This is the right call for data integrity.
- **Domain validation:** No schema, persisted-domain, or validator changes.
- **Benchmark methodology:** No changes.

## Verification

- 23 tests passed.
- 44 tests were deselected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #646