### PR TITLE
docs: correct FastEmbed E5 model examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ When client-side encryption is enabled, the remote sync server sees **only metad
 | `MNEMOSYNE_CONTEXT_INCLUDE_CONSOLIDATED` | *(unset)* | Include consolidated working-memory rows in `get_context()` prompt injection. Default: excluded. Truthy values: `1`, `true`, `yes`, `on`. Does not affect `recall()`. |
 | `MNEMOSYNE_EMBEDDING_API_URL` | `${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}` | Preferred name for custom embedding API endpoint (OpenAI-compatible). Falls back to `OPENROUTER_BASE_URL`. |
 | `MNEMOSYNE_EMBEDDING_API_KEY` | `${OPENROUTER_API_KEY:-${OPENAI_API_KEY:-}}` | Preferred name for embedding API key. Falls back to `OPENROUTER_API_KEY`, then `OPENAI_API_KEY`. |
-| `MNEMOSYNE_EMBEDDING_MODEL` | `BAAI/bge-small-en-v1.5` | Embedding model. Low-resource multilingual: `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`; larger options: `intfloat/multilingual-e5-base`, `BAAI/bge-m3`. |
+| `MNEMOSYNE_EMBEDDING_MODEL` | `BAAI/bge-small-en-v1.5` | Embedding model. Low-resource multilingual: `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`; larger FastEmbed E5 option: `intfloat/multilingual-e5-large`; `BAAI/bge-m3` is another multilingual option. |
 | `MNEMOSYNE_EMBEDDING_DIM` | *(unset)* | Optional embedding dimension override (positive integer); takes precedence over the built-in model table. Blank/whitespace-only is treated as unset. |
 
 Full reference: [docs/configuration.md](docs/configuration.md)
@@ -363,8 +363,8 @@ Default embeddings are English-optimized (`bge-small-en-v1.5`). For **non-Englis
 # Low-resource local multilingual embeddings
 export MNEMOSYNE_EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
 
-# Larger multilingual embeddings
-export MNEMOSYNE_EMBEDDING_MODEL=intfloat/multilingual-e5-base
+# Larger FastEmbed E5 multilingual embeddings
+export MNEMOSYNE_EMBEDDING_MODEL=intfloat/multilingual-e5-large
 
 # Or Chinese-specific embeddings
 export MNEMOSYNE_EMBEDDING_MODEL=BAAI/bge-small-zh-v1.5

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,8 +200,8 @@ MNEMOSYNE_EMBEDDING_MODEL=BAAI/bge-small-zh-v1.5
 # Low-resource local multilingual embeddings
 MNEMOSYNE_EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
 
-# Or any fastembed-supported model
-MNEMOSYNE_EMBEDDING_MODEL=intfloat/multilingual-e5-base
+# Larger FastEmbed E5 multilingual embeddings
+MNEMOSYNE_EMBEDDING_MODEL=intfloat/multilingual-e5-large
 ```
 
 The embedding dimension resolves in this order: a non-empty explicit `MNEMOSYNE_EMBEDDING_DIM` (positive integer) takes precedence for every model; otherwise Mnemosyne uses its built-in mappings, including the examples below; an unknown model with no explicit dimension **fails loudly at startup** rather than silently assuming 384. Blank/whitespace-only `MNEMOSYNE_EMBEDDING_DIM` is treated as unset (common in Docker Compose and `.env` files).
@@ -216,8 +216,6 @@ Examples of models with built-in dimension mappings (not an exhaustive model cat
 | `BAAI/bge-base-zh-v1.5` | 768 | Chinese |
 | `BAAI/bge-large-zh-v1.5` | 1,024 | Chinese |
 | `BAAI/bge-m3` | 1,024 | Multilingual |
-| `intfloat/multilingual-e5-small` | 384 | Multilingual |
-| `intfloat/multilingual-e5-base` | 768 | Multilingual |
 | `intfloat/multilingual-e5-large` | 1,024 | Multilingual |
 | `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` | 384 | Multilingual |
 | `sentence-transformers/all-MiniLM-L6-v2` | 384 | Multilingual |


### PR DESCRIPTION
## Summary

Fixes #745 with a documentation-only correction for FastEmbed E5 model examples.

- replace the unsupported `intfloat/multilingual-e5-base` examples with `intfloat/multilingual-e5-large`
- remove E5 small/base from the documented native local FastEmbed model table
- keep runtime dimension mappings unchanged for custom/API paths

## Why this scope

FastEmbed 0.5.1, 0.6.1, 0.7.4, and 0.8.0 register `intfloat/multilingual-e5-large` but not E5 small/base. Mnemosyne passes the selected local model directly to FastEmbed, so the previous documented E5-base configuration fails at runtime.

This intentionally does not add automatic custom-model registration. That needs a separate contract for model artifacts, pooling, normalization, and upgrade behavior.

## Validation

- verified the FastEmbed 0.8.0 multilingual E5 registry: only `intfloat/multilingual-e5-large`
- verified no E5 small/base guidance remains in the edited documents
- `git diff --check`
- independent read-only review: approved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Corrects FastEmbed documentation to use supported `intfloat/multilingual-e5-large`.
- Removes unsupported E5 small/base entries from native local model guidance.
- Keeps E5 small/base dimension mappings for custom-model and API paths.
- official support list 
https://qdrant.github.io/fastembed/examples/Supported_Models/#supported-text-embedding-models

## Architecture and Operations

- No changes to working, episodic, or BEAM memory tiers.
- No changes to retrieval, consolidation, veracity, sync, or benchmark systems.
- No changes to Hermes, MCP, CLI, or agent integration surfaces.
- No changes to runtime behavior, privacy posture, or local-first guarantees.
- This documentation-only fix improves maintainability by aligning examples with FastEmbed’s native registry.
- The PR does not add automatic custom-model registration. This preserves clear boundaries for model artifacts, pooling, normalization, and upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->