### PR TITLE
fix(mcp): handle non-ASCII bearer tokens safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **MCP SSE authentication rejects malformed non-ASCII bearer tokens with `401` instead of returning a server error (#739).**
 - **API embedding failures now leave a redacted diagnostic trace (#735).** Final HTTP, network, and invalid-response failures still degrade to keyword-only retrieval, but now log the endpoint and safe error class or status without request content, API keys, URL userinfo, query strings, or fragments.
 - **Hermes tool discovery now honors `memory.mnemosyne.tools` (#725).** Tools outside the configured allowlist are no longer advertised through Hermes provider schemas before provider initialization.
 - **Truncated LLM reasoning traces no longer reach memory persistence (#734).** Malformed or unbalanced `<think>` output is rejected before fact extraction, model-refresh parsing, or sleep consolidation; sleep falls back to AAAK rather than persisting a partial LLM summary.

--- a/mnemosyne/mcp_server.py
+++ b/mnemosyne/mcp_server.py
@@ -189,7 +189,8 @@ def _build_sse_app(host: str = "127.0.0.1"):
 
     middleware = []
     if require_auth:
-        expected = token
+        assert token is not None
+        expected = token.encode("utf-8")
 
         class _BearerTokenMiddleware:
             """Pure-ASGI bearer auth middleware.
@@ -212,12 +213,12 @@ def _build_sse_app(host: str = "127.0.0.1"):
                 if scope.get("type") != "http":
                     await self.app(scope, receive, send)
                     return
-                header = ""
+                header = b""
                 for k, v in scope.get("headers", []):
                     if k == b"authorization":
-                        header = v.decode("latin-1")
+                        header = v
                         break
-                if not header.startswith("Bearer "):
+                if not header.startswith(b"Bearer "):
                     resp = JSONResponse(
                         {"error": "missing bearer token"},
                         status_code=401,
@@ -225,7 +226,7 @@ def _build_sse_app(host: str = "127.0.0.1"):
                     )
                     await resp(scope, receive, send)
                     return
-                presented = header[len("Bearer "):].strip()
+                presented = header[len(b"Bearer "):].strip()
                 if not hmac.compare_digest(presented, expected):
                     resp = JSONResponse(
                         {"error": "invalid bearer token"},

--- a/tests/test_s1_mcp_sse_auth.py
+++ b/tests/test_s1_mcp_sse_auth.py
@@ -12,10 +12,7 @@ Run with: pytest tests/test_s1_mcp_sse_auth.py -v
 """
 from __future__ import annotations
 
-import os
-import sys
-import json
-import subprocess
+import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
@@ -156,6 +153,34 @@ def _starlette_available() -> bool:
         return False
 
 
+def _call_asgi_app(app, *, path: str, method: str, authorization: bytes):
+    """Call an ASGI app with raw header bytes and return emitted messages."""
+    messages = []
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"authorization", authorization)],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        messages.append(message)
+
+    asyncio.run(app(scope, receive, send))
+    return messages
+
+
 @pytest.mark.skipif(
     not _starlette_available(),
     reason="starlette/mcp not installed -- build_sse_app skipped",
@@ -227,6 +252,48 @@ class TestBuildSseApp:
         assert resp.status_code == 401
         body = resp.json()
         assert "invalid bearer token" in body.get("error", "").lower()
+
+    @pytest.mark.parametrize(
+        ("path", "method"),
+        [("/sse", "GET"), ("/messages/", "POST")],
+    )
+    def test_bearer_middleware_rejects_non_ascii_token_without_500(
+        self, monkeypatch, path, method
+    ):
+        """Non-ASCII bearer bytes are an auth failure, not a server error."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "supersecret")
+        from mnemosyne.mcp_server import _build_sse_app
+
+        app = _build_sse_app(host="0.0.0.0")
+        messages = _call_asgi_app(
+            app,
+            path=path,
+            method=method,
+            authorization=b"Bearer caf\xe9",
+        )
+
+        response_start = next(
+            message for message in messages if message["type"] == "http.response.start"
+        )
+        assert response_start["status"] == 401
+
+    def test_bearer_middleware_accepts_matching_ascii_token(self, monkeypatch):
+        """A matching ASCII token passes through the auth middleware."""
+        monkeypatch.setenv("MNEMOSYNE_MCP_TOKEN", "supersecret")
+        from mnemosyne.mcp_server import _build_sse_app
+
+        app = _build_sse_app(host="0.0.0.0")
+        messages = _call_asgi_app(
+            app,
+            path="/not-found",
+            method="GET",
+            authorization=b"Bearer supersecret",
+        )
+
+        response_start = next(
+            message for message in messages if message["type"] == "http.response.start"
+        )
+        assert response_start["status"] == 404
 
     def test_bearer_middleware_rejects_malformed_header(self, monkeypatch):
         """Token without 'Bearer ' prefix is rejected as missing."""


### PR DESCRIPTION
## Summary

- keep MCP SSE bearer tokens as bytes through parsing and constant-time comparison
- return `401 Unauthorized` for malformed non-ASCII bearer bytes instead of raising `TypeError`
- cover both authenticated routes, `GET /sse` and `POST /messages/`
- preserve matching and mismatching ASCII-token behavior

## Root cause

The pure-ASGI auth middleware decoded the raw `Authorization` header with Latin-1 and passed the resulting strings to `hmac.compare_digest()`. Python rejects non-ASCII string operands there, so malformed bearer material could raise `TypeError` and produce a server error.

The fix compares raw presented bytes with the UTF-8 bytes of the configured token. This keeps constant-time comparison and avoids an unsupported string-comparison path.

This is scoped to the current SSE transport routes; it does not add or change a streamable `/mcp` endpoint.

## Validation

- TDD regression: both non-ASCII route cases failed with the reported `TypeError` before the fix
- MCP SSE auth and MCP server tests: 110 passed
- Core test suite: 2680 passed, 34 skipped, 7 subtests passed
- Ruff on changed files: passed
- Python compileall: passed

Closes #739


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed non-ASCII bearer-token handling for `GET /sse` and `POST /messages/`.
- Compared raw authorization bytes with UTF-8 bytes from the configured token.
- Malformed non-ASCII tokens now return `401 Unauthorized` instead of raising `TypeError`.
- Preserved valid and invalid ASCII-token behavior.
- Added integration coverage for authentication and routing responses.

## Architectural impact

- No changes to working, episodic, or BEAM memory tiers.
- No changes to retrieval, consolidation, veracity, sync, or benchmark methodology.
- No changes to Hermes or CLI integration.
- The existing MCP SSE authentication surface now handles malformed input safely.
- No changes to the streamable `/mcp` endpoint.
- The fix preserves local-first behavior. It adds no external service, data flow, or privacy exposure.
- Byte-based constant-time comparison is the right call for authentication correctness and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->