### PR TITLE
docs: document Hermes integration test setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,18 @@ Mnemosyne is a personal project that grew into something useful. If you're here,
 ```bash
 git clone https://github.com/AxDSan/mnemosyne.git
 cd mnemosyne
+
+# Core tests (matches the CI default and avoids embedding-model downloads)
 pip install -e ".[all,dev]"
-python -m pytest tests/ -v
+MNEMOSYNE_NO_EMBEDDINGS=1 python -m pytest tests/ -v
+
+# Hermes integration tests
+pip install -e "./integrations/hermes[dev]"
+MNEMOSYNE_NO_EMBEDDINGS=1 python -m pytest integrations/hermes/tests/ -v
 ```
+
+The Hermes provider is packaged separately from `mnemosyne-memory`, so its
+editable install is required before running `integrations/hermes/tests/`.
 
 ## What You Can Do
 
@@ -62,7 +71,7 @@ Mnemosyne is intentionally minimal. Every addition is weighed against these prin
 
 1. **Open an issue first** for non-trivial changes. This prevents wasted effort.
 2. **Keep it focused.** One PR per logical change.
-3. **Add tests.** If you fix a bug or add a feature, include a test in `tests/`.
+3. **Add tests.** If you fix a bug or add a feature, include coverage in the appropriate suite: `tests/` for core behavior or `integrations/hermes/tests/` for Hermes-provider behavior.
 4. **Update the README** if user-facing behavior changes.
 5. **Bump the version** in `mnemosyne/__init__.py` and update `CHANGELOG.md`.
 


### PR DESCRIPTION
## Summary
- document the separate editable `mnemosyne-hermes` install required for Hermes integration tests
- align core and Hermes test commands with CI's no-embedding default
- clarify the appropriate test suite for core versus Hermes-provider changes

## Validation
- `MNEMOSYNE_NO_EMBEDDINGS=1 python -m pytest integrations/hermes/tests/ -q` (166 passed)
- `git diff --check`
- independent docs/scope review approved

Fixes #657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Documents the separate editable `mnemosyne-hermes` installation required for Hermes integration tests.
- Updates core and Hermes test commands to use `MNEMOSYNE_NO_EMBEDDINGS=1`.
- Clarifies which test suite applies to core changes and Hermes-provider changes.

## Architecture and Maintainability

- No changes affect tiered memory, retrieval, consolidation, veracity, sync, or benchmark methodology.
- No changes affect privacy posture or local-first guarantees.
- The Hermes integration surface gains clearer local setup instructions.
- The separate editable installation is the right call because `mnemosyne_hermes` is a distinct distribution.
- The documentation improves local regression testing and reduces contributor setup errors.

## Validation

- Hermes tests passed: 166 tests.
- `git diff --check` passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->