### PR TITLE
fix: recognize bge-m3 embedding alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **`bge-m3` embedding alias resolves its 1024-dimensional vectors (#666).** The unqualified model name now resolves identically to `BAAI/bge-m3`, avoiding an unknown-model startup error when no explicit dimension override is set.
 - **MCP invalidate now reports scope-safe failure (#660).** `mnemosyne_invalidate` returns `memory_not_found` instead of claiming success when its target is outside the current scope or cannot be mutated, preserving scope isolation.
 - **Recall diagnostics were dead under `MNEMOSYNE_POLYPHONIC_RECALL=1`.** The polyphonic branch of `BeamMemory.recall()` returned before the C4 recording block, so every recall that ran through the polyphonic engine (vector/graph/fact/temporal voices) never incremented `mnemosyne_recall_diagnostics` counters — the tool reported `calls: 0` under the flag that production deployments use. The polyphonic branch now records tier hits and call counts itself, mapping engine voices to the existing diagnostic tiers (`vector`→`wm_vec`, `graph`→`em_vec`, `fact`→`em_fts`). Recording is read-only signal and never alters recall behavior. Documented in `docs/benchmarking.md`.
 

--- a/mnemosyne/core/embeddings.py
+++ b/mnemosyne/core/embeddings.py
@@ -168,6 +168,7 @@ def _get_embedding_dim(model_name: str) -> int:
         "sentence-transformers/paraphrase-multilingual-mpnet-base-v2": 768,
         # --- Multilingual BGE ---
         "BAAI/bge-m3": 1024,            # M3: multilingual (100+ langs), 1024-dim
+        "bge-m3": 1024,                 # Common remote/API alias
         "BAAI/bge-multilingual-gemma2": 3584,
         # --- OpenAI ---
         "openai/text-embedding-3-small": 1536,

--- a/tests/test_embeddings_multilingual.py
+++ b/tests/test_embeddings_multilingual.py
@@ -32,7 +32,15 @@ def test_get_embedding_dim_multilingual_models():
     assert embeddings._get_embedding_dim("intfloat/multilingual-e5-small") == 384
     assert embeddings._get_embedding_dim("intfloat/multilingual-e5-base") == 768
     assert embeddings._get_embedding_dim("intfloat/multilingual-e5-large") == 1024
-    assert embeddings._get_embedding_dim("BAAI/bge-m3") == 1024
+
+
+@pytest.mark.parametrize("model", ["BAAI/bge-m3", "bge-m3"])
+def test_get_embedding_dim_bge_m3_aliases(monkeypatch, model):
+    """Both canonical and common bge-m3 names resolve to 1024 dimensions."""
+    monkeypatch.delenv("MNEMOSYNE_EMBEDDING_DIM", raising=False)
+    for key in ("MNEMOSYNE_NO_EMBEDDINGS", "MNEMOSYNE_SKIP_EMBEDDINGS", "MNEMOSYNE_EMBEDDINGS_OFF"):
+        monkeypatch.delenv(key, raising=False)
+    assert embeddings._get_embedding_dim(model) == 1024
 
 
 def test_get_embedding_dim_jina_models():


### PR DESCRIPTION
## Summary
- Adds the common `bge-m3` remote/API alias to the authoritative embedding-dimension table as 1024D.
- Keeps the #521 fail-fast behavior for arbitrary unknown enabled models unchanged.
## Why this path

The alias is a known 1024D model spelling, so a table entry is the narrow compatibility fix. Generic case or tag normalization is deliberately out of scope.
## Verification

`uv run --extra test pytest -q tests/test_embeddings_multilingual.py tests/test_embedding_dim_fresh_process.py`
Result: 29 passed. The same matrix also passed from an immutable Git archive of this commit.
Fixes #666



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds the `bge-m3` alias to the authoritative embedding-dimension table with 1024 dimensions. This prevents the alias from using the 384-dimensional fallback and avoids vector-table dimension mismatches.

## Architecture impact

- **Core memory architecture:** Corrects vector-table creation for `bge-m3`. No changes to working, episodic, or BEAM memory tiers.
- **Retrieval and consolidation:** No changes.
- **Veracity system and sync layer:** No changes.
- **Privacy and local-first guarantees:** Preserves existing behavior. No data-flow, privacy, or remote-service changes.
- **Agent integration:** No changes to Hermes, MCP, or CLI surfaces.
- **Maintainability:** Centralizes the alias in the authoritative dimension table and preserves fail-fast behavior for unknown enabled models. This is the right call.
- **Scope:** Generic case or tag normalization remains out of scope.

## Tests

The embedding test matrix passed with 29 tests. Tests verify both `BAAI/bge-m3` and `bge-m3` resolve to 1024 dimensions, including validation from an immutable Git archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->