### PR TITLE
fix(hermes): guard register_memory_provider for standalone PluginManager path

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -3299,8 +3299,12 @@ _provider: Optional[Any] = None
 
 def register(ctx):
     """Called by Hermes plugin loader to register CLI commands and tools."""
-    # Register the memory provider first so Hermes discovers it
-    register_memory_provider(ctx)
+    # Register the memory provider first so Hermes discovers it. Only the
+    # memory-provider discovery path (plugins/memory/) provides
+    # register_memory_provider on ctx; the standalone PluginManager path
+    # does not, so guard it.
+    if hasattr(ctx, "register_memory_provider"):
+        register_memory_provider(ctx)
 
     from .cli import register_cli, mnemosyne_command
     ctx.register_cli_command(


### PR DESCRIPTION
## What

The Hermes plugin loader calls `register_memory_provider(ctx)` unconditionally in `register()`. The memory-provider discovery path (`plugins/memory/`) provides that hook on `ctx`, but the standalone `PluginManager` path does not, so plugin load crashes with `AttributeError` when the provider hook is absent.

## Fix

Guard the call with `hasattr(ctx, "register_memory_provider")` before invoking it. No behavior change on the discovery path; the standalone path no longer crashes.

## Test

- Hermes plugin load with the memory-provider discovery path: provider registers as before.
- Standalone PluginManager path: load succeeds, provider hook skipped.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Guards `register_memory_provider(ctx)` with `hasattr`.
- Preserves memory-provider registration for compatible Hermes contexts.
- Allows standalone `PluginManager` loading when the hook is absent.
- Prevents `AttributeError` during plugin loading.

## Architectural impact

- This change affects the Hermes agent integration surface only.
- It does not change tiered memory, retrieval, consolidation, veracity, synchronization, or benchmark behavior.
- It does not change privacy or local-first guarantees.
- It does not change MCP or CLI integration.
- The conditional hook is the right call because it preserves existing provider discovery while supporting contexts with smaller interfaces.
- The change improves maintainability by making plugin loading tolerant of valid context variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->