### PR TITLE
fix: status reports interpreter mismatch instead of version mismatch (#736)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **`mnemosyne-hermes status` now reports the real interpreter mismatch (#736).** The warning compared interpreter paths but claimed a Python version mismatch and printed a bare version number instead of a runnable fix; it now compares the Hermes and installer environments and emits a shell-quoted `→ Run: <python> -m pip install -U 'mnemosyne-hermes[all]'` command.
 - **MCP SSE authentication rejects malformed non-ASCII bearer tokens with `401` instead of returning a server error (#739).**
 - **API embedding failures now leave a redacted diagnostic trace (#735).** Final HTTP, network, and invalid-response failures still degrade to keyword-only retrieval, but now log the endpoint and safe error class or status without request content, API keys, URL userinfo, query strings, or fragments.
 - **Hermes tool discovery now honors `memory.mnemosyne.tools` (#725).** Tools outside the configured allowlist are no longer advertised through Hermes provider schemas before provider initialization.

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -1028,6 +1028,17 @@ def _iter_mnemosyne_profiles(hermes_home_path: str | Path | None = None) -> list
     return selected
 
 
+def _hermes_python_mismatch(hermes_python: Path) -> bool:
+    """Return whether Hermes runs in a different environment from the installer.
+
+    Compares the environment roots (``sys.prefix`` vs the Hermes interpreter's
+    ``parent.parent``) instead of resolved interpreter paths: separate venvs
+    created over one base interpreter resolve to the same binary while keeping
+    different site-packages, so a resolved-path comparison misses the mismatch.
+    """
+    return Path(hermes_python).parent.parent != Path(sys.prefix)
+
+
 def _link_profile(profile_home: Path, source: Path, *, force: bool = False) -> Optional[Path]:
     """Symlink ``profile_home/plugins/mnemosyne`` to source. Idempotent.
 
@@ -2252,14 +2263,14 @@ def main(argv: list[str] | None = None) -> int:
                     _r = _sp.run([str(hermes_python), "--version"], capture_output=True, text=True, timeout=5)
                     _ver = _r.stdout.strip() or _r.stderr.strip()
                     print(f"  Hermes' Python: {hermes_python} ({_ver})")
-                    if state.mode == "symlink" and hermes_python.resolve() != Path(sys.executable).resolve():
+                    if state.mode == "symlink" and _hermes_python_mismatch(hermes_python):
                         print("  ⚠ Different Python interpreters! Install and Hermes are not the same environment.")
-                        print(f"  → Run: {hermes_python} -m pip install -U 'mnemosyne-hermes[all]'")
+                        print(f"  → Run: {shlex.quote(str(hermes_python))} -m pip install -U 'mnemosyne-hermes[all]'")
                 except Exception:
                     print(f"  Hermes' Python: {hermes_python} (unable to check version)")
             else:
                 print("  Hermes' Python: not found")
-            if installed and state.mode == "symlink" and hermes_python and hermes_python.resolve() != Path(sys.executable).resolve():
+            if installed and state.mode == "symlink" and hermes_python and _hermes_python_mismatch(hermes_python):
                 print("  → Hermes Python vs install Python mismatch means the symlink exists but Hermes")
                 print("     may not be able to import mnemosyne core. Run with --dry-run to diagnose.")
             return 0 if installed else 1

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -2253,8 +2253,8 @@ def main(argv: list[str] | None = None) -> int:
                     _ver = _r.stdout.strip() or _r.stderr.strip()
                     print(f"  Hermes' Python: {hermes_python} ({_ver})")
                     if state.mode == "symlink" and hermes_python.resolve() != Path(sys.executable).resolve():
-                        print("  ⚠ Python version MISMATCH! Install and Hermes use different Python versions.")
-                        print(f"  → Run: {_ver.split()[1]}" if " " in _ver else "")
+                        print("  ⚠ Different Python interpreters! Install and Hermes are not the same environment.")
+                        print(f"  → Run: {hermes_python} -m pip install -U 'mnemosyne-hermes[all]'")
                 except Exception:
                     print(f"  Hermes' Python: {hermes_python} (unable to check version)")
             else:

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -514,3 +514,47 @@ def test_install_help_describes_required_wrapper_migration_flags(capsys):
 
     help_text = capsys.readouterr().out
     assert "With --mode symlink and --force" in help_text
+
+
+def _fake_python(root: Path, version: str = "Python 3.12.13") -> Path:
+    bin_dir = root / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    python = bin_dir / "python"
+    python.write_text(f"#!/bin/sh\necho '{version}'\n", encoding="utf-8")
+    python.chmod(python.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return python
+
+
+def test_status_mismatch_names_interpreters_and_emits_a_runnable_command(
+    tmp_path, monkeypatch, capsys
+):
+    """#736: status compared interpreter paths but claimed a version mismatch,
+    and printed a bare version number instead of a command to run."""
+    if sys.platform.startswith("win32"):
+        pytest.skip("POSIX symlink test")
+    hermes_python = _fake_python(tmp_path / "hermes-venv")
+    this_python = _fake_python(tmp_path / "this-env")
+
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kw: hermes_python)
+    monkeypatch.setattr(sys, "executable", str(this_python))
+    monkeypatch.setattr(
+        install,
+        "plugin_state",
+        lambda hermes_home_path=None: install.PluginState(
+            status="installed",
+            installed=True,
+            target=tmp_path / "plugin",
+            link_target=tmp_path / "plugin-target",
+            mode="symlink",
+            message="ok",
+        ),
+    )
+
+    rc = install.main(["status"])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Different Python interpreters" in out
+    assert "version MISMATCH" not in out
+    assert f"→ Run: {hermes_python} -m pip install -U 'mnemosyne-hermes[all]'" in out
+    assert "→ Run: 3.12.13" not in out

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import shlex
 import stat
 import subprocess
 import sys
@@ -529,14 +530,28 @@ def test_status_mismatch_names_interpreters_and_emits_a_runnable_command(
     tmp_path, monkeypatch, capsys
 ):
     """#736: status compared interpreter paths but claimed a version mismatch,
-    and printed a bare version number instead of a command to run."""
+    and printed a bare version number instead of a command to run.
+
+    Two separate venvs over one base interpreter resolve to the same binary,
+    so the check must compare environment roots, not resolved paths.
+    """
     if sys.platform.startswith("win32"):
         pytest.skip("POSIX symlink test")
-    hermes_python = _fake_python(tmp_path / "hermes-venv")
-    this_python = _fake_python(tmp_path / "this-env")
+    base = _fake_python(tmp_path / "base")
+    hermes_venv = tmp_path / "hermes env" / "venv"  # spaces: quoting matters
+    this_venv = tmp_path / "this-env" / "venv"
+    for venv in (hermes_venv, this_venv):
+        (venv / "bin").mkdir(parents=True, exist_ok=True)
+        (venv / "pyvenv.cfg").write_text("home = /base\n", encoding="utf-8")
+        (venv / "bin" / "python").symlink_to(base)
+    hermes_python = hermes_venv / "bin" / "python"
+    this_python = this_venv / "bin" / "python"
+    assert hermes_python.resolve() == this_python.resolve() == base
 
     monkeypatch.setattr(install, "_find_hermes_python", lambda **kw: hermes_python)
     monkeypatch.setattr(sys, "executable", str(this_python))
+    monkeypatch.setattr(sys, "prefix", str(this_venv))
+    monkeypatch.setattr(sys, "version", "3.12.13 (fake interpreter for test)")
     monkeypatch.setattr(
         install,
         "plugin_state",
@@ -550,11 +565,16 @@ def test_status_mismatch_names_interpreters_and_emits_a_runnable_command(
         ),
     )
 
-    rc = install.main(["status"])
+    rc = install.main(["--hermes-home", str(tmp_path), "status"])
 
     out = capsys.readouterr().out
     assert rc == 0
     assert "Different Python interpreters" in out
     assert "version MISMATCH" not in out
-    assert f"→ Run: {hermes_python} -m pip install -U 'mnemosyne-hermes[all]'" in out
+    assert f"  This Python: {this_python} (3.12.13)" in out
+    assert f"  Hermes' Python: {hermes_python} (Python 3.12.13)" in out
+    assert (
+        f"→ Run: {shlex.quote(str(hermes_python))} -m pip install -U 'mnemosyne-hermes[all]'"
+        in out
+    )
     assert "→ Run: 3.12.13" not in out


### PR DESCRIPTION
## Summary

Fixes #736. `mnemosyne-hermes status` compared interpreter **paths** but reported a **version** mismatch, and the follow-up line printed a bare version number instead of a runnable command.

## Changes

`integrations/hermes/src/mnemosyne_hermes/install.py` (status command):

- Message now names what was actually compared: `⚠ Different Python interpreters! Install and Hermes are not the same environment.` (was `Python version MISMATCH! ... different Python versions.`).
- Follow-up line is now a runnable command, aligned with the existing `FIX: Run: ...` shape in `hermes_plugin_entry()` (`__init__.py`):
  `→ Run: {hermes_python} -m pip install -U 'mnemosyne-hermes[all]'`
  (was `→ Run: 3.12.13`, a bare version number, or a blank line when `_ver` had no space).

The other sites documented in the issue (`install.py` "Hermes Python vs install Python mismatch" line and `__init__.py` FIX line) were already correct and are left untouched.

## Verification

- New regression test `test_status_mismatch_names_interpreters_and_emits_a_runnable_command` in `integrations/hermes/tests/test_install_status.py` reproduces the issue's two-venv-over-one-base scenario: asserts the new wording, that `version MISMATCH` is gone, and that the emitted line is the real pip command (not `→ Run: 3.12.13`).
- Full `integrations/hermes/tests/` suite: 399 passed, 1 skipped (with `pip install -e ./integrations/hermes` as CI does).
- `ruff check --select E9,F63,F7,F82` (CI lint selection): clean on both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Corrects `mnemosyne-hermes status` to report different Python interpreters instead of a false Python version mismatch.
- Provides a runnable, shell-quoted command to install `mnemosyne-hermes[all]` into Hermes’ Python environment.
- Adds regression coverage for separate virtual environments that use the same base Python interpreter.
- Preserves the core memory architecture. No changes affect working, episodic, or BEAM memory tiers; retrieval; consolidation; veracity; sync; or benchmark methodology.
- Preserves local-first guarantees and privacy posture. The change adds no external data flow or new service dependency.
- Improves the Hermes CLI integration surface and long-term maintainability by aligning diagnostics with the actual environment comparison.
- This is the right call because it makes remediation actionable without changing memory behavior or weakening local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->