### PR TITLE
fix: validate invalidation replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Invalidation replacement links now require an accessible memory (#676).** `mnemosyne_invalidate` rejects an unknown or out-of-scope non-empty `replacement_id` before changing the target, so rejected replacements do not create links at invalidation time.
 - **`bge-m3` embedding alias resolves its 1024-dimensional vectors (#666).** The unqualified model name now resolves identically to `BAAI/bge-m3`, avoiding an unknown-model startup error when no explicit dimension override is set.
 - **MCP invalidate now reports scope-safe failure (#660).** `mnemosyne_invalidate` returns `memory_not_found` instead of claiming success when its target is outside the current scope or cannot be mutated, preserving scope isolation.
 - **Recall diagnostics were dead under `MNEMOSYNE_POLYPHONIC_RECALL=1`.** The polyphonic branch of `BeamMemory.recall()` returned before the C4 recording block, so every recall that ran through the polyphonic engine (vector/graph/fact/temporal voices) never incremented `mnemosyne_recall_diagnostics` counters — the tool reported `calls: 0` under the flag that production deployments use. The polyphonic branch now records tier hits and call counts itself, mapping engine voices to the existing diagnostic tiers (`vector`→`wm_vec`, `graph`→`em_vec`, `fact`→`em_fts`). Recording is read-only signal and never alters recall behavior. Documented in `docs/benchmarking.md`.

--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -132,7 +132,7 @@ Import Mnemosyne memories from a JSON file or another memory provider (Hindsight
 
 ### 11. `mnemosyne_invalidate`
 
-Mark a memory as expired or superseded. Provide memory_id from recall results. Optionally provide replacement_id to chain old to new. An unknown ID or one not mutable in the current scope returns status: memory_not_found.
+Mark a memory as expired or superseded. Provide memory_id from recall results. Optionally provide a replacement_id that must resolve to a working-memory or episodic-memory record that is accessible in the current session or global scope to chain old to new. An unknown or out-of-scope target or replacement returns status: memory_not_found.
 
 | Parameter | Type | Required | Default |
 |-----------|------|----------|---------|

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4216,6 +4216,60 @@ class BeamMemory:
         Otherwise sets valid_until to now (immediate expiry).
         """
         cursor = self.conn.cursor()
+        if replacement_id:
+            if replacement_id == memory_id:
+                return False
+
+            # The replacement lookup and target update are one write
+            # transaction. For a direct call, BEGIN IMMEDIATE obtains
+            # SQLite's write lock before validation, so another connection
+            # cannot delete a replacement between validation and the link
+            # update. A batch may already own a transaction after earlier
+            # DML; do not begin, commit, or roll back that caller-owned
+            # transaction here.
+            owns_transaction = not self.conn.in_transaction
+
+            def validate_and_invalidate() -> bool:
+                replacement_found = False
+                for table in ("working_memory", "episodic_memory"):
+                    cursor.execute(
+                        f"""
+                        SELECT 1 FROM {table}
+                        WHERE id = ? AND (session_id = ? OR scope = 'global')
+                        LIMIT 1
+                        """,
+                        (replacement_id, self.session_id),
+                    )
+                    if cursor.fetchone() is not None:
+                        replacement_found = True
+                        break
+                if not replacement_found:
+                    return False
+
+                now = datetime.now().isoformat()
+                cursor.execute("""
+                    UPDATE working_memory
+                    SET valid_until = ?, superseded_by = ?
+                    WHERE id = ? AND (session_id = ? OR scope = 'global')
+                """, (now, replacement_id, memory_id, self.session_id))
+                if cursor.rowcount == 0:
+                    cursor.execute("""
+                        UPDATE episodic_memory
+                        SET valid_until = ?, superseded_by = ?
+                        WHERE id = ? AND (session_id = ? OR scope = 'global')
+                    """, (now, replacement_id, memory_id, self.session_id))
+                return cursor.rowcount > 0
+
+            if owns_transaction:
+                with _guarded_transaction(self.conn):
+                    cursor.execute("BEGIN IMMEDIATE")
+                    invalidated = validate_and_invalidate()
+            else:
+                invalidated = validate_and_invalidate()
+            if invalidated:
+                self._invalidate_query_cache()
+            return invalidated
+
         now = datetime.now().isoformat()
         # Try working_memory first
         cursor.execute("""

--- a/mnemosyne/tool_schemas.py
+++ b/mnemosyne/tool_schemas.py
@@ -184,8 +184,9 @@ INVALIDATE_SCHEMA = {
     "name": "mnemosyne_invalidate",
     "description": (
         "Mark a memory as expired or superseded. Provide memory_id from recall results. "
-        "Optionally provide replacement_id to chain old to new. An unknown ID or one "
-        "not mutable in the current scope returns status: memory_not_found."
+        "Optionally provide a replacement_id that must resolve to a working-memory or episodic-memory "
+        "record that is accessible in the current session or global scope to chain old to new. "
+        "An unknown or out-of-scope target or replacement returns status: memory_not_found."
     ),
     "parameters": {
         "type": "object",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13,6 +13,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 import mnemosyne.mcp_tools as mcp_tools
+from mnemosyne.core.beam import BeamMemory
 
 # Test tool schemas
 from mnemosyne.mcp_tools import (
@@ -107,8 +108,12 @@ class TestToolSchemas:
     def test_invalidate_schema_documents_scope_safe_failure(self):
         """Invalidate must not reveal whether an out-of-scope ID exists."""
         invalidate_tool = next(t for t in TOOLS if t["name"] == "mnemosyne_invalidate")
-        assert "memory_not_found" in invalidate_tool["description"]
-        assert "not mutable in the current scope" in invalidate_tool["description"]
+        assert invalidate_tool["description"] == (
+            "Mark a memory as expired or superseded. Provide memory_id from recall results. "
+            "Optionally provide a replacement_id that must resolve to a working-memory or episodic-memory "
+            "record that is accessible in the current session or global scope to chain old to new. "
+            "An unknown or out-of-scope target or replacement returns status: memory_not_found."
+        )
 
     def test_batch_schema_has_operations(self):
         batch_tool = next(t for t in TOOLS if t["name"] == "mnemosyne_batch")
@@ -269,6 +274,99 @@ class TestToolHandlers:
         ).fetchall()
         assert len(successful_rows) == 2
         assert all(row[0] for row in successful_rows)
+
+    def test_handle_invalidate_validates_replacement_in_current_scope(self, tmp_path, monkeypatch):
+        """MCP replacement links must be resolvable before invalidating a target."""
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        mcp = _create_instance(bank="default")
+        target_id = mcp.beam.remember("replacement validation target", scope="session")
+        replacement_id = mcp.beam.remember("authorized replacement", scope="session")
+        global_target_id = mcp.beam.remember("global replacement target", scope="global")
+        global_replacement_id = mcp.beam.remember("global replacement", scope="global")
+
+        foreign = _create_instance(session_id="foreign-session", bank="default")
+        foreign_replacement_id = foreign.beam.remember(
+            "foreign replacement", scope="session"
+        )
+
+        wrapper_events = []
+        monkeypatch.setattr(
+            mcp_tools.Mnemosyne,
+            "_emit_wrapper",
+            lambda _self, event_type, memory_id, **kwargs: wrapper_events.append(
+                (event_type, memory_id, kwargs)
+            ),
+        )
+        cache_invalidations = []
+        monkeypatch.setattr(
+            BeamMemory,
+            "_invalidate_query_cache",
+            lambda self: cache_invalidations.append(self),
+        )
+
+        assert handle_tool_call("mnemosyne_invalidate", {
+            "memory_id": target_id,
+            "replacement_id": "unknown-replacement",
+        }) == {"status": "memory_not_found", "memory_id": target_id}
+        target_row = mcp.beam.conn.execute(
+            "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?", (target_id,)
+        ).fetchone()
+        assert tuple(target_row) == (None, None)
+        assert wrapper_events == []
+        assert cache_invalidations == []
+
+        assert handle_tool_call("mnemosyne_invalidate", {
+            "memory_id": target_id,
+            "replacement_id": foreign_replacement_id,
+        }) == {"status": "memory_not_found", "memory_id": target_id}
+        target_row = mcp.beam.conn.execute(
+            "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?", (target_id,)
+        ).fetchone()
+        assert tuple(target_row) == (None, None)
+        assert wrapper_events == []
+        assert cache_invalidations == []
+
+        assert handle_tool_call("mnemosyne_invalidate", {
+            "memory_id": target_id,
+            "replacement_id": target_id,
+        }) == {"status": "memory_not_found", "memory_id": target_id}
+        target_row = mcp.beam.conn.execute(
+            "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?", (target_id,)
+        ).fetchone()
+        assert tuple(target_row) == (None, None)
+        assert wrapper_events == []
+        assert cache_invalidations == []
+
+        assert handle_tool_call("mnemosyne_invalidate", {
+            "memory_id": target_id,
+            "replacement_id": replacement_id,
+        }) == {"status": "invalidated", "memory_id": target_id}
+        target_row = mcp.beam.conn.execute(
+            "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?", (target_id,)
+        ).fetchone()
+        assert target_row[0] is not None
+        assert target_row[1] == replacement_id
+
+        assert handle_tool_call("mnemosyne_invalidate", {
+            "memory_id": global_target_id,
+            "replacement_id": global_replacement_id,
+        }) == {"status": "invalidated", "memory_id": global_target_id}
+        global_target_row = mcp.beam.conn.execute(
+            "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?", (global_target_id,)
+        ).fetchone()
+        assert global_target_row[0] is not None
+        assert global_target_row[1] == global_replacement_id
+        assert len(cache_invalidations) == 2
+        assert wrapper_events == [
+            ("MEMORY_INVALIDATED", target_id, {"replacement_id": replacement_id}),
+            (
+                "MEMORY_INVALIDATED",
+                global_target_id,
+                {"replacement_id": global_replacement_id},
+            ),
+        ]
 
     def test_handle_batch_multiple_remember(self, tmp_path, monkeypatch):
         monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path))

--- a/tests/test_memory_lifecycle.py
+++ b/tests/test_memory_lifecycle.py
@@ -25,3 +25,60 @@ def test_invalidate_emits_wrapper_event_only_after_success(tmp_path, monkeypatch
     assert events == [
         (("MEMORY_INVALIDATED", "present"), {"replacement_id": "replacement"}),
     ]
+
+
+def test_invalidate_accepts_authorized_episodic_replacement(tmp_path):
+    memory = Mnemosyne(session_id="lifecycle", db_path=tmp_path / "memory.db")
+    target_id = memory.beam.remember("working target")
+    replacement_id = memory.beam.consolidate_to_episodic(
+        "episodic replacement", source_wm_ids=[], source="test", importance=1.0
+    )
+
+    assert memory.invalidate(target_id, replacement_id=replacement_id) is True
+    row = memory.beam.conn.execute(
+        "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?", (target_id,)
+    ).fetchone()
+    assert row[0] is not None
+    assert row[1] == replacement_id
+
+
+def test_beam_invalidate_rejects_self_replacement_without_mutation(tmp_path):
+    beam = Mnemosyne(session_id="lifecycle", db_path=tmp_path / "memory.db").beam
+    memory_id = beam.remember("self replacement target")
+
+    assert beam.invalidate(memory_id, replacement_id=memory_id) is False
+    row = beam.conn.execute(
+        "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?", (memory_id,)
+    ).fetchone()
+    assert tuple(row) == (None, None)
+
+
+def test_invalidate_replacement_starts_write_transaction_before_lookup(tmp_path):
+    """Direct replacement invalidation obtains its write lock before lookup."""
+    db_path = tmp_path / "memory.db"
+    beam = Mnemosyne(session_id="lifecycle", db_path=db_path).beam
+    target_id = beam.remember("atomic invalidation target")
+    replacement_id = beam.remember("atomic replacement")
+
+    statements = []
+    beam.conn.set_trace_callback(statements.append)
+    try:
+        assert beam.invalidate(target_id, replacement_id=replacement_id) is True
+    finally:
+        beam.conn.set_trace_callback(None)
+
+    begin_index = next(
+        index
+        for index, statement in enumerate(statements)
+        if statement.lstrip().upper().startswith("BEGIN IMMEDIATE")
+    )
+    replacement_lookup_index = next(
+        index
+        for index, statement in enumerate(statements)
+        if statement.lstrip().upper().startswith("SELECT 1 FROM WORKING_MEMORY")
+    )
+    assert begin_index < replacement_lookup_index
+    target_row = beam.conn.execute(
+        "SELECT superseded_by FROM working_memory WHERE id = ?", (target_id,)
+    ).fetchone()
+    assert target_row[0] == replacement_id

--- a/tests/test_mnemosyne_batch_tool.py
+++ b/tests/test_mnemosyne_batch_tool.py
@@ -78,6 +78,37 @@ def test_batch_update_and_invalidate(tmp_path):
     assert invalidated[0]
 
 
+def test_batch_update_then_invalidate_with_replacement_preserves_outer_transaction(tmp_path):
+    provider = _provider(tmp_path)
+    target_id = provider._beam.remember("batch replacement target", importance=0.3)
+    replacement_id = provider._beam.remember("batch replacement", importance=0.3)
+
+    result = json.loads(provider.handle_tool_call("mnemosyne_batch", {
+        "operations": [
+            {
+                "action": "update",
+                "memory_id": target_id,
+                "content": "batch replacement target updated",
+            },
+            {
+                "action": "invalidate",
+                "memory_id": target_id,
+                "replacement_id": replacement_id,
+            },
+        ],
+    }))
+
+    assert result["status"] == "ok"
+    assert [item["status"] for item in result["results"]] == ["updated", "invalidated"]
+    target = provider._beam.get(target_id)
+    assert target["content"] == "batch replacement target updated"
+    row = provider._beam.conn.execute(
+        "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?", (target_id,)
+    ).fetchone()
+    assert row[0] is not None
+    assert row[1] == replacement_id
+
+
 def test_batch_extract_remember_uses_provider_default_scope(tmp_path):
     provider = _provider(tmp_path)
     provider._default_scope = "session"


### PR DESCRIPTION
## Summary

Fixes #676 by validating a non-empty `replacement_id` before an invalidation mutates its target.

- Requires the replacement to resolve in `working_memory` or `episodic_memory` within the caller's current session or global scope.
- Returns the existing scope-safe `memory_not_found` response for an unknown or out-of-scope target or replacement.
- Leaves the target, query cache, and wrapper-event stream untouched when replacement validation fails.

## Contract and scope

This preserves #675's authorization-safe false-to-`memory_not_found` contract. It deliberately does not add cross-session cleanup, new status types, migration behavior, or Hermes-provider changes.

Why this path: `BeamMemory.invalidate()` owns the durable target mutation and cache invalidation; validating there protects MCP and every core caller consistently. The MCP regression verifies the public response and no-event behavior.

## Verification

- `MNEMOSYNE_NO_EMBEDDINGS=1 pytest tests/test_mcp_server.py tests/test_memory_lifecycle.py tests/test_enhanced_recall_cache.py -q` → 103 passed in an isolated archive with `test,mcp` extras.
- Generated tool-schema check, Python compilation, and `git diff --check` passed.
- Independent final review: PASS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- `BeamMemory.invalidate()` now validates non-empty `replacement_id` values in `working_memory` and `episodic_memory` before mutation.
- Validation accepts only current-session or global memories.
- Invalid or inaccessible targets and replacements return `memory_not_found`.
- Failed validation leaves the target, query cache, and wrapper-event stream unchanged.
- Working-memory invalidation now has regression coverage with authorized episodic replacements.

## Architectural impact

- This is the right call for the tiered memory architecture. Core invalidation now enforces scope and existence rules before changing memory state.
- The change preserves replacement links and expiration metadata for valid invalidations.
- It does not change BEAM behavior, retrieval strategies, consolidation, veracity processing, or the sync layer.
- It does not add cross-session cleanup or migration behavior.

## Privacy and local-first posture

- Scope validation strengthens the privacy boundary between sessions.
- The existing authorization-safe `memory_not_found` response avoids exposing whether inaccessible memories exist.
- The change preserves local-first behavior. It adds no remote dependency, provider behavior, or synchronization requirement.
- No aspect of the PR erodes the local-first design.

## Agent integration surfaces

- MCP behavior now rejects fabricated or out-of-scope replacement IDs before reporting success.
- The shared `BeamMemory` implementation applies the rule to MCP and other core callers.
- Hermes and CLI integrations are unchanged.
- Tool schemas and API documentation now describe the current-scope requirement.

## Maintainability and verification

- Centralizing validation in `BeamMemory.invalidate()` avoids caller-specific behavior.
- Regression tests cover unknown targets, invalid replacements, scope checks, cache and event preservation, valid replacements, and working-memory invalidation.
- Schema checks, compilation, lifecycle tests, MCP tests, and whitespace validation were completed.
- The PR does not change benchmark methodology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->