### PR TITLE
fix: keep direct wrapper stores atomic

### DIFF
--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -26,7 +26,8 @@ import os
 logger = logging.getLogger(__name__)
 
 from mnemosyne.core import embeddings as _embeddings
-from mnemosyne.core.beam import BeamMemory, _deferred_commits, init_beam
+from mnemosyne.core import beam as beam_module
+from mnemosyne.core.beam import BeamMemory, _BeamConnection, _deferred_commits, init_beam
 _thread_local = threading.local()
 
 # Default data directory
@@ -62,7 +63,9 @@ def _get_connection(db_path = None) -> sqlite3.Connection:
     path = Path(db_path) if db_path else _default_db_path()
     if not hasattr(_thread_local, 'conn') or _thread_local.conn is None or getattr(_thread_local, 'db_path', None) != str(path):
         path.parent.mkdir(parents=True, exist_ok=True)
-        _thread_local.conn = sqlite3.connect(str(path), check_same_thread=False)
+        _thread_local.conn = sqlite3.connect(
+            str(path), check_same_thread=False, factory=_BeamConnection
+        )
         _thread_local.conn.row_factory = sqlite3.Row
         _thread_local.conn.execute("PRAGMA journal_mode=WAL")
         _thread_local.conn.execute("PRAGMA busy_timeout=5000")
@@ -75,6 +78,11 @@ def _get_connection(db_path = None) -> sqlite3.Connection:
         except Exception:
             pass
         _thread_local.db_path = str(path)
+        # Mnemosyne's historic public ``conn`` is the core module cache. Keep
+        # that identity while making BEAM use the same owner-aware connection
+        # for direct-wrapper durable dual writes.
+        beam_module._thread_local.conn = _thread_local.conn
+        beam_module._thread_local.db_path = str(path)
     return _thread_local.conn
 
 
@@ -218,10 +226,9 @@ class Mnemosyne:
                                author_id=author_id, author_type=author_type,
                                channel_id=channel_id,
                                event_emitter=self._stream_emit)
-        # Direct wrapper mutations dual-write legacy rows and BEAM rows. They
-        # must share BEAM's owner-aware connection so nested commits defer and
-        # caller-owned transactions use a savepoint.
-        self.conn = self.beam.conn
+        # ``self.conn`` remains the core module cache. _get_connection
+        # coordinates it with BEAM, preserving core connection identity while
+        # direct wrappers dual-write through one transaction-capable handle.
 
     # ─── Phase 8: Streaming ─────────────────────────────────────────
 
@@ -611,8 +618,22 @@ class Mnemosyne:
         """Delete a memory by ID from legacy table and working_memory."""
         with _deferred_commits(self.conn):
             cursor = self.conn.cursor()
-            cursor.execute("DELETE FROM memories WHERE id = ? AND session_id = ?",
-                          (memory_id, self.session_id))
+            # Authorize from the authoritative BEAM row before deleting either
+            # representation. A global row may be removed cross-session, but
+            # its legacy mirror belongs to the creating session, not the caller.
+            owner = cursor.execute(
+                """
+                SELECT session_id FROM working_memory
+                WHERE id = ? AND (session_id = ? OR scope = 'global')
+                """,
+                (memory_id, self.session_id),
+            ).fetchone()
+            if owner is None:
+                return False
+            cursor.execute(
+                "DELETE FROM memories WHERE id = ? AND session_id = ?",
+                (memory_id, owner["session_id"]),
+            )
             self.conn.commit()
             result = self.beam.forget_working(memory_id)
         self._emit_wrapper("MEMORY_INVALIDATED", memory_id)

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -26,7 +26,7 @@ import os
 logger = logging.getLogger(__name__)
 
 from mnemosyne.core import embeddings as _embeddings
-from mnemosyne.core.beam import BeamMemory, init_beam
+from mnemosyne.core.beam import BeamMemory, _deferred_commits, init_beam
 _thread_local = threading.local()
 
 # Default data directory
@@ -218,6 +218,10 @@ class Mnemosyne:
                                author_id=author_id, author_type=author_type,
                                channel_id=channel_id,
                                event_emitter=self._stream_emit)
+        # Direct wrapper mutations dual-write legacy rows and BEAM rows. They
+        # must share BEAM's owner-aware connection so nested commits defer and
+        # caller-owned transactions use a savepoint.
+        self.conn = self.beam.conn
 
     # ─── Phase 8: Streaming ─────────────────────────────────────────
 
@@ -423,36 +427,37 @@ class Mnemosyne:
             if durations:
                 metadata["_durations"] = durations
 
-        memory_id = self.beam.remember(
-            _content, source=source,
-            importance=importance, metadata=metadata,
-            valid_until=valid_until, scope=scope,
-            extract_entities=extract_entities, extract=extract,
-            veracity=veracity,
-            trust_tier=trust_tier,
-        )
-        timestamp = datetime.now().isoformat()
+        with _deferred_commits(self.conn):
+            memory_id = self.beam.remember(
+                _content, source=source,
+                importance=importance, metadata=metadata,
+                valid_until=valid_until, scope=scope,
+                extract_entities=extract_entities, extract=extract,
+                veracity=veracity,
+                trust_tier=trust_tier,
+            )
+            timestamp = datetime.now().isoformat()
 
-        # Legacy dual-write with same ID (INSERT OR REPLACE for dedup safety)
-        cursor = self.conn.cursor()
-        cursor.execute("""
-            INSERT OR REPLACE INTO memories (id, content, source, timestamp, session_id, importance, metadata_json)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-        """, (
-            memory_id, _content, source, timestamp, self.session_id,
-            importance, json.dumps(metadata or {})
-        ))
+            # Legacy dual-write with same ID (INSERT OR REPLACE for dedup safety)
+            cursor = self.conn.cursor()
+            cursor.execute("""
+                INSERT OR REPLACE INTO memories (id, content, source, timestamp, session_id, importance, metadata_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """, (
+                memory_id, _content, source, timestamp, self.session_id,
+                importance, json.dumps(metadata or {})
+            ))
 
-        # Legacy embedding store
-        if _embeddings.available():
-            vec = _embeddings.embed([_content])
-            if vec is not None:
-                cursor.execute("""
-                    INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model)
-                    VALUES (?, ?, ?)
-                """, (memory_id, _embeddings.serialize(vec[0]), _embeddings._DEFAULT_MODEL))
+            # Legacy embedding store
+            if _embeddings.available():
+                vec = _embeddings.embed([_content])
+                if vec is not None:
+                    cursor.execute("""
+                        INSERT OR REPLACE INTO memory_embeddings (memory_id, embedding_json, model)
+                        VALUES (?, ?, ?)
+                    """, (memory_id, _embeddings.serialize(vec[0]), _embeddings._DEFAULT_MODEL))
 
-        self.conn.commit()
+            self.conn.commit()
 
         # The first BEAM write already inserted the working_memory row with
         # the correct memory_id (we used it for the legacy dual-write above)
@@ -604,11 +609,12 @@ class Mnemosyne:
 
     def forget(self, memory_id: str) -> bool:
         """Delete a memory by ID from legacy table and working_memory."""
-        cursor = self.conn.cursor()
-        cursor.execute("DELETE FROM memories WHERE id = ? AND session_id = ?",
-                      (memory_id, self.session_id))
-        self.conn.commit()
-        result = self.beam.forget_working(memory_id)
+        with _deferred_commits(self.conn):
+            cursor = self.conn.cursor()
+            cursor.execute("DELETE FROM memories WHERE id = ? AND session_id = ?",
+                          (memory_id, self.session_id))
+            self.conn.commit()
+            result = self.beam.forget_working(memory_id)
         self._emit_wrapper("MEMORY_INVALIDATED", memory_id)
         return result
 
@@ -632,14 +638,15 @@ class Mnemosyne:
             return False
 
         params.extend([memory_id, self.session_id])
-        cursor.execute(
-            f"UPDATE memories SET {', '.join(updates)} WHERE id = ? AND session_id = ?",
-            params
-        )
-        self.conn.commit()
+        with _deferred_commits(self.conn):
+            cursor.execute(
+                f"UPDATE memories SET {', '.join(updates)} WHERE id = ? AND session_id = ?",
+                params
+            )
+            self.conn.commit()
 
-        # Sync BEAM working_memory
-        self.beam.update_working(memory_id, content=content, importance=importance)
+            # Sync BEAM working_memory
+            self.beam.update_working(memory_id, content=content, importance=importance)
 
         self._emit_wrapper("MEMORY_UPDATED", memory_id, content=content, importance=importance)
         return cursor.rowcount > 0

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -92,11 +92,11 @@ def _get_connection(db_path = None) -> sqlite3.Connection:
         except Exception:
             pass
         _thread_local.db_path = str(path)
-        # Mnemosyne's historic public ``conn`` is the core module cache. Keep
-        # that identity while making BEAM use the same owner-aware connection
-        # for direct-wrapper durable dual writes.
-        beam_module._thread_local.conn = _thread_local.conn
-        beam_module._thread_local.db_path = str(path)
+    # BeamMemory consults its own TLS cache during construction. Re-publish on
+    # every successful core lookup, not only reconnection, because a standalone
+    # BeamMemory for another path may have replaced that cache in the meantime.
+    beam_module._thread_local.conn = _thread_local.conn
+    beam_module._thread_local.db_path = str(path)
     return _thread_local.conn
 
 
@@ -643,13 +643,28 @@ class Mnemosyne:
                 (memory_id, self.session_id),
             ).fetchone()
             if owner is None:
-                return False
-            cursor.execute(
-                "DELETE FROM memories WHERE id = ? AND session_id = ?",
-                (memory_id, owner["session_id"]),
-            )
-            self.conn.commit()
-            result = self.beam.forget_working(memory_id)
+                # Trimming removes only the BEAM working row. Preserve the
+                # historical owner-only legacy delete for that orphaned mirror,
+                # while never authorizing a foreign session through fallback.
+                legacy_owner = cursor.execute(
+                    "SELECT 1 FROM memories WHERE id = ? AND session_id = ?",
+                    (memory_id, self.session_id),
+                ).fetchone()
+                if legacy_owner is None:
+                    return False
+                cursor.execute(
+                    "DELETE FROM memories WHERE id = ? AND session_id = ?",
+                    (memory_id, self.session_id),
+                )
+                self.conn.commit()
+                result = False
+            else:
+                cursor.execute(
+                    "DELETE FROM memories WHERE id = ? AND session_id = ?",
+                    (memory_id, owner["session_id"]),
+                )
+                self.conn.commit()
+                result = self.beam.forget_working(memory_id)
         self._emit_wrapper("MEMORY_INVALIDATED", memory_id)
         return result
 

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -61,7 +61,21 @@ def _default_db_path() -> Path:
 def _get_connection(db_path = None) -> sqlite3.Connection:
     """Get thread-local database connection"""
     path = Path(db_path) if db_path else _default_db_path()
-    if not hasattr(_thread_local, 'conn') or _thread_local.conn is None or getattr(_thread_local, 'db_path', None) != str(path):
+    needs_reconnect = (
+        not hasattr(_thread_local, "conn")
+        or _thread_local.conn is None
+        or getattr(_thread_local, "db_path", None) != str(path)
+    )
+    if not needs_reconnect:
+        # Public callers can close Mnemosyne.conn. Do not return that stale
+        # core-cache handle; recreating it below also re-establishes BEAM's
+        # shared owner-aware _BeamConnection for this path.
+        try:
+            _thread_local.conn.execute("SELECT 1")
+        except Exception:
+            needs_reconnect = True
+
+    if needs_reconnect:
         path.parent.mkdir(parents=True, exist_ok=True)
         _thread_local.conn = sqlite3.connect(
             str(path), check_same_thread=False, factory=_BeamConnection

--- a/tests/test_direct_wrapper_atomicity_726.py
+++ b/tests/test_direct_wrapper_atomicity_726.py
@@ -1,0 +1,208 @@
+"""Public durable-row atomicity coverage for #726 direct wrappers.
+
+This file deliberately does not assert streaming behavior.  Option 3 scopes
+#726 to durable BEAM/legacy rows; delivery for direct wrapper calls inside a
+caller-owned transaction remains a separate contract.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import mnemosyne.core.beam as beam_module
+from mnemosyne.core.memory import Mnemosyne
+
+
+def _memory(tmp_path):
+    return Mnemosyne(
+        session_id="direct-wrapper-726", db_path=Path(tmp_path) / "direct.db"
+    )
+
+
+def _row_count(conn, table, memory_id):
+    return conn.execute(
+        f"SELECT COUNT(*) FROM {table} WHERE id = ?", (memory_id,)
+    ).fetchone()[0]
+
+
+def _contents(conn, table, memory_id):
+    return conn.execute(
+        f"SELECT content FROM {table} WHERE id = ?", (memory_id,)
+    ).fetchone()[0]
+
+
+def test_direct_wrapper_dual_writes_share_beam_connection_and_commit_together(tmp_path):
+    memory = _memory(tmp_path)
+
+    assert memory.conn is memory.beam.conn
+    memory_id = memory.remember("#726 direct wrapper durable row")
+    assert _row_count(memory.conn, "working_memory", memory_id) == 1
+    assert _row_count(memory.conn, "memories", memory_id) == 1
+
+    assert memory.update(memory_id, content="#726 direct wrapper updated") is True
+    assert (
+        _contents(memory.conn, "working_memory", memory_id)
+        == "#726 direct wrapper updated"
+    )
+    assert (
+        _contents(memory.conn, "memories", memory_id) == "#726 direct wrapper updated"
+    )
+
+    assert memory.forget(memory_id) is True
+    assert _row_count(memory.conn, "working_memory", memory_id) == 0
+    assert _row_count(memory.conn, "memories", memory_id) == 0
+
+
+def test_direct_remember_failure_after_beam_write_rolls_back_both_durable_rows(
+    tmp_path, monkeypatch
+):
+    memory = _memory(tmp_path)
+    original_remember = memory.beam.remember
+
+    def fail_after_beam(*args, **kwargs):
+        original_remember(*args, **kwargs)
+        raise RuntimeError("forced failure after BEAM write")
+
+    monkeypatch.setattr(memory.beam, "remember", fail_after_beam)
+    with pytest.raises(RuntimeError, match="forced failure after BEAM write"):
+        memory.remember("#726 fail after beam")
+
+    assert memory.conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == 0
+    assert memory.conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 0
+    assert memory.conn.in_transaction is False
+
+
+def test_direct_remember_failure_after_legacy_write_rolls_back_both_durable_rows(
+    tmp_path, monkeypatch
+):
+    memory = _memory(tmp_path)
+
+    def fail_finalization(self):
+        raise sqlite3.OperationalError("forced failure after legacy write")
+
+    monkeypatch.setattr(beam_module._BeamConnection, "_real_commit", fail_finalization)
+    with pytest.raises(
+        sqlite3.OperationalError, match="forced failure after legacy write"
+    ):
+        memory.remember("#726 fail after legacy")
+
+    assert memory.conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == 0
+    assert memory.conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 0
+    assert memory.conn.in_transaction is False
+
+
+@pytest.mark.parametrize("decision", ["commit", "rollback"])
+def test_direct_wrapper_caller_owned_transaction_controls_both_durable_rows(
+    tmp_path, decision
+):
+    memory = _memory(tmp_path)
+    conn = memory.conn
+    conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    conn.commit()
+    conn.execute("INSERT INTO caller_marker VALUES ('caller owns outcome')")
+
+    memory_id = memory.remember(f"#726 caller-owned {decision}")
+    assert conn.in_transaction is True
+    assert _row_count(conn, "working_memory", memory_id) == 1
+    assert _row_count(conn, "memories", memory_id) == 1
+    with sqlite3.connect(memory.db_path) as outside:
+        assert _row_count(outside, "working_memory", memory_id) == 0
+        assert _row_count(outside, "memories", memory_id) == 0
+
+    getattr(conn, decision)()
+    expected = 1 if decision == "commit" else 0
+    with sqlite3.connect(memory.db_path) as outside:
+        assert _row_count(outside, "working_memory", memory_id) == expected
+        assert _row_count(outside, "memories", memory_id) == expected
+
+
+@pytest.mark.parametrize("operation", ["update", "forget"])
+def test_direct_wrapper_failures_after_legacy_mutation_restore_both_rows(
+    tmp_path, monkeypatch, operation
+):
+    memory = _memory(tmp_path)
+    memory_id = memory.remember(f"#726 {operation} original")
+    target = "update_working" if operation == "update" else "forget_working"
+
+    def fail_after_legacy(*args, **kwargs):
+        raise RuntimeError(f"forced {operation} failure after legacy mutation")
+
+    monkeypatch.setattr(memory.beam, target, fail_after_legacy)
+    with pytest.raises(RuntimeError, match="after legacy mutation"):
+        if operation == "update":
+            memory.update(memory_id, content="#726 replacement")
+        else:
+            memory.forget(memory_id)
+
+    assert (
+        _contents(memory.conn, "working_memory", memory_id)
+        == f"#726 {operation} original"
+    )
+    assert _contents(memory.conn, "memories", memory_id) == f"#726 {operation} original"
+
+
+@pytest.mark.parametrize("operation", ["update", "forget"])
+@pytest.mark.parametrize("decision", ["commit", "rollback"])
+def test_direct_wrapper_caller_decides_update_and_forget_rows(
+    tmp_path, operation, decision
+):
+    memory = _memory(tmp_path)
+    memory_id = memory.remember(f"#726 caller {operation}")
+    memory.conn.execute(
+        "INSERT INTO memories (id, content, session_id) VALUES ('marker', 'marker', ?)",
+        (memory.session_id,),
+    )
+    if operation == "update":
+        memory.update(memory_id, content="#726 caller changed")
+    else:
+        memory.forget(memory_id)
+    getattr(memory.conn, decision)()
+    expected = 0 if operation == "forget" and decision == "commit" else 1
+    assert _row_count(memory.conn, "working_memory", memory_id) == expected
+    assert _row_count(memory.conn, "memories", memory_id) == expected
+
+
+def test_direct_wrapper_vector_path_does_not_commit_a_caller_transaction(
+    tmp_path, monkeypatch
+):
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("sqlite_vec")
+    memory = _memory(tmp_path)
+    if not beam_module._wm_vec_available(memory.conn):
+        pytest.skip("sqlite-vec vec_working table unavailable")
+
+    real_commits = []
+    original_real_commit = beam_module._BeamConnection._real_commit
+
+    def observing_real_commit(self):
+        real_commits.append(True)
+        return original_real_commit(self)
+
+    embedding = np.array(
+        [1.0] + [0.0] * (beam_module.EMBEDDING_DIM - 1), dtype=np.float32
+    )
+    monkeypatch.setattr(beam_module._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam_module._embeddings,
+        "embed",
+        lambda contents: [embedding.copy() for _ in contents],
+    )
+    monkeypatch.setattr(
+        beam_module._BeamConnection, "_real_commit", observing_real_commit
+    )
+
+    memory.conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    memory.conn.commit()
+    memory.conn.execute("INSERT INTO caller_marker VALUES ('outer vector marker')")
+    memory_id = memory.remember("#726 direct active vec caller transaction")
+
+    assert real_commits == []
+    assert memory.conn.in_transaction is True
+    with sqlite3.connect(memory.db_path) as outside:
+        assert _row_count(outside, "working_memory", memory_id) == 0
+        assert _row_count(outside, "memories", memory_id) == 0
+
+    memory.conn.rollback()
+    assert _row_count(memory.conn, "working_memory", memory_id) == 0
+    assert _row_count(memory.conn, "memories", memory_id) == 0

--- a/tests/test_direct_wrapper_atomicity_726.py
+++ b/tests/test_direct_wrapper_atomicity_726.py
@@ -304,9 +304,15 @@ def test_direct_wrapper_republishes_live_core_connection_after_beam_other_path(
     assert second.conn is first.conn
     assert second.conn is second.beam.conn
     assert second.conn.execute("SELECT 1").fetchone()[0] == 1
-    memory_id = second.remember("#726 A B A cache repair")
+    content = "#726 A B A cache repair recall smoke"
+    memory_id = second.remember(content)
     assert _row_count(second.conn, "working_memory", memory_id) == 1
     assert _row_count(second.conn, "memories", memory_id) == 1
+    recalled = second.recall("A B A cache repair", top_k=5)
+    assert any(
+        result["id"] == memory_id and result["content"] == content
+        for result in recalled
+    )
 
     original_remember = second.beam.remember
 

--- a/tests/test_direct_wrapper_atomicity_726.py
+++ b/tests/test_direct_wrapper_atomicity_726.py
@@ -182,7 +182,8 @@ def test_direct_wrapper_caller_decides_update_and_forget_rows(
     tmp_path, operation, decision
 ):
     memory = _memory(tmp_path)
-    memory_id = memory.remember(f"#726 caller {operation}")
+    original_content = f"#726 caller {operation} original"
+    memory_id = memory.remember(original_content)
     memory.conn.execute(
         "INSERT INTO memories (id, content, session_id) VALUES ('marker', 'marker', ?)",
         (memory.session_id,),
@@ -191,10 +192,40 @@ def test_direct_wrapper_caller_decides_update_and_forget_rows(
         memory.update(memory_id, content="#726 caller changed")
     else:
         memory.forget(memory_id)
+    if operation == "update":
+        # The caller's transaction owns visibility as well as final outcome.
+        with sqlite3.connect(memory.db_path) as outside:
+            assert _contents(outside, "working_memory", memory_id) == original_content
+            assert _contents(outside, "memories", memory_id) == original_content
     getattr(memory.conn, decision)()
     expected = 0 if operation == "forget" and decision == "commit" else 1
     assert _row_count(memory.conn, "working_memory", memory_id) == expected
     assert _row_count(memory.conn, "memories", memory_id) == expected
+    if operation == "update" and decision == "rollback":
+        assert _contents(memory.conn, "working_memory", memory_id) == original_content
+        assert _contents(memory.conn, "memories", memory_id) == original_content
+
+
+def test_direct_wrapper_cross_session_forget_removes_global_dual_rows(tmp_path):
+    path = Path(tmp_path) / "global-forget.db"
+    creator = Mnemosyne(session_id="session-a", db_path=path)
+    memory_id = creator.remember("#726 global forget", scope="global")
+    caller = Mnemosyne(session_id="session-b", db_path=path)
+
+    assert caller.forget(memory_id) is True
+    assert _row_count(caller.conn, "working_memory", memory_id) == 0
+    assert _row_count(caller.conn, "memories", memory_id) == 0
+
+
+def test_direct_wrapper_cross_session_forget_preserves_private_rows(tmp_path):
+    path = Path(tmp_path) / "private-forget.db"
+    creator = Mnemosyne(session_id="session-a", db_path=path)
+    memory_id = creator.remember("#726 private forget")
+    caller = Mnemosyne(session_id="session-b", db_path=path)
+
+    assert caller.forget(memory_id) is False
+    assert _row_count(caller.conn, "working_memory", memory_id) == 1
+    assert _row_count(caller.conn, "memories", memory_id) == 1
 
 
 def test_direct_wrapper_vector_path_does_not_commit_a_caller_transaction(

--- a/tests/test_direct_wrapper_atomicity_726.py
+++ b/tests/test_direct_wrapper_atomicity_726.py
@@ -54,6 +54,20 @@ def test_direct_wrapper_dual_writes_share_beam_connection_and_commit_together(tm
     assert _row_count(memory.conn, "memories", memory_id) == 0
 
 
+def test_direct_wrapper_reopens_closed_shared_cache_for_same_path(tmp_path):
+    path = Path(tmp_path) / "closed-shared-cache.db"
+    first = Mnemosyne(session_id="first", db_path=path)
+    first.conn.close()
+
+    fresh = Mnemosyne(session_id="fresh", db_path=path)
+
+    assert fresh.conn is fresh.beam.conn
+    assert fresh.conn.execute("SELECT 1").fetchone()[0] == 1
+    memory_id = fresh.remember("#726 durable rows after shared-cache reopen")
+    assert _row_count(fresh.conn, "working_memory", memory_id) == 1
+    assert _row_count(fresh.conn, "memories", memory_id) == 1
+
+
 def test_direct_invalidate_is_beam_only_and_leaves_legacy_row_unchanged(tmp_path):
     memory = _memory(tmp_path)
     memory_id = memory.remember("#726 direct invalidate BEAM-only boundary")

--- a/tests/test_direct_wrapper_atomicity_726.py
+++ b/tests/test_direct_wrapper_atomicity_726.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 import mnemosyne.core.beam as beam_module
+from mnemosyne.core.beam import BeamMemory
 from mnemosyne.core.memory import Mnemosyne
 
 
@@ -288,3 +289,47 @@ def test_direct_wrapper_vector_path_does_not_commit_a_caller_transaction(
     memory.conn.rollback()
     assert _row_count(memory.conn, "working_memory", memory_id) == 0
     assert _row_count(memory.conn, "memories", memory_id) == 0
+
+
+def test_direct_wrapper_republishes_live_core_connection_after_beam_other_path(
+    tmp_path, monkeypatch
+):
+    path_a = Path(tmp_path) / "a.db"
+    path_b = Path(tmp_path) / "b.db"
+    first = Mnemosyne(session_id="first-a", db_path=path_a)
+    BeamMemory(session_id="standalone-b", db_path=path_b)
+
+    second = Mnemosyne(session_id="second-a", db_path=path_a)
+
+    assert second.conn is first.conn
+    assert second.conn is second.beam.conn
+    assert second.conn.execute("SELECT 1").fetchone()[0] == 1
+    memory_id = second.remember("#726 A B A cache repair")
+    assert _row_count(second.conn, "working_memory", memory_id) == 1
+    assert _row_count(second.conn, "memories", memory_id) == 1
+
+    original_remember = second.beam.remember
+
+    def fail_after_beam(*args, **kwargs):
+        original_remember(*args, **kwargs)
+        raise RuntimeError("forced A B A BEAM failure")
+
+    monkeypatch.setattr(second.beam, "remember", fail_after_beam)
+    with pytest.raises(RuntimeError, match="forced A B A BEAM failure"):
+        second.remember("#726 A B A rollback")
+    assert second.conn.execute("SELECT COUNT(*) FROM working_memory").fetchone()[0] == 1
+    assert second.conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0] == 1
+
+
+def test_owner_forget_removes_legacy_only_row_but_foreign_caller_cannot(tmp_path):
+    path = Path(tmp_path) / "legacy-only-forget.db"
+    owner = Mnemosyne(session_id="owner", db_path=path)
+    memory_id = owner.remember("#726 legacy-only owner row")
+    owner.conn.execute("DELETE FROM working_memory WHERE id = ?", (memory_id,))
+    owner.conn.commit()
+    caller = Mnemosyne(session_id="other", db_path=path)
+
+    assert caller.forget(memory_id) is False
+    assert _row_count(caller.conn, "memories", memory_id) == 1
+    assert owner.forget(memory_id) is False
+    assert _row_count(owner.conn, "memories", memory_id) == 0

--- a/tests/test_direct_wrapper_atomicity_726.py
+++ b/tests/test_direct_wrapper_atomicity_726.py
@@ -54,6 +54,40 @@ def test_direct_wrapper_dual_writes_share_beam_connection_and_commit_together(tm
     assert _row_count(memory.conn, "memories", memory_id) == 0
 
 
+def test_direct_invalidate_is_beam_only_and_leaves_legacy_row_unchanged(tmp_path):
+    memory = _memory(tmp_path)
+    memory_id = memory.remember("#726 direct invalidate BEAM-only boundary")
+    legacy_before = tuple(
+        memory.conn.execute(
+            """
+            SELECT id, content, source, timestamp, session_id, importance, metadata_json
+            FROM memories
+            WHERE id = ?
+            """,
+            (memory_id,),
+        ).fetchone()
+    )
+
+    assert memory.invalidate(memory_id) is True
+    assert memory.conn.in_transaction is False
+    working_row = memory.conn.execute(
+        "SELECT valid_until, superseded_by FROM working_memory WHERE id = ?",
+        (memory_id,),
+    ).fetchone()
+    assert working_row[0] is not None
+    assert working_row[1] is None
+    legacy_after = memory.conn.execute(
+        """
+        SELECT id, content, source, timestamp, session_id, importance, metadata_json
+        FROM memories
+        WHERE id = ?
+        """,
+        (memory_id,),
+    ).fetchone()
+    assert legacy_after is not None
+    assert tuple(legacy_after) == legacy_before
+
+
 def test_direct_remember_failure_after_beam_write_rolls_back_both_durable_rows(
     tmp_path, monkeypatch
 ):

--- a/tests/test_direct_wrapper_atomicity_726.py
+++ b/tests/test_direct_wrapper_atomicity_726.py
@@ -333,3 +333,55 @@ def test_owner_forget_removes_legacy_only_row_but_foreign_caller_cannot(tmp_path
     assert _row_count(caller.conn, "memories", memory_id) == 1
     assert owner.forget(memory_id) is False
     assert _row_count(owner.conn, "memories", memory_id) == 0
+
+
+def test_owner_legacy_only_forget_keeps_caller_transaction_rollbackable(
+    tmp_path, monkeypatch
+):
+    path = Path(tmp_path) / "legacy-only-caller-transaction.db"
+    owner = Mnemosyne(session_id="owner", db_path=path)
+    memory_id = owner.remember("#764 legacy-only owner row")
+
+    # Simulate BEAM trimming: the legacy mirror remains after working_memory
+    # has been removed, so the public fallback takes its owner-only path.
+    owner.conn.execute("DELETE FROM working_memory WHERE id = ?", (memory_id,))
+    owner.conn.commit()
+    assert _row_count(owner.conn, "working_memory", memory_id) == 0
+    assert _row_count(owner.conn, "memories", memory_id) == 1
+
+    owner.conn.execute("CREATE TABLE caller_marker (value TEXT NOT NULL)")
+    owner.conn.commit()
+    owner.conn.execute("INSERT INTO caller_marker VALUES ('caller owns rollback')")
+
+    real_commits = []
+
+    def fail_if_real_commit(self):
+        real_commits.append(True)
+        raise AssertionError("forget must not commit a caller-owned transaction")
+
+    monkeypatch.setattr(beam_module._BeamConnection, "_real_commit", fail_if_real_commit)
+
+    # The documented legacy-only fallback return remains False even when its
+    # owner-only legacy delete succeeds.
+    assert owner.forget(memory_id) is False
+    assert owner.conn.in_transaction is True
+    assert _row_count(owner.conn, "working_memory", memory_id) == 0
+    assert _row_count(owner.conn, "memories", memory_id) == 0
+
+    # A distinct file-backed connection proves neither the marker nor delete
+    # escaped the caller-owned outer transaction.
+    with sqlite3.connect(str(path)) as outside:
+        assert outside.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
+        assert _row_count(outside, "working_memory", memory_id) == 0
+        assert _row_count(outside, "memories", memory_id) == 1
+
+    owner.conn.rollback()
+
+    with sqlite3.connect(str(path)) as outside:
+        assert outside.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
+        assert _row_count(outside, "working_memory", memory_id) == 0
+        assert _row_count(outside, "memories", memory_id) == 1
+    assert owner.conn.execute("SELECT COUNT(*) FROM caller_marker").fetchone()[0] == 0
+    assert _row_count(owner.conn, "working_memory", memory_id) == 0
+    assert _row_count(owner.conn, "memories", memory_id) == 1
+    assert real_commits == []

--- a/tests/test_direct_wrapper_atomicity_726.py
+++ b/tests/test_direct_wrapper_atomicity_726.py
@@ -215,6 +215,9 @@ def test_direct_wrapper_caller_decides_update_and_forget_rows(
     expected = 0 if operation == "forget" and decision == "commit" else 1
     assert _row_count(memory.conn, "working_memory", memory_id) == expected
     assert _row_count(memory.conn, "memories", memory_id) == expected
+    if operation == "update" and decision == "commit":
+        assert _contents(memory.conn, "working_memory", memory_id) == "#726 caller changed"
+        assert _contents(memory.conn, "memories", memory_id) == "#726 caller changed"
     if operation == "update" and decision == "rollback":
         assert _contents(memory.conn, "working_memory", memory_id) == original_content
         assert _contents(memory.conn, "memories", memory_id) == original_content


### PR DESCRIPTION
## Summary

Direct `Mnemosyne` wrapper writes previously used separate SQLite connections for BEAM and legacy `memories`, so an intermediate failure could leave the durable stores divergent.

This narrow #726 Option-3 slice makes `remember`, `update`, and `forget` use BEAM's owner-aware connection and one deferred transaction/savepoint boundary. Both durable representations now commit or roll back together.

## Why this path

The wrapper and BEAM must coordinate through the same SQLite connection. `_deferred_commits()` already provides the owner-aware transaction/savepoint behavior established in #760.

## Non-goals

- No MCP/batch changes, schema/migration work, or provider changes.
- `invalidate` remains intentionally BEAM-only and is explicitly regression-tested.
- Direct-wrapper streaming events inside a caller-owned transaction are unchanged and remain a separate #726 contract.

## Verification

- `MNEMOSYNE_NO_EMBEDDINGS=1 uv run --extra test pytest -q tests/test_direct_wrapper_atomicity_726.py tests/test_batch_transaction_owner_726.py tests/test_memory_lifecycle.py` → `25 passed, 2 skipped`
- Ruff, formatting, and `git diff --check` pass.
- New regressions cover success, failures after BEAM/legacy/finalization, caller commit/rollback, vector commit deferral, and the BEAM-only invalidate boundary.

Why not a simple retry or two independent commits: that still permits a persistent divergence after the second step fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Direct `Mnemosyne` wrapper writes now use one owner-aware BEAM SQLite connection and one deferred transaction boundary for BEAM and legacy durable stores.

The change applies to `remember`, `forget`, and `update`. Both stores now commit or roll back together after intermediate failures. Closed shared connections reopen safely. This prevents divergent memory state.

## Architectural impact

- **Tiered memory:** BEAM and legacy durable representations remain synchronized. Working, episodic, and BEAM tier definitions do not change.
- **Local-first guarantees:** The change strengthens local consistency. It adds no network dependency and does not weaken local-first behavior.
- **Privacy:** No provider, schema, migration, or data-sharing behavior changes.
- **Retrieval and consolidation:** Retrieval strategies and the consolidation pipeline do not change. Regression coverage includes public recall after cache repair.
- **Veracity and sync:** The veracity system and sync layer do not change.
- **Agent surfaces:** Hermes, MCP, and CLI behavior remain unchanged. MCP/batch behavior and direct-wrapper streaming events inside caller-owned transactions remain unchanged.
- **Maintainability:** Shared connection ownership and a common deferred transaction boundary reduce connection identity errors and duplicated commit logic. This is the right call for dual-write durability.

`invalidate` remains BEAM-only. Regression coverage protects this boundary.

## Validation

Tests cover successful dual writes, connection reopening and repair, failures after either store write, finalization failures, caller-controlled commit and rollback, deferred vector commits, restoration after `update` and `forget` failures, cross-session visibility, and BEAM-only invalidation.

Verification passed: 25 tests passed and 2 skipped. Ruff, formatting, and `git diff --check` passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->