### PR TITLE
fix: preserve caller transactions in memory batches

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1305,58 +1305,61 @@ def _guarded_transaction(conn: sqlite3.Connection):
 
 @contextlib.contextmanager
 def _deferred_commits(conn: sqlite3.Connection):
-    """Suppress nested commit() calls so the caller can wrap many
-    sub-helpers in a single transaction.
+    """Defer nested commits without stealing a caller-owned transaction.
 
-    Pairs with `_BeamConnection`'s `_defer_commit` flag. If the
-    passed connection isn't a `_BeamConnection` (e.g., a test
-    constructed `BeamMemory` with a raw sqlite3 connection, or a
-    legacy caller built its own conn), the context manager degrades
-    to a no-op -- inner commits still fire, performance regression
-    isn't fixed for that code path but correctness is preserved.
-
-    Threading: `_BeamConnection._defer_commit` is per-connection.
-    BeamMemory uses thread-local connections (see _get_connection),
-    so the flag is visible only to the calling thread. A future
-    refactor that shares the connection across threads would need
-    a lock here.
+    A BEAM-owned batch starts and commits its own transaction.  When a caller
+    already has a transaction open, the batch is isolated in a savepoint: it
+    releases on success and rolls back only its own writes on failure.  In
+    particular, neither path may commit or roll back the caller's marker rows.
     """
-    is_beam_conn = isinstance(conn, _BeamConnection)
-    if not is_beam_conn:
-        # Degrade gracefully: inner commits fire as before. This
-        # keeps the path callable from tests that build conns
-        # manually but loses the batching perf win on that code path.
+    if not isinstance(conn, _BeamConnection):
+        # Raw sqlite connections cannot suppress C-level commit calls. Retain
+        # the established compatibility behavior for legacy/manual callers.
         yield
         return
 
+    owns_transaction = not conn.in_transaction
+    savepoint = "mnemosyne_deferred_commits"
+    previously_deferred = conn._defer_commit
+    if owns_transaction:
+        conn.execute("BEGIN")
+    else:
+        conn.execute(f"SAVEPOINT {savepoint}")
     conn._defer_commit = True
     try:
         yield
     except Exception:
-        conn._defer_commit = False
+        conn._defer_commit = previously_deferred
         try:
-            conn.rollback()
+            if owns_transaction:
+                conn.rollback()
+            else:
+                conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                conn.execute(f"RELEASE SAVEPOINT {savepoint}")
         except sqlite3.Error:
             pass
         raise
     else:
-        conn._defer_commit = False
+        conn._defer_commit = previously_deferred
         try:
-            conn._real_commit()
+            if owns_transaction:
+                conn._real_commit()
+            else:
+                conn.execute(f"RELEASE SAVEPOINT {savepoint}")
         except sqlite3.Error as exc:
-            logger.error(
-                "_deferred_commits: final commit failed: %s; "
-                "rolling back the buffered transaction",
-                exc,
-            )
+            logger.error("_deferred_commits: finalization failed: %s", exc)
             try:
-                conn.rollback()
+                if owns_transaction:
+                    conn.rollback()
+                else:
+                    conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                    conn.execute(f"RELEASE SAVEPOINT {savepoint}")
             except sqlite3.Error:
                 pass
             raise
     finally:
-        # Defense in depth: clear the flag on any control-flow path.
-        conn._defer_commit = False
+        # Preserve an enclosing deferral scope if this context was nested.
+        conn._defer_commit = previously_deferred
 
 
 def _generate_id(content: str) -> str:
@@ -2263,15 +2266,12 @@ def _vec_table_insert(conn: sqlite3.Connection, table: str, rowid: int, embeddin
             f"INSERT INTO {table}(rowid, embedding) VALUES (?, ?)",
             (rowid, emb_json)
         )
-    # Ensure the insert is committed even when the caller's connection
-    # has _defer_commit=True (_BeamConnection). Without this, inserts
-    # sit in the deferred transaction and disappear if the caller
-    # later rolls back or the connection is reused in a different context.
+    # Respect the caller's transaction boundary.  `_BeamConnection.commit()`
+    # intentionally becomes a no-op while `_deferred_commits()` is active, so
+    # vector rows remain atomic with their working-memory row instead of
+    # prematurely committing an enclosing batch/caller transaction.
     if commit:
-        if isinstance(conn, _BeamConnection):
-            conn._real_commit()
-        else:
-            conn.commit()
+        conn.commit()
 
 
 def _wm_rowid(conn: sqlite3.Connection, memory_id: str) -> Optional[int]:

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1258,7 +1258,13 @@ class _BeamConnection(sqlite3.Connection):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._defer_commit = False
+        self._savepoint_counter = 0
         self._vec_working_count_cache: Optional[Tuple[int, int, int]] = None
+
+    def _next_savepoint_name(self, purpose: str) -> str:
+        """Return a connection-local, SQLite-safe savepoint identifier."""
+        self._savepoint_counter += 1
+        return f"mnemosyne_{purpose}_{self._savepoint_counter}"
 
     def commit(self) -> None:
         if self._defer_commit:
@@ -1287,17 +1293,31 @@ def _guarded_transaction(conn: sqlite3.Connection):
     itself guarded so a dead connection cannot mask the original
     exception.
 
-    Not used by ``_deferred_commits()``: that context manager implements
-    commit-DEFERRAL semantics (suppressing nested commits behind a
-    per-connection flag), which is a different mechanism from a plain
-    guarded transaction.
+    During ``_deferred_commits()``, guarded operations take a local savepoint
+    instead: a connection-wide rollback would otherwise erase caller-owned
+    writes and invalidate the enclosing batch savepoint.
     """
+    # A deferred batch may be nested in a caller-owned transaction. Its
+    # commit suppression does not make ``rollback()`` safe: a connection-wide
+    # rollback would erase the caller's writes and invalidate the batch's
+    # savepoint. Give each guarded operation its own savepoint instead.
+    deferred_savepoint = None
+    if isinstance(conn, _BeamConnection) and conn._defer_commit:
+        deferred_savepoint = conn._next_savepoint_name("guarded_transaction")
+        conn.execute(f"SAVEPOINT {deferred_savepoint}")
     try:
         yield
-        conn.commit()
+        if deferred_savepoint is None:
+            conn.commit()
+        else:
+            conn.execute(f"RELEASE SAVEPOINT {deferred_savepoint}")
     except Exception:
         try:
-            conn.rollback()
+            if deferred_savepoint is None:
+                conn.rollback()
+            else:
+                conn.execute(f"ROLLBACK TO SAVEPOINT {deferred_savepoint}")
+                conn.execute(f"RELEASE SAVEPOINT {deferred_savepoint}")
         except sqlite3.Error:
             pass  # rollback of a dead connection must not mask the cause
         raise
@@ -1319,7 +1339,7 @@ def _deferred_commits(conn: sqlite3.Connection):
         return
 
     owns_transaction = not conn.in_transaction
-    savepoint = "mnemosyne_deferred_commits"
+    savepoint = conn._next_savepoint_name("deferred_commits")
     previously_deferred = conn._defer_commit
     if owns_transaction:
         conn.execute("BEGIN")

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -1293,31 +1293,30 @@ def _guarded_transaction(conn: sqlite3.Connection):
     itself guarded so a dead connection cannot mask the original
     exception.
 
-    During ``_deferred_commits()``, guarded operations take a local savepoint
-    instead: a connection-wide rollback would otherwise erase caller-owned
-    writes and invalidate the enclosing batch savepoint.
+    For an already-open ``_BeamConnection`` transaction, guarded operations
+    take a local savepoint instead: a connection-wide commit or rollback would
+    otherwise steal or erase caller-owned writes.
     """
-    # A deferred batch may be nested in a caller-owned transaction. Its
-    # commit suppression does not make ``rollback()`` safe: a connection-wide
-    # rollback would erase the caller's writes and invalidate the batch's
-    # savepoint. Give each guarded operation its own savepoint instead.
-    deferred_savepoint = None
-    if isinstance(conn, _BeamConnection) and conn._defer_commit:
-        deferred_savepoint = conn._next_savepoint_name("guarded_transaction")
-        conn.execute(f"SAVEPOINT {deferred_savepoint}")
+    # An active _BeamConnection transaction can be caller-owned even when
+    # commit deferral is inactive. Never commit or roll back that outer
+    # transaction; isolate this guarded operation in its own savepoint.
+    savepoint = None
+    if isinstance(conn, _BeamConnection) and conn.in_transaction:
+        savepoint = conn._next_savepoint_name("guarded_transaction")
+        conn.execute(f"SAVEPOINT {savepoint}")
     try:
         yield
-        if deferred_savepoint is None:
+        if savepoint is None:
             conn.commit()
         else:
-            conn.execute(f"RELEASE SAVEPOINT {deferred_savepoint}")
+            conn.execute(f"RELEASE SAVEPOINT {savepoint}")
     except Exception:
         try:
-            if deferred_savepoint is None:
+            if savepoint is None:
                 conn.rollback()
             else:
-                conn.execute(f"ROLLBACK TO SAVEPOINT {deferred_savepoint}")
-                conn.execute(f"RELEASE SAVEPOINT {deferred_savepoint}")
+                conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                conn.execute(f"RELEASE SAVEPOINT {savepoint}")
         except sqlite3.Error:
             pass  # rollback of a dead connection must not mask the cause
         raise
@@ -4191,8 +4190,10 @@ class BeamMemory:
         # consolidation pass is writing) must roll back rather than abandon
         # the thread-local connection inside an open, stale transaction --
         # see _guarded_transaction.
+        owns_transaction = not self.conn.in_transaction
         with _guarded_transaction(self.conn):
-            cursor.execute("BEGIN TRANSACTION")
+            if owns_transaction:
+                cursor.execute("BEGIN TRANSACTION")
             for ts, ids in updates.items():
                 placeholders = ",".join("?" for _ in ids)
                 cursor.execute(

--- a/tests/test_batch_transaction_owner_726.py
+++ b/tests/test_batch_transaction_owner_726.py
@@ -1,9 +1,12 @@
 """Public regression coverage for #726 batch transaction ownership."""
 
+import contextlib
+import sqlite3
 from pathlib import Path
 
+import mnemosyne.core.beam as beam_module
 from mnemosyne.batch_tool import apply_beam_batch, validate_batch_operations
-from mnemosyne.core.beam import BeamMemory
+from mnemosyne.core.beam import BeamMemory, _deferred_commits
 
 
 def _beam(tmp_path):
@@ -91,3 +94,208 @@ def test_failed_batch_rolls_back_its_savepoint_without_events_or_caller_data_los
 
     beam.conn.rollback()
     assert beam.conn.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
+
+
+def test_forget_cascade_failure_after_guard_preserves_caller_transaction(
+    tmp_path, monkeypatch
+):
+    beam = _beam(tmp_path)
+    target_id = beam.remember("#726 cascade target")
+    beam.annotations.add(target_id, "test", "annotation")
+    annotation_count = beam.conn.execute(
+        "SELECT COUNT(*) FROM annotations WHERE memory_id = ?", (target_id,)
+    ).fetchone()[0]
+    beam.conn.execute(
+        f"""
+        CREATE TRIGGER forced_annotation_failure
+        BEFORE DELETE ON annotations
+        WHEN OLD.memory_id = '{target_id}'
+        BEGIN
+            SELECT RAISE(ABORT, 'forced cascade failure');
+        END
+        """
+    )
+    beam.conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    beam.conn.commit()
+    beam.conn.execute("INSERT INTO caller_marker VALUES ('survives guarded rollback')")
+
+    entered_guard = []
+    original_guard = beam_module._guarded_transaction
+
+    @contextlib.contextmanager
+    def observing_guard(conn):
+        entered_guard.append(True)
+        with original_guard(conn):
+            yield
+
+    monkeypatch.setattr(beam_module, "_guarded_transaction", observing_guard)
+    events = []
+    result = apply_beam_batch(
+        beam,
+        validate_batch_operations(
+            [
+                {"action": "remember", "content": "#726 must roll back after guard"},
+                {"action": "forget", "memory_id": target_id},
+            ]
+        ),
+        audit_event=lambda name, **kwargs: events.append((name, kwargs)),
+    )
+
+    assert entered_guard == [True]  # Failure is downstream of forget_working's guard.
+    assert result["status"] == "error"
+    assert result["failed_index"] == 1
+    assert "forced cascade failure" in result["error"]
+    assert events == []
+    assert beam.conn.in_transaction is True
+    assert beam.conn.execute("SELECT value FROM caller_marker").fetchone()[0] == (
+        "survives guarded rollback"
+    )
+    assert _count_content(beam.conn, "#726 must roll back after guard") == 0
+    assert beam.get(target_id)["content"] == "#726 cascade target"
+    assert (
+        beam.conn.execute(
+            "SELECT COUNT(*) FROM annotations WHERE memory_id = ?", (target_id,)
+        ).fetchone()[0]
+        == annotation_count
+    )
+
+
+def test_nested_deferred_commits_use_distinct_savepoints_and_restore_deferral(tmp_path):
+    beam = _beam(tmp_path)
+    conn = beam.conn
+    conn.execute("CREATE TABLE deferred_probe (value TEXT NOT NULL)")
+    conn.commit()
+    conn.execute("INSERT INTO deferred_probe VALUES ('caller')")
+    statements = []
+    conn.set_trace_callback(statements.append)
+    try:
+        with _deferred_commits(conn):
+            assert conn._defer_commit is True
+            conn.execute("INSERT INTO deferred_probe VALUES ('outer')")
+            with _deferred_commits(conn):
+                assert conn._defer_commit is True
+                conn.execute("INSERT INTO deferred_probe VALUES ('inner')")
+            assert conn._defer_commit is True
+    finally:
+        conn.set_trace_callback(None)
+
+    savepoints = [
+        statement
+        for statement in statements
+        if statement.startswith("SAVEPOINT mnemosyne_deferred_commits_")
+    ]
+    assert len(savepoints) == 2
+    assert len(set(savepoints)) == 2
+    assert conn._defer_commit is False
+    assert [
+        row[0]
+        for row in conn.execute("SELECT value FROM deferred_probe ORDER BY rowid")
+    ] == [
+        "caller",
+        "outer",
+        "inner",
+    ]
+    conn.rollback()
+
+
+def test_nested_deferred_failure_restores_outer_deferral_and_rolls_back_only_inner(
+    tmp_path,
+):
+    beam = _beam(tmp_path)
+    conn = beam.conn
+    conn.execute("CREATE TABLE deferred_probe (value TEXT NOT NULL)")
+    conn.commit()
+    conn.execute("INSERT INTO deferred_probe VALUES ('caller')")
+
+    with _deferred_commits(conn):
+        conn.execute("INSERT INTO deferred_probe VALUES ('outer')")
+        try:
+            with _deferred_commits(conn):
+                conn.execute("INSERT INTO deferred_probe VALUES ('inner')")
+                raise RuntimeError("nested failure")
+        except RuntimeError:
+            pass
+        assert conn._defer_commit is True
+        assert [
+            row[0]
+            for row in conn.execute("SELECT value FROM deferred_probe ORDER BY rowid")
+        ] == [
+            "caller",
+            "outer",
+        ]
+
+    assert conn._defer_commit is False
+    assert [
+        row[0]
+        for row in conn.execute("SELECT value FROM deferred_probe ORDER BY rowid")
+    ] == [
+        "caller",
+        "outer",
+    ]
+    conn.rollback()
+
+
+def test_forced_active_vec_path_defers_commit_inside_caller_owned_batch(
+    tmp_path, monkeypatch
+):
+    beam = _beam(tmp_path)
+    beam.conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    beam.conn.execute("CREATE TABLE vector_probe (memory_id TEXT NOT NULL)")
+    beam.conn.commit()
+
+    vec_calls = []
+    real_commits = []
+    original_real_commit = beam_module._BeamConnection._real_commit
+
+    def forced_vec_insert(conn, table, rowid, embedding, *, commit=True):
+        vec_calls.append((table, commit))
+        memory_id = conn.execute(
+            "SELECT id FROM working_memory WHERE rowid = ?", (rowid,)
+        ).fetchone()[0]
+        conn.execute("INSERT INTO vector_probe VALUES (?)", (memory_id,))
+        if commit:
+            conn.commit()
+
+    def observing_real_commit(self):
+        real_commits.append(True)
+        return original_real_commit(self)
+
+    class Vector:
+        def tolist(self):
+            return [0.0] * beam_module.EMBEDDING_DIM
+
+    monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam_module._embeddings,
+        "embed",
+        lambda contents: [Vector() for _ in contents],
+    )
+    monkeypatch.setattr(beam_module, "_wm_vec_available", lambda conn: True)
+    monkeypatch.setattr(beam_module, "_vec_table_insert", forced_vec_insert)
+    monkeypatch.setattr(
+        beam_module._BeamConnection, "_real_commit", observing_real_commit
+    )
+
+    beam.conn.execute("INSERT INTO caller_marker VALUES ('outer vector marker')")
+    result = apply_beam_batch(
+        beam,
+        validate_batch_operations(
+            [{"action": "remember", "content": "#726 forced active vec batch"}]
+        ),
+    )
+
+    assert result["status"] == "ok"
+    assert vec_calls == [("vec_working", True)]
+    assert real_commits == []
+    assert beam.conn.in_transaction is True
+    with sqlite3.connect(beam.db_path) as outside:
+        assert outside.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
+        assert outside.execute("SELECT COUNT(*) FROM vector_probe").fetchone()[0] == 0
+
+    beam.conn.rollback()
+    assert beam.conn.execute("SELECT COUNT(*) FROM vector_probe").fetchone()[0] == 0
+
+    beam.remember("#726 forced active vec direct")
+    assert vec_calls[-1] == ("vec_working", True)
+    with sqlite3.connect(beam.db_path) as outside:
+        assert outside.execute("SELECT COUNT(*) FROM vector_probe").fetchone()[0] == 1

--- a/tests/test_batch_transaction_owner_726.py
+++ b/tests/test_batch_transaction_owner_726.py
@@ -4,6 +4,8 @@ import contextlib
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 import mnemosyne.core.beam as beam_module
 from mnemosyne.batch_tool import apply_beam_batch, validate_batch_operations
 from mnemosyne.core.beam import BeamMemory, _deferred_commits, _guarded_transaction
@@ -310,51 +312,37 @@ def test_get_context_preserves_caller_owned_transaction_without_nested_begin(tmp
     assert conn.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
 
 
-def test_forced_active_vec_path_defers_commit_inside_caller_owned_batch(
+def test_active_sqlite_vec_path_defers_commit_inside_caller_owned_batch(
     tmp_path, monkeypatch
 ):
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("sqlite_vec")
     beam = _beam(tmp_path)
+    if not beam_module._wm_vec_available(beam.conn):
+        pytest.skip("sqlite-vec vec_working table unavailable")
+
     beam.conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
-    beam.conn.execute("CREATE TABLE vector_probe (memory_id TEXT NOT NULL)")
     beam.conn.commit()
 
-    vec_calls = []
     real_commits = []
     original_real_commit = beam_module._BeamConnection._real_commit
-
-    def forced_vec_insert(conn, table, rowid, embedding, *, commit=True):
-        vec_calls.append((table, commit))
-        memory_id = conn.execute(
-            "SELECT id FROM working_memory WHERE rowid = ?", (rowid,)
-        ).fetchone()[0]
-        conn.execute("INSERT INTO vector_probe VALUES (?)", (memory_id,))
-        if commit:
-            conn.commit()
 
     def observing_real_commit(self):
         real_commits.append(True)
         return original_real_commit(self)
 
-    class SyntheticEmbedding:
-        def __array__(self, dtype=None, copy=None):
-            # Some CI environments have NumPy, so support its conversion at
-            # the fallback-store boundary before vec_working is reached.
-            numpy = __import__("numpy")
-            return numpy.zeros(beam_module.EMBEDDING_DIM, dtype=dtype)
-
-        def tolist(self):
-            # Other CI environments deliberately omit NumPy; serialize() then
-            # consumes this same real-vector-shaped interface directly.
-            return [0.0] * beam_module.EMBEDDING_DIM
+    # Keep the embedding backend deterministic while exercising production's
+    # real float conversion, sqlite-vec SQL, and vec_working virtual table.
+    embedding = np.array(
+        [1.0] + [0.0] * (beam_module.EMBEDDING_DIM - 1), dtype=np.float32
+    )
 
     monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
     monkeypatch.setattr(
         beam_module._embeddings,
         "embed",
-        lambda contents: [SyntheticEmbedding() for _ in contents],
+        lambda contents: [embedding.copy() for _ in contents],
     )
-    monkeypatch.setattr(beam_module, "_wm_vec_available", lambda conn: True)
-    monkeypatch.setattr(beam_module, "_vec_table_insert", forced_vec_insert)
     monkeypatch.setattr(
         beam_module._BeamConnection, "_real_commit", observing_real_commit
     )
@@ -368,17 +356,57 @@ def test_forced_active_vec_path_defers_commit_inside_caller_owned_batch(
     )
 
     assert result["status"] == "ok"
-    assert vec_calls == [("vec_working", True)]
     assert real_commits == []
     assert beam.conn.in_transaction is True
+    memory_id = result["results"][0]["memory_id"]
+    rowid = beam.conn.execute(
+        "SELECT rowid FROM working_memory WHERE id = ?", (memory_id,)
+    ).fetchone()[0]
+    assert (
+        beam.conn.execute(
+            "SELECT COUNT(*) FROM memory_embeddings WHERE memory_id = ?", (memory_id,)
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        beam.conn.execute(
+            "SELECT COUNT(*) FROM vec_working WHERE rowid = ?", (rowid,)
+        ).fetchone()[0]
+        == 1
+    )
+
     with sqlite3.connect(beam.db_path) as outside:
         assert outside.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
-        assert outside.execute("SELECT COUNT(*) FROM vector_probe").fetchone()[0] == 0
+        assert (
+            outside.execute(
+                "SELECT COUNT(*) FROM working_memory WHERE id = ?", (memory_id,)
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            outside.execute(
+                "SELECT COUNT(*) FROM memory_embeddings WHERE memory_id = ?",
+                (memory_id,),
+            ).fetchone()[0]
+            == 0
+        )
 
     beam.conn.rollback()
-    assert beam.conn.execute("SELECT COUNT(*) FROM vector_probe").fetchone()[0] == 0
-
-    beam.remember("#726 forced active vec direct")
-    assert vec_calls[-1] == ("vec_working", True)
-    with sqlite3.connect(beam.db_path) as outside:
-        assert outside.execute("SELECT COUNT(*) FROM vector_probe").fetchone()[0] == 1
+    assert (
+        beam.conn.execute(
+            "SELECT COUNT(*) FROM working_memory WHERE id = ?", (memory_id,)
+        ).fetchone()[0]
+        == 0
+    )
+    assert (
+        beam.conn.execute(
+            "SELECT COUNT(*) FROM memory_embeddings WHERE memory_id = ?", (memory_id,)
+        ).fetchone()[0]
+        == 0
+    )
+    assert (
+        beam.conn.execute(
+            "SELECT COUNT(*) FROM vec_working WHERE rowid = ?", (rowid,)
+        ).fetchone()[0]
+        == 0
+    )

--- a/tests/test_batch_transaction_owner_726.py
+++ b/tests/test_batch_transaction_owner_726.py
@@ -1,0 +1,93 @@
+"""Public regression coverage for #726 batch transaction ownership."""
+
+from pathlib import Path
+
+from mnemosyne.batch_tool import apply_beam_batch, validate_batch_operations
+from mnemosyne.core.beam import BeamMemory
+
+
+def _beam(tmp_path):
+    return BeamMemory(
+        session_id="batch-owner-726", db_path=Path(tmp_path) / "batch-owner.db"
+    )
+
+
+def _count_content(conn, content):
+    return conn.execute(
+        "SELECT COUNT(*) FROM working_memory WHERE content = ?", (content,)
+    ).fetchone()[0]
+
+
+def test_caller_owned_batch_releases_savepoint_and_outer_rollback_removes_batch_writes(
+    tmp_path,
+):
+    beam = _beam(tmp_path)
+    existing_id = beam.remember("#726 before update")
+
+    beam.conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    beam.conn.commit()
+    beam.conn.execute("INSERT INTO caller_marker VALUES ('outer marker')")
+
+    result = apply_beam_batch(
+        beam,
+        validate_batch_operations(
+            [
+                {"action": "remember", "content": "#726 remembered in batch"},
+                {
+                    "action": "update",
+                    "memory_id": existing_id,
+                    "content": "#726 updated in batch",
+                },
+            ]
+        ),
+    )
+
+    assert result["status"] == "ok"
+    assert beam.conn.in_transaction is True
+    assert (
+        beam.conn.execute("SELECT value FROM caller_marker").fetchone()[0]
+        == "outer marker"
+    )
+
+    beam.conn.rollback()
+    assert _count_content(beam.conn, "#726 remembered in batch") == 0
+    assert beam.get(existing_id)["content"] == "#726 before update"
+    assert beam.conn.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
+
+
+def test_failed_batch_rolls_back_its_savepoint_without_events_or_caller_data_loss(
+    tmp_path,
+):
+    beam = _beam(tmp_path)
+    events = []
+
+    beam.conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    beam.conn.commit()
+    beam.conn.execute("INSERT INTO caller_marker VALUES ('survives')")
+
+    result = apply_beam_batch(
+        beam,
+        validate_batch_operations(
+            [
+                {"action": "remember", "content": "#726 must roll back"},
+                {
+                    "action": "update",
+                    "memory_id": "missing",
+                    "content": "never written",
+                },
+            ]
+        ),
+        audit_event=lambda name, **kwargs: events.append((name, kwargs)),
+    )
+
+    assert result["status"] == "error"
+    assert result["failed_index"] == 1
+    assert events == []
+    assert beam.conn.in_transaction is True
+    assert (
+        beam.conn.execute("SELECT value FROM caller_marker").fetchone()[0] == "survives"
+    )
+    assert _count_content(beam.conn, "#726 must roll back") == 0
+
+    beam.conn.rollback()
+    assert beam.conn.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0

--- a/tests/test_batch_transaction_owner_726.py
+++ b/tests/test_batch_transaction_owner_726.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import mnemosyne.core.beam as beam_module
 from mnemosyne.batch_tool import apply_beam_batch, validate_batch_operations
-from mnemosyne.core.beam import BeamMemory, _deferred_commits
+from mnemosyne.core.beam import BeamMemory, _deferred_commits, _guarded_transaction
 
 
 def _beam(tmp_path):
@@ -235,6 +235,81 @@ def test_nested_deferred_failure_restores_outer_deferral_and_rolls_back_only_inn
     conn.rollback()
 
 
+def test_guarded_transaction_success_preserves_non_deferred_caller_transaction(
+    tmp_path,
+):
+    beam = _beam(tmp_path)
+    conn = beam.conn
+    conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    conn.execute("CREATE TABLE guarded_probe (value TEXT NOT NULL)")
+    conn.commit()
+    conn.execute("INSERT INTO caller_marker VALUES ('caller')")
+
+    with _guarded_transaction(conn):
+        conn.execute("INSERT INTO guarded_probe VALUES ('guarded')")
+
+    assert conn.in_transaction is True
+    assert conn.execute("SELECT value FROM caller_marker").fetchone()[0] == "caller"
+    with sqlite3.connect(beam.db_path) as outside:
+        assert outside.execute("SELECT COUNT(*) FROM guarded_probe").fetchone()[0] == 0
+
+    conn.rollback()
+    assert conn.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM guarded_probe").fetchone()[0] == 0
+
+
+def test_guarded_transaction_failure_preserves_non_deferred_caller_transaction(
+    tmp_path,
+):
+    beam = _beam(tmp_path)
+    conn = beam.conn
+    conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    conn.execute("CREATE TABLE guarded_probe (value TEXT NOT NULL)")
+    conn.commit()
+    conn.execute("INSERT INTO caller_marker VALUES ('caller')")
+
+    try:
+        with _guarded_transaction(conn):
+            conn.execute("INSERT INTO guarded_probe VALUES ('discarded')")
+            raise RuntimeError("forced guarded failure")
+    except RuntimeError as exc:
+        assert str(exc) == "forced guarded failure"
+
+    assert conn.in_transaction is True
+    assert conn.execute("SELECT value FROM caller_marker").fetchone()[0] == "caller"
+    assert conn.execute("SELECT COUNT(*) FROM guarded_probe").fetchone()[0] == 0
+
+    conn.rollback()
+    assert conn.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
+
+
+def test_get_context_preserves_caller_owned_transaction_without_nested_begin(tmp_path):
+    beam = _beam(tmp_path)
+    beam.remember("#726 context item")
+    conn = beam.conn
+    conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    conn.commit()
+    conn.execute("INSERT INTO caller_marker VALUES ('before context')")
+    statements = []
+    conn.set_trace_callback(statements.append)
+    try:
+        rows = beam.get_context()
+    finally:
+        conn.set_trace_callback(None)
+
+    assert [row["content"] for row in rows] == ["#726 context item"]
+    assert "BEGIN TRANSACTION" not in statements
+    assert conn.in_transaction is True
+    assert (
+        conn.execute("SELECT value FROM caller_marker").fetchone()[0]
+        == "before context"
+    )
+    conn.execute("INSERT INTO caller_marker VALUES ('after context')")
+
+    conn.rollback()
+    assert conn.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
+
+
 def test_forced_active_vec_path_defers_commit_inside_caller_owned_batch(
     tmp_path, monkeypatch
 ):
@@ -260,15 +335,23 @@ def test_forced_active_vec_path_defers_commit_inside_caller_owned_batch(
         real_commits.append(True)
         return original_real_commit(self)
 
-    class Vector:
+    class SyntheticEmbedding:
+        def __array__(self, dtype=None, copy=None):
+            # Some CI environments have NumPy, so support its conversion at
+            # the fallback-store boundary before vec_working is reached.
+            numpy = __import__("numpy")
+            return numpy.zeros(beam_module.EMBEDDING_DIM, dtype=dtype)
+
         def tolist(self):
+            # Other CI environments deliberately omit NumPy; serialize() then
+            # consumes this same real-vector-shaped interface directly.
             return [0.0] * beam_module.EMBEDDING_DIM
 
     monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
     monkeypatch.setattr(
         beam_module._embeddings,
         "embed",
-        lambda contents: [Vector() for _ in contents],
+        lambda contents: [SyntheticEmbedding() for _ in contents],
     )
     monkeypatch.setattr(beam_module, "_wm_vec_available", lambda conn: True)
     monkeypatch.setattr(beam_module, "_vec_table_insert", forced_vec_insert)


### PR DESCRIPTION
## Summary

Establishes the first #726 foundation slice: `mnemosyne_batch` now respects transaction ownership instead of committing or rolling back an already-open caller transaction.

- uses connection-local, unique savepoints for caller-owned and nested batch/guard scopes
- prevents guarded `forget` failures from rolling back the caller transaction
- prevents vector ingestion from bypassing active commit deferral via `_real_commit()`
- keeps audit events deferred until the batch scope succeeds

## Proof

Focused public batch regressions cover:

- caller-owned `remember -> update`, followed by outer rollback
- failure inside `forget_working()` after the guard is entered, preserving caller work and emitting no audit event
- nested success/failure savepoint behavior and deferral-flag restoration
- active vector path without an inner real commit or premature publication

Local matrix: `17 passed` (`test_mnemosyne_batch_tool.py` + `test_batch_transaction_owner_726.py`), Ruff and `git diff --check` clean.

## Scope

This does **not** solve the separate wrapper Legacy + BEAM dual-write atomicity contract. That remains tracked by #726 as a subsequent slice.

Refs #726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Preserves caller-owned transactions in `mnemosyne_batch`.
- Uses connection-local savepoints for nested batches and guarded operations.
- Prevents failed operations from committing, rolling back, or corrupting caller data.
- Defers audit events until batch success.
- Preserves commit deferral during vector ingestion.
- Restores nested deferral state after success or failure.

## Architectural impact

- Strengthens local-first behavior by keeping transaction control with the caller.
- Improves atomicity for working-memory and vector-storage writes.
- Protects privacy by keeping transaction and audit-event handling local.
- Does not change tiered-memory behavior across working, episodic, or BEAM memory.
- Does not change retrieval, consolidation, veracity, synchronization, Hermes, MCP, or CLI interfaces.
- Does not change the separate wrapper Legacy and BEAM dual-write contract tracked by `#726`.
- Adds regression coverage for transaction ownership, nested savepoints, guarded `forget_working()` failures, audit suppression, deferral restoration, and vector ingestion.
- The savepoint model is the right call for nested memory operations because it isolates failures without taking ownership of the caller’s transaction.
- The changes improve maintainability by making transaction ownership and nested deferral state explicit.
- No change erodes the local-first design or introduces a remote data path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->