### PR TITLE
Fix/polyphonic prefetch signal fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Polyphonic recall now injects raw conversation transcripts into Hermes prefetch (#696, #615, #677).** When `MNEMOSYNE_POLYPHONIC_RECALL=1`, the polyphonic engine only populated `score` (a small RRF `combined_score`) and `voice_scores` on its results, omitting the `keyword_score` / `fts_score` / `dense_score` fields the Hermes provider's prefetch filter (and its 0.20 score floor) reads. Raw `[USER]` working-memory rows were consequently scored ~0 and silently dropped from automatic prefetch. The polyphonic path now emits the standard per-signal scores on a linear-comparable 0-1 scale (with the existing veracity/tier multipliers applied), so raw conversation transcripts surface in prefetch under the polyphonic flag.
+
 ### Added
 
 - **MCP clients can now retire canonical facts with `mnemosyne_forget_canonical` (#723).** The tool is discoverable and callable by default over MCP; retirement removes the current slot from active recall while preserving it as history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
-- **Polyphonic recall now injects raw conversation transcripts into Hermes prefetch (#696, #615, #677).** When `MNEMOSYNE_POLYPHONIC_RECALL=1`, the polyphonic engine only populated `score` (a small RRF `combined_score`) and `voice_scores` on its results, omitting the `keyword_score` / `fts_score` / `dense_score` fields the Hermes provider's prefetch filter (and its 0.20 score floor) reads. Raw `[USER]` working-memory rows were consequently scored ~0 and silently dropped from automatic prefetch. The polyphonic path now emits the standard per-signal scores on a linear-comparable 0-1 scale (with the existing veracity/tier multipliers applied), so raw conversation transcripts surface in prefetch under the polyphonic flag.
+- **Hermes prefetch now injects raw conversation transcripts under polyphonic recall (#696, #615, #677).** The Hermes prefetch adapter drops a result when it lacks the linear per-signal fields (`keyword_score`/`fts_score`/`dense_score`) and its `score` is below 0.20. Polyphonic engine results carry only `voice_scores` provenance (RRF-ranked) and a small combined `score`, so raw `[USER]` transcript rows were silently filtered out and never surfaced in prefetch under `MNEMOSYNE_POLYPHONIC_RECALL=1`. The adapter now recognises polyphonic results (`voice_scores` with vector/graph/fact/temporal keys), lets them pass their existing lexical gate without applying the linear per-signal signal and 0.20 score floors, and uses the strongest voice contribution for ranking. The core recall pipeline is unchanged.
 
 ### Added
 

--- a/docs/api/configuration.mdx
+++ b/docs/api/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-version: 3.16.0
+version: 3.17.0
 config_key_count: 106
 env_only_count: 44
 generated_at: "auto"

--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -1,13 +1,13 @@
 ---
 title: "MCP Tool Schema"
-version: 3.16.0
-tool_count: 37
-mcp_tool_count: 29
+version: 3.17.0
+tool_count: 36
+mcp_tool_count: 28
 plugin_only_tool_count: 8
 generated_at: "auto"
 ---
 
-# MCP Tool Schema (v3.16.0)
+# MCP Tool Schema (v3.17.0)
 
 > **Generated file. Do not edit by hand.**
 > Source: `mnemosyne/tool_schemas.py` and `mnemosyne/mcp_tools.py`.

--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -1,8 +1,8 @@
 ---
 title: "MCP Tool Schema"
 version: 3.17.0
-tool_count: 36
-mcp_tool_count: 28
+tool_count: 37
+mcp_tool_count: 29
 plugin_only_tool_count: 8
 generated_at: "auto"
 ---

--- a/hermes_memory_provider/plugin.yaml
+++ b/hermes_memory_provider/plugin.yaml
@@ -1,5 +1,5 @@
 name: mnemosyne
-version: 3.16.0
+version: 3.17.0
 description: "Native local memory for Hermes — SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, temporal triples, and bidirectional sync with optional client-side encryption. Zero cloud. Zero latency."
 author: Abdias J
 provides_tools:

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -68,9 +68,9 @@ This is how Hermes builds memory from what it says *and* what it does.
 
 ### 2. Recall
 
-Recall is intentional. Agents decide when to recall, what scope, and how many results. There is no automatic retrieval dumping context into every prompt.
+Explicit `mnemosyne_recall` is intentional — agents decide when to recall, what scope, and how many results. In addition, the provider performs **automatic pre-turn prefetch**: before an LLM call it injects relevant memories into the prompt as a `## Mnemosyne Context` block. Prefetch is deliberately conservative and is not "automatic retrieval dumping context into every prompt." It applies a lexical gate — a memory must share multiple distinctive non-generic terms with the query and meet a minimum query-coverage fraction — before silent injection. Linear recall results must additionally clear per-signal signal and score floors, which favors distilled facts and preferences over raw transcripts. Under `MNEMOSYNE_POLYPHONIC_RECALL=1`, results ranked by the polyphonic engine (RRF over vector/graph/fact/temporal voices) pass the lexical gate without the linear score floors, so raw `[USER]` conversation transcripts surface in prefetch too.
 
-When `mnemosyne_recall` fires, Mnemosyne runs hybrid search: vector similarity finds semantic matches, FTS5 full-text finds keyword matches, and importance scoring boosts what matters. All three weights are tunable per-query so you can bias toward recency, relevance, or both.
+When `mnemosyne_recall` fires, Mnemosyne also runs hybrid search: vector similarity finds semantic matches, FTS5 full-text finds keyword matches, and importance scoring boosts what matters. All three weights are tunable per-query so you can bias toward recency, relevance, or both.
 
 Returned context can include prior decisions, constraints, failure modes, project patterns, and execution outcomes: without stuffing irrelevant history into the prompt.
 
@@ -225,6 +225,7 @@ No required config. Everything defaults to `~/.mnemosyne/`. Optional overrides:
 | `MNEMOSYNE_PREFETCH_CONTENT_CHARS` | `0` | Per-memory prefetch content cap (`0` = full content) |
 | `MNEMOSYNE_PREFETCH_MIN_DISTINCTIVE_TOKENS` | `2` | Shared non-generic terms required for automatic prefetch injection |
 | `MNEMOSYNE_PREFETCH_MIN_QUERY_COVERAGE` | `0.30` | Minimum fraction of non-generic query terms covered by a prefetched memory |
+| `MNEMOSYNE_POLYPHONIC_RECALL` | `0` | Route recall through the polyphonic engine (RRF over vector/graph/fact/temporal voices); prefetch then admits raw transcripts past the lexical gate without the linear score floors |
 | `MNEMOSYNE_PREFETCH_CANONICAL_RARE_TOKEN_MAX_FREQUENCY` | `1` | Maximum canonical document frequency that permits a one-token match (`0` disables the exception) |
 | `MNEMOSYNE_PREFETCH_CANONICAL_GENERIC_TOKENS` | path-specific built-in canonical set | Complete replacement for the canonical generic-token set used by automatic and explicit canonical lookup; does not affect working/episodic prefetch |
 | `MNEMOSYNE_PREFETCH_CANONICAL_EXTRA_GENERIC_TOKENS` | _(empty)_ | Extra owner/deployment terms added to automatic canonical prefetch only |

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -513,12 +513,33 @@ def _canonical_prefetch_rows(store: Any, owner_id: str, query: str, *, limit: in
     return candidates[:limit]
 
 
+def _prefetch_is_polyphonic(row: Dict[str, Any]) -> bool:
+    """True when a recall result came from the polyphonic engine.
+
+    The polyphonic engine ranks via RRF and carries `voice_scores` (keys
+    vector/graph/fact/temporal) instead of the linear per-signal
+    keyword/fts/dense fields. Such rows are already relevance-ranked by the
+    engine, so prefetch must not drop them merely for lacking the linear
+    signal fields.
+    """
+    vs = row.get("voice_scores")
+    if not isinstance(vs, dict) or not vs:
+        return False
+    return bool(set(vs) & {"vector", "graph", "fact", "temporal"})
+
+
 def _prefetch_topic_signal(row: Dict[str, Any]) -> float:
     signal = max(
         float(row.get("keyword_score") or 0.0),
         float(row.get("fts_score") or 0.0),
         float(row.get("dense_score") or 0.0),
     )
+    if _prefetch_is_polyphonic(row):
+        # Polyphonic results are ranked by the engine (RRF over its voices)
+        # and expose only `voice_scores` provenance -- not fabricated per-signal
+        # scores. Use the strongest voice contribution as an honest relevance
+        # proxy so these rows can be ranked without inventing fts/dense values.
+        signal = max(float(v) for v in (row.get("voice_scores") or {}).values())
     if row.get("fact_match") or row.get("entity_match"):
         signal = max(signal, 0.20)
     return signal
@@ -1527,14 +1548,20 @@ class MnemosyneMemoryProvider(HermesPersonaPromptMixin, MemoryProvider):
                 # mnemosyne_recall remains available for semantic exploration.
                 if not _prefetch_has_distinctive_lexical_evidence(query, r.get("content", "")):
                     continue
-                signal = _prefetch_topic_signal(r)
-                score = float(r.get("score") or 0.0)
-                importance = float(r.get("importance") or 0.0)
-                required_signal = 0.18 if _prefetch_is_raw(r) else 0.08
-                if signal < required_signal:
-                    continue
-                if score < 0.20 and importance < 0.65:
-                    continue
+                # Polyphonic results are already relevance-ranked by the engine
+                # (RRF over vector/graph/fact/temporal voices) and expose only
+                # `voice_scores` provenance, not the linear per-signal fields.
+                # They pass the lexical gate above, so do not drop them for the
+                # absent keyword/fts/dense signal or the linear 0.20 score floor.
+                if not _prefetch_is_polyphonic(r):
+                    signal = _prefetch_topic_signal(r)
+                    score = float(r.get("score") or 0.0)
+                    importance = float(r.get("importance") or 0.0)
+                    required_signal = 0.18 if _prefetch_is_raw(r) else 0.08
+                    if signal < required_signal:
+                        continue
+                    if score < 0.20 and importance < 0.65:
+                        continue
                 filtered.append(r)
 
             if canonical_rows:

--- a/integrations/hermes/tests/test_prefetch_hardening.py
+++ b/integrations/hermes/tests/test_prefetch_hardening.py
@@ -407,12 +407,14 @@ def test_prefetch_injects_polyphonic_user_transcript():
     assert "norway news marker" in block
 
 
-def test_prefetch_excludes_foreign_polyphonic_row_without_lexical_evidence():
-    """"A polyphonic [USER] row from a foreign session/channel (no shared
-    topical terms with the query) must not be injected -- the adapter still
-    enforces the lexical gate for polyphonic results, so a relevant transcript
-    is injected while an unrelated one from another session/channel is kept
-    out."""
+def test_prefetch_excludes_polyphonic_row_without_lexical_evidence():
+    """A polyphonic [USER] row that shares no topical terms with the query must
+    not be injected -- the adapter still enforces the lexical gate for
+    polyphonic results, so a matching transcript is injected while an unrelated
+    one is kept out. (Session/channel scope isolation is not the adapter's job:
+    `BeamMemory.recall()` already returns only in-scope rows via its candidate
+    queries -- see the core `test_recall_session_scope_excludes_foreign_row_sharing_query_terms`
+    for the two-session shared-term case.)"""
     p = _provider([
         {
             "content": "[USER] carol said the norway news marker is on page two",
@@ -438,3 +440,38 @@ def test_prefetch_excludes_foreign_polyphonic_row_without_lexical_evidence():
 
     assert "norway news marker" in block
     assert "sentinelxyz" not in block
+
+
+def test_prefetch_ranks_polyphonic_rows_by_strongest_voice():
+    """When multiple polyphonic rows all clear the lexical gate, prefetch ranks
+    them by the strongest voice contribution (`_prefetch_topic_signal` uses
+    max(voice_scores)), so the row with the stronger voice is injected first.
+    The adapter ranks honestly from `voice_scores` rather than fabricating
+    linear per-signal values."""
+    p = _provider([
+        {
+            "content": "[USER] carol said the norway news marker is on page two",
+            "source": "conversation",
+            "timestamp": "2026-08-11T09:00:00Z",
+            "importance": 0.5,
+            "score": 0.034,
+            "voice_scores": {"vector": 0.019, "temporal": 0.016},
+            "trust_tier": "STATED",
+        },
+        {
+            "content": "[USER] bob tracked the norway news marker in the log",
+            "source": "conversation",
+            "timestamp": "2026-08-11T09:01:00Z",
+            "importance": 0.5,
+            "score": 0.034,
+            "voice_scores": {"vector": 0.050, "temporal": 0.012},
+            "trust_tier": "STATED",
+        },
+    ])
+
+    block = p.prefetch("norway news marker")
+
+    assert "bob tracked" in block and "carol said" in block
+    assert block.index("bob tracked") < block.index("carol said"), (
+        "row with the stronger voice contribution should rank first"
+    )

--- a/integrations/hermes/tests/test_prefetch_hardening.py
+++ b/integrations/hermes/tests/test_prefetch_hardening.py
@@ -380,3 +380,61 @@ def test_canonical_prefetch_respects_higher_distinctive_token_minimum(monkeypatc
     rows = _canonical_prefetch_rows(store, "default", "fragrant jasmine soup")
 
     assert rows == []
+
+
+def test_prefetch_injects_polyphonic_user_transcript():
+    """A raw [USER] conversation row returned by the polyphonic engine (which
+    carries only `voice_scores` provenance -- no linear keyword/fts/dense
+    fields and an RRF-scale `score`) is now injected by prefetch.
+
+    Regression: the adapter used to drop these on the missing per-signal
+    signal together with the 0.20 score floor, so raw conversation transcripts
+    never surfaced in prefetch under MNEMOSYNE_POLYPHONIC_RECALL=1."""
+    p = _provider([
+        {
+            "content": "[USER] carol said the norway news marker is on page two",
+            "source": "conversation",
+            "timestamp": "2026-08-11T09:00:00Z",
+            "importance": 0.5,
+            "score": 0.034,                       # RRF-scale combined score
+            "voice_scores": {"vector": 0.019, "temporal": 0.016},  # polyphonic
+            "trust_tier": "STATED",
+        },
+    ])
+
+    block = p.prefetch("norway news marker")
+
+    assert "norway news marker" in block
+
+
+def test_prefetch_excludes_foreign_polyphonic_row_without_lexical_evidence():
+    """"A polyphonic [USER] row from a foreign session/channel (no shared
+    topical terms with the query) must not be injected -- the adapter still
+    enforces the lexical gate for polyphonic results, so a relevant transcript
+    is injected while an unrelated one from another session/channel is kept
+    out."""
+    p = _provider([
+        {
+            "content": "[USER] carol said the norway news marker is on page two",
+            "source": "conversation",
+            "timestamp": "2026-08-11T09:00:00Z",
+            "importance": 0.5,
+            "score": 0.034,
+            "voice_scores": {"vector": 0.019, "temporal": 0.016},
+            "trust_tier": "STATED",
+        },
+        {
+            "content": "[USER] unrelated sentinelxyz chat about quantum logs",
+            "source": "conversation",
+            "timestamp": "2026-08-11T10:00:00Z",
+            "importance": 0.9,
+            "score": 0.05,
+            "voice_scores": {"graph": 0.02, "fact": 0.015},
+            "trust_tier": "STATED",
+        },
+    ])
+
+    block = p.prefetch("norway news marker")
+
+    assert "norway news marker" in block
+    assert "sentinelxyz" not in block

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.16.0"
+__version__ = "3.17.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6052,7 +6052,6 @@ class BeamMemory:
                 channel_id=channel_id,
                 veracity=veracity, memory_type=memory_type,
                 cross_session=cross_session,
-                importance_weight=importance_weight,
             )
             # [C4] Polyphonic path diagnostics. The linear-path recording
             # below (record_call / record_tier_hits at the end of recall())
@@ -7921,8 +7920,7 @@ class BeamMemory:
                            channel_id: Optional[str] = None,
                            veracity: Optional[str] = None,
                            memory_type: Optional[str] = None,
-                           cross_session: Optional[bool] = None,
-                           importance_weight: Optional[float] = None) -> List[Dict]:
+                           cross_session: Optional[bool] = None) -> List[Dict]:
         """[E5] Polyphonic recall path.
 
         Delegates to PolyphonicRecallEngine when MNEMOSYNE_POLYPHONIC_RECALL=1.
@@ -7987,58 +7985,9 @@ class BeamMemory:
                       "unknown": UNKNOWN_WEIGHT}
         tier_weight_map = {1: TIER1_WEIGHT, 2: TIER2_WEIGHT, 3: TIER3_WEIGHT}
 
-        # Emit the standard per-signal relevance fields nested consumers
-        # expect. The Hermes provider's prefetch filter thresholds on
-        # keyword_score / fts_score / dense_score (via _prefetch_topic_signal)
-        # and a 0.20 score floor; a raw RRF combined_score (~0.02-0.05) and
-        # voice_scores alone never satisfy it, so raw [USER] conversation
-        # transcripts were scored ~0 and silently dropped from prefetch when
-        # polyphonic recall was enabled. Recompute the same lexical / vector
-        # / recency signal the linear path uses so the scales match.
-        query_lower = query.lower()
-        query_tokens = _recall_tokens(query_lower)
-        # Resolve the importance weight through the same linear scoring
-        # contract, so a config or caller-provided weight affects both recall
-        # paths consistently (the polyphonic branch returns before recall()
-        # normalizes weights for the linear scorer).
-        _, _, poly_iw = _normalize_weights(None, None, importance_weight)
-        wm_vec_sims_map = {}
-
         final = []
         cursor = self.conn.cursor()
         now_iso = datetime.now(timezone.utc).isoformat()
-
-        # Bounded dense-similarity lookup scoped to the polyphonic candidate
-        # IDs only -- not a broad k=N vector search. Fetch just the candidates'
-        # embeddings and cosine-compare against the query vector, using the
-        # same memory_embeddings source as the linear path, so the fallback
-        # JSON scan never touches unrelated working-memory rows.
-        if query_embedding is not None and polyphonic_results:
-            try:
-                _cand_ids = [
-                    r.memory_id for r in polyphonic_results
-                    if not r.memory_id.startswith("cf_")
-                ]
-                if _cand_ids:
-                    _ph = ",".join("?" * len(_cand_ids))
-                    _emb_rows = cursor.execute(
-                        f"SELECT memory_id, embedding_json FROM memory_embeddings "
-                        f"WHERE memory_id IN ({_ph})",
-                        tuple(_cand_ids),
-                    ).fetchall()
-                    _qnorm = float(np.linalg.norm(query_embedding))
-                    for _mid, _ej in _emb_rows:
-                        try:
-                            _v = np.array(json.loads(_ej), dtype=np.float32)
-                            _vn = float(np.linalg.norm(_v))
-                            if _qnorm > 0 and _vn > 0:
-                                wm_vec_sims_map[_mid] = float(
-                                    np.dot(query_embedding, _v) / (_qnorm * _vn)
-                                )
-                        except Exception:
-                            continue
-            except Exception:
-                wm_vec_sims_map = {}
 
         for r in polyphonic_results:
             memory_id = r.memory_id
@@ -8076,41 +8025,6 @@ class BeamMemory:
 
             row_dict["score"] = score
             row_dict["voice_scores"] = dict(r.voice_scores)
-
-            # Emit linear-path-compatible per-signal scores and keep `score`
-            # on a comparable 0-1 scale so the Hermes prefetch filter (and any
-            # other relevance-thresholding consumer) can gate on them
-            # regardless of which recall engine produced the row.
-            _content = row_dict.get("content") or ""
-            _kw = _lexical_relevance(query_tokens, _content, query_lower)
-            _dense = wm_vec_sims_map.get(memory_id, 0.0)
-            _imp = min(max(float(row_dict.get("importance") or 0.0), 0.0), 1.0)
-            _decay = _recency_decay(row_dict.get("timestamp") or "")
-            _kw_share = (1.0 - poly_iw) * 0.6
-            _rc_share = (1.0 - poly_iw) * 0.4
-            _base = _kw * _kw_share + _imp * poly_iw + (_kw ** 2) * 0.08
-            if _dense > 0:
-                _base = _base * 0.80 + _dense * 0.20
-            _lin_score = _base * (_rc_share + (1.0 - _rc_share) * _decay)
-            # Apply the same veracity / tier multipliers the RRF score received
-            # so the linear-comparable score preserves the ordering semantics
-            # the engine path already composes (stated > unknown, tier decay).
-            if not _env_disabled("MNEMOSYNE_VERACITY_MULTIPLIER"):
-                _lin_score *= weight_map.get(
-                    row_dict.get("veracity") or "unknown", UNKNOWN_WEIGHT
-                )
-            if row_dict.get("tier") == "episodic":
-                _lin_score *= tier_weight_map.get(
-                    row_dict.get("degradation_tier") or 1, 1.0
-                )
-            row_dict["keyword_score"] = round(_kw, 4)
-            row_dict["fts_score"] = round(_kw, 4)
-            row_dict["dense_score"] = round(_dense, 4)
-            # Keep the RRF multi-voice ordering when it is stronger,
-            # otherwise let the linear relevance score carry the ordering so
-            # any relevance threshold sees a comparable 0-1 scale.
-            if row_dict["score"] < _lin_score:
-                row_dict["score"] = round(_lin_score, 4)
             final.append(row_dict)
             # No early-break: dedup needs to see all candidates before
             # truncation, otherwise a wm row dropped from top-K by an

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -7985,6 +7985,25 @@ class BeamMemory:
                       "unknown": UNKNOWN_WEIGHT}
         tier_weight_map = {1: TIER1_WEIGHT, 2: TIER2_WEIGHT, 3: TIER3_WEIGHT}
 
+        # Emit the standard per-signal relevance fields nested consumers
+        # expect. The Hermes provider's prefetch filter thresholds on
+        # keyword_score / fts_score / dense_score (via _prefetch_topic_signal)
+        # and a 0.20 score floor; a raw RRF combined_score (~0.02-0.05) and
+        # voice_scores alone never satisfy it, so raw [USER] conversation
+        # transcripts were scored ~0 and silently dropped from prefetch when
+        # polyphonic recall was enabled. Recompute the same lexical / vector
+        # / recency signal the linear path uses so the scales match.
+        query_lower = query.lower()
+        query_tokens = _recall_tokens(query_lower)
+        poly_iw = float(os.environ.get("MNEMOSYNE_IMPORTANCE_WEIGHT", "0.2"))
+        wm_vec_sims_map = {}
+        if query_embedding is not None:
+            try:
+                _w = _wm_vec_search(self.conn, query_embedding, k=1000)
+                wm_vec_sims_map = {vr["id"]: float(vr["sim"]) for vr in _w}
+            except Exception:
+                wm_vec_sims_map = {}
+
         final = []
         cursor = self.conn.cursor()
         now_iso = datetime.now(timezone.utc).isoformat()
@@ -8025,6 +8044,41 @@ class BeamMemory:
 
             row_dict["score"] = score
             row_dict["voice_scores"] = dict(r.voice_scores)
+
+            # Emit linear-path-compatible per-signal scores and keep `score`
+            # on a comparable 0-1 scale so the Hermes prefetch filter (and any
+            # other relevance-thresholding consumer) can gate on them
+            # regardless of which recall engine produced the row.
+            _content = row_dict.get("content") or ""
+            _kw = _lexical_relevance(query_tokens, _content, query_lower)
+            _dense = wm_vec_sims_map.get(memory_id, 0.0)
+            _imp = min(max(float(row_dict.get("importance") or 0.0), 0.0), 1.0)
+            _decay = _recency_decay(row_dict.get("timestamp") or "")
+            _kw_share = (1.0 - poly_iw) * 0.6
+            _rc_share = (1.0 - poly_iw) * 0.4
+            _base = _kw * _kw_share + _imp * poly_iw + (_kw ** 2) * 0.08
+            if _dense > 0:
+                _base = _base * 0.80 + _dense * 0.20
+            _lin_score = _base * (_rc_share + (1.0 - _rc_share) * _decay)
+            # Apply the same veracity / tier multipliers the RRF score received
+            # so the linear-comparable score preserves the ordering semantics
+            # the engine path already composes (stated > unknown, tier decay).
+            if not _env_disabled("MNEMOSYNE_VERACITY_MULTIPLIER"):
+                _lin_score *= weight_map.get(
+                    row_dict.get("veracity") or "unknown", UNKNOWN_WEIGHT
+                )
+            if row_dict.get("tier") == "episodic":
+                _lin_score *= tier_weight_map.get(
+                    row_dict.get("degradation_tier") or 1, 1.0
+                )
+            row_dict["keyword_score"] = round(_kw, 4)
+            row_dict["fts_score"] = round(_kw, 4)
+            row_dict["dense_score"] = round(_dense, 4)
+            # Keep the RRF multi-voice ordering when it is stronger,
+            # otherwise let the linear relevance score carry the ordering so
+            # any relevance threshold sees a comparable 0-1 scale.
+            if row_dict["score"] < _lin_score:
+                row_dict["score"] = round(_lin_score, 4)
             final.append(row_dict)
             # No early-break: dedup needs to see all candidates before
             # truncation, otherwise a wm row dropped from top-K by an

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6052,6 +6052,7 @@ class BeamMemory:
                 channel_id=channel_id,
                 veracity=veracity, memory_type=memory_type,
                 cross_session=cross_session,
+                importance_weight=importance_weight,
             )
             # [C4] Polyphonic path diagnostics. The linear-path recording
             # below (record_call / record_tier_hits at the end of recall())
@@ -7920,7 +7921,8 @@ class BeamMemory:
                            channel_id: Optional[str] = None,
                            veracity: Optional[str] = None,
                            memory_type: Optional[str] = None,
-                           cross_session: Optional[bool] = None) -> List[Dict]:
+                           cross_session: Optional[bool] = None,
+                           importance_weight: Optional[float] = None) -> List[Dict]:
         """[E5] Polyphonic recall path.
 
         Delegates to PolyphonicRecallEngine when MNEMOSYNE_POLYPHONIC_RECALL=1.
@@ -7995,18 +7997,48 @@ class BeamMemory:
         # / recency signal the linear path uses so the scales match.
         query_lower = query.lower()
         query_tokens = _recall_tokens(query_lower)
-        poly_iw = float(os.environ.get("MNEMOSYNE_IMPORTANCE_WEIGHT", "0.2"))
+        # Resolve the importance weight through the same linear scoring
+        # contract, so a config or caller-provided weight affects both recall
+        # paths consistently (the polyphonic branch returns before recall()
+        # normalizes weights for the linear scorer).
+        _, _, poly_iw = _normalize_weights(None, None, importance_weight)
         wm_vec_sims_map = {}
-        if query_embedding is not None:
-            try:
-                _w = _wm_vec_search(self.conn, query_embedding, k=1000)
-                wm_vec_sims_map = {vr["id"]: float(vr["sim"]) for vr in _w}
-            except Exception:
-                wm_vec_sims_map = {}
 
         final = []
         cursor = self.conn.cursor()
         now_iso = datetime.now(timezone.utc).isoformat()
+
+        # Bounded dense-similarity lookup scoped to the polyphonic candidate
+        # IDs only -- not a broad k=N vector search. Fetch just the candidates'
+        # embeddings and cosine-compare against the query vector, using the
+        # same memory_embeddings source as the linear path, so the fallback
+        # JSON scan never touches unrelated working-memory rows.
+        if query_embedding is not None and polyphonic_results:
+            try:
+                _cand_ids = [
+                    r.memory_id for r in polyphonic_results
+                    if not r.memory_id.startswith("cf_")
+                ]
+                if _cand_ids:
+                    _ph = ",".join("?" * len(_cand_ids))
+                    _emb_rows = cursor.execute(
+                        f"SELECT memory_id, embedding_json FROM memory_embeddings "
+                        f"WHERE memory_id IN ({_ph})",
+                        tuple(_cand_ids),
+                    ).fetchall()
+                    _qnorm = float(np.linalg.norm(query_embedding))
+                    for _mid, _ej in _emb_rows:
+                        try:
+                            _v = np.array(json.loads(_ej), dtype=np.float32)
+                            _vn = float(np.linalg.norm(_v))
+                            if _qnorm > 0 and _vn > 0:
+                                wm_vec_sims_map[_mid] = float(
+                                    np.dot(query_embedding, _v) / (_qnorm * _vn)
+                                )
+                        except Exception:
+                            continue
+            except Exception:
+                wm_vec_sims_map = {}
 
         for r in polyphonic_results:
             memory_id = r.memory_id

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -27,6 +27,7 @@ all arms run with flag=ON to test against the polyphonic engine
 instead of the inline bonus shortcut.
 """
 
+import os
 import sqlite3
 import tempfile
 from datetime import datetime, timedelta, timezone
@@ -587,7 +588,7 @@ class TestE5ResultShape:
         from mnemosyne.core.polyphonic_recall import PolyphonicResult
 
         class _StubEngine:
-            def recall(self, query, query_embedding=None, top_k=10):
+            def recall(self, query, query_embedding=None, top_k=10, **kwargs):
                 return [PolyphonicResult(
                     memory_id=seed_id, combined_score=0.035,
                     voice_scores={"vector": 0.019, "temporal": 0.016},

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -568,26 +568,19 @@ class TestE5ResultShape:
                 f"result has no content; engine didn't map row back: {r}"
             )
 
-    def test_polyphonic_results_emit_per_signal_scores(
+    def test_polyphonic_results_expose_voice_provenance(
         self, temp_db, monkeypatch, disable_llm
     ):
-        """Flag ON: polyphonic results emit the same per-signal
-        keyword/fts/dense scores (and a threshold-comparable `score`) as the
-        linear path.
-
-        The Hermes provider's prefetch filter gates on
-        keyword_score/fts_score/dense_score (via _prefetch_topic_signal) and a
-        0.20 score floor. When polyphonic recall was enabled the engine only
-        carried a tiny RRF `combined_score` and `voice_scores`, so raw [USER]
-        conversation transcripts were scored ~0 and silently dropped. Stubbing
-        the engine to return the seeded row deterministically forces the
-        scoring path to run, so we assert the emitted fields instead of letting
-        an empty result set pass vacuously."""
+        """Flag ON: polyphonic results expose `voice_scores` provenance -- the
+        field the Hermes prefetch adapter keys its eligibility on -- instead of
+        the linear per-signal keyword/fts/dense fields. Stubbing the engine
+        makes this non-vacuous: the seeded row is returned and must carry
+        polyphonic voice keys so downstream adapters can detect it as an
+        engine-ranked result rather than dropping it for the missing fields."""
         monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
-        beam = BeamMemory(session_id="e5-signals", db_path=temp_db)
-        marker = "e5signalsmarkerabc"
+        beam = BeamMemory(session_id="e5-voice", db_path=temp_db)
         seed_id = beam.remember(
-            f"[USER] carol mentioned the {marker} deploy today",
+            "[USER] carol discussed the voiceprovenancemarker deploy today",
             source="conversation", importance=0.5,
         )
 
@@ -596,65 +589,16 @@ class TestE5ResultShape:
         class _StubEngine:
             def recall(self, query, query_embedding=None, top_k=10):
                 return [PolyphonicResult(
-                    memory_id=seed_id, combined_score=0.5,
-                    voice_scores={"vector": 0.9}, metadata={},
+                    memory_id=seed_id, combined_score=0.035,
+                    voice_scores={"vector": 0.019, "temporal": 0.016},
+                    metadata={},
                 )]
 
         monkeypatch.setattr(beam, "_get_polyphonic_engine", lambda: _StubEngine())
-
-        results = beam.recall(f"the {marker} deploy", top_k=10)
-        marker_row = next((r for r in results if r["id"] == seed_id), None)
-        assert marker_row is not None, (
-            "stubbed engine returned the seed but mapping/filters dropped it; "
-            f"got {[r['content'] for r in results]}"
-        )
-        for field in ("keyword_score", "fts_score", "dense_score"):
-            assert field in marker_row, f"polyphonic result missing {field}"
-            assert isinstance(marker_row[field], (int, float))
-        assert marker_row["keyword_score"] > 0, f"keyword_score not positive: {marker_row}"
-        assert marker_row["fts_score"] > 0, f"fts_score not positive: {marker_row}"
-        assert marker_row["score"] >= 0.20, (
-            f"score below the prefetch floor (0.20): {marker_row}"
-        )
-
-    def test_polyphonic_per_signal_score_preserves_veracity_ordering(
-        self, temp_db, monkeypatch, disable_llm
-    ):
-        """Flag ON: the linear-comparable score still applies the veracity
-        multiplier, so a 'stated' row outranks an equally-relevant 'unknown'
-        row on the polyphonic path (regression for v1 dropping veracity)."""
-        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
-        beam = BeamMemory(session_id="e5-veracity", db_path=temp_db)
-        marker = "e5veracitymarkerabc"
-        stated_id = beam.remember(
-            f"carol finalized the {marker} plan", source="conversation",
-            importance=0.5, veracity="stated",
-        )
-        unknown_id = beam.remember(
-            f"dave discussed the {marker} plan", source="conversation",
-            importance=0.5, veracity="unknown",
-        )
-
-        from mnemosyne.core.polyphonic_recall import PolyphonicResult
-
-        class _StubEngine:
-            def recall(self, query, query_embedding=None, top_k=10):
-                return [
-                    PolyphonicResult(memory_id=stated_id, combined_score=0.5,
-                                     voice_scores={"vector": 0.9}, metadata={}),
-                    PolyphonicResult(memory_id=unknown_id, combined_score=0.5,
-                                     voice_scores={"vector": 0.9}, metadata={}),
-                ]
-
-        monkeypatch.setattr(beam, "_get_polyphonic_engine", lambda: _StubEngine())
-
-        results = beam.recall(f"the {marker} plan", top_k=10)
-        by_id = {r["id"]: r for r in results}
-        assert stated_id in by_id and unknown_id in by_id, (
-            f"both seeded rows should surface: {list(by_id)}"
-        )
-        assert by_id[stated_id]["score"] > by_id[unknown_id]["score"], (
-            "stated row should outrank unknown row (veracity multiplier applied "
-            f"to the linear-comparable score): "
-            f"stated={by_id[stated_id]['score']} unknown={by_id[unknown_id]['score']}"
+        results = beam.recall("voiceprovenancemarker", top_k=10)
+        row = next((r for r in results if r["id"] == seed_id), None)
+        assert row is not None, f"stub row missing from recall: {results}"
+        vs = row.get("voice_scores", {})
+        assert set(vs) & {"vector", "graph", "fact", "temporal"}, (
+            f"expected polyphonic voice provenance in voice_scores, got {vs}"
         )

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -27,7 +27,6 @@ all arms run with flag=ON to test against the polyphonic engine
 instead of the inline bonus shortcut.
 """
 
-import os
 import sqlite3
 import tempfile
 from datetime import datetime, timedelta, timezone

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -568,3 +568,38 @@ class TestE5ResultShape:
             assert r.get("content"), (
                 f"result has no content; engine didn't map row back: {r}"
             )
+
+    def test_polyphonic_results_emit_per_signal_scores(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Flag ON: polyphonic results emit the same per-signal
+        keyword/fts/dense scores (and a threshold-comparable `score`) as the
+        linear path.
+
+        The Hermes provider's prefetch filter gates on
+        keyword_score/fts_score/dense_score (via _prefetch_topic_signal) and a
+        0.20 score floor. When polyphonic recall was enabled the engine only
+        carried a tiny RRF `combined_score` and `voice_scores`, so raw [USER]
+        conversation transcripts were scored ~0 and silently dropped. Every
+        polyphonic result must therefore carry these fields so nested
+        consumers don't need a per-engine special case."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="e5-signals", db_path=temp_db)
+        marker = "e5signalsmarkerabc"
+        _seed_recallable_content(beam, [
+            (f"[USER] carol mentioned the {marker} deploy today", "conversation", 0.5),
+            (f"the {marker} launch window closes friday", "conversation", 0.6),
+        ])
+
+        results = beam.recall(f"the {marker} deploy", top_k=10)
+        # In the no-embeddings CI env a voice may not match, so the engine can
+        # return zero rows (matching the suite's defensive convention). The
+        # contract under test: ANY polyphonic result carries the per-signal
+        # scores the Hermes prefetch filter depends on.
+        for r in results:
+            for field in ("keyword_score", "fts_score", "dense_score"):
+                assert field in r, f"polyphonic result missing {field}: {r}"
+                assert isinstance(r[field], (int, float)), (
+                    f"{field} not numeric: {r}"
+                )
+            assert isinstance(r["score"], (int, float))

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -579,26 +579,82 @@ class TestE5ResultShape:
         keyword_score/fts_score/dense_score (via _prefetch_topic_signal) and a
         0.20 score floor. When polyphonic recall was enabled the engine only
         carried a tiny RRF `combined_score` and `voice_scores`, so raw [USER]
-        conversation transcripts were scored ~0 and silently dropped. Every
-        polyphonic result must therefore carry these fields so nested
-        consumers don't need a per-engine special case."""
+        conversation transcripts were scored ~0 and silently dropped. Stubbing
+        the engine to return the seeded row deterministically forces the
+        scoring path to run, so we assert the emitted fields instead of letting
+        an empty result set pass vacuously."""
         monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
         beam = BeamMemory(session_id="e5-signals", db_path=temp_db)
         marker = "e5signalsmarkerabc"
-        _seed_recallable_content(beam, [
-            (f"[USER] carol mentioned the {marker} deploy today", "conversation", 0.5),
-            (f"the {marker} launch window closes friday", "conversation", 0.6),
-        ])
+        seed_id = beam.remember(
+            f"[USER] carol mentioned the {marker} deploy today",
+            source="conversation", importance=0.5,
+        )
+
+        from mnemosyne.core.polyphonic_recall import PolyphonicResult
+
+        class _StubEngine:
+            def recall(self, query, query_embedding=None, top_k=10):
+                return [PolyphonicResult(
+                    memory_id=seed_id, combined_score=0.5,
+                    voice_scores={"vector": 0.9}, metadata={},
+                )]
+
+        monkeypatch.setattr(beam, "_get_polyphonic_engine", lambda: _StubEngine())
 
         results = beam.recall(f"the {marker} deploy", top_k=10)
-        # In the no-embeddings CI env a voice may not match, so the engine can
-        # return zero rows (matching the suite's defensive convention). The
-        # contract under test: ANY polyphonic result carries the per-signal
-        # scores the Hermes prefetch filter depends on.
-        for r in results:
-            for field in ("keyword_score", "fts_score", "dense_score"):
-                assert field in r, f"polyphonic result missing {field}: {r}"
-                assert isinstance(r[field], (int, float)), (
-                    f"{field} not numeric: {r}"
-                )
-            assert isinstance(r["score"], (int, float))
+        marker_row = next((r for r in results if r["id"] == seed_id), None)
+        assert marker_row is not None, (
+            "stubbed engine returned the seed but mapping/filters dropped it; "
+            f"got {[r['content'] for r in results]}"
+        )
+        for field in ("keyword_score", "fts_score", "dense_score"):
+            assert field in marker_row, f"polyphonic result missing {field}"
+            assert isinstance(marker_row[field], (int, float))
+        assert marker_row["keyword_score"] > 0, f"keyword_score not positive: {marker_row}"
+        assert marker_row["fts_score"] > 0, f"fts_score not positive: {marker_row}"
+        assert marker_row["score"] >= 0.20, (
+            f"score below the prefetch floor (0.20): {marker_row}"
+        )
+
+    def test_polyphonic_per_signal_score_preserves_veracity_ordering(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Flag ON: the linear-comparable score still applies the veracity
+        multiplier, so a 'stated' row outranks an equally-relevant 'unknown'
+        row on the polyphonic path (regression for v1 dropping veracity)."""
+        monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "1")
+        beam = BeamMemory(session_id="e5-veracity", db_path=temp_db)
+        marker = "e5veracitymarkerabc"
+        stated_id = beam.remember(
+            f"carol finalized the {marker} plan", source="conversation",
+            importance=0.5, veracity="stated",
+        )
+        unknown_id = beam.remember(
+            f"dave discussed the {marker} plan", source="conversation",
+            importance=0.5, veracity="unknown",
+        )
+
+        from mnemosyne.core.polyphonic_recall import PolyphonicResult
+
+        class _StubEngine:
+            def recall(self, query, query_embedding=None, top_k=10):
+                return [
+                    PolyphonicResult(memory_id=stated_id, combined_score=0.5,
+                                     voice_scores={"vector": 0.9}, metadata={}),
+                    PolyphonicResult(memory_id=unknown_id, combined_score=0.5,
+                                     voice_scores={"vector": 0.9}, metadata={}),
+                ]
+
+        monkeypatch.setattr(beam, "_get_polyphonic_engine", lambda: _StubEngine())
+
+        results = beam.recall(f"the {marker} plan", top_k=10)
+        by_id = {r["id"]: r for r in results}
+        assert stated_id in by_id and unknown_id in by_id, (
+            f"both seeded rows should surface: {list(by_id)}"
+        )
+        assert by_id[stated_id]["score"] > by_id[unknown_id]["score"], (
+            "stated row should outrank unknown row (veracity multiplier applied "
+            f"to the linear-comparable score): "
+            f"stated={by_id[stated_id]['score']} unknown={by_id[unknown_id]['score']}"
+        )

--- a/tests/test_beam_e5_polyphonic_recall.py
+++ b/tests/test_beam_e5_polyphonic_recall.py
@@ -599,6 +599,40 @@ class TestE5ResultShape:
         row = next((r for r in results if r["id"] == seed_id), None)
         assert row is not None, f"stub row missing from recall: {results}"
         vs = row.get("voice_scores", {})
-        assert set(vs) & {"vector", "graph", "fact", "temporal"}, (
-            f"expected polyphonic voice provenance in voice_scores, got {vs}"
+        assert vs == {"vector": 0.019, "temporal": 0.016}, (
+            "expected the exact polyphonic voice_scores mapping from the "
+            f"engine stub (not merely a supported key), got {vs}"
+        )
+
+    def test_recall_session_scope_excludes_foreign_row_sharing_query_terms(
+        self, temp_db, monkeypatch, disable_llm
+    ):
+        """Scope isolation: a foreign-session row that shares the query terms
+        under another session's scope is excluded by recall. Scope filtering is
+        engine-independent -- it is applied to the candidate queries inside
+        `BeamMemory.recall()` (session_id OR scope='global') -- so the Hermes
+        prefetch adapter, which consumes recall() output, can never see or
+        inject a foreign-session transcript that lexically matches a query.
+        Uses the deterministic linear path: polyphonic recall with embeddings
+        disabled returns no hits, which would make a real-engine scope test
+        vacuous. The scope predicate is identical for both engines."""
+        monkeypatch.delenv("MNEMOSYNE_POLYPHONIC_RECALL", raising=False)
+        beam_a = BeamMemory(session_id="scope-a", db_path=temp_db)
+        beam_b = BeamMemory(session_id="scope-b", db_path=temp_db)
+
+        marker = "scopezonemarkerx"
+        a_id = beam_a.remember(
+            f"[USER] carol discussed the {marker} deploy today",
+            source="conversation", importance=0.5,
+        )
+        b_id = beam_b.remember(
+            f"[USER] {marker} news marker is on page two",
+            source="conversation", importance=0.9,
+        )
+
+        results = beam_a.recall(marker, top_k=10)
+        ids = {r["id"] for r in results}
+        assert a_id in ids, "own-session row missing from recall -- test vacuous"
+        assert b_id not in ids, (
+            "foreign-session row sharing query terms leaked into session scope"
         )


### PR DESCRIPTION
## Description

What does this change do and why? Keep it focused.

Fixes a bug where raw conversation transcripts never surface in Hermes
automatic prefetch when `MNEMOSYNE_POLYPHONIC_RECALL=1`.

The polyphonic recall path (`_recall_polyphonic`) returns results carrying
only `score` (a small RRF `combined_score`) and `voice_scores` provenance,
omitting the `keyword_score` / `fts_score` / `dense_score` fields that the
Hermes provider's prefetch filter reads via `_prefetch_topic_signal`. With
those fields absent the topical signal is 0, and the tiny RRF score is below
the 0.20 floor, so raw `[USER]` working-memory rows are silently dropped from
prefetch — breaking cross-session transcript recall under the polyphonic
flag.

The fix lives in the Hermes adapter, not the core engine. Prefetch now
recognises polyphonic results (via their `voice_scores` provenance), lets
them pass the existing lexical gate without applying the linear per-signal
signal and 0.20 score floors, and ranks them by the strongest voice
contribution. The core recall pipeline (RRF ordering, dedup, `top_k`,
provenance) is completely unchanged — raw conversation transcripts now
surface in prefetch under `MNEMOSYNE_POLYPHONIC_RECALL=1` without fabricating
signals or altering engine output.

## Related Issue

Closes #700

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / performance
- [x] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Existing tests still pass (`pytest tests/ -v`)
- [x] New tests added for any new functionality
- [x] Manual verification (describe what you tested)

Manual verification: with the adapter fix applied on a real store and
`MNEMOSYNE_POLYPHONIC_RECALL=1`, a raw `[USER]` conversation turn about
"Norway news" / "July game releases" stored in one thread now surfaces in
the Hermes prefetch context of a different thread on a matching query —
previously it was scored ~0 (no linear signal fields) and never injected.
Verified end-to-end against a real database.

## Checklist

- [x] Version bumped in `mnemosyne/__init__.py` (3.16.0 → 3.17.0)
- [x] `CHANGELOG.md` updated with a brief entry
- [x] README updated if user-facing behavior changed
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixes Hermes automatic prefetch for polyphonic recall when `MNEMOSYNE_POLYPHONIC_RECALL=1`.
- Hermes identifies polyphonic results through `voice_scores`, keeps the existing lexical gate, bypasses linear signal and score floors, and ranks by the strongest voice contribution.
- Core recall behavior remains unchanged. Ordering, scoring, deduplication, filtering, `top_k`, caller scope, and session isolation remain intact.
- Raw `[USER]` transcripts can now surface when relevant. Unrelated session and channel rows remain excluded.

## Architecture and privacy impact

- The change affects the Hermes integration surface only. It does not change working, episodic, or BEAM memory tiers.
- It does not change retrieval strategies in core Mnemosyne, consolidation, the veracity system, or the sync layer.
- The fix adds no scans, hydration, fabricated signal fields, or new data movement.
- Local-first guarantees remain unchanged. The prefetch path continues to use local recall results.
- Privacy posture remains unchanged. Existing lexical filtering and caller scope protection remain active.
- MCP and CLI behavior do not change. Configuration and generated documentation now report version `3.17.0`.
- The adapter-only design is the right call. It fixes the integration contract without weakening core recall guarantees or increasing architectural coupling.

## Maintainability and verification

- Tests cover `voice_scores` provenance, strongest-voice ranking, lexical exclusion, raw transcript injection, and foreign-session isolation.
- The changelog, README, plugin metadata, package version, and generated API documentation were updated to `3.17.0`.
- No benchmark methodology or performance baseline changes are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->