### PR TITLE
fix: fail closed on truncated reasoning traces

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4635,11 +4635,6 @@ class BeamMemory:
         values and pass it here. `None` falls back to 'unknown' (matches
         legacy behavior + schema default).
         """
-        from mnemosyne.core import local_llm
-
-        summary = local_llm._sanitize_reasoning_output(summary)
-        if local_llm._is_invalid_reasoning_output(summary):
-            raise ValueError("Cannot consolidate malformed reasoning output")
         memory_id = _generate_id(summary)
         timestamp = datetime.now().isoformat()
         # Typed memory classification
@@ -4658,9 +4653,7 @@ class BeamMemory:
             row_veracity = clamp_veracity(
                 veracity, context="consolidate_to_episodic.veracity"
             )
-        # Strip closed <think>...</think> blocks that some LLMs emit
-        import re as _re
-        summary = _re.sub(r"<think>.*?</think>", "", summary, flags=_re.DOTALL).strip()
+
         # Compute the embedding BEFORE the INSERT opens the write transaction.
         # embed() can be a network call (API embeddings, 30s timeout) or a
         # heavy CPU call; running it after the INSERT held the SQLite write
@@ -8783,18 +8776,14 @@ class BeamMemory:
                     invalid_reasoning = False
                     if len(chunks) == 1:
                         # All memories fit in one prompt.
-                        summary = local_llm.summarize_memories(
-                            chunks[0], source=source, preserve_invalid=True
-                        )
+                        summary = local_llm._summarize_memories(chunks[0], source=source)
                         invalid_reasoning = local_llm._is_invalid_reasoning_output(summary)
                     else:
                         # Multi-chunk: any malformed trace invalidates the
                         # complete LLM result instead of silently dropping it.
                         chunk_summaries = []
                         for chunk in chunks:
-                            chunk_summary = local_llm.summarize_memories(
-                                chunk, source=source, preserve_invalid=True
-                            )
+                            chunk_summary = local_llm._summarize_memories(chunk, source=source)
                             if local_llm._is_invalid_reasoning_output(chunk_summary):
                                 invalid_reasoning = True
                                 break
@@ -8805,16 +8794,21 @@ class BeamMemory:
                             if len(chunk_summaries) == 1:
                                 summary = chunk_summaries[0]
                             else:
-                                summary = local_llm.summarize_memories(
+                                summary = local_llm._summarize_memories(
                                     chunk_summaries,
                                     source=f"{source} (consolidated)",
-                                    preserve_invalid=True,
                                 )
                                 invalid_reasoning = local_llm._is_invalid_reasoning_output(summary)
                                 # Preserve the existing non-reasoning fallback.
                                 if not invalid_reasoning and not summary:
                                     summary = " | ".join(chunk_summaries)
                     if invalid_reasoning:
+                        logger.warning(
+                            "sleep: malformed reasoning trace for source=%r (items=%d) "
+                            "— falling back to AAAK compression",
+                            source,
+                            len(items),
+                        )
                         summary = None
                     if summary:
                         llm_used_count += 1

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4635,6 +4635,11 @@ class BeamMemory:
         values and pass it here. `None` falls back to 'unknown' (matches
         legacy behavior + schema default).
         """
+        from mnemosyne.core import local_llm
+
+        summary = local_llm._sanitize_reasoning_output(summary)
+        if local_llm._is_invalid_reasoning_output(summary):
+            raise ValueError("Cannot consolidate malformed reasoning output")
         memory_id = _generate_id(summary)
         timestamp = datetime.now().isoformat()
         # Typed memory classification
@@ -8775,28 +8780,42 @@ class BeamMemory:
 
                 chunks = local_llm.chunk_memories_by_budget(lines, source=source)
                 if chunks:
+                    invalid_reasoning = False
                     if len(chunks) == 1:
-                        # All memories fit in one prompt
-                        summary = local_llm.summarize_memories(chunks[0], source=source)
+                        # All memories fit in one prompt.
+                        summary = local_llm.summarize_memories(
+                            chunks[0], source=source, preserve_invalid=True
+                        )
+                        invalid_reasoning = local_llm._is_invalid_reasoning_output(summary)
                     else:
-                        # Multi-chunk: summarize each chunk, then summarize the summaries
+                        # Multi-chunk: any malformed trace invalidates the
+                        # complete LLM result instead of silently dropping it.
                         chunk_summaries = []
                         for chunk in chunks:
-                            chunk_summary = local_llm.summarize_memories(chunk, source=source)
+                            chunk_summary = local_llm.summarize_memories(
+                                chunk, source=source, preserve_invalid=True
+                            )
+                            if local_llm._is_invalid_reasoning_output(chunk_summary):
+                                invalid_reasoning = True
+                                break
                             if chunk_summary:
                                 chunk_summaries.append(chunk_summary)
-                        if chunk_summaries:
-                            # Second-pass: summarize the chunk summaries
+                        if not invalid_reasoning and chunk_summaries:
+                            # Second-pass: summarize the chunk summaries.
                             if len(chunk_summaries) == 1:
                                 summary = chunk_summaries[0]
                             else:
                                 summary = local_llm.summarize_memories(
                                     chunk_summaries,
-                                    source=f"{source} (consolidated)"
+                                    source=f"{source} (consolidated)",
+                                    preserve_invalid=True,
                                 )
-                                # If second-pass also overflows, concatenate
-                                if not summary:
+                                invalid_reasoning = local_llm._is_invalid_reasoning_output(summary)
+                                # Preserve the existing non-reasoning fallback.
+                                if not invalid_reasoning and not summary:
                                     summary = " | ".join(chunk_summaries)
+                    if invalid_reasoning:
+                        summary = None
                     if summary:
                         llm_used_count += 1
                         llm_succeeded = True

--- a/mnemosyne/core/extraction.py
+++ b/mnemosyne/core/extraction.py
@@ -220,6 +220,10 @@ def extract_facts(text: str) -> List[str]:
 
     if attempted:
         diag.record_attempt("host")
+        if local_llm._is_invalid_reasoning_output(host_text):
+            diag.record_failure("host", reason="malformed_reasoning_trace")
+            diag.record_call(succeeded=False)
+            return []
         if host_text:
             facts = _parse_facts(host_text)
             if facts:
@@ -244,7 +248,12 @@ def extract_facts(text: str) -> List[str]:
         if llm is not None:
             try:
                 raw_output = _call_local_extraction_llm(llm, prompt)
-                facts = _parse_facts(local_llm._clean_output(raw_output))
+                cleaned_output = local_llm._clean_output(raw_output)
+                if local_llm._is_invalid_reasoning_output(cleaned_output):
+                    diag.record_failure("local", reason="malformed_reasoning_trace")
+                    diag.record_call(succeeded=False)
+                    return []
+                facts = _parse_facts(cleaned_output)
                 if facts:
                     diag.record_success("local", fact_count=len(facts))
                     diag.record_call(succeeded=True)
@@ -279,7 +288,12 @@ def extract_facts(text: str) -> List[str]:
             )
             raw_output = ""
         if raw_output:
-            facts = _parse_facts(local_llm._clean_output(raw_output))
+            cleaned_output = local_llm._clean_output(raw_output)
+            if local_llm._is_invalid_reasoning_output(cleaned_output):
+                diag.record_failure("remote", reason="malformed_reasoning_trace")
+                diag.record_call(succeeded=False)
+                return []
+            facts = _parse_facts(cleaned_output)
             if facts:
                 diag.record_success("remote", fact_count=len(facts))
                 diag.record_call(succeeded=True)
@@ -303,7 +317,12 @@ def extract_facts(text: str) -> List[str]:
     if llm is not None:
         try:
             raw_output = _call_local_extraction_llm(llm, prompt)
-            facts = _parse_facts(local_llm._clean_output(raw_output))
+            cleaned_output = local_llm._clean_output(raw_output)
+            if local_llm._is_invalid_reasoning_output(cleaned_output):
+                diag.record_failure("local", reason="malformed_reasoning_trace")
+                diag.record_call(succeeded=False)
+                return []
+            facts = _parse_facts(cleaned_output)
             if facts:
                 diag.record_success("local", fact_count=len(facts))
                 diag.record_call(succeeded=True)

--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -431,31 +431,44 @@ def _try_host_llm(
     return (True, text)
 
 
-_INVALID_REASONING_OUTPUT = "\x00mnemosyne-invalid-reasoning-output\x00"
+class _InvalidReasoningOutput:
+    """Private marker for a model response that must never be persisted."""
+
+    def __bool__(self) -> bool:
+        return False
+
+
+_INVALID_REASONING_OUTPUT = _InvalidReasoningOutput()
 
 
 def _is_invalid_reasoning_output(value: object) -> bool:
     """Return whether *value* is an unsafe, malformed reasoning response."""
-    return value == _INVALID_REASONING_OUTPUT
+    return value is _INVALID_REASONING_OUTPUT
 
 
-def _sanitize_reasoning_output(text: str) -> str:
+def _sanitize_reasoning_output(text: str):
     """Remove balanced think traces and reject malformed traces fail-closed."""
-    tags = list(re.finditer(r"</?think\s*>", text, flags=re.IGNORECASE))
+    if not isinstance(text, str):
+        return _INVALID_REASONING_OUTPUT
+    tags = list(re.finditer(r"<(/?)think\b[^>]*>", text, flags=re.IGNORECASE))
     depth = 0
     for tag in tags:
-        if tag.group(0).lstrip().startswith("</"):
+        if tag.group(1):
             depth -= 1
             if depth < 0:
                 return _INVALID_REASONING_OUTPUT
         else:
             depth += 1
+            if depth > 1:
+                return _INVALID_REASONING_OUTPUT
     if depth:
         return _INVALID_REASONING_OUTPUT
-    return re.sub(r"<think\s*>.*?</think\s*>", "", text, flags=re.DOTALL | re.IGNORECASE).strip()
+    return re.sub(
+        r"<think\b[^>]*>.*?</think\b[^>]*>", "", text, flags=re.DOTALL | re.IGNORECASE
+    ).strip()
 
 
-def _clean_output(text: str) -> str:
+def _clean_output(text: str):
     """Strip assistant tokens and extra whitespace from model output."""
     text = _sanitize_reasoning_output(text)
     if _is_invalid_reasoning_output(text):
@@ -691,9 +704,9 @@ def _call_remote_llm(prompt: str, temperature: float = 0.3) -> Optional[str]:
     return None
 
 
-def summarize_memories(
-    memories: List[str], source: str = "", *, preserve_invalid: bool = False
-) -> Optional[str]:
+def _summarize_memories(
+    memories: List[str], source: str = ""
+):
     """Summarize a batch of working-memory items into a single episodic string.
 
     Fallback chain:
@@ -717,7 +730,7 @@ def summarize_memories(
     # chunk_memories_by_budget() respects LLM_N_CTX and safety margins.
     chunks = chunk_memories_by_budget(memories, source=source)
 
-    def _summarize_chunk(chunk_memories: List[str], chunk_source: str = "") -> Optional[str]:
+    def _summarize_chunk(chunk_memories: List[str], chunk_source: str = ""):
         """Summarize a single chunk of memories via the fallback chain."""
         host_prompt = _build_host_prompt(chunk_memories, source=chunk_source)
         prompt = _build_prompt(chunk_memories, source=chunk_source)
@@ -726,7 +739,7 @@ def summarize_memories(
         attempted, text = _try_host_llm(host_prompt, max_tokens=LLM_MAX_TOKENS, temperature=0.3)
         if attempted:
             if _is_invalid_reasoning_output(text):
-                return _INVALID_REASONING_OUTPUT if preserve_invalid else None
+                return _INVALID_REASONING_OUTPUT
             if text:
                 return text
             raw = _call_local_llm(prompt)
@@ -760,7 +773,7 @@ def summarize_memories(
     for chunk in chunks:
         summary = _summarize_chunk(chunk, chunk_source=source)
         if _is_invalid_reasoning_output(summary):
-            return _INVALID_REASONING_OUTPUT if preserve_invalid else None
+            return _INVALID_REASONING_OUTPUT
         if summary:
             chunk_summaries.append(summary)
 
@@ -771,7 +784,13 @@ def summarize_memories(
     if len(chunk_summaries) > 1:
         final = _summarize_chunk(chunk_summaries, chunk_source=f"{source} [chunked {len(chunks)} parts]")
         if _is_invalid_reasoning_output(final):
-            return _INVALID_REASONING_OUTPUT if preserve_invalid else None
+            return _INVALID_REASONING_OUTPUT
         return final if final else chunk_summaries[0]
 
     return chunk_summaries[0]
+
+
+def summarize_memories(memories: List[str], source: str = "") -> Optional[str]:
+    """Public summary API; malformed reasoning degrades to no LLM output."""
+    summary = _summarize_memories(memories, source=source)
+    return summary if isinstance(summary, str) else None

--- a/mnemosyne/core/local_llm.py
+++ b/mnemosyne/core/local_llm.py
@@ -427,13 +427,39 @@ def _try_host_llm(
     # so _parse_facts() can consume them. Just trim whitespace.
     text = raw.strip() if isinstance(raw, str) and raw.strip() else None
     if text:
-        text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
+        text = _sanitize_reasoning_output(text)
     return (True, text)
+
+
+_INVALID_REASONING_OUTPUT = "\x00mnemosyne-invalid-reasoning-output\x00"
+
+
+def _is_invalid_reasoning_output(value: object) -> bool:
+    """Return whether *value* is an unsafe, malformed reasoning response."""
+    return value == _INVALID_REASONING_OUTPUT
+
+
+def _sanitize_reasoning_output(text: str) -> str:
+    """Remove balanced think traces and reject malformed traces fail-closed."""
+    tags = list(re.finditer(r"</?think\s*>", text, flags=re.IGNORECASE))
+    depth = 0
+    for tag in tags:
+        if tag.group(0).lstrip().startswith("</"):
+            depth -= 1
+            if depth < 0:
+                return _INVALID_REASONING_OUTPUT
+        else:
+            depth += 1
+    if depth:
+        return _INVALID_REASONING_OUTPUT
+    return re.sub(r"<think\s*>.*?</think\s*>", "", text, flags=re.DOTALL | re.IGNORECASE).strip()
 
 
 def _clean_output(text: str) -> str:
     """Strip assistant tokens and extra whitespace from model output."""
-    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+    text = _sanitize_reasoning_output(text)
+    if _is_invalid_reasoning_output(text):
+        return text
     text = text.replace("<|assistant|>", "").replace("<|user|>", "")
     text = text.replace("</s>", "").strip()
     text = re.sub(r"^(Summarize the following memories.*?[.!?:]\s*)", "", text, flags=re.IGNORECASE | re.DOTALL)
@@ -665,7 +691,9 @@ def _call_remote_llm(prompt: str, temperature: float = 0.3) -> Optional[str]:
     return None
 
 
-def summarize_memories(memories: List[str], source: str = "") -> Optional[str]:
+def summarize_memories(
+    memories: List[str], source: str = "", *, preserve_invalid: bool = False
+) -> Optional[str]:
     """Summarize a batch of working-memory items into a single episodic string.
 
     Fallback chain:
@@ -697,11 +725,15 @@ def summarize_memories(memories: List[str], source: str = "") -> Optional[str]:
         # 0. Host backend.
         attempted, text = _try_host_llm(host_prompt, max_tokens=LLM_MAX_TOKENS, temperature=0.3)
         if attempted:
+            if _is_invalid_reasoning_output(text):
+                return _INVALID_REASONING_OUTPUT if preserve_invalid else None
             if text:
                 return text
             raw = _call_local_llm(prompt)
             if raw:
                 cleaned = _clean_output(raw)
+                if _is_invalid_reasoning_output(cleaned):
+                    return _INVALID_REASONING_OUTPUT
                 return cleaned if cleaned else None
             return None
 
@@ -710,12 +742,16 @@ def summarize_memories(memories: List[str], source: str = "") -> Optional[str]:
             raw = _call_remote_llm(prompt)
             if raw:
                 cleaned = _clean_output(raw)
+                if _is_invalid_reasoning_output(cleaned):
+                    return _INVALID_REASONING_OUTPUT
                 return cleaned if cleaned else None
 
         # 2. Local LLM (llama-cpp-python or ctransformers fallback).
         raw = _call_local_llm(prompt)
         if raw:
             cleaned = _clean_output(raw)
+            if _is_invalid_reasoning_output(cleaned):
+                return _INVALID_REASONING_OUTPUT
             return cleaned if cleaned else None
         return None
 
@@ -723,6 +759,8 @@ def summarize_memories(memories: List[str], source: str = "") -> Optional[str]:
     chunk_summaries = []
     for chunk in chunks:
         summary = _summarize_chunk(chunk, chunk_source=source)
+        if _is_invalid_reasoning_output(summary):
+            return _INVALID_REASONING_OUTPUT if preserve_invalid else None
         if summary:
             chunk_summaries.append(summary)
 
@@ -732,6 +770,8 @@ def summarize_memories(memories: List[str], source: str = "") -> Optional[str]:
     # If multiple chunks, do a second-pass summary to consolidate chunk summaries.
     if len(chunk_summaries) > 1:
         final = _summarize_chunk(chunk_summaries, chunk_source=f"{source} [chunked {len(chunks)} parts]")
+        if _is_invalid_reasoning_output(final):
+            return _INVALID_REASONING_OUTPUT if preserve_invalid else None
         return final if final else chunk_summaries[0]
 
     return chunk_summaries[0]

--- a/mnemosyne/core/model_refresh.py
+++ b/mnemosyne/core/model_refresh.py
@@ -219,6 +219,9 @@ def infer_model_update_proposals(
         attempted_host = False
         raw = None
 
+    if local_llm._is_invalid_reasoning_output(raw):
+        return []
+
     if raw is None and not attempted_host:
         try:
             raw = local_llm._call_remote_llm(prompt, temperature=0.1)

--- a/mnemosyne/core/model_refresh.py
+++ b/mnemosyne/core/model_refresh.py
@@ -227,7 +227,9 @@ def infer_model_update_proposals(
             raw = local_llm._call_remote_llm(prompt, temperature=0.1)
         except Exception:
             raw = None
-    if not raw:
+    if isinstance(raw, str):
+        raw = local_llm._sanitize_reasoning_output(raw)
+    if not isinstance(raw, str) or not raw or local_llm._is_invalid_reasoning_output(raw):
         return []
     return parse_model_update_proposals(raw, allowed_categories=allowed)
 

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -817,6 +817,18 @@ class TestWorkingMemory:
 
 
 class TestEpisodicMemory:
+    def test_consolidate_rejects_malformed_reasoning_before_insert(self, temp_db):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+
+        with pytest.raises(ValueError, match="malformed reasoning"):
+            beam.consolidate_to_episodic(
+                summary="<think>truncated at the token limit",
+                source_wm_ids=["wm1"],
+            )
+
+        count = beam.conn.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0]
+        assert count == 0
+
     def test_consolidate_and_recall(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         eid = beam.consolidate_to_episodic(
@@ -852,6 +864,30 @@ class TestScratchpad:
 
 
 class TestSleepCycle:
+    def test_sleep_falls_back_to_aaak_for_token_truncated_reasoning(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
+        beam.conn.execute(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("old-think", "User prefers dark mode", "conversation", old_ts, "s1"),
+        )
+        beam.conn.commit()
+
+        from mnemosyne.core import local_llm
+        truncated_generation = "<think>reasoning cut off at max_tokens"
+        monkeypatch.setattr(local_llm, "llm_available", lambda: True)
+        monkeypatch.setattr(local_llm, "_try_host_llm", lambda *_args, **_kwargs: (False, None))
+        monkeypatch.setattr(local_llm, "_call_local_llm", lambda *_args, **_kwargs: truncated_generation)
+
+        result = beam.sleep()
+        content = beam.conn.execute("SELECT content FROM episodic_memory").fetchone()[0]
+        assert result["status"] == "consolidated"
+        assert result["llm_used"] == 0
+        assert content.startswith("[conversation] ")
+        assert "<think>" not in content
+        assert "truncated" not in content
+
     def test_sleep_consolidates_old_memories(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         # Inject old working memories

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -817,17 +817,14 @@ class TestWorkingMemory:
 
 
 class TestEpisodicMemory:
-    def test_consolidate_rejects_malformed_reasoning_before_insert(self, temp_db):
+    def test_consolidate_preserves_literal_think_markup(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
+        summary = "User wrote </think> in a literal example"
 
-        with pytest.raises(ValueError, match="malformed reasoning"):
-            beam.consolidate_to_episodic(
-                summary="<think>truncated at the token limit",
-                source_wm_ids=["wm1"],
-            )
+        beam.consolidate_to_episodic(summary=summary, source_wm_ids=["wm1"])
 
-        count = beam.conn.execute("SELECT COUNT(*) FROM episodic_memory").fetchone()[0]
-        assert count == 0
+        content = beam.conn.execute("SELECT content FROM episodic_memory").fetchone()[0]
+        assert content == summary
 
     def test_consolidate_and_recall(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
@@ -864,6 +861,53 @@ class TestScratchpad:
 
 
 class TestSleepCycle:
+    def test_sleep_discards_all_chunk_summaries_after_malformed_chunk(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
+        beam.conn.executemany(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("chunk-a", "first source memory", "conversation", old_ts, "s1"),
+                ("chunk-b", "second source memory", "conversation", old_ts, "s1"),
+            ],
+        )
+        beam.conn.commit()
+
+        from mnemosyne.core import local_llm
+        monkeypatch.setattr(local_llm, "llm_available", lambda: True)
+        monkeypatch.setattr(local_llm, "chunk_memories_by_budget", lambda *_args, **_kwargs: [["a"], ["b"]])
+        results = iter(["first LLM chunk", local_llm._INVALID_REASONING_OUTPUT])
+        monkeypatch.setattr(local_llm, "_summarize_memories", lambda *_args, **_kwargs: next(results))
+
+        beam.sleep()
+        content = beam.conn.execute("SELECT content FROM episodic_memory").fetchone()[0]
+        assert "first LLM chunk" not in content
+        assert content.startswith("[conversation] ")
+
+    def test_sleep_discards_chunk_summaries_after_invalid_second_pass(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        old_ts = (datetime.now() - timedelta(hours=200)).isoformat()
+        beam.conn.executemany(
+            "INSERT INTO working_memory (id, content, source, timestamp, session_id) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("chunk-a", "first source memory", "conversation", old_ts, "s1"),
+                ("chunk-b", "second source memory", "conversation", old_ts, "s1"),
+            ],
+        )
+        beam.conn.commit()
+
+        from mnemosyne.core import local_llm
+        monkeypatch.setattr(local_llm, "llm_available", lambda: True)
+        monkeypatch.setattr(local_llm, "chunk_memories_by_budget", lambda *_args, **_kwargs: [["a"], ["b"]])
+        results = iter(["first LLM chunk", "second LLM chunk", local_llm._INVALID_REASONING_OUTPUT])
+        monkeypatch.setattr(local_llm, "_summarize_memories", lambda *_args, **_kwargs: next(results))
+
+        beam.sleep()
+        content = beam.conn.execute("SELECT content FROM episodic_memory").fetchone()[0]
+        assert "first LLM chunk" not in content
+        assert "second LLM chunk" not in content
+        assert content.startswith("[conversation] ")
+
     def test_sleep_falls_back_to_aaak_for_token_truncated_reasoning(self, temp_db, monkeypatch):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         old_ts = (datetime.now() - timedelta(hours=200)).isoformat()

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -4,8 +4,6 @@ Tests for Mnemosyne Structured Fact Extraction (Phase 2)
 
 import os
 import sys
-import json
-import sqlite3
 import tempfile
 from pathlib import Path
 
@@ -18,9 +16,9 @@ from mnemosyne.core.extraction import (
     _build_extraction_prompt,
     _call_local_extraction_llm,
     _parse_facts,
-    EXTRACTION_PROMPT_TEMPLATE,
 )
 from mnemosyne.core.triples import init_triples
+from mnemosyne.extraction.diagnostics import get_diagnostics, reset_extraction_stats
 
 
 class MockLLM:
@@ -219,7 +217,6 @@ def test_extraction_prompt_configurable():
         
         # Re-import to pick up new env var
         # (In real usage, you'd restart; here we test the constant directly)
-        from mnemosyne.core.extraction import EXTRACTION_PROMPT_TEMPLATE as ep
         # Note: module-level constants are set at import time, so this tests
         # that the code structure supports it. The actual override requires
         # re-import or setting before import.
@@ -283,7 +280,7 @@ if __name__ == "__main__":
 
 from unittest.mock import patch  # noqa: E402
 
-from mnemosyne.core import extraction as _extraction_mod, local_llm  # noqa: E402
+from mnemosyne.core import local_llm  # noqa: E402
 from mnemosyne.core.llm_backends import (  # noqa: E402
     CallableLLMBackend,
     set_host_llm_backend,
@@ -382,6 +379,33 @@ def test_host_extract_facts_rejects_token_truncated_reasoning(monkeypatch):
         assert extract_facts("Denis prefers dark mode.") == []
     remote.assert_not_called()
     local.assert_not_called()
+
+
+def test_remote_extract_facts_rejects_token_truncated_reasoning(monkeypatch):
+    """Malformed remote output records its tier and returns no facts."""
+    reset_extraction_stats()
+    monkeypatch.setattr(local_llm, "LLM_ENABLED", True)
+    monkeypatch.setattr(local_llm, "HOST_LLM_ENABLED", False)
+    monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://remote/v1")
+    monkeypatch.setattr(local_llm, "_call_remote_llm", lambda *_args, **_kwargs: "<think>truncated")
+
+    assert extract_facts("Denis prefers dark mode.") == []
+    samples = get_diagnostics().snapshot()["by_tier"]["remote"]["error_samples"]
+    assert samples[-1]["reason"] == "malformed_reasoning_trace"
+
+
+def test_local_extract_facts_rejects_token_truncated_reasoning(monkeypatch):
+    """Malformed local output records its tier and returns no facts."""
+    reset_extraction_stats()
+    monkeypatch.setattr(local_llm, "LLM_ENABLED", True)
+    monkeypatch.setattr(local_llm, "HOST_LLM_ENABLED", False)
+    monkeypatch.setattr(local_llm, "LLM_BASE_URL", "")
+    monkeypatch.setattr(local_llm, "llm_available", lambda: True)
+    monkeypatch.setattr(local_llm, "_load_llm", lambda: lambda *_args, **_kwargs: "<think>truncated")
+
+    assert extract_facts("Denis prefers dark mode.") == []
+    samples = get_diagnostics().snapshot()["by_tier"]["local"]["error_samples"]
+    assert samples[-1]["reason"] == "malformed_reasoning_trace"
 
 
 def test_host_extract_facts_remote_path_uses_temperature_zero(monkeypatch):

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -370,6 +370,20 @@ def test_host_extract_facts_preserves_bulleted_output(monkeypatch):
     assert not any(f.startswith("-") for f in facts)
 
 
+def test_host_extract_facts_rejects_token_truncated_reasoning(monkeypatch):
+    """Malformed reasoning must not fall through to another extraction tier."""
+    _enable_host(monkeypatch)
+    set_host_llm_backend(CallableLLMBackend(
+        "test", lambda *a, **k: "<think>reasoning truncated by max_tokens"
+    ))
+
+    with patch.object(local_llm, "_call_remote_llm") as remote, \
+         patch.object(local_llm, "_load_llm") as local:
+        assert extract_facts("Denis prefers dark mode.") == []
+    remote.assert_not_called()
+    local.assert_not_called()
+
+
 def test_host_extract_facts_remote_path_uses_temperature_zero(monkeypatch):
     """REGRESSION (codex finding 2): extract_facts must pass temperature=0.0
     even on the standalone remote path, not just the host path."""

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -278,9 +278,9 @@ if __name__ == "__main__":
 # Host LLM backend integration (decisions A1, A3, C2)
 # ---------------------------------------------------------------------------
 
-from unittest.mock import patch  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
 
-from mnemosyne.core import local_llm  # noqa: E402
+from mnemosyne.core import extraction as _extraction_mod, local_llm  # noqa: E402
 from mnemosyne.core.llm_backends import (  # noqa: E402
     CallableLLMBackend,
     set_host_llm_backend,
@@ -387,9 +387,17 @@ def test_remote_extract_facts_rejects_token_truncated_reasoning(monkeypatch):
     monkeypatch.setattr(local_llm, "LLM_ENABLED", True)
     monkeypatch.setattr(local_llm, "HOST_LLM_ENABLED", False)
     monkeypatch.setattr(local_llm, "LLM_BASE_URL", "http://remote/v1")
-    monkeypatch.setattr(local_llm, "_call_remote_llm", lambda *_args, **_kwargs: "<think>truncated")
+    remote = MagicMock(return_value="<think>truncated")
+    local = MagicMock()
+    parse = MagicMock()
+    monkeypatch.setattr(local_llm, "_call_remote_llm", remote)
+    monkeypatch.setattr(local_llm, "_load_llm", local)
+    monkeypatch.setattr(_extraction_mod, "_parse_facts", parse)
 
     assert extract_facts("Denis prefers dark mode.") == []
+    remote.assert_called_once()
+    local.assert_not_called()
+    parse.assert_not_called()
     samples = get_diagnostics().snapshot()["by_tier"]["remote"]["error_samples"]
     assert samples[-1]["reason"] == "malformed_reasoning_trace"
 
@@ -401,9 +409,14 @@ def test_local_extract_facts_rejects_token_truncated_reasoning(monkeypatch):
     monkeypatch.setattr(local_llm, "HOST_LLM_ENABLED", False)
     monkeypatch.setattr(local_llm, "LLM_BASE_URL", "")
     monkeypatch.setattr(local_llm, "llm_available", lambda: True)
-    monkeypatch.setattr(local_llm, "_load_llm", lambda: lambda *_args, **_kwargs: "<think>truncated")
+    local = MagicMock(return_value="<think>truncated")
+    parse = MagicMock()
+    monkeypatch.setattr(local_llm, "_load_llm", lambda: local)
+    monkeypatch.setattr(_extraction_mod, "_parse_facts", parse)
 
     assert extract_facts("Denis prefers dark mode.") == []
+    local.assert_called_once()
+    parse.assert_not_called()
     samples = get_diagnostics().snapshot()["by_tier"]["local"]["error_samples"]
     assert samples[-1]["reason"] == "malformed_reasoning_trace"
 

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -465,6 +465,11 @@ class TestThinkTagStripping:
         raw = "<think>only thinking, no output</think>"
         assert local_llm._clean_output(raw) == ""
 
+    def test_clean_output_rejects_nested_think_tags(self):
+        assert local_llm._is_invalid_reasoning_output(
+            local_llm._clean_output("<think>outer<think>inner</think>outer</think>")
+        )
+
     def test_clean_output_rejects_unclosed_think_tag(self):
         raw = "middle<think>reasoning truncated at the token limit"
         assert local_llm._is_invalid_reasoning_output(local_llm._clean_output(raw))

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -465,11 +465,14 @@ class TestThinkTagStripping:
         raw = "<think>only thinking, no output</think>"
         assert local_llm._clean_output(raw) == ""
 
-    def test_clean_output_does_not_strip_unclosed_think_tag(self):
-        """Unclosed think tags are left as-is since we cannot determine
-        where thinking ends and the response begins."""
-        raw = "middle<think>reasoning that never closes"
-        assert local_llm._clean_output(raw) == raw
+    def test_clean_output_rejects_unclosed_think_tag(self):
+        raw = "middle<think>reasoning truncated at the token limit"
+        assert local_llm._is_invalid_reasoning_output(local_llm._clean_output(raw))
+
+    def test_clean_output_rejects_unmatched_closing_think_tag(self):
+        assert local_llm._is_invalid_reasoning_output(
+            local_llm._clean_output("safe prefix</think> malformed ordering")
+        )
 
     def test_try_host_llm_strips_think_tags(self, monkeypatch):
         """Host LLM output with closed think tags should be cleaned."""
@@ -484,8 +487,8 @@ class TestThinkTagStripping:
         assert attempted is True
         assert text == "Summary of memories."
 
-    def test_try_host_llm_does_not_strip_unclosed_think_tag(self, monkeypatch):
-        """Unclosed think tags in host output are left as-is."""
+    def test_try_host_llm_rejects_unclosed_think_tag(self, monkeypatch):
+        """Token-truncated host reasoning must not reach a persistence caller."""
         monkeypatch.setattr(local_llm, "LLM_ENABLED", True)
         monkeypatch.setattr(local_llm, "HOST_LLM_ENABLED", True)
         monkeypatch.setattr(local_llm, "HOST_LLM_TIMEOUT", 5.0)
@@ -495,8 +498,7 @@ class TestThinkTagStripping:
 
         attempted, text = local_llm._try_host_llm("test prompt", max_tokens=128, temperature=0.3)
         assert attempted is True
-        # Unclosed tag is not stripped - we can't tell where thinking ends
-        assert "<think>" in text
+        assert local_llm._is_invalid_reasoning_output(text)
 
 
 class TestRemoteLLMFallback:

--- a/tests/test_model_refresh_confidence_hardening.py
+++ b/tests/test_model_refresh_confidence_hardening.py
@@ -29,6 +29,25 @@ from mnemosyne.core.canonical import CanonicalStore
 from mnemosyne.core import model_refresh
 
 
+def test_model_refresh_rejects_malformed_host_reasoning(monkeypatch):
+    from mnemosyne.core import local_llm
+
+    monkeypatch.setattr(local_llm, "_try_host_llm", lambda *_args, **_kwargs: (True, local_llm._INVALID_REASONING_OUTPUT))
+    monkeypatch.setattr(model_refresh, "parse_model_update_proposals", lambda *_args, **_kwargs: pytest.fail("must not parse"))
+
+    assert model_refresh.infer_model_update_proposals([{"id": "wm1", "content": "x"}]) == []
+
+
+def test_model_refresh_rejects_malformed_remote_reasoning(monkeypatch):
+    from mnemosyne.core import local_llm
+
+    monkeypatch.setattr(local_llm, "_try_host_llm", lambda *_args, **_kwargs: (False, None))
+    monkeypatch.setattr(local_llm, "_call_remote_llm", lambda *_args, **_kwargs: "<think>truncated")
+    monkeypatch.setattr(model_refresh, "parse_model_update_proposals", lambda *_args, **_kwargs: pytest.fail("must not parse"))
+
+    assert model_refresh.infer_model_update_proposals([{"id": "wm1", "content": "x"}]) == []
+
+
 def _proposal(**overrides):
     base = {
         "category": "model:user",

--- a/tests/test_model_refresh_confidence_hardening.py
+++ b/tests/test_model_refresh_confidence_hardening.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import sqlite3
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -32,20 +33,29 @@ from mnemosyne.core import model_refresh
 def test_model_refresh_rejects_malformed_host_reasoning(monkeypatch):
     from mnemosyne.core import local_llm
 
-    monkeypatch.setattr(local_llm, "_try_host_llm", lambda *_args, **_kwargs: (True, local_llm._INVALID_REASONING_OUTPUT))
+    host = MagicMock(return_value=(True, local_llm._INVALID_REASONING_OUTPUT))
+    remote = MagicMock()
+    monkeypatch.setattr(local_llm, "_try_host_llm", host)
+    monkeypatch.setattr(local_llm, "_call_remote_llm", remote)
     monkeypatch.setattr(model_refresh, "parse_model_update_proposals", lambda *_args, **_kwargs: pytest.fail("must not parse"))
 
     assert model_refresh.infer_model_update_proposals([{"id": "wm1", "content": "x"}]) == []
+    host.assert_called_once()
+    remote.assert_not_called()
 
 
 def test_model_refresh_rejects_malformed_remote_reasoning(monkeypatch):
     from mnemosyne.core import local_llm
 
-    monkeypatch.setattr(local_llm, "_try_host_llm", lambda *_args, **_kwargs: (False, None))
-    monkeypatch.setattr(local_llm, "_call_remote_llm", lambda *_args, **_kwargs: "<think>truncated")
+    host = MagicMock(return_value=(False, None))
+    remote = MagicMock(return_value="<think>truncated")
+    monkeypatch.setattr(local_llm, "_try_host_llm", host)
+    monkeypatch.setattr(local_llm, "_call_remote_llm", remote)
     monkeypatch.setattr(model_refresh, "parse_model_update_proposals", lambda *_args, **_kwargs: pytest.fail("must not parse"))
 
     assert model_refresh.infer_model_update_proposals([{"id": "wm1", "content": "x"}]) == []
+    host.assert_called_once()
+    remote.assert_called_once()
 
 
 def _proposal(**overrides):

--- a/tests/test_sleep_lock_hygiene.py
+++ b/tests/test_sleep_lock_hygiene.py
@@ -85,7 +85,7 @@ class TestSleepLockHygiene:
             txn_open_during_summarize.append(beam.conn.in_transaction)
             return f"summary of {len(lines)} items"
 
-        monkeypatch.setattr(local_llm, "summarize_memories", fake_summarize)
+        monkeypatch.setattr(local_llm, "_summarize_memories", fake_summarize)
 
         result = beam.sleep()
 


### PR DESCRIPTION
## Summary

Prevent incomplete or malformed `<think>` reasoning traces from reaching fact extraction, sleep consolidation, or model-refresh persistence paths.

- Remove balanced reasoning blocks and fail closed on unbalanced or nested reasoning markup.
- Stop extraction when the producing LLM tier returns malformed reasoning.
- Make sleep discard every LLM chunk summary and use the existing AAAK fallback if any chunk or the consolidation pass is malformed.
- Keep the general `consolidate_to_episodic()` API opaque to LLM markup so literal user content is not rewritten or rejected.
- Add boundary tests for host extraction, single- and multi-chunk sleep fallback, nested tags, literal episodic markup, and model-output sanitization.

Fixes #722.

## Why this boundary

`local_llm` is the common producer boundary for local, remote, and host LLM outputs. Its private invalid marker lets sleep distinguish malformed output from an ordinary empty result without exposing a new public API contract. Extraction and model refresh reject malformed producer output before parsing or persistence.

## Non-goals

- No cleanup or re-embedding of existing data.
- No changes to token budgets, prompts, chunk limits, or the general LLM lifecycle.
- No heuristic repair of truncated reasoning or JSON.
- No change to non-LLM callers of `consolidate_to_episodic()`.

## Why not trim to end-of-output?

A truncated trace has no reliable boundary between private reasoning and valid output. Keeping any suffix or prefix risks persisting reasoning or a partial result, so the existing AAAK fallback is used instead.

## Verification

```text
MNEMOSYNE_NO_EMBEDDINGS=1 .venv/bin/python -m pytest -q \
  tests/test_local_llm.py tests/test_extraction.py \
  tests/test_beam.py tests/test_model_refresh_stress.py
186 passed, 1 skipped
```

Also checked: `python3 -m py_compile` for changed core modules and `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR prevents malformed `<think>` reasoning traces from entering Mnemosyne’s memory pipeline.

- **Extraction:** Fact extraction fails closed for unbalanced, nested, or truncated reasoning from host, local, and remote LLM tiers.
- **BEAM and episodic memory:** Sleep consolidation discards partial LLM summaries when any chunk or consolidation pass is invalid. It uses the existing AAAK fallback instead. `consolidate_to_episodic()` preserves literal user content, including `<think>` markup.
- **Model refresh:** Model-update proposals reject invalid reasoning output before parsing or persistence.
- **Privacy and local-first behavior:** The change reduces the risk of storing private reasoning narration or incomplete model output. It adds no external services and preserves local-first guarantees.
- **Architecture:** The change strengthens working-to-episodic and BEAM consolidation boundaries. It does not change retrieval, tier definitions, the veracity system, synchronization, or benchmark methodology.
- **Agent integration:** Hermes, MCP, and CLI surfaces remain unchanged.
- **Maintainability:** Centralized sanitization and an invalid-output sentinel provide consistent fail-closed behavior. Regression tests cover extraction, sleep fallback, nested tags, literal episodic content, and model refresh.
- **Architectural assessment:** Fail-closed validation at persistence boundaries is the right call. It protects memory integrity without changing retrieval or integration contracts.
- **Verification:** 186 tests passed, 1 test was skipped, and compilation and whitespace checks succeeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->