### PR TITLE
test(hermes): cover no-yaml allowlist parity

### DIFF
--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -406,6 +406,7 @@ def test_tool_whitelist_null_without_yaml_exposes_all_tools(
 @pytest.mark.parametrize(
     ("tools", "expected", "unknown"),
     [
+        (None, PROVIDER_TOOL_NAMES, False),
         (["mnemosyne_remember", "mnemosyne_recall"], ["mnemosyne_remember", "mnemosyne_recall"], False),
         ([], [], False),
         (["mnemosyne_not_real"], None, True),
@@ -423,7 +424,12 @@ def test_tool_whitelist_without_yaml_matches_pyyaml(
         if unknown:
             with pytest.raises(ValueError, match="Unknown Mnemosyne tool.*mnemosyne_not_real") as exc_info:
                 provider.get_tool_schemas()
-            normal[name] = str(exc_info.value)
+            normal[name] = {
+                "exception": str(exc_info.value),
+                "dispatch": json.loads(
+                    provider.handle_tool_call("mnemosyne_remember", {"content": "x"})
+                ),
+            }
         else:
             assert _schema_names(provider) == expected
             if expected:
@@ -446,7 +452,10 @@ def test_tool_whitelist_without_yaml_matches_pyyaml(
         if unknown:
             with pytest.raises(ValueError, match="Unknown Mnemosyne tool.*mnemosyne_not_real") as exc_info:
                 provider.get_tool_schemas()
-            assert str(exc_info.value) == normal[name]
+            assert str(exc_info.value) == normal[name]["exception"]
+            assert json.loads(
+                provider.handle_tool_call("mnemosyne_remember", {"content": "x"})
+            ) == normal[name]["dispatch"]
         else:
             assert _schema_names(provider) == expected
             if expected:

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -77,6 +77,8 @@ def _config_schema(module):
 def _write_mnemosyne_config(hermes_home: Path, tools) -> None:
     if tools is None:
         body = "memory:\n  provider: mnemosyne\n  mnemosyne: {}\n"
+    elif not tools:
+        body = "memory:\n  provider: mnemosyne\n  mnemosyne:\n    tools: []\n"
     else:
         rendered_tools = "\n".join(f"      - {tool}" for tool in tools)
         body = (
@@ -327,13 +329,19 @@ def test_tool_whitelist_uses_hermes_home_before_initialize(tmp_path, monkeypatch
         assert provider.has_tool("mnemosyne_forget") is False
 
 
-def test_tool_whitelist_without_home_preserves_full_surface(tmp_path, monkeypatch, provider_modules):
+@pytest.mark.parametrize("hermes_home", [None, ""])
+def test_tool_whitelist_without_home_preserves_full_surface(
+    tmp_path, monkeypatch, provider_modules, hermes_home
+):
     default_home = tmp_path / "home"
     default_hermes_home = default_home / ".hermes"
     default_hermes_home.mkdir(parents=True)
     _write_mnemosyne_config(default_hermes_home, ["mnemosyne_remember"])
     monkeypatch.setenv("HOME", str(default_home))
-    monkeypatch.delenv("HERMES_HOME", raising=False)
+    if hermes_home is None:
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_HOME", hermes_home)
 
     expected = PROVIDER_TOOL_NAMES
     for module in provider_modules.values():
@@ -393,6 +401,47 @@ def test_tool_whitelist_null_without_yaml_exposes_all_tools(
         assert _json_stable(provider.get_tool_schemas()) == _json_stable(
             _filtered_schemas(module, PROVIDER_TOOL_NAMES)
         )
+
+
+@pytest.mark.parametrize(
+    ("tools", "expected", "unknown"),
+    [
+        (["mnemosyne_remember", "mnemosyne_recall"], ["mnemosyne_remember", "mnemosyne_recall"], False),
+        ([], [], False),
+        (["mnemosyne_not_real"], None, True),
+    ],
+)
+def test_tool_whitelist_without_yaml_matches_pyyaml(
+    tmp_path, monkeypatch, provider_modules, tools, expected, unknown
+):
+    """The fallback parser must preserve PyYAML allowlist semantics."""
+    _write_mnemosyne_config(tmp_path, tools)
+
+    normal = {}
+    for name, module in provider_modules.items():
+        provider = _provider_for_config(module, tmp_path)
+        if unknown:
+            with pytest.raises(ValueError, match="Unknown Mnemosyne tool.*mnemosyne_not_real"):
+                provider.get_tool_schemas()
+            normal[name] = "error"
+        else:
+            assert _schema_names(provider) == expected
+            normal[name] = _json_stable(provider.get_tool_schemas())
+
+    monkeypatch.setitem(sys.modules, "yaml", None)
+    for name, module in provider_modules.items():
+        provider = _provider_for_config(module, tmp_path)
+        if unknown:
+            with pytest.raises(ValueError, match="Unknown Mnemosyne tool.*mnemosyne_not_real"):
+                provider.get_tool_schemas()
+            assert normal[name] == "error"
+        else:
+            assert _schema_names(provider) == expected
+            assert _json_stable(provider.get_tool_schemas()) == normal[name]
+            if expected:
+                assert provider.has_tool(expected[0]) is True
+                rejected = json.loads(provider.handle_tool_call("mnemosyne_forget", {"memory_id": "x"}))
+                assert rejected == {"error": "Unknown Mnemosyne tool: mnemosyne_forget"}
 
 
 def test_tool_whitelist_re_resolves_after_initialize_home_changes(

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -426,7 +426,13 @@ def test_tool_whitelist_without_yaml_matches_pyyaml(
             normal[name] = "error"
         else:
             assert _schema_names(provider) == expected
-            normal[name] = _json_stable(provider.get_tool_schemas())
+            if expected:
+                normal[name] = _json_stable(provider.get_tool_schemas())
+            else:
+                assert provider.has_tool("mnemosyne_remember") is False
+                normal[name] = json.loads(
+                    provider.handle_tool_call("mnemosyne_remember", {"content": "x"})
+                )
 
     monkeypatch.setitem(sys.modules, "yaml", None)
     for name, module in provider_modules.items():
@@ -437,11 +443,14 @@ def test_tool_whitelist_without_yaml_matches_pyyaml(
             assert normal[name] == "error"
         else:
             assert _schema_names(provider) == expected
-            assert _json_stable(provider.get_tool_schemas()) == normal[name]
             if expected:
+                assert _json_stable(provider.get_tool_schemas()) == normal[name]
                 assert provider.has_tool(expected[0]) is True
                 rejected = json.loads(provider.handle_tool_call("mnemosyne_forget", {"memory_id": "x"}))
                 assert rejected == {"error": "Unknown Mnemosyne tool: mnemosyne_forget"}
+            else:
+                assert provider.has_tool("mnemosyne_remember") is False
+                assert json.loads(provider.handle_tool_call("mnemosyne_remember", {"content": "x"})) == normal[name]
 
 
 def test_tool_whitelist_re_resolves_after_initialize_home_changes(

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -421,13 +421,19 @@ def test_tool_whitelist_without_yaml_matches_pyyaml(
     for name, module in provider_modules.items():
         provider = _provider_for_config(module, tmp_path)
         if unknown:
-            with pytest.raises(ValueError, match="Unknown Mnemosyne tool.*mnemosyne_not_real"):
+            with pytest.raises(ValueError, match="Unknown Mnemosyne tool.*mnemosyne_not_real") as exc_info:
                 provider.get_tool_schemas()
-            normal[name] = "error"
+            normal[name] = str(exc_info.value)
         else:
             assert _schema_names(provider) == expected
             if expected:
-                normal[name] = _json_stable(provider.get_tool_schemas())
+                normal[name] = {
+                    "schemas": _json_stable(provider.get_tool_schemas()),
+                    "has_tool": {tool_name: provider.has_tool(tool_name) for tool_name in expected},
+                    "rejected": json.loads(
+                        provider.handle_tool_call("mnemosyne_forget", {"memory_id": "x"})
+                    ),
+                }
             else:
                 assert provider.has_tool("mnemosyne_remember") is False
                 normal[name] = json.loads(
@@ -438,16 +444,17 @@ def test_tool_whitelist_without_yaml_matches_pyyaml(
     for name, module in provider_modules.items():
         provider = _provider_for_config(module, tmp_path)
         if unknown:
-            with pytest.raises(ValueError, match="Unknown Mnemosyne tool.*mnemosyne_not_real"):
+            with pytest.raises(ValueError, match="Unknown Mnemosyne tool.*mnemosyne_not_real") as exc_info:
                 provider.get_tool_schemas()
-            assert normal[name] == "error"
+            assert str(exc_info.value) == normal[name]
         else:
             assert _schema_names(provider) == expected
             if expected:
-                assert _json_stable(provider.get_tool_schemas()) == normal[name]
-                assert provider.has_tool(expected[0]) is True
-                rejected = json.loads(provider.handle_tool_call("mnemosyne_forget", {"memory_id": "x"}))
-                assert rejected == {"error": "Unknown Mnemosyne tool: mnemosyne_forget"}
+                assert _json_stable(provider.get_tool_schemas()) == normal[name]["schemas"]
+                assert {tool_name: provider.has_tool(tool_name) for tool_name in expected} == normal[name]["has_tool"]
+                assert json.loads(
+                    provider.handle_tool_call("mnemosyne_forget", {"memory_id": "x"})
+                ) == normal[name]["rejected"]
             else:
                 assert provider.has_tool("mnemosyne_remember") is False
                 assert json.loads(provider.handle_tool_call("mnemosyne_remember", {"content": "x"})) == normal[name]

--- a/tests/test_hermes_provider_parity.py
+++ b/tests/test_hermes_provider_parity.py
@@ -401,6 +401,15 @@ def test_tool_whitelist_null_without_yaml_exposes_all_tools(
         assert _json_stable(provider.get_tool_schemas()) == _json_stable(
             _filtered_schemas(module, PROVIDER_TOOL_NAMES)
         )
+        assert provider.has_tool("mnemosyne_remember") is True
+        assert json.loads(
+            provider.handle_tool_call("mnemosyne_remember", {"content": "x"})
+        ) == {
+            "status": "memory_unavailable",
+            "tool": "mnemosyne_remember",
+            "reason": "Mnemosyne not initialized",
+            "error": "Mnemosyne unavailable: Mnemosyne not initialized",
+        }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds test-only regression coverage following #725:

- `HERMES_HOME` unset and empty both ignore `~/.hermes`.
- The minimal no-PyYAML parser matches PyYAML for restricted, empty, and unknown `memory.mnemosyne.tools` values.
- The config fixture now serializes an explicit empty allowlist as `tools: []`, rather than an ambiguous blank YAML key.

## Why this path

The provider behavior was already correct on main; these tests pin configuration-parser parity and the no-default-home invariant.

## Non-goals

No production parser, provider, lifecycle, or packaging changes.

## Verification

- `MNEMOSYNE_NO_EMBEDDINGS=1 .venv/bin/python -m pytest -q tests/test_hermes_provider_parity.py` → 67 passed
- `MNEMOSYNE_NO_EMBEDDINGS=1 .venv/bin/python -m pytest -q integrations/hermes/tests/test_persona_plugin_registration.py` → 3 passed
- `python3 scripts/verify-docs.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds regression tests for Hermes configuration behavior.
- Confirms unset and empty `HERMES_HOME` values ignore `~/.hermes`.
- Confirms fallback parser parity with PyYAML for restricted, empty, null, and unknown tool values.
- Updates fixtures to serialize empty allowlists as `tools: []`.

## Architectural impact

- No changes to working, episodic, or BEAM memory tiers.
- No changes to retrieval, consolidation, veracity, sync, or benchmark methodology.
- No changes to production Hermes, MCP, CLI, provider, lifecycle, or packaging code.
- Preserves local-first behavior by testing configuration isolation from `~/.hermes`.
- Adds no privacy or data-flow changes.
- Improves Hermes agent integration reliability through test-only coverage.
- Improves maintainability by documenting parser parity and empty-list semantics through regression tests.
- This is the right call because it strengthens configuration guarantees without changing production behavior or weakening local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->