### PR TITLE
docs: add embedding model reindex runbook

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -204,9 +204,9 @@ MNEMOSYNE_EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L
 MNEMOSYNE_EMBEDDING_MODEL=intfloat/multilingual-e5-base
 ```
 
-The embedding dimension resolves in this order: an explicit `MNEMOSYNE_EMBEDDING_DIM` (positive integer) takes precedence for every model; otherwise the built-in table below provides known dimensions; an unknown model with no explicit dimension **fails loudly at startup** rather than silently assuming 384. Blank/whitespace-only `MNEMOSYNE_EMBEDDING_DIM` is treated as unset (common in Docker Compose and `.env` files).
+The embedding dimension resolves in this order: a non-empty explicit `MNEMOSYNE_EMBEDDING_DIM` (positive integer) takes precedence for every model; otherwise Mnemosyne uses its built-in mappings, including the examples below; an unknown model with no explicit dimension **fails loudly at startup** rather than silently assuming 384. Blank/whitespace-only `MNEMOSYNE_EMBEDDING_DIM` is treated as unset (common in Docker Compose and `.env` files).
 
-Supported models with known dimensions:
+Examples of models with built-in dimension mappings (not an exhaustive model catalog):
 
 | Model | Dims | Language |
 |---|---|---|
@@ -226,13 +226,36 @@ Supported models with known dimensions:
 | `openai/text-embedding-3-small` | 1,536 | API |
 | `openai/text-embedding-3-large` | 3,072 | API |
 
-For models not in the table (e.g. `mxbai-embed-large` via a custom endpoint), set the dimension explicitly:
+For an unknown or custom model (for example, `mxbai-embed-large` via a custom endpoint), set a non-empty explicit dimension only when you know its actual output dimension:
 
 ```bash
-MNEMOSYNE_EMBEDDING_DIM=768
+MNEMOSYNE_EMBEDDING_DIM=<actual-output-dimension>
 ```
 
-> **Warning:** Changing the embedding model after data has been stored will cause a dimension mismatch. The vec0 virtual table is locked to the dimension it was created with. **Stores created under the old silent-384 fallback**: setting the model's true dimension can trigger the existing dimension-mismatch guard, so operators may need the documented reindex/recovery path rather than treating the override as a one-step fix.
+> **Warning:** Changing the embedding model after data has been stored requires a reindex, even when the old and new models have the same dimension: their embedding spaces are incompatible. When dimensions differ, the vec0 virtual table is also locked to the dimension it was created with. **Stores created under the old silent-384 fallback**: setting the model's true dimension can trigger the existing dimension-mismatch guard, so use the reindex path below rather than treating the override as a one-step fix.
+
+#### Changing an embedding model safely
+
+1. Persist `MNEMOSYNE_EMBEDDING_MODEL` with the target model in the deployment configuration, so it survives restarts. If `MNEMOSYNE_EMBEDDING_DIM` is non-empty, persist the intended explicit dimension there too; for an unknown or custom model, use it only when you know the model's actual output dimension.
+2. Stop the provider or gateway before reindexing to avoid concurrent writers.
+3. Before invoking any reindex command, run the CLI from the same persisted deployment environment/configuration that the provider or gateway will use after restart—or load/export that exact configuration into the admin shell. Confirm both the target model and any explicit `MNEMOSYNE_EMBEDDING_DIM` are the post-restart values.
+4. Inspect the non-mutating rebuild plan:
+
+   ```bash
+   mnemosyne reindex --model <target-model> --dry-run
+   ```
+
+   It **must** report the intended model and intended dimension. Do **not** run `--yes` if either differs from the post-restart configuration.
+5. Run the rebuild only after that check passes:
+
+   ```bash
+   mnemosyne reindex --model <target-model> --yes
+   ```
+
+   The CLI creates a backup by default, re-embeds working and episodic memory, and rebuilds sqlite-vec tables at the dimension selected by that effective configuration. `--model` affects only that invocation; it does not override an explicit `MNEMOSYNE_EMBEDDING_DIM`. Therefore, the target sqlite-vec dimension is not determined by the `--model` name alone.
+6. Restart the provider or gateway and smoke-test recall.
+
+See [Health and repair](cli-reference.md#health-and-repair) for the `reindex` command and flag reference.
 
 ## LLM Consolidation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,7 +253,7 @@ MNEMOSYNE_EMBEDDING_DIM=<actual-output-dimension>
    ```
 
    The CLI creates a backup by default, re-embeds working and episodic memory, and, when sqlite-vec is available, rebuilds its tables at the dimension selected by that effective configuration. `--model` affects only that invocation; it does not override an explicit `MNEMOSYNE_EMBEDDING_DIM`. Therefore, the target sqlite-vec dimension is not determined by the `--model` name alone.
-6. Restart the provider or gateway and verify recall for both working and episodic memory through the deployment's configured retrieval path.
+6. Restart the provider or gateway and verify recall for both working and episodic memory through the deployment's configured retrieval path. When sqlite-vec is available, also verify vector-backed recall for both tiers.
 
 See [Health and repair](cli-reference.md#health-and-repair) for the `reindex` command and flag reference.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,7 +237,7 @@ MNEMOSYNE_EMBEDDING_DIM=<actual-output-dimension>
 #### Changing an embedding model safely
 
 1. Persist `MNEMOSYNE_EMBEDDING_MODEL` with the target model in the deployment configuration, so it survives restarts. If `MNEMOSYNE_EMBEDDING_DIM` is non-empty, persist the intended explicit dimension there too; for an unknown or custom model, use it only when you know the model's actual output dimension.
-2. Stop the provider or gateway before reindexing to avoid concurrent writers.
+2. Stop the provider or gateway and every other process that can write to the same local SQLite database before reindexing.
 3. Before invoking any reindex command, run the CLI from the same persisted deployment environment/configuration that the provider or gateway will use after restart—or load/export that exact configuration into the admin shell. Confirm both the target model and any explicit `MNEMOSYNE_EMBEDDING_DIM` are the post-restart values.
 4. Inspect the non-mutating rebuild plan:
 
@@ -252,8 +252,8 @@ MNEMOSYNE_EMBEDDING_DIM=<actual-output-dimension>
    mnemosyne reindex --model <target-model> --yes
    ```
 
-   The CLI creates a backup by default, re-embeds working and episodic memory, and rebuilds sqlite-vec tables at the dimension selected by that effective configuration. `--model` affects only that invocation; it does not override an explicit `MNEMOSYNE_EMBEDDING_DIM`. Therefore, the target sqlite-vec dimension is not determined by the `--model` name alone.
-6. Restart the provider or gateway and smoke-test recall.
+   The CLI creates a backup by default, re-embeds working and episodic memory, and, when sqlite-vec is available, rebuilds its tables at the dimension selected by that effective configuration. `--model` affects only that invocation; it does not override an explicit `MNEMOSYNE_EMBEDDING_DIM`. Therefore, the target sqlite-vec dimension is not determined by the `--model` name alone.
+6. Restart the provider or gateway and verify recall for both working and episodic memory through the deployment's configured retrieval path.
 
 See [Health and repair](cli-reference.md#health-and-repair) for the `reindex` command and flag reference.
 


### PR DESCRIPTION
## Summary

Closes #697.

Adds a safe, source-verified runbook for changing an embedding model and rebuilding vectors. It covers the persisted model/dimension configuration, a fail-closed dry-run check, the default backup, and post-reindex verification.

## Why this path

`mnemosyne reindex` is the existing recovery command. This PR documents its actual contract rather than changing runtime behavior.

## Non-goals

- No default-model recommendation or change.
- No CLI, schema, backup, or configuration-precedence changes.

## Verification

- `python3 scripts/verify-docs.py`
- `python3 scripts/generate-docs.py --check`
- Targeted runbook content assertions
- `git diff --check`

Independent current-head review verified the CLI and embedding-dimension claims against source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds a source-verified runbook for changing embedding models and rebuilding vectors.
- Documents persisted model and dimension configuration, writer shutdown, fail-closed dry-run validation, default backups, synchronous reindexing, and post-reindex recall testing.
- Clarifies that reindexing rebuilds working and episodic memory vectors and recreates sqlite-vec tables at the target dimension.
- Improves startup safety for custom models by prioritizing valid positive dimension overrides and rejecting unknown models without an explicit dimension.
- Preserves local-first operation. The change adds no network dependency, sync behavior, agent integration change, schema change, or runtime behavior change.
- Does not alter BEAM memory, retrieval strategies, consolidation, veracity, benchmarks, Hermes, MCP, or CLI semantics.
- Improves long-term maintainability by documenting existing `mnemosyne reindex` behavior and linking configuration requirements to CLI flag semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->