### PR TITLE
fix: allow updating global-scope memories from any session

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4493,7 +4493,7 @@ class BeamMemory:
             return False
         params.extend([memory_id, self.session_id])
         cursor.execute(
-            f"UPDATE working_memory SET {', '.join(updates)} WHERE id = ? AND session_id = ?",
+            f"UPDATE working_memory SET {', '.join(updates)} WHERE id = ? AND (session_id = ? OR scope = 'global')",
             params
         )
         affected = cursor.rowcount

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1083,10 +1083,18 @@ def init_beam(db_path: Path = None):
     # --- Migration: temporal validity + scope (v2.2) ---
     _add_column_if_missing(conn, "working_memory", "valid_until", "TIMESTAMP DEFAULT NULL")
     _add_column_if_missing(conn, "working_memory", "superseded_by", "TEXT DEFAULT NULL")
-    _add_column_if_missing(conn, "working_memory", "scope", "TEXT DEFAULT 'global'")
+    if _add_column_if_missing(conn, "working_memory", "scope", "TEXT DEFAULT 'session'"):
+        # Pre-scope rows only carried a session_id -- they were session-private.
+        # The ADD COLUMN default would backfill them as 'global', which would
+        # make them readable AND (with cross-session update authorization)
+        # writable from any other session. Normalize to 'session'.
+        conn.execute("UPDATE working_memory SET scope = 'session' WHERE scope = 'global'")
+        conn.commit()
     _add_column_if_missing(conn, "episodic_memory", "valid_until", "TIMESTAMP DEFAULT NULL")
     _add_column_if_missing(conn, "episodic_memory", "superseded_by", "TEXT DEFAULT NULL")
-    _add_column_if_missing(conn, "episodic_memory", "scope", "TEXT DEFAULT 'global'")
+    if _add_column_if_missing(conn, "episodic_memory", "scope", "TEXT DEFAULT 'session'"):
+        conn.execute("UPDATE episodic_memory SET scope = 'session' WHERE scope = 'global'")
+        conn.commit()
 
     # --- NAI-0 Covering Indexes (v2.5) ---
     cursor.execute("""CREATE INDEX IF NOT EXISTS idx_em_scope_imp
@@ -1384,14 +1392,19 @@ def _sanitize_utf8(text: str) -> str:
         return text.encode('utf-8', errors='replace').decode('utf-8')
 
 
-def _add_column_if_missing(conn: sqlite3.Connection, table: str, column: str, col_type: str):
-    """Safely add a column if it doesn't already exist (SQLite migration helper)."""
+def _add_column_if_missing(conn: sqlite3.Connection, table: str, column: str, col_type: str) -> bool:
+    """Safely add a column if it doesn't already exist (SQLite migration helper).
+
+    Returns True when the column was added, False when it already existed.
+    """
     cursor = conn.cursor()
     cursor.execute(f"PRAGMA table_info({table})")
     existing = {row[1] for row in cursor.fetchall()}
     if column not in existing:
         cursor.execute(f"ALTER TABLE {table} ADD COLUMN {column} {col_type}")
         conn.commit()
+        return True
+    return False
 
 
 @dataclass(frozen=True)

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -614,35 +614,48 @@ class Mnemosyne:
 
     def update(self, memory_id: str, content: str = None,
                importance: float = None) -> bool:
-        """Update an existing memory in legacy table and BEAM."""
-        cursor = self.conn.cursor()
+        """Update an existing memory in BEAM working_memory (primary store).
 
+        Mirrors the legacy table best-effort when a legacy row exists.
+        Authorization follows the same pattern as get()/invalidate():
+        the caller may update its own session's memories or global-scoped
+        memories from any session.
+        """
+        if content is None and importance is None:
+            return False
+
+        # Primary store: BEAM working_memory.
+        beam_ok = self.beam.update_working(
+            memory_id, content=content, importance=importance
+        )
+
+        # Legacy mirror: best-effort, scoped to this session's rows only.
+        legacy_ok = False
+        cursor = self.conn.cursor()
         updates = []
         params = []
-
         if content is not None:
             updates.append("content = ?")
             params.append(content)
-
         if importance is not None:
             updates.append("importance = ?")
             params.append(importance)
+        if updates:
+            params.extend([memory_id, self.session_id])
+            cursor.execute(
+                f"UPDATE memories SET {', '.join(updates)} "
+                "WHERE id = ? AND session_id = ?",
+                params
+            )
+            self.conn.commit()
+            legacy_ok = cursor.rowcount > 0
 
-        if not updates:
-            return False
-
-        params.extend([memory_id, self.session_id])
-        cursor.execute(
-            f"UPDATE memories SET {', '.join(updates)} WHERE id = ? AND session_id = ?",
-            params
-        )
-        self.conn.commit()
-
-        # Sync BEAM working_memory
-        self.beam.update_working(memory_id, content=content, importance=importance)
-
-        self._emit_wrapper("MEMORY_UPDATED", memory_id, content=content, importance=importance)
-        return cursor.rowcount > 0
+        if beam_ok or legacy_ok:
+            self._emit_wrapper(
+                "MEMORY_UPDATED", memory_id,
+                content=content, importance=importance,
+            )
+        return beam_ok or legacy_ok
 
     def invalidate(self, memory_id: str, replacement_id: str = None) -> bool:
         """Mark a memory as expired or superseded. Delegates to BEAM."""

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -650,12 +650,12 @@ class Mnemosyne:
             self.conn.commit()
             legacy_ok = cursor.rowcount > 0
 
-        if beam_ok or legacy_ok:
+        if beam_ok:
             self._emit_wrapper(
                 "MEMORY_UPDATED", memory_id,
                 content=content, importance=importance,
             )
-        return beam_ok or legacy_ok
+        return beam_ok
 
     def invalidate(self, memory_id: str, replacement_id: str = None) -> bool:
         """Mark a memory as expired or superseded. Delegates to BEAM."""

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -630,7 +630,6 @@ class Mnemosyne:
         )
 
         # Legacy mirror: best-effort, scoped to this session's rows only.
-        legacy_ok = False
         cursor = self.conn.cursor()
         updates = []
         params = []
@@ -648,7 +647,6 @@ class Mnemosyne:
                 params
             )
             self.conn.commit()
-            legacy_ok = cursor.rowcount > 0
 
         if beam_ok:
             self._emit_wrapper(

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -2529,6 +2529,87 @@ class TestUpdateCrossSessionAuthorization:
         assert row is not None
         assert row["importance"] == 0.95
 
+    def test_mnemosyne_update_session_memory_from_another_session_denied(
+        self, temp_db, monkeypatch
+    ):
+        """Mnemosyne.update() must deny cross-session updates of session-scoped
+        memories: False, content unchanged, and no MEMORY_UPDATED event."""
+        from mnemosyne.core.memory import Mnemosyne
+
+        mnem = Mnemosyne(session_id="s1", db_path=temp_db)
+        mid = mnem.remember("s1 private fact", source="test")
+        assert mid is not None
+
+        other = Mnemosyne(session_id="s2", db_path=temp_db)
+        events = []
+        monkeypatch.setattr(
+            other, "_emit_wrapper",
+            lambda *args, **kwargs: events.append((args, kwargs)),
+        )
+        ok = other.update(mid, content="tampered")
+        assert ok is False
+
+        row = mnem.get(mid)
+        assert row is not None
+        assert row["content"] == "s1 private fact"
+        assert events == []
+
+    def test_empty_and_unknown_updates_do_not_emit(self, temp_db, monkeypatch):
+        """Empty updates (no content, no importance) and unknown IDs must
+        return False without emitting MEMORY_UPDATED."""
+        from mnemosyne.core.memory import Mnemosyne
+
+        mnem = Mnemosyne(session_id="s1", db_path=temp_db)
+        mid = mnem.remember("something", source="test")
+        events = []
+        monkeypatch.setattr(
+            mnem, "_emit_wrapper",
+            lambda *args, **kwargs: events.append((args, kwargs)),
+        )
+
+        assert mnem.update(mid) is False
+        assert mnem.update("deadbeefdeadbeef", importance=0.9) is False
+        assert events == []
+
+    def test_scope_migration_backfills_legacy_rows_as_session(self, temp_db):
+        """Pre-scope rows must be backfilled as 'session' when the scope column
+        is added -- the ADD COLUMN default would otherwise mark them 'global',
+        making them writable from any other session."""
+        import sqlite3
+
+        conn = sqlite3.connect(str(temp_db))
+        conn.execute("""CREATE TABLE working_memory (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            source TEXT,
+            timestamp TEXT,
+            session_id TEXT DEFAULT 'default',
+            importance REAL DEFAULT 0.5,
+            metadata_json TEXT,
+            veracity TEXT DEFAULT 'unknown',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )""")
+        conn.execute(
+            "INSERT INTO working_memory (id, content, session_id) "
+            "VALUES ('legacy1', 'old private note', 'session-a')"
+        )
+        conn.commit()
+        conn.close()
+
+        # Initializing BeamMemory runs the schema migrations.
+        beam = BeamMemory(session_id="session-a", db_path=str(temp_db))
+
+        conn = sqlite3.connect(str(temp_db))
+        scope = conn.execute(
+            "SELECT scope FROM working_memory WHERE id = 'legacy1'"
+        ).fetchone()[0]
+        conn.close()
+        assert scope == "session", f"legacy row must be backfilled 'session', got {scope!r}"
+
+        # The backfilled row must NOT be writable from another session.
+        other = BeamMemory(session_id="session-b", db_path=str(temp_db))
+        assert other.update_working("legacy1", importance=0.99) is False
+
 
 class TestEmbeddingDimConfig:
     """Tests for MNEMOSYNE_EMBEDDING_DIM env var override.

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -2474,6 +2474,62 @@ class TestUpdateRefreshesDerivedState:
         )
 
 
+class TestUpdateCrossSessionAuthorization:
+    """update_working()/Mnemosyne.update() must follow the same authorization
+    pattern as get()/invalidate(): (session_id = ? OR scope = 'global').
+
+    Before the fix, both were session-locked, so a global-scope memory
+    (e.g. a durable user fact) could never be updated from a later session
+    -- update() reported "not_found" even though get() and invalidate()
+    could reach the row.
+    """
+
+    def test_update_global_memory_from_another_session(self, temp_db):
+        """A global-scope memory must be updatable from any session."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        mid = beam.remember(
+            "The speed of light is 299,792,458 m/s",
+            source="test", scope="global",
+        )
+        assert mid is not None
+
+        other = BeamMemory(session_id="s2", db_path=temp_db)
+        ok = other.update_working(
+            mid, content="The speed of light is exactly 299,792,458 m/s"
+        )
+        assert ok is True
+
+        row = other.get(mid)
+        assert row is not None
+        assert "exactly" in row["content"]
+
+    def test_update_session_memory_from_another_session_denied(self, temp_db):
+        """A session-scoped memory must NOT be updatable from another session."""
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        mid = beam.remember("private note for s1", source="test")
+        assert mid is not None
+
+        other = BeamMemory(session_id="s2", db_path=temp_db)
+        ok = other.update_working(mid, importance=0.99)
+        assert ok is False
+
+    def test_mnemosyne_update_global_memory_from_another_session(self, temp_db):
+        """Mnemosyne.update() must also allow cross-session updates of global memories."""
+        from mnemosyne.core.memory import Mnemosyne
+
+        mnem = Mnemosyne(session_id="s1", db_path=temp_db)
+        mid = mnem.remember("Krakatoa erupted in 1883", source="test", scope="global")
+        assert mid is not None
+
+        other = Mnemosyne(session_id="s2", db_path=temp_db)
+        ok = other.update(mid, importance=0.95)
+        assert ok is True
+
+        row = other.get(mid)
+        assert row is not None
+        assert row["importance"] == 0.95
+
+
 class TestEmbeddingDimConfig:
     """Tests for MNEMOSYNE_EMBEDDING_DIM env var override.
 

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -2597,7 +2597,7 @@ class TestUpdateCrossSessionAuthorization:
         conn.close()
 
         # Initializing BeamMemory runs the schema migrations.
-        beam = BeamMemory(session_id="session-a", db_path=str(temp_db))
+        BeamMemory(session_id="session-a", db_path=str(temp_db))
 
         conn = sqlite3.connect(str(temp_db))
         scope = conn.execute(


### PR DESCRIPTION
## Summary

`update_working()` and `Mnemosyne.update()` were session-locked, so a **global-scope** memory (e.g. a durable user fact) could never be updated from a later session: `update()` reported `not_found` even though `get()` and `invalidate()` could reach the row.

## Root cause

- `beam.update_working()`: `UPDATE working_memory ... WHERE id = ? AND session_id = ?` — the only write path that does **not** use the `(session_id = ? OR scope = 'global')` authorization pattern already used by `get()` and `invalidate()`.
- `Mnemosyne.update()`: reported success based on a `UPDATE memories ... WHERE id = ? AND session_id = ?` against the **legacy** table (which no longer holds BEAM-era rows), while the result of the real BEAM update was discarded.

## Fix

- `beam.update_working()`: same authorization pattern as `get()`/`invalidate()` — `(session_id = ? OR scope = 'global')`.
- `Mnemosyne.update()`: BEAM `working_memory` is now the primary store and its result determines the return value; the legacy `memories` table is a best-effort mirror, still scoped to the caller's session. Returns `False` when nothing matched (previously it could claim success while the BEAM row was untouched).

## Security

Session-scoped memories remain **not** updatable from other sessions — only the caller's own session rows and `scope='global'` rows are writable, matching the existing read/invalidate boundary.

## Tests

Added `TestUpdateCrossSessionAuthorization` in `tests/test_beam.py`:

- `test_update_global_memory_from_another_session` — global memory updatable from any session (was the bug)
- `test_update_session_memory_from_another_session_denied` — session-scoped memory still protected
- `test_mnemosyne_update_global_memory_from_another_session` — `Mnemosyne.update()` propagates cross-session

Verified with `MNEMOSYNE_NO_EMBEDDINGS=1 python -m pytest tests/test_beam.py -k "TestUpdateCrossSessionAuthorization or TestUpdateRefreshesDerivedState"` (existing update tests + new ones pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Global-scope BEAM memories support authorized cross-session updates.
- Session-scoped memories remain protected from other sessions.
- `Mnemosyne.update()` uses BEAM `working_memory` as the primary store.
- Legacy `memories` rows receive best-effort session-scoped mirrors.
- Failed, empty, unknown, or unauthorized updates return `False`.
- `MEMORY_UPDATED` events emit only after a successful BEAM update.
- Scope migration defaults and backfills existing rows as `session`.

## Architectural impact

This change strengthens the working-memory tier and makes BEAM the authoritative update path. It does not change episodic memory, retrieval, consolidation, veracity, synchronization, or benchmark methodology.

The authorization rule is the right call. It supports shared global memory while preserving session privacy. The local-first design remains unchanged because updates use local stores and add no remote dependency.

Hermes, MCP, and CLI integration surfaces do not change. The BEAM-first flow improves maintainability by separating the primary store from the legacy compatibility mirror and by returning a clear update result.

Regression tests cover cross-session authorization, denied updates, event suppression, update propagation, empty and unknown updates, batch behavior, and migration backfill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->