### PR TITLE
fix(cli): normalize MSYS backup destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Windows Git Bash/MSYS backup destinations no longer silently land on a drive-relative path (#659).** `mnemosyne backup /c/...` now writes to the intended `C:/...` destination. Ambiguous POSIX-rooted destinations are rejected before backup creation instead of reporting success for a different location; native Windows, UNC, and relative paths remain supported.
+
 - **Invalidation replacement links now require an accessible memory (#676).** `mnemosyne_invalidate` rejects an unknown or out-of-scope non-empty `replacement_id` before changing the target, so rejected replacements do not create links at invalidation time.
 - **`bge-m3` embedding alias resolves its 1024-dimensional vectors (#666).** The unqualified model name now resolves identically to `BAAI/bge-m3`, avoiding an unknown-model startup error when no explicit dimension override is set.
 - **MCP invalidate now reports scope-safe failure (#660).** `mnemosyne_invalidate` returns `memory_not_found` instead of claiming success when its target is outside the current scope or cannot be mutated, preserving scope isolation.

--- a/mnemosyne/cli.py
+++ b/mnemosyne/cli.py
@@ -10,7 +10,7 @@ import os
 import sys
 import json
 import importlib.metadata
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import NoReturn
 
 def _default_data_dir() -> str:
@@ -1013,11 +1013,52 @@ def cmd_sync_generate_key(args):
     print("\nStore this key securely. It is the only way to decrypt synced payloads.", file=sys.stderr)
 
 
+def _normalize_backup_output_dir_arg(value: str, *, windows: bool | None = None) -> str:
+    """Normalize an explicit backup directory at the CLI boundary.
+
+    Git Bash/MSYS passes Windows drive paths as ``/c/...``. Passing that raw
+    spelling to ``pathlib.Path`` on Windows creates a drive-relative ``\\c\\...``
+    path, so a successful backup can land somewhere other than the directory the
+    user named. Convert only the unambiguous MSYS drive form. Other POSIX-rooted
+    paths are rejected before the backup backend runs instead of being silently
+    redirected.
+    """
+    if windows is None:
+        windows = os.name == "nt"
+    if not windows or not value.startswith("/"):
+        return value
+
+    unc_parts = value[2:].split("/") if value.startswith("//") else []
+    if (
+        value.startswith("//")
+        and not value.startswith("///")
+        and len(unc_parts) >= 2
+        and unc_parts[0]
+        and unc_parts[1]
+        and PureWindowsPath(value).is_absolute()
+    ):
+        return value
+
+    if (
+        len(value) >= 2
+        and value[1].isascii()
+        and value[1].isalpha()
+        and (len(value) == 2 or value[2] in "/\\")
+    ):
+        remainder = value[2:].replace("\\", "/") if len(value) > 2 else "/"
+        return f"{value[1].upper()}:{remainder}"
+
+    raise ValueError(
+        "On Windows, backup paths beginning with '/' must use an MSYS drive path "
+        "such as /c/backups, or a native absolute path such as C:/backups."
+    )
+
+
 def cmd_backup(args):
     """Create a compressed backup of the database."""
     from mnemosyne.dr.recovery import create_backup
-    output_dir = Path(args[0]) if args else None
     try:
+        output_dir = Path(_normalize_backup_output_dir_arg(args[0])) if args else None
         result = create_backup(backup_dir=output_dir)
         print(f"Backup created: {result['backup_path']}")
         print(f"  Original size: {result['original_size']:,} bytes")

--- a/tests/test_cli_backup_paths.py
+++ b/tests/test_cli_backup_paths.py
@@ -1,0 +1,113 @@
+"""CLI backup-path normalization regressions for Windows/MSYS (#659)."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mnemosyne import cli
+
+
+def test_msys_drive_path_is_normalized_only_on_windows():
+    assert cli._normalize_backup_output_dir_arg("/c/Users/alice/backups", windows=True) == (
+        "C:/Users/alice/backups"
+    )
+    assert cli._normalize_backup_output_dir_arg("/D/archive", windows=True) == "D:/archive"
+    assert cli._normalize_backup_output_dir_arg("/c", windows=True) == "C:/"
+    assert cli._normalize_backup_output_dir_arg(r"/c\Users\alice\backups", windows=True) == (
+        "C:/Users/alice/backups"
+    )
+    assert cli._normalize_backup_output_dir_arg("/c/Users/alice/backups", windows=False) == (
+        "/c/Users/alice/backups"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "C:/Users/alice/backups",
+        r"C:\Users\alice\backups",
+        r"\\server\share\backups",
+        "//server/share/backups",
+        "relative/backups",
+    ],
+)
+def test_native_unc_and_relative_paths_are_preserved(path):
+    assert cli._normalize_backup_output_dir_arg(path, windows=True) == path
+
+
+@pytest.mark.parametrize("path", ["/tmp/backups", "///server/share", "/1/backups", "/é/backups"])
+def test_ambiguous_posix_rooted_path_is_rejected_on_windows(path):
+    with pytest.raises(ValueError, match="MSYS drive path"):
+        cli._normalize_backup_output_dir_arg(path, windows=True)
+
+
+def test_cmd_backup_passes_normalized_msys_path_to_backend(monkeypatch, capsys):
+    captured = {}
+
+    def fake_normalize(value):
+        assert value == "/c/Users/alice/backups"
+        return "C:/Users/alice/backups"
+
+    def fake_backup(*, backup_dir):
+        captured["backup_dir"] = backup_dir
+        return {
+            "backup_path": backup_dir / "mnemosyne_backup.db.gz",
+            "original_size": 10,
+            "backup_size": 5,
+            "db_checksum": "abc123",
+        }
+
+    from mnemosyne.dr import recovery
+
+    monkeypatch.setattr(cli, "_normalize_backup_output_dir_arg", fake_normalize)
+    monkeypatch.setattr(recovery, "create_backup", fake_backup)
+
+    cli.cmd_backup(["/c/Users/alice/backups"])
+
+    assert captured["backup_dir"] == Path("C:/Users/alice/backups")
+    assert "Backup created:" in capsys.readouterr().out
+
+
+def test_production_os_detection_drives_cmd_backup_normalization(monkeypatch, capsys):
+    captured = {}
+
+    def fake_backup(*, backup_dir):
+        captured["backup_dir"] = backup_dir
+        return {
+            "backup_path": backup_dir / "mnemosyne_backup.db.gz",
+            "original_size": 10,
+            "backup_size": 5,
+            "db_checksum": "abc123",
+        }
+
+    from mnemosyne.dr import recovery
+
+    monkeypatch.setattr(cli, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(recovery, "create_backup", fake_backup)
+
+    cli.cmd_backup(["/c/Users/alice/backups"])
+
+    assert captured["backup_dir"] == Path("C:/Users/alice/backups")
+    assert "Backup created:" in capsys.readouterr().out
+
+
+def test_cmd_backup_fails_before_backend_for_rejected_path(monkeypatch, capsys):
+    from mnemosyne.dr import recovery
+
+    def fail_if_called(**_kwargs):
+        raise AssertionError("backend must not run for an invalid output path")
+
+    def reject(_value):
+        raise ValueError("bad path")
+
+    monkeypatch.setattr(cli, "_normalize_backup_output_dir_arg", reject)
+    monkeypatch.setattr(recovery, "create_backup", fail_if_called)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.cmd_backup(["/tmp/backups"])
+
+    assert exc.value.code == 2
+    captured = capsys.readouterr()
+    assert "bad path" in captured.err
+    assert "Backup created:" not in captured.out


### PR DESCRIPTION
## Summary
- normalize Git Bash/MSYS `/c/...` backup destinations to native Windows drive paths before backup creation
- preserve native drive, UNC, and relative paths; reject ambiguous POSIX-rooted Windows inputs before side effects
- add CLI boundary regressions and an Unreleased changelog entry

## Validation
- `uv run --with pytest --with numpy --with sqlite-vec python -m pytest tests/test_cli_backup_paths.py tests/test_recovery_paths.py -q` (18 passed)
- `uv run --with ruff ruff check mnemosyne/cli.py tests/test_cli_backup_paths.py`

Fixes #659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Normalizes Git Bash/MSYS `/c/...` backup paths to native Windows drive paths.
- Preserves native Windows, UNC, and relative paths.
- Rejects ambiguous POSIX-rooted paths before backup creation and backend execution.
- Adds CLI regression tests and an Unreleased changelog entry.

## Architectural impact

- **Core memory architecture:** No changes to working, episodic, or BEAM memory tiers.
- **Retrieval and consolidation:** No changes.
- **Veracity system:** No changes.
- **Sync layer:** No changes.
- **Privacy posture:** Preserves local-only backup behavior. The change does not add telemetry or external data transfer.
- **Local-first guarantees:** Strengthens local-first behavior by ensuring backups reach the requested local destination.
- **Agent integration:** No changes to Hermes, MCP, or other agent surfaces. The CLI boundary now reports failure instead of false success for invalid destinations.
- **Maintainability:** Centralized path validation and focused regression tests improve Windows portability and reduce backup-path ambiguity.

## Architectural assessment

- Normalizing unambiguous `/x/...` paths is the right call for Git Bash/MSYS users.
- Rejecting ambiguous POSIX-rooted paths before side effects prevents silent data misplacement.
- No changes erode the local-first design.
- No benchmark methodology changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->