### PR TITLE
chore(release): correct the pending version to 4.0.0 and add the migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
   **Breaking:** pointing `MNEMOSYNE_EMBEDDING_API_URL` at a custom endpoint with a model not in the built-in table now requires `MNEMOSYNE_EMBEDDING_DIM=<N>`, otherwise direct core/MCP-provider startup exits at import with an actionable error (the `mnemosyne-hermes` wrapper catches this and reports the provider unavailable instead of exiting). Blank/empty `MNEMOSYNE_EMBEDDING_DIM` and `MNEMOSYNE_EMBEDDING_MODEL` (common in Docker Compose and `.env` files) are normalized to unset/default rather than treated as explicit invalid values.
 
-  **Upgrade note for stores created under the old silent-384 fallback:** setting the model's true dimension can trigger the existing dimension-mismatch guard. Use the documented reindex/recovery path rather than treating the override as a one-step fix.
+  **Upgrade note for stores created under the old silent-384 fallback:** setting the model's true dimension can trigger the existing dimension-mismatch guard. Use the documented reindex/recovery path rather than treating the override as a one-step fix. See [docs/migration-4.0.md](docs/migration-4.0.md).
 
 ### Fixed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Local-first, zero-cloud memory for AI agents. SQLite-backed. Sub-millisecond. Fu
 | [Security & Privacy](security.md) | Threat model, encryption internals, BYOK comparison |
 | [Benchmarking](benchmarking.md) | Maintainer guide: per-tool A/B benchmark env vars, diagnostics, pure-recall mode, test sequence template |
 | [Benchmark Results Analysis](benchmark-results-analysis.md) | Output-file schemas + analysis recipes (per-ability scores, paired bootstrap CIs, voice attribution). AI-assistant-friendly reference |
+| [Migrating to 4.0](migration-4.0.md) | The single breaking change in 4.0, who it affects, and the reindex path for stores created under the old silent-384 fallback |
 | [Changelog](changelog.md) | Pointer to the root `CHANGELOG.md`, plus release-state notes |
 
 ## Generated references

--- a/docs/api/configuration.mdx
+++ b/docs/api/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-version: 3.16.0
+version: 4.0.0
 config_key_count: 106
 env_only_count: 44
 generated_at: "auto"

--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -1,13 +1,13 @@
 ---
 title: "MCP Tool Schema"
-version: 3.16.0
+version: 4.0.0
 tool_count: 37
 mcp_tool_count: 29
 plugin_only_tool_count: 8
 generated_at: "auto"
 ---
 
-# MCP Tool Schema (v3.16.0)
+# MCP Tool Schema (v4.0.0)
 
 > **Generated file. Do not edit by hand.**
 > Source: `mnemosyne/tool_schemas.py` and `mnemosyne/mcp_tools.py`.

--- a/docs/migration-4.0.md
+++ b/docs/migration-4.0.md
@@ -1,0 +1,93 @@
+# Migrating to Mnemosyne 4.0
+
+4.0 carries one breaking change. Most installations are unaffected and can
+upgrade without doing anything. Read the first section to find out which group
+you are in before changing any configuration.
+
+## Am I affected?
+
+You are affected only if **both** of these are true:
+
+1. You point `MNEMOSYNE_EMBEDDING_API_URL` at a custom embedding endpoint, and
+2. the model you use is not in Mnemosyne's built-in model table, and you have
+   not set `MNEMOSYNE_EMBEDDING_DIM`.
+
+You are **not** affected if you use the default embedding model, use any model
+in the built-in table (`BAAI/bge-small-en-v1.5`, `BAAI/bge-m3` and the other
+listed models), already set `MNEMOSYNE_EMBEDDING_DIM`, or run with embeddings
+disabled (`MNEMOSYNE_NO_EMBEDDINGS=1`).
+
+## What changed
+
+Before 4.0, an unrecognised embedding model silently resolved to 384
+dimensions, which is `bge-small`'s dimension. A sqlite-vec table is
+dimensioned at creation time, so that guess was written permanently into any
+fresh database. Anyone running a different model, for example
+`mxbai-embed-large` at 1024 dimensions through a custom endpoint, ended up
+with a store whose vector index could never match its embeddings. Vector
+search returned wrong results with no error anywhere.
+
+From 4.0 the dimension is resolved in this order:
+
+1. An explicit `MNEMOSYNE_EMBEDDING_DIM`, which must be a positive integer.
+2. The built-in model table.
+3. Otherwise `ValueError`, raised at import.
+
+An unknown model with no explicit dimension now fails at startup instead of
+corrupting a store quietly.
+
+## What you will see
+
+Direct core and MCP-provider startup exits at import with an error naming both
+the model and the variable to set. The `mnemosyne-hermes` wrapper catches the
+error and reports the provider as unavailable rather than exiting the host.
+
+## The fix
+
+Set the dimension your model actually produces:
+
+```bash
+export MNEMOSYNE_EMBEDDING_DIM=1024   # use your model's real dimension
+```
+
+Blank or empty `MNEMOSYNE_EMBEDDING_DIM` and `MNEMOSYNE_EMBEDDING_MODEL`
+values, which are common in Docker Compose files and `.env` files, are treated
+as unset rather than as invalid values, so you do not need to remove empty
+declarations.
+
+## If your store was created under the old fallback
+
+This is the case that needs care. If a database was created while the silent
+384 fallback was in effect, its vector tables are already dimensioned at 384
+even though your model emits something else. Setting the correct dimension will
+now trip the existing dimension-mismatch guard on startup.
+
+That guard is not a corruption report. Your memories are intact and recall
+falls back to keyword search until the index is rebuilt. You have two options:
+
+* **Keep the existing vectors.** Relaunch with `MNEMOSYNE_EMBEDDING_DIM` set to
+  the dimension already in the database, along with the model that matches it.
+* **Re-embed at the correct dimension.** Run
+  `MNEMOSYNE_EMBEDDING_DIM=<N> mnemosyne reindex`, which backs the store up
+  before rebuilding.
+
+Run `mnemosyne doctor` afterwards to confirm. It reports the resolved
+`embeddings_dim` alongside `embeddings_model`, so you can verify the
+resolution without reading a traceback.
+
+Do not treat the override alone as a one-step fix for an existing store. It
+changes what the process expects, not what the database contains.
+
+## Standalone Hermes package
+
+`mnemosyne-hermes` versions separately on its own `0.x` line and is not part of
+this major bump. It does carry one behaviour change worth knowing about if you
+upgrade both at once: a symlink install now fails closed when no validated
+interpreter is found, naming `--python`, where it previously proceeded.
+`--no-bootstrap` continues without dependency validation, since it installs
+nothing into Hermes' environment.
+
+## Related issues
+
+* #518, #521: fail loud on unknown embedding model
+* #666: `bge-m3` alias resolves its 1024-dimensional vectors

--- a/hermes_memory_provider/plugin.yaml
+++ b/hermes_memory_provider/plugin.yaml
@@ -1,5 +1,5 @@
 name: mnemosyne
-version: 3.16.0
+version: 4.0.0
 description: "Native local memory for Hermes — SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, temporal triples, and bidirectional sync with optional client-side encryption. Zero cloud. Zero latency."
 author: Abdias J
 provides_tools:

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "3.16.0"
+__version__ = "4.0.0"
 __author__ = "Abdias J"
 __license__ = "MIT"
 


### PR DESCRIPTION
#521 landed a breaking change: an unknown embedding model now raises at import instead of silently resolving to 384 dimensions, and a custom `MNEMOSYNE_EMBEDDING_API_URL` endpoint using a model outside the built-in table requires `MNEMOSYNE_EMBEDDING_DIM`. The CHANGELOG marks it `Breaking:`, and RELEASING.md counts altered env var semantics and changed default behaviour as MAJOR. The bump that shipped alongside it went 3.15.1 to 3.16.0, a MINOR.

Nothing is tagged yet, so this is still correctable. Sets the pending version to 4.0.0 in the two files that carry it, and regenerates the docs that embed it.

CHANGELOG keeps its `[Unreleased]` heading on purpose. Promoting it to a dated `[4.0.0]` section is a release action, and a dated heading for a version that has not shipped is the exact drift RELEASING.md was written to stop. `release.py prepare` does that at tag time.

Adds `docs/migration-4.0.md`: who is affected, who is not, the fix, and the reindex path for stores created under the old silent-384 fallback, where setting the true dimension trips the dimension-mismatch guard. RELEASING.md requires a migration guide for a major.

Not a release. No tag, no beta cycle, sibling repos untouched.

`release.py check 4.0.0` passes everything except the `[4.0.0]` CHANGELOG section, which is correct at this stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates the pending release version from `3.16.0` to `4.0.0` in package, plugin, and generated API documentation.
- Adds `docs/migration-4.0.md` with configuration changes, startup errors, `mnemosyne doctor` checks, and reindexing guidance for stores created with the silent 384-dimension fallback.
- Documents affected users with unknown embedding models or custom endpoints. Custom endpoints now require `MNEMOSYNE_EMBEDDING_DIM` when the model is not in the built-in table.
- Updates the changelog and documentation navigation. The changelog remains under `[Unreleased]`.

## Architecture and integration impact

- The tiered memory architecture is unchanged. Working memory, episodic memory, and BEAM are not modified.
- Retrieval strategies and the consolidation pipeline are unchanged.
- The veracity system and sync layer are unchanged.
- The migration guidance improves store correctness by requiring reindexing when legacy stores used the incorrect 384-dimension fallback.
- Hermes receives a documented symlink-install behavior change. MCP tool schema documentation reflects the new version without tool-count changes.
- CLI verification is documented through `mnemosyne doctor`.
- The local-first design is preserved. This PR adds no hosted service, telemetry, remote dependency, or sync behavior.
- Privacy posture is unchanged.
- Benchmark methodology is unchanged.
- Requiring explicit embedding dimensions and failing early for unknown models is the right call. It prevents silent vector-shape errors and improves long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->