### PR TITLE
fix(hermes): honor tool allowlist during discovery

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -3311,17 +3311,17 @@ def register(ctx):
         handler_fn=mnemosyne_command,
     )
 
-    # Register all tools (29 memory + 3 sync + 4 persona) so the agent can call them.
+    # Register the configured tools so the PluginManager surface matches memory
+    # provider discovery. The provider resolves HERMES_HOME before initialize().
     # Note: when loaded via memory provider discovery (plugins/memory/),
     # the ctx is a _ProviderCollector whose register_tool() is a no-op --
     # tools are surfaced through get_tool_schemas() via the memory manager
     # instead. This registration covers the standalone PluginManager path.
-    from .tools import ALL_TOOL_SCHEMAS
     from functools import partial
 
     global _provider
     _provider = MnemosyneMemoryProvider()
-    for _schema in ALL_TOOL_SCHEMAS:
+    for _schema in _provider.get_tool_schemas():
         _name = _schema["name"]
         # Sync tools route through SyncAdapter, persona tools through PersonaAdapter,
         # memory tools through main provider.

--- a/integrations/hermes/tests/test_persona_plugin_registration.py
+++ b/integrations/hermes/tests/test_persona_plugin_registration.py
@@ -72,3 +72,14 @@ def test_plugin_registration_honors_tool_allowlist_before_initialize(tmp_path, m
     plugin.register(context)
 
     assert list(context.tools) == ["mnemosyne_remember", "mnemosyne_recall"]
+
+
+def test_plugin_registration_without_allowlist_exposes_full_surface(monkeypatch):
+    """Standalone PluginManager preserves the complete historical tool surface."""
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(plugin, "_provider", None)
+
+    context = _Context()
+    plugin.register(context)
+
+    assert list(context.tools) == [schema["name"] for schema in plugin.ALL_TOOL_SCHEMAS]

--- a/integrations/hermes/tests/test_persona_plugin_registration.py
+++ b/integrations/hermes/tests/test_persona_plugin_registration.py
@@ -25,6 +25,9 @@ class _Provider:
     def handle_tool_call(self, _tool_name, _arguments):
         return '{"status": "ok"}'
 
+    def get_tool_schemas(self):
+        return [{"name": "mnemosyne_persona_promote", "description": ""}]
+
 
 class _PersonaAdapter:
     received_beam = None
@@ -51,3 +54,21 @@ def test_persona_tool_uses_plugin_registered_provider_beam(monkeypatch):
     context.tools["mnemosyne_persona_promote"]({"memory_id": "memory-1"})
 
     assert _PersonaAdapter.received_beam is provider._beam
+
+
+def test_plugin_registration_honors_tool_allowlist_before_initialize(tmp_path, monkeypatch):
+    """Standalone PluginManager registration must not advertise excluded tools."""
+    (tmp_path / "config.yaml").write_text(
+        "memory:\n"
+        "  mnemosyne:\n"
+        "    tools:\n"
+        "      - mnemosyne_remember\n"
+        "      - mnemosyne_recall\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(plugin, "_provider", None)
+
+    context = _Context()
+    plugin.register(context)
+
+    assert list(context.tools) == ["mnemosyne_remember", "mnemosyne_recall"]

--- a/mnemosyne/hermes_config.py
+++ b/mnemosyne/hermes_config.py
@@ -72,6 +72,8 @@ def read_config_key_without_yaml(config_path: str, key: str) -> Any:
         value = stripped.split(":", 1)[1].strip()
         if value == "[]":
             return []
+        if value in {"null", "~"}:
+            return None
         if value:
             return value.strip('"\'')
         items = []

--- a/mnemosyne/hermes_config.py
+++ b/mnemosyne/hermes_config.py
@@ -14,7 +14,11 @@ def read_hermes_config_key(hermes_home: str | None, key: str) -> Any:
     provider whitelist/default-scope path working in minimal Hermes plugin
     environments where PyYAML is not installed.
     """
-    config_path = os.path.join(hermes_home, "config.yaml") if hermes_home else ""
+    # Schema discovery happens before a provider receives initialize(...,
+    # hermes_home=...). HERMES_HOME is the explicit active-profile authority in
+    # that phase; do not fall back to ~/.hermes, which could cross profiles.
+    resolved_home = hermes_home or os.environ.get("HERMES_HOME")
+    config_path = os.path.join(resolved_home, "config.yaml") if resolved_home else ""
     if not config_path or not os.path.exists(config_path):
         return None
     try:

--- a/mnemosyne/hermes_config.py
+++ b/mnemosyne/hermes_config.py
@@ -72,7 +72,7 @@ def read_config_key_without_yaml(config_path: str, key: str) -> Any:
         value = stripped.split(":", 1)[1].strip()
         if value == "[]":
             return []
-        if value in {"null", "~"}:
+        if value.lower() == "null" or value == "~":
             return None
         if value:
             return value.strip('"\'')

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -375,18 +375,24 @@ def test_tool_whitelist_null_exposes_all_tools(tmp_path, monkeypatch, provider_m
         )
 
 
-def test_tool_whitelist_null_without_yaml_exposes_all_tools(tmp_path, monkeypatch, provider_modules):
+@pytest.mark.parametrize("null_value", ["null", "~"])
+def test_tool_whitelist_null_without_yaml_exposes_all_tools(
+    tmp_path, monkeypatch, provider_modules, null_value
+):
     """The minimal config parser must preserve YAML null as no whitelist."""
     (tmp_path / "config.yaml").write_text(
         "memory:\n"
         "  mnemosyne:\n"
-        "    tools: null\n"
+        f"    tools: {null_value}\n"
     )
     monkeypatch.setitem(sys.modules, "yaml", None)
 
     for module in provider_modules.values():
         provider = _provider_for_config(module, tmp_path)
         assert _schema_names(provider) == PROVIDER_TOOL_NAMES
+        assert _json_stable(provider.get_tool_schemas()) == _json_stable(
+            _filtered_schemas(module, PROVIDER_TOOL_NAMES)
+        )
 
 
 def test_tool_whitelist_filters_schemas_before_routing(tmp_path, provider_modules):

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -302,7 +302,11 @@ def test_tool_whitelist_uses_hermes_home_before_initialize(tmp_path, monkeypatch
 
 
 def test_tool_whitelist_without_home_preserves_full_surface(tmp_path, monkeypatch, provider_modules):
-    _write_mnemosyne_config(tmp_path, ["mnemosyne_remember"])
+    default_home = tmp_path / "home"
+    default_hermes_home = default_home / ".hermes"
+    default_hermes_home.mkdir(parents=True)
+    _write_mnemosyne_config(default_hermes_home, ["mnemosyne_remember"])
+    monkeypatch.setenv("HOME", str(default_home))
     monkeypatch.delenv("HERMES_HOME", raising=False)
 
     expected = list(_tool_schemas(provider_modules["hermes_memory_provider"]))
@@ -323,6 +327,20 @@ def test_explicit_hermes_home_overrides_environment(tmp_path, monkeypatch):
 
     assert read_hermes_config_key(str(explicit_home), "tools") == ["mnemosyne_remember"]
     assert read_hermes_config_key(None, "tools") == ["mnemosyne_recall"]
+    assert read_hermes_config_key("", "tools") == ["mnemosyne_recall"]
+
+
+def test_tool_whitelist_null_exposes_all_tools(tmp_path, provider_modules):
+    (tmp_path / "config.yaml").write_text(
+        "memory:\n"
+        "  provider: mnemosyne\n"
+        "  mnemosyne:\n"
+        "    tools: null\n"
+    )
+
+    expected = list(_tool_schemas(provider_modules["hermes_memory_provider"]))
+    for module in provider_modules.values():
+        assert _schema_names(_provider_for_config(module, tmp_path)) == expected
 
 
 def test_tool_whitelist_filters_schemas_before_routing(tmp_path, provider_modules):

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -93,6 +93,11 @@ def _schema_names(provider) -> list[str]:
     return [schema["name"] for schema in provider.get_tool_schemas()]
 
 
+def _filtered_schemas(module, names: list[str]):
+    schemas = _tool_schemas(module)
+    return [schemas[name] for name in names]
+
+
 PROVIDER_TOOL_NAMES = [
     "mnemosyne_remember", "mnemosyne_recall", "mnemosyne_shared_remember",
     "mnemosyne_shared_recall", "mnemosyne_shared_forget", "mnemosyne_shared_stats",
@@ -315,6 +320,9 @@ def test_tool_whitelist_uses_hermes_home_before_initialize(tmp_path, monkeypatch
     for module in provider_modules.values():
         provider = module.MnemosyneMemoryProvider()
         assert _schema_names(provider) == allowed
+        assert _json_stable(provider.get_tool_schemas()) == _json_stable(
+            _filtered_schemas(module, allowed)
+        )
         assert provider.has_tool("mnemosyne_remember") is True
         assert provider.has_tool("mnemosyne_forget") is False
 
@@ -360,7 +368,25 @@ def test_tool_whitelist_null_exposes_all_tools(tmp_path, monkeypatch, provider_m
     monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
     expected = PROVIDER_TOOL_NAMES
     for module in provider_modules.values():
-        assert _schema_names(_provider_for_config(module, tmp_path)) == expected
+        provider = _provider_for_config(module, tmp_path)
+        assert _schema_names(provider) == expected
+        assert _json_stable(provider.get_tool_schemas()) == _json_stable(
+            _filtered_schemas(module, expected)
+        )
+
+
+def test_tool_whitelist_null_without_yaml_exposes_all_tools(tmp_path, monkeypatch, provider_modules):
+    """The minimal config parser must preserve YAML null as no whitelist."""
+    (tmp_path / "config.yaml").write_text(
+        "memory:\n"
+        "  mnemosyne:\n"
+        "    tools: null\n"
+    )
+    monkeypatch.setitem(sys.modules, "yaml", None)
+
+    for module in provider_modules.values():
+        provider = _provider_for_config(module, tmp_path)
+        assert _schema_names(provider) == PROVIDER_TOOL_NAMES
 
 
 def test_tool_whitelist_filters_schemas_before_routing(tmp_path, provider_modules):

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -289,6 +289,42 @@ def test_tool_whitelist_omitted_exposes_all_tools(tmp_path, provider_modules):
     assert observed["mnemosyne_hermes"] == all_tools
 
 
+def test_tool_whitelist_uses_hermes_home_before_initialize(tmp_path, monkeypatch, provider_modules):
+    allowed = ["mnemosyne_remember", "mnemosyne_recall"]
+    _write_mnemosyne_config(tmp_path, allowed)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    for module in provider_modules.values():
+        provider = module.MnemosyneMemoryProvider()
+        assert _schema_names(provider) == allowed
+        assert provider.has_tool("mnemosyne_remember") is True
+        assert provider.has_tool("mnemosyne_forget") is False
+
+
+def test_tool_whitelist_without_home_preserves_full_surface(tmp_path, monkeypatch, provider_modules):
+    _write_mnemosyne_config(tmp_path, ["mnemosyne_remember"])
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    expected = list(_tool_schemas(provider_modules["hermes_memory_provider"]))
+    for module in provider_modules.values():
+        assert _schema_names(module.MnemosyneMemoryProvider()) == expected
+
+
+def test_explicit_hermes_home_overrides_environment(tmp_path, monkeypatch):
+    from mnemosyne.hermes_config import read_hermes_config_key
+
+    explicit_home = tmp_path / "explicit"
+    env_home = tmp_path / "environment"
+    explicit_home.mkdir()
+    env_home.mkdir()
+    _write_mnemosyne_config(explicit_home, ["mnemosyne_remember"])
+    _write_mnemosyne_config(env_home, ["mnemosyne_recall"])
+    monkeypatch.setenv("HERMES_HOME", str(env_home))
+
+    assert read_hermes_config_key(str(explicit_home), "tools") == ["mnemosyne_remember"]
+    assert read_hermes_config_key(None, "tools") == ["mnemosyne_recall"]
+
+
 def test_tool_whitelist_filters_schemas_before_routing(tmp_path, provider_modules):
     allowed = ["mnemosyne_remember", "mnemosyne_recall", "mnemosyne_sleep"]
     _write_mnemosyne_config(tmp_path, allowed)

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -375,7 +375,7 @@ def test_tool_whitelist_null_exposes_all_tools(tmp_path, monkeypatch, provider_m
         )
 
 
-@pytest.mark.parametrize("null_value", ["null", "~"])
+@pytest.mark.parametrize("null_value", ["null", "Null", "NULL", "~", ""])
 def test_tool_whitelist_null_without_yaml_exposes_all_tools(
     tmp_path, monkeypatch, provider_modules, null_value
 ):
@@ -393,6 +393,25 @@ def test_tool_whitelist_null_without_yaml_exposes_all_tools(
         assert _json_stable(provider.get_tool_schemas()) == _json_stable(
             _filtered_schemas(module, PROVIDER_TOOL_NAMES)
         )
+
+
+def test_tool_whitelist_re_resolves_after_initialize_home_changes(
+    tmp_path, monkeypatch, provider_modules
+):
+    """initialize() must supersede pre-discovery HERMES_HOME tool selection."""
+    env_home = tmp_path / "environment"
+    initialized_home = tmp_path / "initialized"
+    env_home.mkdir()
+    initialized_home.mkdir()
+    _write_mnemosyne_config(env_home, ["mnemosyne_remember"])
+    _write_mnemosyne_config(initialized_home, ["mnemosyne_recall"])
+    monkeypatch.setenv("HERMES_HOME", str(env_home))
+
+    for module in provider_modules.values():
+        provider = module.MnemosyneMemoryProvider()
+        assert _schema_names(provider) == ["mnemosyne_remember"]
+        provider._hermes_home = str(initialized_home)
+        assert _schema_names(provider) == ["mnemosyne_recall"]
 
 
 def test_tool_whitelist_filters_schemas_before_routing(tmp_path, provider_modules):

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -93,6 +93,24 @@ def _schema_names(provider) -> list[str]:
     return [schema["name"] for schema in provider.get_tool_schemas()]
 
 
+PROVIDER_TOOL_NAMES = [
+    "mnemosyne_remember", "mnemosyne_recall", "mnemosyne_shared_remember",
+    "mnemosyne_shared_recall", "mnemosyne_shared_forget", "mnemosyne_shared_stats",
+    "mnemosyne_sleep", "mnemosyne_stats", "mnemosyne_invalidate", "mnemosyne_validate",
+    "mnemosyne_get", "mnemosyne_triple_add", "mnemosyne_triple_query",
+    "mnemosyne_triple_end", "mnemosyne_remember_canonical",
+    "mnemosyne_recall_canonical", "mnemosyne_forget_canonical",
+    "mnemosyne_apply_pending", "mnemosyne_model_card", "mnemosyne_model_refresh",
+    "mnemosyne_scratchpad_write", "mnemosyne_scratchpad_read",
+    "mnemosyne_scratchpad_clear", "mnemosyne_export", "mnemosyne_update",
+    "mnemosyne_forget", "mnemosyne_batch", "mnemosyne_import", "mnemosyne_diagnose",
+    "mnemosyne_recall_diagnostics", "mnemosyne_task_progress",
+    "mnemosyne_graph_query", "mnemosyne_graph_link", "mnemosyne_sync_push",
+    "mnemosyne_sync_pull", "mnemosyne_sync_status", "mnemosyne_persona_promote",
+    "mnemosyne_persona_demote", "mnemosyne_persona_list", "mnemosyne_persona_reinforce",
+]
+
+
 def _provider_for_config(module, hermes_home: Path):
     provider = module.MnemosyneMemoryProvider()
     provider._hermes_home = str(hermes_home)
@@ -309,7 +327,7 @@ def test_tool_whitelist_without_home_preserves_full_surface(tmp_path, monkeypatc
     monkeypatch.setenv("HOME", str(default_home))
     monkeypatch.delenv("HERMES_HOME", raising=False)
 
-    expected = list(_tool_schemas(provider_modules["hermes_memory_provider"]))
+    expected = PROVIDER_TOOL_NAMES
     for module in provider_modules.values():
         assert _schema_names(module.MnemosyneMemoryProvider()) == expected
 
@@ -330,7 +348,7 @@ def test_explicit_hermes_home_overrides_environment(tmp_path, monkeypatch):
     assert read_hermes_config_key("", "tools") == ["mnemosyne_recall"]
 
 
-def test_tool_whitelist_null_exposes_all_tools(tmp_path, provider_modules):
+def test_tool_whitelist_null_exposes_all_tools(tmp_path, monkeypatch, provider_modules):
     (tmp_path / "config.yaml").write_text(
         "memory:\n"
         "  provider: mnemosyne\n"
@@ -338,7 +356,9 @@ def test_tool_whitelist_null_exposes_all_tools(tmp_path, provider_modules):
         "    tools: null\n"
     )
 
-    expected = list(_tool_schemas(provider_modules["hermes_memory_provider"]))
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    expected = PROVIDER_TOOL_NAMES
     for module in provider_modules.values():
         assert _schema_names(_provider_for_config(module, tmp_path)) == expected
 

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -410,8 +410,18 @@ def test_tool_whitelist_re_resolves_after_initialize_home_changes(
     for module in provider_modules.values():
         provider = module.MnemosyneMemoryProvider()
         assert _schema_names(provider) == ["mnemosyne_remember"]
-        provider._hermes_home = str(initialized_home)
+        assert provider.has_tool("mnemosyne_remember") is True
+        assert provider.has_tool("mnemosyne_recall") is False
+
+        provider.initialize(
+            "allowlist-home-change",
+            hermes_home=str(initialized_home),
+            agent_context="subagent",
+        )
+
         assert _schema_names(provider) == ["mnemosyne_recall"]
+        assert provider.has_tool("mnemosyne_remember") is False
+        assert provider.has_tool("mnemosyne_recall") is True
 
 
 def test_tool_whitelist_filters_schemas_before_routing(tmp_path, provider_modules):


### PR DESCRIPTION
## Summary

Fixes #645 by making the `memory.mnemosyne.tools` allowlist apply during provider schema discovery, before `initialize()` receives a `hermes_home` argument.

- resolve an absent/falsy explicit home from the active `$HERMES_HOME` only
- preserve explicit `hermes_home` precedence over `$HERMES_HOME`
- keep no-env behavior as the historical full tool surface
- add pre-initialization parity coverage for both provider implementations

## Contract and scope

`$HERMES_HOME` is the explicit active-profile authority during discovery. This deliberately does **not** fall back to `~/.hermes`, which could cross profile/home boundaries. Existing list order, null/empty/unknown-name semantics, and execution-time rejection remain unchanged.

Non-goals: handler/core-config changes, config migration, and direct PluginManager registration lifecycle changes.

## Verification

- `MNEMOSYNE_NO_EMBEDDINGS=1 .venv/bin/python -m pytest -q tests/test_hermes_provider_parity.py` → `56 passed`
- `python3 scripts/verify-docs.py` → generated docs match code
- `git diff --check` clean
- independent current-head review: approved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Applies `memory.mnemosyne.tools` during Hermes schema discovery.
- Uses explicit `hermes_home` first, then `$HERMES_HOME`.
- Preserves the full tool surface when neither home is configured.
- Preserves tool ordering, null and empty allowlists, unknown names, and execution-time rejection.
- Updates standalone Hermes plugin registration to use provider-configured schemas.
- Adds parity coverage for both provider implementations.

## Architectural impact

- **Core memory architecture:** No changes to working, episodic, or BEAM memory tiers.
- **Retrieval and consolidation:** No changes.
- **Veracity system and sync layer:** No changes.
- **Privacy and local-first design:** Preserved. The change adds no remote services or data flows. The allowlist reduces the advertised Hermes tool surface.
- **Agent integration:** Hermes schema discovery now matches execution-time permissions. MCP and CLI behavior remain unchanged.
- **Maintainability:** Centralized home resolution and provider-based schema registration remove pre-initialization inconsistencies. Configuration precedence remains explicit.
- **Benchmark methodology:** No changes.

Applying the allowlist before provider initialization is the right call. It prevents misleading Hermes schemas and improves privacy and audit accuracy without weakening execution-time enforcement.

The change does not alter Mnemosyne’s memory architecture or erode its local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->