### PR TITLE
fix: warn before uncached local model download

### DIFF
--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -124,6 +124,7 @@ def _download_model() -> Path:
     size_notice = " (approximately 656 MB)" if default_artifact else ""
     logger.warning(
         "Downloading local LLM model %s from %s%s to %s. "
+        "The current operation will block until the download completes. "
         "Set MNEMOSYNE_LLM_ENABLED=false for AAAK-only consolidation, "
         "or pre-cache the GGUF to avoid this download.",
         DEFAULT_MODEL_FILE,

--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -9,6 +9,7 @@ Model cache: ~/.hermes/mnemosyne/models/
 Default model: openbmb/MiniCPM5-1B-GGUF (Q4_K_M, ~656MB)
 """
 
+import logging
 import os
 import sys
 import re
@@ -19,6 +20,8 @@ from typing import List, Optional
 DEFAULT_MODEL_REPO = "openbmb/MiniCPM5-1B-GGUF"
 DEFAULT_MODEL_FILE = "MiniCPM5-1B-Q4_K_M.gguf"
 MODEL_CACHE_DIR = Path.home() / ".hermes" / "mnemosyne" / "models"
+
+logger = logging.getLogger(__name__)
 
 LLM_ENABLED = os.environ.get("MNEMOSYNE_LLM_ENABLED", "true").lower() in ("1", "true", "yes")
 LLM_MAX_TOKENS=int(os.environ.get("MNEMOSYNE_LLM_MAX_TOKENS", "2048") or "2048")
@@ -114,6 +117,20 @@ def _download_model() -> Path:
             "huggingface_hub not installed. Run: pip install huggingface-hub"
         )
 
+    default_artifact = (
+        DEFAULT_MODEL_REPO == "openbmb/MiniCPM5-1B-GGUF"
+        and DEFAULT_MODEL_FILE == "MiniCPM5-1B-Q4_K_M.gguf"
+    )
+    size_notice = " (approximately 656 MB)" if default_artifact else ""
+    logger.warning(
+        "Downloading local LLM model %s from %s%s to %s. "
+        "Set MNEMOSYNE_LLM_ENABLED=false for AAAK-only consolidation, "
+        "or pre-cache the GGUF to avoid this download.",
+        DEFAULT_MODEL_FILE,
+        DEFAULT_MODEL_REPO,
+        size_notice,
+        MODEL_CACHE_DIR,
+    )
     downloaded = hf_hub_download(
         repo_id=DEFAULT_MODEL_REPO,
         filename=DEFAULT_MODEL_FILE,

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import sys
 import types
-import pytest
 from unittest.mock import patch, MagicMock
 
 from mnemosyne.core import local_llm
@@ -357,7 +356,7 @@ class TestHostLLMBackend:
         monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://remote/v1")
         set_host_llm_backend(CallableLLMBackend("test", lambda *a, **k: "Host summary."))
         with patch.object(local_llm, "_call_remote_llm", return_value="Remote summary.") as mock_remote, \
-             patch.object(local_llm, "_call_local_llm", return_value=None) as mock_local:
+             patch.object(local_llm, "_call_local_llm", return_value=None):
             # Host gated by LLM_ENABLED → not attempted; remote also gated → not called;
             # local: _call_local_llm internally checks via _load_llm() which itself
             # gates on LLM_ENABLED (preserving prior behavior). End result: None.
@@ -441,15 +440,15 @@ class TestThinkTagStripping:
     """
 
     def test_clean_output_strips_closed_think_tags(self):
-        raw = f"<think>let me reason</think> The answer is 42."
+        raw = "<think>let me reason</think> The answer is 42."
         assert local_llm._clean_output(raw) == "The answer is 42."
 
     def test_clean_output_strips_multiline_closed_think_tags(self):
-        raw = f"<think>step 1\nstep 2</think>\nFinal answer."
+        raw = "<think>step 1\nstep 2</think>\nFinal answer."
         assert local_llm._clean_output(raw) == "Final answer."
 
     def test_clean_output_strips_multiple_think_blocks(self):
-        raw = f"<think>first</think>middle<think>second</think>end"
+        raw = "<think>first</think>middle<think>second</think>end"
         assert local_llm._clean_output(raw) == "middleend"
 
     def test_clean_output_preserves_text_without_think_tags(self):
@@ -457,13 +456,13 @@ class TestThinkTagStripping:
         assert local_llm._clean_output(raw) == "Just a normal summary with no thinking."
 
     def test_clean_output_empty_after_stripping(self):
-        raw = f"<think>only thinking, no output</think>"
+        raw = "<think>only thinking, no output</think>"
         assert local_llm._clean_output(raw) == ""
 
     def test_clean_output_does_not_strip_unclosed_think_tag(self):
         """Unclosed think tags are left as-is since we cannot determine
         where thinking ends and the response begins."""
-        raw = f"middle<think>reasoning that never closes"
+        raw = "middle<think>reasoning that never closes"
         assert local_llm._clean_output(raw) == raw
 
     def test_try_host_llm_strips_think_tags(self, monkeypatch):
@@ -473,7 +472,7 @@ class TestThinkTagStripping:
         monkeypatch.setattr(local_llm, "HOST_LLM_TIMEOUT", 5.0)
         monkeypatch.setattr(local_llm, "HOST_LLM_PROVIDER", None)
         monkeypatch.setattr(local_llm, "HOST_LLM_MODEL", None)
-        set_host_llm_backend(CallableLLMBackend("test", lambda prompt, **kw: f"<think>reasoning</think>Summary of memories."))
+        set_host_llm_backend(CallableLLMBackend("test", lambda prompt, **kw: "<think>reasoning</think>Summary of memories."))
 
         attempted, text = local_llm._try_host_llm("test prompt", max_tokens=128, temperature=0.3)
         assert attempted is True
@@ -486,7 +485,7 @@ class TestThinkTagStripping:
         monkeypatch.setattr(local_llm, "HOST_LLM_TIMEOUT", 5.0)
         monkeypatch.setattr(local_llm, "HOST_LLM_PROVIDER", None)
         monkeypatch.setattr(local_llm, "HOST_LLM_MODEL", None)
-        set_host_llm_backend(CallableLLMBackend("test", lambda prompt, **kw: f"<think>reasoning\nActual output"))
+        set_host_llm_backend(CallableLLMBackend("test", lambda prompt, **kw: "<think>reasoning\nActual output"))
 
         attempted, text = local_llm._try_host_llm("test prompt", max_tokens=128, temperature=0.3)
         assert attempted is True

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -17,16 +17,15 @@ REAL_LOAD_LLM = local_llm._load_llm
 
 
 class TestLocalModelDownloadNotice:
-    def test_uncached_default_model_logs_notice_before_download(self, monkeypatch, tmp_path, caplog):
-        """The default GGUF warning is emitted once before its network fetch."""
+    def test_uncached_default_model_logs_notice_before_download(self, monkeypatch, tmp_path, caplog, capsys):
+        """The default GGUF warning is logged before its network fetch, not printed."""
         cache_dir = tmp_path / "models"
         events = []
+        download_calls = []
 
         def fake_download(**kwargs):
             events.append("download")
-            assert kwargs["repo_id"] == "openbmb/MiniCPM5-1B-GGUF"
-            assert kwargs["filename"] == "MiniCPM5-1B-Q4_K_M.gguf"
-            assert kwargs["local_dir"] == str(cache_dir)
+            download_calls.append(kwargs)
             return str(cache_dir / kwargs["filename"])
 
         monkeypatch.setattr(local_llm, "MODEL_CACHE_DIR", cache_dir)
@@ -44,6 +43,13 @@ class TestLocalModelDownloadNotice:
         local_llm._download_model()
 
         assert events == ["warning", "download"]
+        assert download_calls == [{
+            "repo_id": "openbmb/MiniCPM5-1B-GGUF",
+            "filename": "MiniCPM5-1B-Q4_K_M.gguf",
+            "local_dir": str(cache_dir),
+            "local_dir_use_symlinks": False,
+        }]
+        assert capsys.readouterr().out == ""
         message = caplog.records[-1].getMessage()
         assert "MiniCPM5-1B-Q4_K_M.gguf" in message
         assert "openbmb/MiniCPM5-1B-GGUF" in message

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -54,6 +54,7 @@ class TestLocalModelDownloadNotice:
         assert "openbmb/MiniCPM5-1B-GGUF" in message
         assert str(cache_dir) in message
         assert "approximately 656 MB" in message
+        assert "current operation will block until the download completes" in message
         assert "MNEMOSYNE_LLM_ENABLED=false" in message
         assert "pre-cache" in message
 

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -1,7 +1,9 @@
 import builtins
+import logging
 import os
 import subprocess
 import sys
+import types
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -10,6 +12,85 @@ from mnemosyne.core.llm_backends import (
     CallableLLMBackend,
     set_host_llm_backend,
 )
+
+REAL_LOAD_LLM = local_llm._load_llm
+
+
+class TestLocalModelDownloadNotice:
+    def test_uncached_default_model_logs_notice_before_download(self, monkeypatch, tmp_path, caplog):
+        """The default GGUF warning is emitted once before its network fetch."""
+        cache_dir = tmp_path / "models"
+        events = []
+
+        def fake_download(**kwargs):
+            events.append("download")
+            assert kwargs["repo_id"] == "openbmb/MiniCPM5-1B-GGUF"
+            assert kwargs["filename"] == "MiniCPM5-1B-Q4_K_M.gguf"
+            assert kwargs["local_dir"] == str(cache_dir)
+            return str(cache_dir / kwargs["filename"])
+
+        monkeypatch.setattr(local_llm, "MODEL_CACHE_DIR", cache_dir)
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_REPO", "openbmb/MiniCPM5-1B-GGUF")
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_FILE", "MiniCPM5-1B-Q4_K_M.gguf")
+        monkeypatch.setitem(sys.modules, "huggingface_hub", types.SimpleNamespace(hf_hub_download=fake_download))
+        caplog.set_level(logging.WARNING, logger=local_llm.__name__)
+        original_warning = local_llm.logger.warning
+
+        def record_warning(*args, **kwargs):
+            events.append("warning")
+            return original_warning(*args, **kwargs)
+
+        monkeypatch.setattr(local_llm.logger, "warning", record_warning)
+        local_llm._download_model()
+
+        assert events == ["warning", "download"]
+        message = caplog.records[-1].getMessage()
+        assert "MiniCPM5-1B-Q4_K_M.gguf" in message
+        assert "openbmb/MiniCPM5-1B-GGUF" in message
+        assert str(cache_dir) in message
+        assert "approximately 656 MB" in message
+        assert "MNEMOSYNE_LLM_ENABLED=false" in message
+        assert "pre-cache" in message
+
+    def test_cached_model_skips_notice_and_download(self, monkeypatch, tmp_path, caplog):
+        """An already cached GGUF does not produce download-related output."""
+        cache_dir = tmp_path / "models"
+        cache_dir.mkdir()
+        model_file = cache_dir / "cached.gguf"
+        model_file.touch()
+        monkeypatch.setattr(local_llm, "MODEL_CACHE_DIR", cache_dir)
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_FILE", model_file.name)
+        caplog.set_level(logging.WARNING, logger=local_llm.__name__)
+
+        with patch.dict(sys.modules, {"huggingface_hub": None}):
+            assert local_llm._download_model() == model_file
+
+        assert not caplog.records
+
+    def test_overridden_model_omits_default_size_and_failed_download_falls_back(self, monkeypatch, tmp_path, caplog):
+        """Custom artifacts avoid a misleading size claim and retain AAAK fallback."""
+        cache_dir = tmp_path / "models"
+
+        def failed_download(**kwargs):
+            raise OSError("offline")
+
+        monkeypatch.setattr(local_llm, "MODEL_CACHE_DIR", cache_dir)
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_REPO", "example/custom-gguf")
+        monkeypatch.setattr(local_llm, "DEFAULT_MODEL_FILE", "custom.gguf")
+        monkeypatch.setattr(local_llm, "LLM_ENABLED", True)
+        monkeypatch.setattr(local_llm, "_llm_instance", None)
+        monkeypatch.setattr(local_llm, "_llm_available", None)
+        monkeypatch.setattr(local_llm, "_load_llm", REAL_LOAD_LLM)
+        monkeypatch.setitem(sys.modules, "huggingface_hub", types.SimpleNamespace(hf_hub_download=failed_download))
+        caplog.set_level(logging.WARNING, logger=local_llm.__name__)
+
+        assert local_llm._load_llm() is None
+        assert local_llm._llm_available is False
+        assert len(caplog.records) == 1
+        message = caplog.records[0].getMessage()
+        assert "custom.gguf" in message
+        assert "example/custom-gguf" in message
+        assert "656 MB" not in message
 
 
 class TestRemoteLLM:


### PR DESCRIPTION
## Summary

Fixes #703 with a single warning before an uncached local GGUF download starts.

- Logs the effective model filename, HuggingFace repository and destination cache path.
- Includes the approximate 656 MB size only for the built-in default artifact.
- Explains the AAAK-only opt-out (`MNEMOSYNE_LLM_ENABLED=false`) and pre-cache option.
- Keeps all default, cache, download, retry and fallback behavior unchanged.
- Does not write to CLI/MCP stdout.

## Verification

- `91 passed` — focused local-LLM and extraction suite.
- Immutable archive run at `05e7c70c50ade4bda1988aaa7cb7d4dfacfc9732`: `91 passed`, integrity pass.
- Covers uncached warning-before-download, cached no-warning/no-download, failed-download fallback, effective override wording, stdout silence, and recorded download kwargs.
- `git diff --check` passes.

## Scope

No opt-in/default change, cache relocation, backup-policy change, fallback-routing change, docs, version bump, or new configuration surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds a warning before an uncached local GGUF model download.
- Reports the model filename, HuggingFace repository, cache path, approximate size, and blocking behavior.
- Preserves `MNEMOSYNE_LLM_ENABLED=false` and pre-cache guidance.
- Preserves cache behavior, retries, fallback to AAAK, stdout behavior, and defaults.
- Adds focused tests with 91 passing tests, integrity checks, and `git diff --check`.

## Architectural impact

- **Core memory architecture:** No changes to working, episodic, or BEAM memory tiers.
- **Retrieval and consolidation:** No changes.
- **Veracity system:** No changes.
- **Sync layer:** No changes.
- **Agent integration:** No changes to Hermes, MCP, or CLI interfaces.
- **Privacy and local-first design:** Improves transparency for the existing local model download. It adds no telemetry or remote inference. The local-model opt-out remains available.
- **Maintainability:** Keeps download messaging in `_download_model()` and adds focused behavioral tests.
- **Benchmark methodology:** No changes.

This is the right call for the issue. It improves observability without changing model selection, fallback routing, opt-in behavior, or local-first guarantees. It does not alter memory architecture or agent integration surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->