### PR TITLE
fix(hermes): guard register_memory_provider for standalone PluginManager path

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -3299,8 +3299,12 @@ _provider: Optional[Any] = None
 
 def register(ctx):
     """Called by Hermes plugin loader to register CLI commands and tools."""
-    # Register the memory provider first so Hermes discovers it
-    register_memory_provider(ctx)
+    # Register the memory provider first so Hermes discovers it. Only the
+    # memory-provider discovery path (plugins/memory/) provides
+    # register_memory_provider on ctx; the standalone PluginManager path
+    # does not, so guard it.
+    if hasattr(ctx, "register_memory_provider"):
+        register_memory_provider(ctx)
 
     from .cli import register_cli, mnemosyne_command
     ctx.register_cli_command(


### PR DESCRIPTION
## What

The Hermes plugin loader calls `register_memory_provider(ctx)` unconditionally in `register()`. The memory-provider discovery path (`plugins/memory/`) provides that hook on `ctx`, but the standalone `PluginManager` path does not, so plugin load crashes with `AttributeError` when the provider hook is absent.

## Fix

Guard the call with `hasattr(ctx, "register_memory_provider")` before invoking it. No behavior change on the discovery path; the standalone path no longer crashes.

## Test

- Hermes plugin load with the memory-provider discovery path: provider registers as before.
- Standalone PluginManager path: load succeeds, provider hook skipped.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Guards `register_memory_provider(ctx)` with `hasattr(ctx, "register_memory_provider")`.
- Preserves memory-provider registration for Hermes discovery contexts.
- Prevents `AttributeError` when standalone `PluginManager` contexts load plugins.

## Architectural impact

- The change does not alter tiered memory, retrieval, consolidation, veracity, or sync behavior.
- The change does not modify privacy posture or local-first guarantees.
- Hermes plugin loading becomes compatible with both supported context types.
- MCP and CLI integration surfaces remain unchanged.
- No benchmark methodology changes.
- The conditional hook improves long-term maintainability by respecting the differing capabilities of plugin contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->