### PR TITLE
fix(shmr): pass list to embeddings.embed, drop non-existent facts.status filter (#762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **SHMR clustering no longer crashes with a dimension mismatch (#762).** `harmonize()`'s `_embed()` passed a `str` to `embeddings.embed()`, which expects `List[str]`; the string was iterated per character, so each embedding's dimension scaled with the text length and `_cluster_by_similarity()` failed whenever two candidates had different lengths. `_embed()` now wraps the text in a list, returns a fixed-dimension vector, and degrades to zeros when embeddings are unavailable. The `harmonize()` facts query also drops a filter on a `status` column that the `facts` table does not have, so the candidate step no longer raises `OperationalError`.
 - **`mnemosyne-hermes status` now reports the real interpreter mismatch (#736).** The warning compared interpreter paths but claimed a Python version mismatch and printed a bare version number instead of a runnable fix; it now compares the Hermes and installer environments and emits a shell-quoted `→ Run: <python> -m pip install -U 'mnemosyne-hermes[all]'` command.
 - **MCP SSE authentication rejects malformed non-ASCII bearer tokens with `401` instead of returning a server error (#739).**
 - **API embedding failures now leave a redacted diagnostic trace (#735).** Final HTTP, network, and invalid-response failures still degrade to keyword-only retrieval, but now log the endpoint and safe error class or status without request content, API keys, URL userinfo, query strings, or fragments.

--- a/mnemosyne/core/shmr.py
+++ b/mnemosyne/core/shmr.py
@@ -74,7 +74,10 @@ def _init_schema(conn):
 
 def _embed(text: str) -> np.ndarray:
     """Embed text using Mnemosyne's embedding pipeline (BAAI/bge-small)."""
-    emb = _embeddings.embed(text)
+    emb = _embeddings.embed([text])
+    if emb is None or len(emb) == 0:
+        return np.zeros(EMBEDDING_DIM, dtype=np.float32)
+    emb = emb[0]
     if emb.ndim > 1:
         emb = emb.flatten()
     return emb.astype(np.float32)
@@ -406,11 +409,10 @@ def harmonize(beam, batch_size: int = None, max_iterations: int = None,
     # Prioritize: recent facts + high-confidence episodic memories
     candidates = []
 
-    # Facts (status = active or NULL)
+    # Facts (beam's `facts` table has no `status` column; all facts are active)
     fact_rows = cursor.execute("""
         SELECT fact_id, subject, predicate, object, confidence, timestamp
         FROM facts
-        WHERE status = 'active' OR status IS NULL
         ORDER BY created_at DESC
         LIMIT ?
     """, (batch_size,)).fetchall()

--- a/tests/test_shmr.py
+++ b/tests/test_shmr.py
@@ -51,8 +51,23 @@ def test_embed_passes_list_and_returns_fixed_dim(monkeypatch):
 def test_embed_fixed_dim_independent_of_text_length(monkeypatch):
     _fake_embed_module(monkeypatch)
 
-    shapes = {shmr._embed("short").shape[0] for t in ("a", "long text here", "finished")}
+    shapes = {
+        shmr._embed(t).shape[0]
+        for t in ("a", "long text here", "finished")
+    }
     assert shapes == {shmr.EMBEDDING_DIM}
+
+
+def test_embed_falls_back_to_zero_vector_for_missing_or_empty_results(monkeypatch):
+    expected = np.zeros(shmr.EMBEDDING_DIM, dtype=np.float32)
+
+    for response in (None, np.empty((0, shmr.EMBEDDING_DIM), dtype=np.float32)):
+        monkeypatch.setattr(shmr._embeddings, "embed", lambda texts: response)
+        emb = shmr._embed("finished")
+
+        assert emb.shape == (shmr.EMBEDDING_DIM,)
+        assert emb.dtype == np.float32
+        np.testing.assert_array_equal(emb, expected)
 
 
 def test_cluster_by_similarity_tolerates_variable_length_texts(monkeypatch):

--- a/tests/test_shmr.py
+++ b/tests/test_shmr.py
@@ -1,0 +1,90 @@
+"""SHMR regression tests for issue #762.
+
+`_embed()` used to pass a ``str`` to ``embeddings.embed()``, which expects a
+``List[str]`` and iterates it per item.  A ``str`` is iterated per character,
+so the returned vector became ``dim * len(text)`` instead of ``dim``; the
+clustering step then crashed with a dimension mismatch whenever two candidates
+had different text lengths.  These tests pin the fixed contracts:
+
+- ``_embed()`` hands ``embed()`` a list and returns a flat ``(EMBEDDING_DIM,)``
+  vector regardless of input length.
+- ``_cluster_by_similarity()`` tolerates variable-length candidate texts.
+- ``harmonize()`` degrades gracefully when embeddings are disabled.
+"""
+import numpy as np
+
+from mnemosyne.core import shmr
+from mnemosyne.core.beam import BeamMemory
+
+
+def _fake_embed_module(monkeypatch):
+    """Replace ``shmr._embeddings.embed`` with a faithful fastembed stand-in.
+
+    Mirrors the real contract that made the bug observable: a ``str`` argument
+    is iterated per character (as ``embeddings.embed`` does with ``for t in
+    texts``), while a list produces one vector per item.
+    """
+    seen = []
+
+    def fake_embed(texts):
+        seen.append(texts)
+        if isinstance(texts, str):
+            texts = list(texts)
+        return np.stack(
+            [np.full(shmr.EMBEDDING_DIM, 0.5, dtype=np.float32) for _ in texts]
+        )
+
+    monkeypatch.setattr(shmr._embeddings, "embed", fake_embed)
+    return seen
+
+
+def test_embed_passes_list_and_returns_fixed_dim(monkeypatch):
+    seen = _fake_embed_module(monkeypatch)
+
+    emb = shmr._embed("finished")
+
+    assert isinstance(seen[-1], list)
+    assert seen[-1] == ["finished"]
+    assert emb.shape == (shmr.EMBEDDING_DIM,)
+
+
+def test_embed_fixed_dim_independent_of_text_length(monkeypatch):
+    _fake_embed_module(monkeypatch)
+
+    shapes = {shmr._embed("short").shape[0] for t in ("a", "long text here", "finished")}
+    assert shapes == {shmr.EMBEDDING_DIM}
+
+
+def test_cluster_by_similarity_tolerates_variable_length_texts(monkeypatch):
+    _fake_embed_module(monkeypatch)
+
+    candidates = [
+        {"embedding": shmr._embed("short"), "content": "a"},
+        {"embedding": shmr._embed("a considerably longer episodic recollection"), "content": "b"},
+        {"embedding": shmr._embed("finished"), "content": "c"},
+    ]
+
+    clusters = shmr._cluster_by_similarity(candidates, threshold=0.1)
+
+    assert isinstance(clusters, list)
+    assert sum(len(c) for c in clusters) == len(candidates)
+
+
+def test_harmonize_degrades_gracefully_without_embeddings(tmp_path, monkeypatch):
+    monkeypatch.setattr(shmr._embeddings, "embed", lambda texts: None)
+    db_path = str(tmp_path / "shmr.db")
+    beam = BeamMemory(session_id="shmr-test", db_path=db_path)
+
+    conn = beam.conn
+    for i, subject in enumerate(("alice", "bob", "carol")):
+        conn.execute(
+            "INSERT INTO facts (fact_id, session_id, subject, predicate, object, timestamp)"
+            " VALUES (?, 'shmr-test', ?, 'likes', ?, datetime('now'))",
+            (f"f{i}", subject, f"item {i}"),
+        )
+    conn.commit()
+
+    result = shmr.harmonize(beam)
+
+    assert isinstance(result, dict)
+    assert "clusters_found" in result

--- a/tests/test_shmr.py
+++ b/tests/test_shmr.py
@@ -52,10 +52,10 @@ def test_embed_fixed_dim_independent_of_text_length(monkeypatch):
     _fake_embed_module(monkeypatch)
 
     shapes = {
-        shmr._embed(t).shape[0]
+        shmr._embed(t).shape
         for t in ("a", "long text here", "finished")
     }
-    assert shapes == {shmr.EMBEDDING_DIM}
+    assert shapes == {(shmr.EMBEDDING_DIM,)}
 
 
 def test_embed_falls_back_to_zero_vector_for_missing_or_empty_results(monkeypatch):


### PR DESCRIPTION
## Description

`harmonize()` (SHMR) always crashed during clustering with a dimension mismatch. `_embed()` passed a `str` to `embeddings.embed()`, which expects `List[str]`; the string was iterated per character, so each embedding's dimension scaled with the text length (`384 × len(text)`) and `_cluster_by_similarity()`'s pairwise `np.dot` failed whenever two candidates had different lengths (`ValueError: shapes (1536,) and (1920,) not aligned`).

The fix:
- `_embed()` now wraps the text in a list (`embed([text])`), returns the first vector, and degrades to `np.zeros(EMBEDDING_DIM)` when embeddings are unavailable (`MNEMOSYNE_NO_EMBEDDINGS=1`).
- `harmonize()`'s facts query drops a `WHERE status = 'active' OR status IS NULL` filter on a `status` column the `facts` table does not have, so the candidate step no longer raises `OperationalError: no such column: status`.

## Related Issue

Closes #762

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Existing tests still pass (`pytest tests/ -v`)
- [x] New tests added for any new functionality
- [x] Manual verification (describe what you tested)

New `tests/test_shmr.py` (4 tests) proves the contract: `_embed()` receives a list and returns a fixed `(EMBEDDING_DIM,)` vector independent of text length; `_cluster_by_similarity()` tolerates variable-length candidates; `harmonize()` degrades gracefully without embeddings. All 4 tests failed before the fix (dimension mismatch / `no such column`) and pass after.

Verification run: `pytest tests/test_shmr.py tests/test_embedding_prefixes.py -q` → 9 passed. `ruff==0.15.22` clean on changed files. `git diff --check` clean.

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py` — N/A (release bumps owned by release process per `RELEASING.md`)
- [x] `CHANGELOG.md` updated with a brief entry (#762)
- [ ] README updated if user-facing behavior changed — N/A (internal bugfix, no public surface change)
- [x] Code follows the project's principles:
  - No new external dependencies
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes SHMR `harmonize()` clustering failures by passing embeddings as a one-item list.
- Returns fixed-size embeddings and uses a zero-vector fallback when embeddings are unavailable.
- Removes the invalid `facts.status` filter from fact retrieval.
- Adds regression tests for embedding dimensions, variable-length candidates, and missing embeddings.
- Updates the changelog.

## Architecture impact

- Improves the SHMR consolidation pipeline and clustering reliability.
- Preserves stable retrieval behavior for memory text with different lengths.
- Does not change working, episodic, or BEAM tier behavior.
- Does not change the veracity system or sync layer.
- Does not change Hermes, MCP, or CLI integration surfaces.
- Keeps embedding-dependent behavior local.
- Preserves local-first operation when embeddings are unavailable.
- Improves maintainability through focused regression tests and removal of an invalid database filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->