### PR TITLE
docs: clarify LLM consolidation configuration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -295,7 +295,7 @@ sleep()
     ├── Chunk by token budget
     ├── Summarize via LLM
     │     ├── Host backend (if MNEMOSYNE_HOST_LLM_ENABLED=true and registered)
-    │     ├── Remote OpenAI-compatible API (if an explicit or provider-preset-resolved base URL is available)
+    │     ├── Remote OpenAI-compatible API (if `MNEMOSYNE_LLM_ENABLED=true`, no host call was attempted, an explicit or provider-preset-resolved base URL is available, and `MNEMOSYNE_FORCE_LOCAL` is not enabled)
     │     ├── Local GGUF (ctransformers / llama-cpp-python)
     │     └── AAAK encoding (keyword-based, no LLM)
     ├── Store summary in episodic_memory with embedding

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 Mnemosyne is a local-first memory system built entirely on SQLite. There is no external database and no required network service: storage, indexing, and retrieval all run in-process against a single file.
 
-Network access is opt-in and never on the retrieval path. Four subsystems can reach out when you configure them: sync (`mnemosyne sync`), remote LLM summarization (`MNEMOSYNE_LLM_BASE_URL`), API-served embeddings (`MNEMOSYNE_EMBEDDING_API_URL`), and LLM conflict detection. With none of them configured, Mnemosyne makes no network calls and needs no API keys.
+SQLite and lexical retrieval do not require network access. Four configured subsystems can reach out: sync (`mnemosyne sync`), remote LLM summarization (`MNEMOSYNE_LLM_BASE_URL` or `MNEMOSYNE_LLM_PROVIDER`), API-served embeddings (`MNEMOSYNE_EMBEDDING_API_URL`, including query-time embedding requests), and LLM conflict detection. In addition, the default-enabled local GGUF fallback can download its approximately 656 MB model from Hugging Face on its first uncached use. Set `MNEMOSYNE_LLM_ENABLED=false` for AAAK-only consolidation, or pre-cache the GGUF model; cached local fallback does not require network access.
 
 ## BEAM: Bilevel Episodic-Associative Memory
 
@@ -295,7 +295,7 @@ sleep()
     ├── Chunk by token budget
     ├── Summarize via LLM
     │     ├── Host backend (if MNEMOSYNE_HOST_LLM_ENABLED=true and registered)
-    │     ├── Remote OpenAI-compatible API (if BASE_URL set)
+    │     ├── Remote OpenAI-compatible API (if an explicit or provider-preset-resolved base URL is available)
     │     ├── Local GGUF (ctransformers / llama-cpp-python)
     │     └── AAAK encoding (keyword-based, no LLM)
     ├── Store summary in episodic_memory with embedding

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -250,7 +250,7 @@ MNEMOSYNE_EMBEDDING_DIM=768
 
 `MNEMOSYNE_LLM_ENABLED=false` disables all LLM-backed consolidation, including Hermes host routing and configured remote endpoints; Mnemosyne then uses its AAAK/no-LLM fallback. The generated [configuration reference](api/configuration.mdx) records the current distinction between this environment gate and the separately declared `config.yaml` key.
 
-When the gate is enabled and neither a usable host backend nor a configured remote endpoint succeeds, Mnemosyne falls back to the local GGUF model. Its default cache location is `~/.hermes/mnemosyne/models`; the first local fallback can download the configured model from Hugging Face.
+When the gate is enabled and neither a usable host backend nor a configured remote endpoint succeeds, Mnemosyne falls back to the local GGUF model. The default `MiniCPM5-1B-Q4_K_M.gguf` model is approximately 656 MB and is cached in `~/.hermes/mnemosyne/models`. `sleep()` is synchronous, so the first uncached local fallback can block while it downloads the model from Hugging Face. To avoid a download, set `MNEMOSYNE_LLM_ENABLED=false` for AAAK-only consolidation or pre-cache the GGUF model; a cached local fallback does not require network access.
 
 ### Remote LLM (OpenAI-compatible)
 
@@ -263,7 +263,7 @@ Use a remote model instead of the local MiniCPM5-1B GGUF:
 | `MNEMOSYNE_LLM_MODEL` | *(none)* | Model identifier sent in requests |
 | `MNEMOSYNE_LLM_TIMEOUT` | `60` | HTTP timeout in seconds for remote LLM calls. Increase for slow proxies or models with long generation times (e.g. `300` for reasoning models routed through local proxies). |
 
-With `MNEMOSYNE_LLM_ENABLED` enabled, Mnemosyne uses the remote endpoint when no host call was attempted, `MNEMOSYNE_LLM_BASE_URL` is set, and `MNEMOSYNE_FORCE_LOCAL` is not enabled. On failure it falls back to the local GGUF backend, then AAAK encoding.
+With `MNEMOSYNE_LLM_ENABLED` enabled, Mnemosyne uses the remote endpoint when no host call was attempted, an explicit or provider-preset-resolved remote base URL is available, and `MNEMOSYNE_FORCE_LOCAL` is not enabled. On failure it falls back to the local GGUF backend, then AAAK encoding.
 
 Works with: llama.cpp server, vLLM, Ollama, LM Studio, or any OpenAI-compatible API.
 
@@ -311,10 +311,10 @@ When the host call fails, the adapter falls back to the local GGUF model rather 
 
 With `MNEMOSYNE_LLM_ENABLED=true`:
 
-```
+```text
 0. Host LLM adapter (if MNEMOSYNE_HOST_LLM_ENABLED=true AND a backend is registered)
    ↓ (on failure: skip remote, go to local)
-1. Remote LLM (if no host call was attempted, MNEMOSYNE_LLM_BASE_URL is set, AND MNEMOSYNE_FORCE_LOCAL is not enabled)
+1. Remote LLM (if no host call was attempted, an explicit or provider-preset-resolved remote base URL is available, AND MNEMOSYNE_FORCE_LOCAL is not enabled)
    ↓ (on failure)
 2. Local LLM (llama-cpp-python / ctransformers + MiniCPM5-1B GGUF)
    ↓ (on failure or not installed)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,13 +240,17 @@ MNEMOSYNE_EMBEDDING_DIM=768
 
 | Variable | Default | Description |
 |---|---|---|
-| `MNEMOSYNE_LLM_ENABLED` | `false` | Enable LLM summarization during sleep cycle |
+| `MNEMOSYNE_LLM_ENABLED` | `true` | Global gate for host, remote, and local LLM-backed consolidation. Resolved from the environment when the local-LLM module is imported; currently not controlled by `config.yaml` `llm_enabled`. |
 | `MNEMOSYNE_LLM_N_CTX` | `2048` | Context window size for the local model |
-| `MNEMOSYNE_LLM_MAX_TOKENS` | `512` | Maximum output tokens per summary |
+| `MNEMOSYNE_LLM_MAX_TOKENS` | `2048` | Maximum output tokens per summary |
 | `MNEMOSYNE_LLM_N_THREADS` | `4` | CPU threads for local inference |
 | `MNEMOSYNE_LLM_REPO` | `openbmb/MiniCPM5-1B-GGUF` | HuggingFace repo for GGUF model |
 | `MNEMOSYNE_LLM_FILE` | `MiniCPM5-1B-Q4_K_M.gguf` | GGUF filename |
 | `MNEMOSYNE_SLEEP_PROMPT` | *(built-in)* | Optional sleep/consolidation prompt override. Supports `{source}`, `{memories}`, and `{memory_count}` placeholders for language-specific summaries. |
+
+`MNEMOSYNE_LLM_ENABLED=false` disables all LLM-backed consolidation, including Hermes host routing and configured remote endpoints; Mnemosyne then uses its AAAK/no-LLM fallback. The generated [configuration reference](api/configuration.mdx) records the current distinction between this environment gate and the separately declared `config.yaml` key.
+
+When the gate is enabled and neither a usable host backend nor a configured remote endpoint succeeds, Mnemosyne falls back to the local GGUF model. Its default cache location is `~/.hermes/mnemosyne/models`; the first local fallback can download the configured model from Hugging Face.
 
 ### Remote LLM (OpenAI-compatible)
 
@@ -259,7 +263,7 @@ Use a remote model instead of the local MiniCPM5-1B GGUF:
 | `MNEMOSYNE_LLM_MODEL` | *(none)* | Model identifier sent in requests |
 | `MNEMOSYNE_LLM_TIMEOUT` | `60` | HTTP timeout in seconds for remote LLM calls. Increase for slow proxies or models with long generation times (e.g. `300` for reasoning models routed through local proxies). |
 
-When `MNEMOSYNE_LLM_BASE_URL` is set, Mnemosyne uses the remote endpoint for consolidation. Falls back to local ctransformers if the remote is unreachable, then to AAAK encoding.
+With `MNEMOSYNE_LLM_ENABLED` enabled, Mnemosyne uses the remote endpoint when no host call was attempted, `MNEMOSYNE_LLM_BASE_URL` is set, and `MNEMOSYNE_FORCE_LOCAL` is not enabled. On failure it falls back to the local GGUF backend, then AAAK encoding.
 
 Works with: llama.cpp server, vLLM, Ollama, LM Studio, or any OpenAI-compatible API.
 
@@ -305,10 +309,12 @@ When the host call fails, the adapter falls back to the local GGUF model rather 
 
 ### Fallback Chain
 
+With `MNEMOSYNE_LLM_ENABLED=true`:
+
 ```
 0. Host LLM adapter (if MNEMOSYNE_HOST_LLM_ENABLED=true AND a backend is registered)
    ↓ (on failure: skip remote, go to local)
-1. Remote LLM (if MNEMOSYNE_LLM_BASE_URL is set AND host is not enabled)
+1. Remote LLM (if no host call was attempted, MNEMOSYNE_LLM_BASE_URL is set, AND MNEMOSYNE_FORCE_LOCAL is not enabled)
    ↓ (on failure)
 2. Local LLM (llama-cpp-python / ctransformers + MiniCPM5-1B GGUF)
    ↓ (on failure or not installed)


### PR DESCRIPTION
## Summary
- correct the effective `MNEMOSYNE_LLM_ENABLED` and local max-token defaults
- document the global host, remote, local, and AAAK fallback contract
- make the current environment-vs-config.yaml distinction explicit

## Validation
- `python3 scripts/generate-docs.py --check`
- `python3 scripts/verify-docs.py`
- `uv run --with pytest python -m pytest tests/test_local_llm.py tests/test_extraction.py -q` (58 passed)
- independent current-diff review approved

Fixes #617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates LLM consolidation documentation.
- Corrects defaults to `MNEMOSYNE_LLM_ENABLED=true` and `MNEMOSYNE_LLM_MAX_TOKENS=2048`.
- Documents the host → remote → local GGUF → AAAK fallback chain.
- Clarifies environment variables versus `config.yaml`.
- Documents first-use model downloads and offline operation options.
- Includes documentation checks and 58 passing local LLM and extraction tests.

## Architectural impact

- Changes no working, episodic, or BEAM memory tiers.
- Changes no retrieval strategy, veracity system, sync layer, benchmark methodology, or CLI/MCP integration surface.
- Changes no consolidation implementation.
- Documents how consolidation stores summaries in episodic memory and removes source rows from working memory.
- Clarifies Hermes host routing and remote provider resolution.
- Improving the documented fallback contract is the right call for long-term maintainability.

## Privacy and local-first impact

- The enabled default can download the approximately 656 MB GGUF model during first-use consolidation.
- Query-time API embeddings, remote LLM summarization, sync, and conflict detection can access the network.
- A cached local GGUF fallback does not require network access.
- Users can pre-cache the model or set `MNEMOSYNE_LLM_ENABLED=false` for AAAK-only, offline consolidation.
- `MNEMOSYNE_LLM_ENABLED=false` disables Hermes host routing and configured remote endpoints.
- Remote use requires the enabled gate, an explicit or provider-resolved endpoint, no attempted host call, and no `MNEMOSYNE_FORCE_LOCAL`.
- The default behavior weakens the zero-configuration local-first guarantee because first-use consolidation may trigger network access and a large model download.
- No implementation change weakens memory architecture or agent integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->