### PR TITLE
fix(hermes): export the resolved memory bank

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -5,8 +5,8 @@ Available via: hermes mnemosyne <subcommand>
 
 from __future__ import annotations
 
-import json
 import importlib.metadata
+import json
 import os
 import sqlite3
 from pathlib import Path
@@ -61,12 +61,15 @@ _EXPORT_REQUIRED_TABLES = frozenset(_EXPORT_REQUIRED_COLUMNS)
 def _export_schema_is_complete_read_only(db_path: Path) -> bool:
     """Check selected export tables and read columns without opening it writable."""
     db_uri = f"{db_path.resolve().as_uri()}?mode=ro"
-    with sqlite3.connect(db_uri, uri=True) as conn:
+    conn = sqlite3.connect(db_uri, uri=True)
+    try:
         for table, required_columns in _EXPORT_REQUIRED_COLUMNS.items():
             # Table names are from the local fixed contract, not user input.
             columns = {row[1] for row in conn.execute(f'PRAGMA table_info("{table}")')}
             if not required_columns <= columns:
                 return False
+    finally:
+        conn.close()
     return True
 
 
@@ -270,8 +273,8 @@ def mnemosyne_command(args):
             # or output path can be initialized.
             print(f"Bank not found: {bank}")
             return 1
-        except Exception as e:
-            print(f"Bank validation failed: {e}")
+        except Exception:
+            print("Bank validation failed")
             return 1
 
     try:
@@ -330,7 +333,7 @@ def mnemosyne_command(args):
         # Unknown-bank guard now runs before the beam is built (see top of
         # mnemosyne_command), so bank is guaranteed to exist here.
         try:
-            from mnemosyne.diagnose import run_diagnostics, auto_fix
+            from mnemosyne.diagnose import auto_fix, run_diagnostics
             result = run_diagnostics(bank=bank)
             resolved_bank = bank or "default"
             print("\nMnemosyne Diagnostics")

--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -16,34 +16,58 @@ _BANK_HELP = (
     "when profile_isolation is enabled, otherwise the shared default bank."
 )
 
-# These are the persistent tables read unconditionally by Mnemosyne's JSON
-# exporter. Checking their names through SQLite's read-only URI gives selected
-# banks a fail-closed boundary before constructing Beam/Mnemosyne (whose schema
-# setup is intentionally write-capable).
-_EXPORT_REQUIRED_TABLES = frozenset({
-    "annotations",
-    "canonical_facts",
-    "consolidation_log",
-    "episodic_memory",
-    "memories",
-    "memory_embeddings",
-    "scratchpad",
-    "triples",
-    "working_memory",
-})
+# Persistent table columns read unconditionally by Mnemosyne's JSON exporter:
+# Mnemosyne.export_to_file(), BeamMemory.export_to_dict(), and the TripleStore,
+# AnnotationStore, and CanonicalStore export_all() methods. Checking this
+# contract through SQLite's read-only URI gives selected banks a fail-closed
+# boundary before constructing Beam/Mnemosyne (whose schema setup is intentionally
+# write-capable). It deliberately excludes optional sync and vector storage.
+_EXPORT_REQUIRED_COLUMNS = {
+    "working_memory": frozenset({
+        "id", "content", "source", "timestamp", "session_id", "importance",
+        "metadata_json", "valid_until", "superseded_by", "scope", "recall_count",
+        "last_recalled", "created_at", "veracity", "consolidated_at",
+        "consolidation_claimed_at",
+    }),
+    "episodic_memory": frozenset({
+        "id", "content", "source", "timestamp", "session_id", "importance",
+        "metadata_json", "summary_of", "valid_until", "superseded_by", "scope",
+        "recall_count", "last_recalled", "created_at",
+    }),
+    "scratchpad": frozenset({"id", "content", "session_id", "created_at", "updated_at"}),
+    "consolidation_log": frozenset({
+        "id", "session_id", "items_consolidated", "summary_preview", "created_at",
+    }),
+    "memories": frozenset({
+        "id", "content", "source", "timestamp", "session_id", "importance",
+        "metadata_json", "created_at",
+    }),
+    "memory_embeddings": frozenset({"memory_id", "embedding_json", "model", "created_at"}),
+    "triples": frozenset({
+        "id", "subject", "predicate", "object", "valid_from", "valid_until",
+        "source", "confidence", "created_at",
+    }),
+    "annotations": frozenset({
+        "id", "memory_id", "kind", "value", "source", "confidence", "created_at",
+    }),
+    "canonical_facts": frozenset({
+        "id", "owner_id", "category", "name", "body", "source", "confidence",
+        "version", "valid_from", "valid_until", "created_at",
+    }),
+}
+_EXPORT_REQUIRED_TABLES = frozenset(_EXPORT_REQUIRED_COLUMNS)
 
 
 def _export_schema_is_complete_read_only(db_path: Path) -> bool:
-    """Check the selected export DB's required tables without opening it writable."""
-    placeholders = ", ".join("?" for _ in _EXPORT_REQUIRED_TABLES)
+    """Check selected export tables and read columns without opening it writable."""
     db_uri = f"{db_path.resolve().as_uri()}?mode=ro"
     with sqlite3.connect(db_uri, uri=True) as conn:
-        rows = conn.execute(
-            "SELECT name FROM sqlite_master "
-            "WHERE type = 'table' AND name IN (" + placeholders + ")",
-            tuple(_EXPORT_REQUIRED_TABLES),
-        )
-        return {row[0] for row in rows} == _EXPORT_REQUIRED_TABLES
+        for table, required_columns in _EXPORT_REQUIRED_COLUMNS.items():
+            # Table names are from the local fixed contract, not user input.
+            columns = {row[1] for row in conn.execute(f'PRAGMA table_info("{table}")')}
+            if not required_columns <= columns:
+                return False
+    return True
 
 
 def _distribution_version(distribution: str) -> str:

--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -8,12 +8,42 @@ from __future__ import annotations
 import json
 import importlib.metadata
 import os
+import sqlite3
 from pathlib import Path
 
 _BANK_HELP = (
     "Mnemosyne bank to operate on. Defaults to the active Hermes profile's bank "
     "when profile_isolation is enabled, otherwise the shared default bank."
 )
+
+# These are the persistent tables read unconditionally by Mnemosyne's JSON
+# exporter. Checking their names through SQLite's read-only URI gives selected
+# banks a fail-closed boundary before constructing Beam/Mnemosyne (whose schema
+# setup is intentionally write-capable).
+_EXPORT_REQUIRED_TABLES = frozenset({
+    "annotations",
+    "canonical_facts",
+    "consolidation_log",
+    "episodic_memory",
+    "memories",
+    "memory_embeddings",
+    "scratchpad",
+    "triples",
+    "working_memory",
+})
+
+
+def _export_schema_is_complete_read_only(db_path: Path) -> bool:
+    """Check the selected export DB's required tables without opening it writable."""
+    placeholders = ", ".join("?" for _ in _EXPORT_REQUIRED_TABLES)
+    db_uri = f"{db_path.resolve().as_uri()}?mode=ro"
+    with sqlite3.connect(db_uri, uri=True) as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'table' AND name IN (" + placeholders + ")",
+            tuple(_EXPORT_REQUIRED_TABLES),
+        )
+        return {row[0] for row in rows} == _EXPORT_REQUIRED_TABLES
 
 
 def _distribution_version(distribution: str) -> str:
@@ -207,7 +237,10 @@ def mnemosyne_command(args):
     if cmd == "export" and bank:
         try:
             from mnemosyne.core.banks import get_bank_db_path_read_only
-            get_bank_db_path_read_only(bank)
+            db_path = get_bank_db_path_read_only(bank)
+            if not _export_schema_is_complete_read_only(db_path):
+                print(f"Bank schema incomplete: {bank}")
+                return 1
         except (FileNotFoundError, ValueError):
             # Named exports require an existing bank database before the beam
             # or output path can be initialized.

--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -264,6 +264,9 @@ def mnemosyne_command(args):
         try:
             from mnemosyne.core.banks import get_bank_db_path_read_only
             db_path = get_bank_db_path_read_only(bank)
+            if not db_path.is_file():
+                print(f"Bank not found: {bank}")
+                return 1
             if not _export_schema_is_complete_read_only(db_path):
                 print(f"Bank schema incomplete: {bank}")
                 return 1

--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -203,7 +203,9 @@ def _resolve_cli_bank(args, cmd):
                     and str(explicit).strip().lower() != "default"
                 ):
                     return _BANK_RESOLUTION_FAILED
-                return bank if bank != "default" else None
+                if bank == "default":
+                    return "default" if cmd == "export" else None
+                return bank
 
         hermes_home = os.environ.get("HERMES_HOME", "")
         if not hermes_home or not _profile_isolation_enabled(hermes_home):
@@ -214,7 +216,7 @@ def _resolve_cli_bank(args, cmd):
         bank = sanitize(basename)
         return bank if bank != "default" else None
     except Exception:
-        return _BANK_RESOLUTION_FAILED
+        return _BANK_RESOLUTION_FAILED if cmd == "export" else None
 
 
 def mnemosyne_command(args):

--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -220,21 +220,6 @@ def mnemosyne_command(args):
         print(f"Mnemosyne Hermes {_distribution_version('mnemosyne-hermes')}")
         return 0
 
-    # Register Hermes host LLM backend so sleep uses Hermes' provider.
-    # Use a try/except fallback chain: the relative import works when loaded
-    # as part of the mnemosyne_hermes package; the absolute import is needed
-    # when this module is loaded standalone (e.g. Hermes user-plugin
-    # discovery via importlib.util.spec_from_file_location, which does not
-    # set up the parent package — breaking relative imports silently).
-    try:
-        try:
-            from .hermes_llm_adapter import register_hermes_host_llm
-        except ImportError:
-            from mnemosyne_hermes.hermes_llm_adapter import register_hermes_host_llm
-        register_hermes_host_llm()
-    except Exception:
-        pass
-
     bank = _resolve_cli_bank(args, cmd)
 
     # Reject unknown named banks BEFORE touching the filesystem. Mnemosyne(bank=)
@@ -276,6 +261,20 @@ def mnemosyne_command(args):
         except Exception:
             print("Bank validation failed")
             return 1
+
+    # Register Hermes host LLM only after export validation. A rejected named
+    # export must not alter host-level runtime state before it exits fail-closed.
+    # Use a try/except fallback chain: the relative import works when loaded
+    # as part of the mnemosyne_hermes package; the absolute import is needed
+    # when this module is loaded standalone via importlib discovery.
+    try:
+        try:
+            from .hermes_llm_adapter import register_hermes_host_llm
+        except ImportError:
+            from mnemosyne_hermes.hermes_llm_adapter import register_hermes_host_llm
+        register_hermes_host_llm()
+    except Exception:
+        pass
 
     try:
         if bank:

--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -204,6 +204,19 @@ def mnemosyne_command(args):
             print(f"Bank validation failed: {e}")
             return 1
 
+    if cmd == "export" and bank:
+        try:
+            from mnemosyne.core.banks import get_bank_db_path_read_only
+            get_bank_db_path_read_only(bank)
+        except (FileNotFoundError, ValueError):
+            # Named exports require an existing bank database before the beam
+            # or output path can be initialized.
+            print(f"Bank not found: {bank}")
+            return 1
+        except Exception as e:
+            print(f"Bank validation failed: {e}")
+            return 1
+
     try:
         if bank:
             # Bank-aware beam (Mnemosyne routes the bank to its own SQLite DB),
@@ -299,7 +312,7 @@ def mnemosyne_command(args):
             return 1
         try:
             from mnemosyne.core.memory import Mnemosyne
-            mem = Mnemosyne(session_id="hermes_default")
+            mem = Mnemosyne(session_id="hermes_default", bank=bank)
             result = mem.export_to_file(output_path)
             print(f"Exported {result['working_memory_count']} working, {result['episodic_memory_count']} episodic, {result['legacy_memories_count']} legacy, {result['triples_count']} triples to {output_path}")
         except Exception as e:

--- a/integrations/hermes/src/mnemosyne_hermes/cli.py
+++ b/integrations/hermes/src/mnemosyne_hermes/cli.py
@@ -56,6 +56,8 @@ _EXPORT_REQUIRED_COLUMNS = {
     }),
 }
 _EXPORT_REQUIRED_TABLES = frozenset(_EXPORT_REQUIRED_COLUMNS)
+# Distinct from ``None``: ``None`` is the valid shared/default-bank selection.
+_BANK_RESOLUTION_FAILED = object()
 
 
 def _export_schema_is_complete_read_only(db_path: Path) -> bool:
@@ -184,7 +186,8 @@ def _resolve_cli_bank(args, cmd):
          (mirrors the provider's HERMES_HOME-basename fallback)
       3. ``None`` -> default/legacy bank (unchanged behavior)
 
-    Never raises: any failure falls back to ``None`` (the default bank).
+    Never raises: resolution failures use a private sentinel so named exports
+    can fail closed rather than silently selecting the default bank.
     """
     try:
         MnemosyneMemoryProvider = _get_provider_class()
@@ -194,6 +197,12 @@ def _resolve_cli_bank(args, cmd):
             explicit = getattr(args, "bank", None)
             if explicit:
                 bank = sanitize(explicit)
+                if (
+                    cmd == "export"
+                    and bank == "default"
+                    and str(explicit).strip().lower() != "default"
+                ):
+                    return _BANK_RESOLUTION_FAILED
                 return bank if bank != "default" else None
 
         hermes_home = os.environ.get("HERMES_HOME", "")
@@ -205,7 +214,7 @@ def _resolve_cli_bank(args, cmd):
         bank = sanitize(basename)
         return bank if bank != "default" else None
     except Exception:
-        return None
+        return _BANK_RESOLUTION_FAILED
 
 
 def mnemosyne_command(args):
@@ -221,6 +230,9 @@ def mnemosyne_command(args):
         return 0
 
     bank = _resolve_cli_bank(args, cmd)
+    if cmd == "export" and bank is _BANK_RESOLUTION_FAILED:
+        print("Bank resolution failed")
+        return 1
 
     # Reject unknown named banks BEFORE touching the filesystem. Mnemosyne(bank=)
     # would otherwise lazily create an empty bank directory + DB on first access

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -12,6 +12,7 @@ silently, again falling back to the default bank.
 
 import importlib.util
 import json
+import sqlite3
 import types
 from pathlib import Path
 
@@ -241,3 +242,35 @@ def test_export_selected_missing_or_incomplete_bank_has_no_artifacts(
     assert not output.exists()
     assert not (selected_path / "mnemosyne.db").exists()
     assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before
+
+
+@pytest.mark.parametrize("selection,bank", [("explicit", "work"), ("implicit", "profile")])
+def test_export_selected_bank_with_incomplete_sqlite_schema_is_untouched(
+    tmp_path, monkeypatch, capsys, selection, bank
+):
+    """A selected SQLite file without Mnemosyne's export schema fails closed."""
+    data_dir = tmp_path / "data"
+    selected_dir = data_dir / "banks" / bank
+    selected_dir.mkdir(parents=True)
+    db_path = selected_dir / "mnemosyne.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE unrelated (id INTEGER PRIMARY KEY)")
+    before_bytes = db_path.read_bytes()
+    before_paths = sorted(path.relative_to(data_dir) for path in data_dir.rglob("*"))
+
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    if selection == "implicit":
+        home = tmp_path / "profiles" / bank
+        _write_config(home, "true")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        args = _export_args(tmp_path / "must-not-exist.json")
+    else:
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        args = _export_args(tmp_path / "must-not-exist.json", bank=bank)
+
+    assert mnemosyne_command(args) == 1
+    assert f"Bank schema incomplete: {bank}" in capsys.readouterr().out
+    assert not Path(args.output).exists()
+    assert db_path.read_bytes() == before_bytes
+    assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -11,11 +11,15 @@ silently, again falling back to the default bank.
 """
 
 import importlib.util
+import json
 import types
 from pathlib import Path
 
-from mnemosyne_hermes.cli import _resolve_cli_bank, _get_provider_class
+import pytest
+from mnemosyne.core.memory import Mnemosyne
+
 import mnemosyne_hermes as _mnh
+from mnemosyne_hermes.cli import _get_provider_class, _resolve_cli_bank, mnemosyne_command
 
 
 def _args(**kw):
@@ -27,6 +31,19 @@ def _write_config(home, isolation):
     (home / "config.yaml").write_text(
         f"memory:\n  mnemosyne:\n    profile_isolation: {isolation}\n"
     )
+
+
+def _export_args(output, bank=None):
+    return _args(mnemosyne_cmd="export", output=str(output), bank=bank)
+
+
+def _seed_bank(bank, content):
+    Mnemosyne(session_id="hermes_default", bank=bank).remember(content)
+
+
+def _exported_contents(path):
+    payload = json.loads(path.read_text())
+    return {memory["content"] for memory in payload["working_memory"]}
 
 
 def test_explicit_bank_takes_precedence_and_is_sanitized(monkeypatch):
@@ -114,3 +131,68 @@ def test_standalone_load_via_spec_resolves_profile_bank(tmp_path, monkeypatch):
         f"standalone load: expected 'work', got {result!r}. "
         "This indicates the absolute-import fallback failed."
     )
+
+
+def test_export_explicit_bank_uses_only_selected_existing_bank(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    _seed_bank(None, "default-only")
+    _seed_bank("work", "work-only")
+
+    output = tmp_path / "work.json"
+    assert mnemosyne_command(_export_args(output, bank="work")) == 0
+    assert _exported_contents(output) == {"work-only"}
+
+
+def test_export_profile_isolation_uses_implicit_selected_bank(tmp_path, monkeypatch):
+    home = tmp_path / "profiles" / "work"
+    _write_config(home, "true")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    _seed_bank(None, "default-only")
+    _seed_bank("work", "profile-work-only")
+
+    output = tmp_path / "profile.json"
+    assert mnemosyne_command(_export_args(output)) == 0
+    assert _exported_contents(output) == {"profile-work-only"}
+
+
+def test_export_without_selected_bank_keeps_legacy_default_behavior(tmp_path, monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    _seed_bank(None, "default-only")
+    _seed_bank("work", "work-only")
+
+    output = tmp_path / "default.json"
+    assert mnemosyne_command(_export_args(output)) == 0
+    assert _exported_contents(output) == {"default-only"}
+
+
+@pytest.mark.parametrize("implicit,incomplete", [(False, False), (True, True)])
+def test_export_missing_or_incomplete_selected_bank_creates_no_artifacts(
+    tmp_path, monkeypatch, capsys, implicit, incomplete
+):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    output = tmp_path / "must-not-exist.json"
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    if implicit:
+        home = tmp_path / "profiles" / "work"
+        _write_config(home, "true")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        if incomplete:
+            (data_dir / "banks" / "work").mkdir(parents=True)
+        args = _export_args(output)
+    else:
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        args = _export_args(output, bank="missing")
+
+    before = sorted(path.relative_to(data_dir) for path in data_dir.rglob("*"))
+    assert mnemosyne_command(args) == 1
+    assert "Bank not found:" in capsys.readouterr().out
+    assert not output.exists()
+    assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -260,6 +260,20 @@ def test_export_without_selected_bank_keeps_legacy_default_behavior(tmp_path, mo
     _assert_export_has_only_label(_read_export(output), "default", "work")
 
 
+def test_export_explicit_default_bank_keeps_legacy_default_behavior(tmp_path, monkeypatch):
+    """Explicit default selects and preflights the populated legacy default DB."""
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    monkeypatch.setattr("mnemosyne.core.beam._vec_available", lambda conn: True)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    _seed_export_sections(None, "default", include_episodic_embedding=True)
+    _seed_export_sections("work", "work", include_episodic_embedding=True)
+
+    output = tmp_path / "explicit-default.json"
+    assert mnemosyne_command(_export_args(output, bank="default")) == 0
+    _assert_export_has_only_label(_read_export(output), "default", "work")
+
+
 @pytest.mark.parametrize(
     "selection,bank",
     [("explicit", "missing"), ("implicit", "work")],
@@ -378,7 +392,7 @@ def test_explicit_default_export_requires_existing_default_bank(tmp_path, monkey
     output_path = tmp_path / "export.json"
 
     assert mnemosyne_command(_export_args(output_path, bank="default")) == 1
-    assert capsys.readouterr().out == "Bank validation failed\n"
+    assert capsys.readouterr().out == "Bank not found: default\n"
     assert not output_path.exists()
 
 

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -24,6 +24,7 @@ from mnemosyne.core.triples import TripleStore
 
 import mnemosyne_hermes as _mnh
 from mnemosyne_hermes.cli import (
+    _EXPORT_REQUIRED_COLUMNS,
     _EXPORT_REQUIRED_TABLES,
     _export_schema_is_complete_read_only,
     _get_provider_class,
@@ -329,18 +330,46 @@ def test_export_selected_bank_with_incomplete_sqlite_schema_is_untouched(
     assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths
 
 
-_EXPORTER_TABLES = frozenset(
-    {
-        "working_memory",
-        "episodic_memory",
-        "scratchpad",
-        "consolidation_log",
-        "memories",
-        "memory_embeddings",
-        "triples",
-        "annotations",
-        "canonical_facts",
-    }
+# Mirror only the columns selected by the current unconditional JSON export
+# queries. This makes a contract change in an exporter fail this boundary test.
+_EXPORTER_REQUIRED_COLUMNS = {
+    "working_memory": frozenset({
+        "id", "content", "source", "timestamp", "session_id", "importance",
+        "metadata_json", "valid_until", "superseded_by", "scope", "recall_count",
+        "last_recalled", "created_at", "veracity", "consolidated_at",
+        "consolidation_claimed_at",
+    }),
+    "episodic_memory": frozenset({
+        "id", "content", "source", "timestamp", "session_id", "importance",
+        "metadata_json", "summary_of", "valid_until", "superseded_by", "scope",
+        "recall_count", "last_recalled", "created_at",
+    }),
+    "scratchpad": frozenset({"id", "content", "session_id", "created_at", "updated_at"}),
+    "consolidation_log": frozenset({
+        "id", "session_id", "items_consolidated", "summary_preview", "created_at",
+    }),
+    "memories": frozenset({
+        "id", "content", "source", "timestamp", "session_id", "importance",
+        "metadata_json", "created_at",
+    }),
+    "memory_embeddings": frozenset({"memory_id", "embedding_json", "model", "created_at"}),
+    "triples": frozenset({
+        "id", "subject", "predicate", "object", "valid_from", "valid_until",
+        "source", "confidence", "created_at",
+    }),
+    "annotations": frozenset({
+        "id", "memory_id", "kind", "value", "source", "confidence", "created_at",
+    }),
+    "canonical_facts": frozenset({
+        "id", "owner_id", "category", "name", "body", "source", "confidence",
+        "version", "valid_from", "valid_until", "created_at",
+    }),
+}
+_EXPORTER_TABLES = frozenset(_EXPORTER_REQUIRED_COLUMNS)
+_EXPORTER_REQUIRED_COLUMN_CASES = tuple(
+    (table, column)
+    for table, columns in sorted(_EXPORTER_REQUIRED_COLUMNS.items())
+    for column in sorted(columns)
 )
 
 
@@ -368,6 +397,7 @@ def test_export_selected_bank_rejects_each_missing_exporter_table_without_mutati
     tmp_path, monkeypatch, capsys, selection, bank, missing_table
 ):
     """Every table read unconditionally by the exporter is a probe dependency."""
+    assert _EXPORT_REQUIRED_COLUMNS == _EXPORTER_REQUIRED_COLUMNS
     assert _EXPORT_REQUIRED_TABLES == _EXPORTER_TABLES
     args, data_dir, db_path = _initialized_selected_export(tmp_path, monkeypatch, selection, bank)
     with sqlite3.connect(db_path) as conn:
@@ -381,6 +411,28 @@ def test_export_selected_bank_rejects_each_missing_exporter_table_without_mutati
     assert db_path.read_bytes() == before_bytes
     assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths
 
+
+@pytest.mark.parametrize("selection,bank", [("explicit", "work"), ("implicit", "profile")])
+@pytest.mark.parametrize("table,column", _EXPORTER_REQUIRED_COLUMN_CASES)
+def test_export_selected_bank_rejects_each_missing_exporter_column_without_mutation(
+    tmp_path, monkeypatch, capsys, selection, bank, table, column
+):
+    """Every unconditional exporter column fails selected-bank preflight closed."""
+    assert _EXPORT_REQUIRED_COLUMNS == _EXPORTER_REQUIRED_COLUMNS
+    args, data_dir, db_path = _initialized_selected_export(tmp_path, monkeypatch, selection, bank)
+    renamed_column = f"missing_export_column_{column}"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            f'ALTER TABLE "{table}" RENAME COLUMN "{column}" TO "{renamed_column}"'
+        )
+    before_bytes = db_path.read_bytes()
+    before_paths = sorted(path.relative_to(data_dir) for path in data_dir.rglob("*"))
+
+    assert mnemosyne_command(args) == 1
+    assert f"Bank schema incomplete: {bank}" in capsys.readouterr().out
+    assert not Path(args.output).exists()
+    assert db_path.read_bytes() == before_bytes
+    assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths
 
 @pytest.mark.parametrize("selection,bank", [("explicit", "work"), ("implicit", "profile")])
 def test_export_selected_bank_does_not_require_optional_sync_table(

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -16,13 +16,8 @@ import sqlite3
 import types
 from pathlib import Path
 
-import pytest
-from mnemosyne.core.annotations import AnnotationStore
-from mnemosyne.core.canonical import CanonicalStore
-from mnemosyne.core.memory import Mnemosyne
-from mnemosyne.core.triples import TripleStore
-
 import mnemosyne_hermes as _mnh
+import pytest
 from mnemosyne_hermes.cli import (
     _EXPORT_REQUIRED_COLUMNS,
     _EXPORT_REQUIRED_TABLES,
@@ -31,6 +26,11 @@ from mnemosyne_hermes.cli import (
     _resolve_cli_bank,
     mnemosyne_command,
 )
+
+from mnemosyne.core.annotations import AnnotationStore
+from mnemosyne.core.canonical import CanonicalStore
+from mnemosyne.core.memory import Mnemosyne
+from mnemosyne.core.triples import TripleStore
 
 
 def _args(**kw):
@@ -275,7 +275,7 @@ def test_export_selected_missing_or_incomplete_bank_has_no_artifacts(
     """
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    output = tmp_path / "must-not-exist.json"
+    output = tmp_path / "export.json"
     monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
     monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
     if selection == "implicit":
@@ -298,6 +298,53 @@ def test_export_selected_missing_or_incomplete_bank_has_no_artifacts(
     assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before
 
 
+def test_export_bank_validation_error_does_not_disclose_exception_details(
+    tmp_path, monkeypatch, capsys
+):
+    """Unexpected preflight errors remain concise and do not expose DB paths."""
+    def raise_validation_error(bank):
+        raise RuntimeError(f"cannot inspect {tmp_path / 'private' / bank / 'mnemosyne.db'}")
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(
+        "mnemosyne.core.banks.get_bank_db_path_read_only", raise_validation_error
+    )
+
+    assert mnemosyne_command(_export_args(tmp_path / "export.json", bank="work")) == 1
+    output = capsys.readouterr().out
+    assert output == "Bank validation failed\n"
+    assert str(tmp_path) not in output
+
+
+@pytest.mark.parametrize("raise_on_execute", [False, True])
+def test_export_schema_probe_closes_connection_on_all_paths(
+    tmp_path, monkeypatch, raise_on_execute
+):
+    """The read-only preflight closes even on early return or query failure."""
+    class Connection:
+        closed = False
+
+        def execute(self, query):
+            if raise_on_execute:
+                raise sqlite3.DatabaseError("query failed")
+            return []
+
+        def close(self):
+            self.closed = True
+
+    connection = Connection()
+    monkeypatch.setattr(
+        "mnemosyne_hermes.cli.sqlite3.connect", lambda *args, **kwargs: connection
+    )
+
+    if raise_on_execute:
+        with pytest.raises(sqlite3.DatabaseError, match="query failed"):
+            _export_schema_is_complete_read_only(tmp_path / "selected.db")
+    else:
+        assert not _export_schema_is_complete_read_only(tmp_path / "selected.db")
+    assert connection.closed
+
+
 @pytest.mark.parametrize("selection,bank", [("explicit", "work"), ("implicit", "profile")])
 def test_export_selected_bank_with_incomplete_sqlite_schema_is_untouched(
     tmp_path, monkeypatch, capsys, selection, bank
@@ -318,10 +365,10 @@ def test_export_selected_bank_with_incomplete_sqlite_schema_is_untouched(
         home = tmp_path / "profiles" / bank
         _write_config(home, "true")
         monkeypatch.setenv("HERMES_HOME", str(home))
-        args = _export_args(tmp_path / "must-not-exist.json")
+        args = _export_args(tmp_path / "export.json")
     else:
         monkeypatch.delenv("HERMES_HOME", raising=False)
-        args = _export_args(tmp_path / "must-not-exist.json", bank=bank)
+        args = _export_args(tmp_path / "export.json", bank=bank)
 
     assert mnemosyne_command(args) == 1
     assert f"Bank schema incomplete: {bank}" in capsys.readouterr().out
@@ -384,10 +431,10 @@ def _initialized_selected_export(tmp_path, monkeypatch, selection, bank):
         home = tmp_path / "profiles" / bank
         _write_config(home, "true")
         monkeypatch.setenv("HERMES_HOME", str(home))
-        args = _export_args(tmp_path / "must-not-exist.json")
+        args = _export_args(tmp_path / "export.json")
     else:
         monkeypatch.delenv("HERMES_HOME", raising=False)
-        args = _export_args(tmp_path / "must-not-exist.json", bank=bank)
+        args = _export_args(tmp_path / "export.json", bank=bank)
     return args, data_dir, db_path
 
 
@@ -433,6 +480,7 @@ def test_export_selected_bank_rejects_each_missing_exporter_column_without_mutat
     assert not Path(args.output).exists()
     assert db_path.read_bytes() == before_bytes
     assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths
+
 
 @pytest.mark.parametrize("selection,bank", [("explicit", "work"), ("implicit", "profile")])
 def test_export_selected_bank_does_not_require_optional_sync_table(

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -16,7 +16,10 @@ import types
 from pathlib import Path
 
 import pytest
+from mnemosyne.core.annotations import AnnotationStore
+from mnemosyne.core.canonical import CanonicalStore
 from mnemosyne.core.memory import Mnemosyne
+from mnemosyne.core.triples import TripleStore
 
 import mnemosyne_hermes as _mnh
 from mnemosyne_hermes.cli import _get_provider_class, _resolve_cli_bank, mnemosyne_command
@@ -37,13 +40,41 @@ def _export_args(output, bank=None):
     return _args(mnemosyne_cmd="export", output=str(output), bank=bank)
 
 
-def _seed_bank(bank, content):
-    Mnemosyne(session_id="hermes_default", bank=bank).remember(content)
+def _seed_export_sections(bank, label):
+    """Seed every export section with a supported synthetic writer."""
+    marker = f"bank-marker-{label}"
+    memory = Mnemosyne(session_id="hermes_default", bank=bank)
+    memory_id = memory.remember(f"working-{marker}")
+    memory.beam.consolidate_to_episodic(f"episodic-{marker}", [memory_id])
+    memory.scratchpad_write(f"scratchpad-{marker}")
+    TripleStore(db_path=memory.db_path).add(f"triple-{marker}", "has", "value")
+    AnnotationStore(db_path=memory.db_path).add(memory_id, "fact", f"annotation-{marker}")
+    CanonicalStore(db_path=memory.db_path).remember(
+        f"owner-{marker}", "profile", "name", f"canonical-{marker}"
+    )
 
 
-def _exported_contents(path):
-    payload = json.loads(path.read_text())
-    return {memory["content"] for memory in payload["working_memory"]}
+def _read_export(path):
+    return json.loads(path.read_text())
+
+
+def _assert_export_has_only_label(payload, selected, excluded):
+    """Assert each seedable, bank-scoped export section is isolated."""
+    marker = f"bank-marker-{selected}"
+    excluded_marker = f"bank-marker-{excluded}"
+    expected_sections = {
+        "working_memory": f"working-{marker}",
+        "episodic_memory": f"episodic-{marker}",
+        "scratchpad": f"scratchpad-{marker}",
+        "legacy_memories": f"working-{marker}",
+        "triples": f"triple-{marker}",
+        "annotations": f"annotation-{marker}",
+        "canonical_facts": f"canonical-{marker}",
+    }
+    for section, expected_marker in expected_sections.items():
+        serialized = json.dumps(payload[section])
+        assert expected_marker in serialized, f"{section} omitted selected-bank content"
+        assert excluded_marker not in serialized, f"{section} leaked other-bank content"
 
 
 def test_explicit_bank_takes_precedence_and_is_sanitized(monkeypatch):
@@ -133,66 +164,80 @@ def test_standalone_load_via_spec_resolves_profile_bank(tmp_path, monkeypatch):
     )
 
 
-def test_export_explicit_bank_uses_only_selected_existing_bank(tmp_path, monkeypatch):
+def test_export_explicit_bank_has_no_default_content_in_seedable_sections(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
     monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
     monkeypatch.delenv("HERMES_HOME", raising=False)
-    _seed_bank(None, "default-only")
-    _seed_bank("work", "work-only")
+    _seed_export_sections(None, "default")
+    _seed_export_sections("work", "work")
 
     output = tmp_path / "work.json"
     assert mnemosyne_command(_export_args(output, bank="work")) == 0
-    assert _exported_contents(output) == {"work-only"}
+    _assert_export_has_only_label(_read_export(output), "work", "default")
 
 
-def test_export_profile_isolation_uses_implicit_selected_bank(tmp_path, monkeypatch):
+def test_export_profile_isolation_has_no_default_content_in_seedable_sections(
+    tmp_path, monkeypatch
+):
     home = tmp_path / "profiles" / "work"
     _write_config(home, "true")
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
     monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
-    _seed_bank(None, "default-only")
-    _seed_bank("work", "profile-work-only")
+    _seed_export_sections(None, "default")
+    _seed_export_sections("work", "work")
 
     output = tmp_path / "profile.json"
     assert mnemosyne_command(_export_args(output)) == 0
-    assert _exported_contents(output) == {"profile-work-only"}
+    _assert_export_has_only_label(_read_export(output), "work", "default")
 
 
 def test_export_without_selected_bank_keeps_legacy_default_behavior(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
     monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
     monkeypatch.delenv("HERMES_HOME", raising=False)
-    _seed_bank(None, "default-only")
-    _seed_bank("work", "work-only")
+    _seed_export_sections(None, "default")
+    _seed_export_sections("work", "work")
 
     output = tmp_path / "default.json"
     assert mnemosyne_command(_export_args(output)) == 0
-    assert _exported_contents(output) == {"default-only"}
+    _assert_export_has_only_label(_read_export(output), "default", "work")
 
 
-@pytest.mark.parametrize("implicit,incomplete", [(False, False), (True, True)])
-def test_export_missing_or_incomplete_selected_bank_creates_no_artifacts(
-    tmp_path, monkeypatch, capsys, implicit, incomplete
+@pytest.mark.parametrize(
+    "selection,bank",
+    [("explicit", "missing"), ("implicit", "work")],
+)
+@pytest.mark.parametrize("state", ["missing", "incomplete"])
+def test_export_selected_missing_or_incomplete_bank_has_no_artifacts(
+    tmp_path, monkeypatch, capsys, selection, bank, state
 ):
+    """A selected named bank needs its directory and SQLite DB before export.
+
+    ``get_bank_db_path_read_only`` defines an incomplete bank as a bank directory
+    without ``mnemosyne.db``; it deliberately accepts any existing SQLite file
+    and does not validate that file's schema.
+    """
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     output = tmp_path / "must-not-exist.json"
     monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
     monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
-    if implicit:
-        home = tmp_path / "profiles" / "work"
+    if selection == "implicit":
+        home = tmp_path / "profiles" / bank
         _write_config(home, "true")
         monkeypatch.setenv("HERMES_HOME", str(home))
-        if incomplete:
-            (data_dir / "banks" / "work").mkdir(parents=True)
         args = _export_args(output)
     else:
         monkeypatch.delenv("HERMES_HOME", raising=False)
-        args = _export_args(output, bank="missing")
+        args = _export_args(output, bank=bank)
+    if state == "incomplete":
+        (data_dir / "banks" / bank).mkdir(parents=True)
 
+    selected_path = data_dir / "banks" / bank
     before = sorted(path.relative_to(data_dir) for path in data_dir.rglob("*"))
     assert mnemosyne_command(args) == 1
     assert "Bank not found:" in capsys.readouterr().out
     assert not output.exists()
+    assert not (selected_path / "mnemosyne.db").exists()
     assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -24,6 +24,7 @@ from mnemosyne.core.triples import TripleStore
 
 import mnemosyne_hermes as _mnh
 from mnemosyne_hermes.cli import (
+    _BANK_RESOLUTION_FAILED,
     _EXPORT_REQUIRED_COLUMNS,
     _EXPORT_REQUIRED_TABLES,
     _export_schema_is_complete_read_only,
@@ -340,6 +341,33 @@ def test_export_missing_selected_bank_fails_before_host_llm_registration(
     assert mnemosyne_command(_export_args(output_path, bank="work")) == 1
     assert "Bank not found: work" in capsys.readouterr().out
     assert registrations == []
+    assert not output_path.exists()
+
+
+def test_export_invalid_explicit_bank_does_not_fall_back_to_default_bank(
+    tmp_path, monkeypatch, capsys
+):
+    """An invalid explicit export bank never selects shared/default data."""
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    output_path = tmp_path / "export.json"
+
+    assert mnemosyne_command(_export_args(output_path, bank="***")) == 1
+    assert capsys.readouterr().out == "Bank resolution failed\n"
+    assert not output_path.exists()
+
+
+def test_export_resolution_failure_does_not_fall_back_to_default_bank(
+    tmp_path, monkeypatch, capsys
+):
+    """A resolver failure never exports the shared/default bank."""
+    monkeypatch.setattr(
+        "mnemosyne_hermes.cli._resolve_cli_bank", lambda *_args: _BANK_RESOLUTION_FAILED
+    )
+    output_path = tmp_path / "export.json"
+
+    assert mnemosyne_command(_export_args(output_path, bank="work")) == 1
+    assert capsys.readouterr().out == "Bank resolution failed\n"
     assert not output_path.exists()
 
 

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -324,6 +324,25 @@ def test_export_bank_validation_error_does_not_disclose_exception_details(
     assert not output_path.exists()
 
 
+def test_export_missing_selected_bank_fails_before_host_llm_registration(
+    tmp_path, monkeypatch, capsys
+):
+    """Rejected named exports leave the host LLM registry untouched."""
+    registrations = []
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr(
+        "mnemosyne_hermes.hermes_llm_adapter.register_hermes_host_llm",
+        lambda: registrations.append("called"),
+    )
+
+    output_path = tmp_path / "export.json"
+    assert mnemosyne_command(_export_args(output_path, bank="work")) == 1
+    assert "Bank not found: work" in capsys.readouterr().out
+    assert registrations == []
+    assert not output_path.exists()
+
+
 @pytest.mark.parametrize("raise_on_execute", [False, True])
 def test_export_schema_probe_closes_connection_on_all_paths(
     tmp_path, monkeypatch, raise_on_execute

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -23,7 +23,13 @@ from mnemosyne.core.memory import Mnemosyne
 from mnemosyne.core.triples import TripleStore
 
 import mnemosyne_hermes as _mnh
-from mnemosyne_hermes.cli import _get_provider_class, _resolve_cli_bank, mnemosyne_command
+from mnemosyne_hermes.cli import (
+    _EXPORT_REQUIRED_TABLES,
+    _export_schema_is_complete_read_only,
+    _get_provider_class,
+    _resolve_cli_bank,
+    mnemosyne_command,
+)
 
 
 def _args(**kw):
@@ -41,8 +47,8 @@ def _export_args(output, bank=None):
     return _args(mnemosyne_cmd="export", output=str(output), bank=bank)
 
 
-def _seed_export_sections(bank, label):
-    """Seed every export section with a supported synthetic writer."""
+def _seed_export_sections(bank, label, *, include_episodic_embedding=False):
+    """Seed every non-optional export section with bank-specific content."""
     marker = f"bank-marker-{label}"
     memory = Mnemosyne(session_id="hermes_default", bank=bank)
     memory_id = memory.remember(f"working-{marker}")
@@ -53,6 +59,43 @@ def _seed_export_sections(bank, label):
     CanonicalStore(db_path=memory.db_path).remember(
         f"owner-{marker}", "profile", "name", f"canonical-{marker}"
     )
+    # The public writers above cover the normal memory sections. The exporter
+    # also reads these persistent rows directly, so use a disposable test DB to
+    # make their bank provenance observable without a vector backend or an
+    # actual consolidation run.
+    if include_episodic_embedding:
+        # Use Beam's connection so a real vec0 table, when present, can be
+        # replaced safely with this disposable, deterministic test table.
+        episode_rowid = memory.conn.execute(
+            "SELECT rowid FROM episodic_memory WHERE content = ?",
+            (f"episodic-{marker}",),
+        ).fetchone()[0]
+        memory.conn.execute("DROP TABLE IF EXISTS vec_episodes")
+        memory.conn.execute(
+            "CREATE TABLE vec_episodes (rowid INTEGER PRIMARY KEY, embedding TEXT NOT NULL)"
+        )
+        memory.conn.execute(
+            "INSERT INTO vec_episodes (rowid, embedding) VALUES (?, ?)",
+            (episode_rowid, json.dumps([f"episodic-embedding-{marker}"])),
+        )
+        memory.conn.commit()
+    with sqlite3.connect(memory.db_path) as conn:
+        conn.execute(
+            "INSERT INTO consolidation_log "
+            "(session_id, items_consolidated, summary_preview, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("hermes_default", 1, f"consolidation-{marker}", "2026-01-01T00:00:00"),
+        )
+        conn.execute(
+            "INSERT INTO memory_embeddings "
+            "(memory_id, embedding_json, model, created_at) VALUES (?, ?, ?, ?)",
+            (
+                f"legacy-embedding-{marker}",
+                json.dumps([f"legacy-embedding-{marker}"]),
+                "test",
+                "2026-01-01T00:00:00",
+            ),
+        )
 
 
 def _read_export(path):
@@ -60,14 +103,17 @@ def _read_export(path):
 
 
 def _assert_export_has_only_label(payload, selected, excluded):
-    """Assert each seedable, bank-scoped export section is isolated."""
+    """Assert every non-optional payload section is selected-bank-only."""
     marker = f"bank-marker-{selected}"
     excluded_marker = f"bank-marker-{excluded}"
     expected_sections = {
         "working_memory": f"working-{marker}",
         "episodic_memory": f"episodic-{marker}",
+        "episodic_embeddings": f"episodic-embedding-{marker}",
         "scratchpad": f"scratchpad-{marker}",
+        "consolidation_log": f"consolidation-{marker}",
         "legacy_memories": f"working-{marker}",
+        "legacy_embeddings": f"legacy-embedding-{marker}",
         "triples": f"triple-{marker}",
         "annotations": f"annotation-{marker}",
         "canonical_facts": f"canonical-{marker}",
@@ -76,6 +122,10 @@ def _assert_export_has_only_label(payload, selected, excluded):
         serialized = json.dumps(payload[section])
         assert expected_marker in serialized, f"{section} omitted selected-bank content"
         assert excluded_marker not in serialized, f"{section} leaked other-bank content"
+    # Section-specific presence above proves that all exporter sections were
+    # actually exercised; this whole-payload check catches a future section
+    # added to the exporter that accidentally binds to the default database.
+    assert excluded_marker not in json.dumps(payload)
 
 
 def test_explicit_bank_takes_precedence_and_is_sanitized(monkeypatch):
@@ -168,9 +218,10 @@ def test_standalone_load_via_spec_resolves_profile_bank(tmp_path, monkeypatch):
 def test_export_explicit_bank_has_no_default_content_in_seedable_sections(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
     monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    monkeypatch.setattr("mnemosyne.core.beam._vec_available", lambda conn: True)
     monkeypatch.delenv("HERMES_HOME", raising=False)
-    _seed_export_sections(None, "default")
-    _seed_export_sections("work", "work")
+    _seed_export_sections(None, "default", include_episodic_embedding=True)
+    _seed_export_sections("work", "work", include_episodic_embedding=True)
 
     output = tmp_path / "work.json"
     assert mnemosyne_command(_export_args(output, bank="work")) == 0
@@ -185,8 +236,9 @@ def test_export_profile_isolation_has_no_default_content_in_seedable_sections(
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
     monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
-    _seed_export_sections(None, "default")
-    _seed_export_sections("work", "work")
+    monkeypatch.setattr("mnemosyne.core.beam._vec_available", lambda conn: True)
+    _seed_export_sections(None, "default", include_episodic_embedding=True)
+    _seed_export_sections("work", "work", include_episodic_embedding=True)
 
     output = tmp_path / "profile.json"
     assert mnemosyne_command(_export_args(output)) == 0
@@ -196,9 +248,10 @@ def test_export_profile_isolation_has_no_default_content_in_seedable_sections(
 def test_export_without_selected_bank_keeps_legacy_default_behavior(tmp_path, monkeypatch):
     monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
     monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    monkeypatch.setattr("mnemosyne.core.beam._vec_available", lambda conn: True)
     monkeypatch.delenv("HERMES_HOME", raising=False)
-    _seed_export_sections(None, "default")
-    _seed_export_sections("work", "work")
+    _seed_export_sections(None, "default", include_episodic_embedding=True)
+    _seed_export_sections("work", "work", include_episodic_embedding=True)
 
     output = tmp_path / "default.json"
     assert mnemosyne_command(_export_args(output)) == 0
@@ -272,5 +325,79 @@ def test_export_selected_bank_with_incomplete_sqlite_schema_is_untouched(
     assert mnemosyne_command(args) == 1
     assert f"Bank schema incomplete: {bank}" in capsys.readouterr().out
     assert not Path(args.output).exists()
+    assert db_path.read_bytes() == before_bytes
+    assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths
+
+
+_EXPORTER_TABLES = frozenset(
+    {
+        "working_memory",
+        "episodic_memory",
+        "scratchpad",
+        "consolidation_log",
+        "memories",
+        "memory_embeddings",
+        "triples",
+        "annotations",
+        "canonical_facts",
+    }
+)
+
+
+def _initialized_selected_export(tmp_path, monkeypatch, selection, bank):
+    """Create a complete selected bank and configure its CLI selection mode."""
+    data_dir = tmp_path / "data"
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
+    _seed_export_sections(bank, "selected")
+    db_path = data_dir / "banks" / bank / "mnemosyne.db"
+    if selection == "implicit":
+        home = tmp_path / "profiles" / bank
+        _write_config(home, "true")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        args = _export_args(tmp_path / "must-not-exist.json")
+    else:
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        args = _export_args(tmp_path / "must-not-exist.json", bank=bank)
+    return args, data_dir, db_path
+
+
+@pytest.mark.parametrize("selection,bank", [("explicit", "work"), ("implicit", "profile")])
+@pytest.mark.parametrize("missing_table", sorted(_EXPORTER_TABLES))
+def test_export_selected_bank_rejects_each_missing_exporter_table_without_mutation(
+    tmp_path, monkeypatch, capsys, selection, bank, missing_table
+):
+    """Every table read unconditionally by the exporter is a probe dependency."""
+    assert _EXPORT_REQUIRED_TABLES == _EXPORTER_TABLES
+    args, data_dir, db_path = _initialized_selected_export(tmp_path, monkeypatch, selection, bank)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(f'DROP TABLE "{missing_table}"')
+    before_bytes = db_path.read_bytes()
+    before_paths = sorted(path.relative_to(data_dir) for path in data_dir.rglob("*"))
+
+    assert mnemosyne_command(args) == 1
+    assert f"Bank schema incomplete: {bank}" in capsys.readouterr().out
+    assert not Path(args.output).exists()
+    assert db_path.read_bytes() == before_bytes
+    assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths
+
+
+@pytest.mark.parametrize("selection,bank", [("explicit", "work"), ("implicit", "profile")])
+def test_export_selected_bank_does_not_require_optional_sync_table(
+    tmp_path, monkeypatch, selection, bank
+):
+    """Optional sync storage is absent from the read-only probe and export path."""
+    args, data_dir, db_path = _initialized_selected_export(tmp_path, monkeypatch, selection, bank)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TABLE IF EXISTS memory_events")
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+    assert "memory_events" not in tables
+    assert _export_schema_is_complete_read_only(db_path)
+    before_bytes = db_path.read_bytes()
+    before_paths = sorted(path.relative_to(data_dir) for path in data_dir.rglob("*"))
+
+    assert mnemosyne_command(args) == 0
+    payload = _read_export(Path(args.output))
+    assert "working-bank-marker-selected" in json.dumps(payload["working_memory"])
     assert db_path.read_bytes() == before_bytes
     assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -16,8 +16,13 @@ import sqlite3
 import types
 from pathlib import Path
 
-import mnemosyne_hermes as _mnh
 import pytest
+from mnemosyne.core.annotations import AnnotationStore
+from mnemosyne.core.canonical import CanonicalStore
+from mnemosyne.core.memory import Mnemosyne
+from mnemosyne.core.triples import TripleStore
+
+import mnemosyne_hermes as _mnh
 from mnemosyne_hermes.cli import (
     _EXPORT_REQUIRED_COLUMNS,
     _EXPORT_REQUIRED_TABLES,
@@ -26,11 +31,6 @@ from mnemosyne_hermes.cli import (
     _resolve_cli_bank,
     mnemosyne_command,
 )
-
-from mnemosyne.core.annotations import AnnotationStore
-from mnemosyne.core.canonical import CanonicalStore
-from mnemosyne.core.memory import Mnemosyne
-from mnemosyne.core.triples import TripleStore
 
 
 def _args(**kw):
@@ -302,18 +302,26 @@ def test_export_bank_validation_error_does_not_disclose_exception_details(
     tmp_path, monkeypatch, capsys
 ):
     """Unexpected preflight errors remain concise and do not expose DB paths."""
+    calls = []
+
     def raise_validation_error(bank):
+        calls.append(bank)
         raise RuntimeError(f"cannot inspect {tmp_path / 'private' / bank / 'mnemosyne.db'}")
 
     monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("MNEMOSYNE_NO_EMBEDDINGS", "1")
     monkeypatch.setattr(
         "mnemosyne.core.banks.get_bank_db_path_read_only", raise_validation_error
     )
 
-    assert mnemosyne_command(_export_args(tmp_path / "export.json", bank="work")) == 1
+    output_path = tmp_path / "export.json"
+    assert mnemosyne_command(_export_args(output_path, bank="work")) == 1
     output = capsys.readouterr().out
     assert output == "Bank validation failed\n"
     assert str(tmp_path) not in output
+    assert calls == ["work"]
+    assert not output_path.exists()
 
 
 @pytest.mark.parametrize("raise_on_execute", [False, True])
@@ -369,10 +377,11 @@ def test_export_selected_bank_with_incomplete_sqlite_schema_is_untouched(
     else:
         monkeypatch.delenv("HERMES_HOME", raising=False)
         args = _export_args(tmp_path / "export.json", bank=bank)
+    output = Path(args.output)
 
     assert mnemosyne_command(args) == 1
     assert f"Bank schema incomplete: {bank}" in capsys.readouterr().out
-    assert not Path(args.output).exists()
+    assert not output.exists()
     assert db_path.read_bytes() == before_bytes
     assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths
 
@@ -451,10 +460,11 @@ def test_export_selected_bank_rejects_each_missing_exporter_table_without_mutati
         conn.execute(f'DROP TABLE "{missing_table}"')
     before_bytes = db_path.read_bytes()
     before_paths = sorted(path.relative_to(data_dir) for path in data_dir.rglob("*"))
+    output = Path(args.output)
 
     assert mnemosyne_command(args) == 1
     assert f"Bank schema incomplete: {bank}" in capsys.readouterr().out
-    assert not Path(args.output).exists()
+    assert not output.exists()
     assert db_path.read_bytes() == before_bytes
     assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths
 
@@ -474,10 +484,11 @@ def test_export_selected_bank_rejects_each_missing_exporter_column_without_mutat
         )
     before_bytes = db_path.read_bytes()
     before_paths = sorted(path.relative_to(data_dir) for path in data_dir.rglob("*"))
+    output = Path(args.output)
 
     assert mnemosyne_command(args) == 1
     assert f"Bank schema incomplete: {bank}" in capsys.readouterr().out
-    assert not Path(args.output).exists()
+    assert not output.exists()
     assert db_path.read_bytes() == before_bytes
     assert sorted(path.relative_to(data_dir) for path in data_dir.rglob("*")) == before_paths
 

--- a/integrations/hermes/tests/test_cli_bank.py
+++ b/integrations/hermes/tests/test_cli_bank.py
@@ -371,6 +371,23 @@ def test_export_resolution_failure_does_not_fall_back_to_default_bank(
     assert not output_path.exists()
 
 
+def test_explicit_default_export_requires_existing_default_bank(tmp_path, monkeypatch, capsys):
+    """An explicit default bank is preflighted instead of bypassing validation."""
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "data"))
+    output_path = tmp_path / "export.json"
+
+    assert mnemosyne_command(_export_args(output_path, bank="default")) == 1
+    assert capsys.readouterr().out == "Bank validation failed\n"
+    assert not output_path.exists()
+
+
+def test_non_export_resolution_failure_keeps_default_fallback(monkeypatch):
+    """Ordinary CLI commands retain legacy fail-soft resolver behavior."""
+    monkeypatch.setattr("mnemosyne_hermes.cli._get_provider_class", lambda: (_ for _ in ()).throw(RuntimeError()))
+    assert _resolve_cli_bank(_args(bank="work"), "stats") is None
+
+
 @pytest.mark.parametrize("raise_on_execute", [False, True])
 def test_export_schema_probe_closes_connection_on_all_paths(
     tmp_path, monkeypatch, raise_on_execute


### PR DESCRIPTION
## Summary

Fixes #690 by making `hermes mnemosyne export` honor its resolved bank context and fail closed for an incomplete selected bank.

- Passes explicit and profile-resolved selected banks to the export-side `Mnemosyne` instance, preventing default-bank export leakage.
- Keeps the legacy no-selected-bank export behavior unchanged.
- Validates a selected bank through a SQLite read-only preflight before Beam/Mnemosyne or output initialization.
- Rejects missing, directory-incomplete, table-incomplete, and column-incomplete selected banks without creating an output artifact or mutating the selected bank.
- Avoids exposing filesystem paths from unexpected validation failures.

## Verification

- `198 passed` — `integrations/hermes/tests/test_cli_bank.py`
- `391 passed` — `integrations/hermes/tests`
- Ruff and `git diff --check` pass.
- Immutable archive run at `df335a571d5f43a88ba1dff6b6def3c355ee0ec4`: `198 passed`, integrity pass.

## Scope

This intentionally does not add migration/repair behavior, vector validation, or generalized schema validation. The preflight covers only the current non-optional JSON-export dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes `hermes mnemosyne export` to use the explicitly selected or profile-resolved memory bank.
- Preserves the default bank when no bank is selected.
- Adds read-only SQLite preflight validation before Beam/Mnemosyne initialization and output creation.
- Rejects missing banks, missing tables, incomplete schemas, and missing required columns without creating output artifacts or mutating local storage.
- Prevents filesystem paths from appearing in unexpected validation errors.
- Adds coverage for bank isolation, profile resolution, schema validation, connection closure, concise errors, and optional sync-table handling.

## Architectural impact

- The change affects the Hermes CLI export integration.
- It keeps bank resolution and the Mnemosyne database path consistent with the CLI Beam.
- It prevents default-bank data leakage during export.
- Read-only validation strengthens privacy and local-first guarantees because it does not migrate, repair, or mutate local storage.
- The change does not modify working, episodic, or BEAM memory tiers.
- The change does not modify retrieval, consolidation, veracity, synchronization, MCP integration, or benchmark methodology.
- The change does not require optional sync storage for export.
- The fixed schema contract and focused regression tests improve long-term maintainability.

## Assessment

Using the resolved bank and validating it before initialization is the right call. It protects bank isolation, prevents unintended data exposure, and avoids misleading output when a bank is missing or incomplete. The implementation also fails before LLM registration and output creation. It does not erode Mnemosyne’s core memory architecture or local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->