### PR TITLE
docs(rfc): correct seven errors in the multimodal RFCs and de-vendor the seam

### DIFF
--- a/docs/rfc/0002-modality-providers.md
+++ b/docs/rfc/0002-modality-providers.md
@@ -1,4 +1,6 @@
-# RFC 0002: Modality Providers and the Atlas Cloud Seam
+# RFC 0002: Modality Providers and the Vision Endpoint Seam
+
+> **Retitled 2026-07-30.** This document was "Modality Providers and the Atlas Cloud Seam". The seam is generic — any OpenAI-compatible vision endpoint — and naming it after one provider misrepresented the design as vendor-coupled when it never was. See the correction in §3.2. Atlas Cloud remains the reference deployment and keeps its configuration recipe in §3.5.
 
 **Status:** Draft
 **Author:** abdiisan
@@ -59,7 +61,7 @@ One trap worth documenting in the recipe: `_is_api_model` (`core/embeddings.py:1
 
 ### 1.4 The `vec_facts` cautionary tale
 
-`vec_facts` was declared as a vec0 virtual table at `beam.py:1218` and **never given a writer**. The consequence is permanent: `reindex_vectors` (`beam.py:2392`) must recreate it empty on every reindex, and the comment at `beam.py:2445` explains why, so its declared dimension "can't mismatch a query." It also occupies a slot in three hardcoded table whitelists (`beam.py:552`, `:1544`, `:2150`).
+`vec_facts` was declared as a vec0 virtual table at `beam.py:1220` and **never given a writer**. The consequence is permanent: `reindex_vectors` (`beam.py:2394`) must recreate it empty on every reindex, and the comment at `beam.py:2448` explains why, so its declared dimension "can't mismatch a query." It also occupies a slot in three hardcoded table whitelists (`beam.py:552`, `:1544`, `:2150`).
 
 This yields a rule that governs §2 of this RFC: **do not declare an interface with no writer.** An unused abstraction is not free optionality, it is a maintenance obligation that every future refactor must carry.
 
@@ -69,7 +71,7 @@ This is the single most important constraint on any multimodal design, and it is
 
 - `_existing_vec_dim` (`beam.py:538`) parses the *stored DDL* of the existing vec tables to recover their dimension. The stored schema, not process config, is the source of truth.
 - On mismatch, `init_beam` **refuses to create the vec tables** and logs `_dim_mismatch_message` (`beam.py:566`). See the guard at `beam.py:799-802`.
-- Recovery is an explicit operator action, `mnemosyne reindex`, which re-embeds everything and recreates the tables at the active dimension (`reindex_vectors`, `beam.py:2392`).
+- Recovery is an explicit operator action, `mnemosyne reindex`, which re-embeds everything and recreates the tables at the active dimension (`reindex_vectors`, `beam.py:2394`).
 
 Any design in which swapping a provider can change `EMBEDDING_DIM` is a design that can silently degrade every user's recall to lexical-only. §2 exists to make that impossible.
 
@@ -112,9 +114,17 @@ A structural mirror of `core/llm_backends.py`.
 
 **Request and result shapes.** Three dataclasses:
 
-- `DescribeRequest`: `modality` (`"image" | "video" | "audio" | "document"`), `uri`, `content_hash`, `mime`, `hint`, `max_moments`, `span_hint`, `timeout`, `detail`.
+- `DescribeRequest`: `modality` (`"image" | "video" | "audio" | "document"`), `uri`, `content_hash`, `mime`, `hint`, `max_moments`, `span_hint`, `timeout`, `detail`, **`fetch`**.
 - `MomentDraft`: `kind` (`caption | shot | transcript | style | ocr | page | summary`), `text`, `t_start_ms`, `t_end_ms`, `page_start`, `page_end`, `char_start`, `char_end`, `bbox`, `speaker`, `confidence`, `extra`.
-- `DescribeResult`: `summary`, `moments: List[MomentDraft]`, `provider`, `model`, `warnings`.
+- `DescribeResult`: `summary`, `moments: List[MomentDraft]`, `provider`, `model`, `warnings`, **`refused`**.
+
+> **Correction (2026-07-30): two fields the original draft omitted, one of which is load-bearing.**
+>
+> **`DescribeRequest.fetch: Optional[Callable[[], Optional[bytes]]]`.** As drafted, the request carried `uri`, `mime`, and `content_hash` — and no way to carry bytes or obtain them. An OpenAI-compatible vision call needs a base64 `image_url` data part for anything that is not a publicly fetchable `https://` URL, so the adapter could describe public URLs and **nothing else**: no local file, no `blob://` reference, which is to say none of the media a privacy-first local memory system actually holds. `fetch` closes this. It is lazy and optional — a backend describing a public URL never calls it, and no bytes are read.
+>
+> This makes RFC 0004's `ContentResolver` a **hard prerequisite of this adapter**, not the independent nicety RFC 0004 §11 implies: `fetch` is supplied from the resolver registry. Sequence accordingly.
+>
+> **`DescribeResult.refused: bool`.** RFC 0003 §2.1 declares `understanding_status='refused'` as a valid state and nothing in this RFC produces it. A provider that declines on safety grounds is meaningfully different from one that failed, and the distinction should survive into the asset row.
 
 `MomentDraft` is deliberately the wire shape of a `media_moments` row in RFC 0003 §2.2, minus identity and binding. A provider proposes drafts; the store assigns ids and decides what to keep.
 
@@ -139,15 +149,24 @@ One method. Text-or-None on failure. `hint` carries the caller's prompt, preserv
 
 *Estimated: ~200 lines in a new file, ~150 lines of tests.*
 
-### 3.2 `mnemosyne/core/modality_atlas.py` (new, ~300 lines)
+### 3.2 `mnemosyne/core/modality_openai_compat.py` (new, ~300 lines)
 
-The Atlas Cloud adapter, and the reference implementation of the protocol.
+The OpenAI-compatible vision adapter, and the reference implementation of the protocol.
+
+> **Correction (2026-07-30): this module was named `modality_atlas.py` in the original draft. Renamed, for a reason worth recording.**
+>
+> Naming a core module after one vendor makes that vendor structural. It is not: the module speaks the OpenAI-compatible `chat/completions` shape, which is served by Atlas Cloud, OpenRouter, Together, Groq, vLLM, LM Studio, Ollama, and a local `llama.cpp` server alike. §3.3's ladder already said "Atlas Cloud / **any OpenAI-compatible vision endpoint**" and §3.4's config keys were already vendor-neutral (`MNEMOSYNE_MODALITY_BASE_URL`, not `MNEMOSYNE_ATLAS_URL`), so the design was never actually coupled — only the module name and the framing were.
+>
+> Probing the partner endpoint made the point concrete. `GET https://api.atlascloud.ai/v1/models` returns **123 models, 30 of them accepting image input — and every one is another vendor's** (OpenAI, Anthropic, Google, Qwen, Moonshot, xAI, ByteDance, Z.ai). Atlas is an OpenAI-compatible **aggregator**. There is no "Atlas vision API" distinct from the generic one to write an adapter against.
+>
+> This also matches the project's partnership policy: sponsorship should produce work that benefits the whole ecosystem, not architecture that privileges one provider. **Atlas Cloud is the reference deployment and a documented recipe (§3.5), not a dependency.** The correct test of this correction is that switching endpoints requires changing environment variables only, and that test belongs in the implementing PR.
 
 - OpenAI-compatible `POST {base_url}/chat/completions` with `image_url` content parts.
-- Reuses the retry, backoff, and timeout shape of `_call_remote_llm` (`core/local_llm.py`) and the rate-limit classifier `_is_rate_limit_error` (`core/embeddings.py:247`). Do not invent a third retry policy.
+- Reuses the retry, backoff, and timeout shape of `_call_remote_llm_with_model` (`core/local_llm.py:458`) and the rate-limit classifier `_is_rate_limit_error` (`core/embeddings.py:247`). Do not invent a third retry policy.
 - Requests strict JSON: a `{"summary": ..., "moments": [...]}` envelope. Parsing follows the tolerance ladder already proven in `core/extraction.py`: JSON first, then partial-JSON salvage, then give up and return `None`. Never raise into `remember()`.
 - Prompt overridable by env, the affordance `core/extraction.py` already provides via `MNEMOSYNE_EXTRACTION_PROMPT`.
 - Selected when `MNEMOSYNE_MODALITY_BASE_URL` and `MNEMOSYNE_MODALITY_API_KEY` are both set.
+- **Optional capability preflight.** `GET {base_url}/models` exposes `input_modalities` per model on Atlas and OpenRouter alike — a convention, not a vendor extension. Use it to warn when the configured vision model is text-only. It must stay strictly optional: an endpoint that does not expose it, or exposes a different shape, must still work. Degrade to silence, never to failure.
 
 *Estimated: ~300 lines in a new file, ~200 lines of tests against a stub HTTP server.*
 
@@ -220,13 +239,13 @@ A `docs/integrations/atlas-cloud.md` page covering all three surfaces in one pla
 
 ## 5. Test obligations
 
-**Process-global reset is mandatory.** `tests/conftest.py:63-71` resets `llm_backends._backend` with the comment "The registry is a process-global; a test that forgets to unregister would otherwise bleed into the next." That block exists because this exact bug happened once. `modality_backends._backends` and `._default` must be reset in the same fixture, in the same style.
+**Process-global reset is mandatory.** `tests/conftest.py:64-69` resets `llm_backends._backend` with the comment "The registry is a process-global; a test that forgets to unregister would otherwise bleed into the next." That block exists because this exact bug happened once. `modality_backends._backends` and `._default` must be reset in the same fixture, in the same style.
 
 **Assert silence when disabled.** With `MNEMOSYNE_MODALITY_ENABLED` unset, a test must assert that no socket is opened and no backend method is called. CI runs with `MNEMOSYNE_NO_EMBEDDINGS=1` and no network expectation; a media path that dials out on import or on plain `remember()` would hang the matrix.
 
 **Assert graceful degradation.** With `modality_enabled=true` and no reachable provider, `describe` returns `None` and the caller proceeds. With a backend that raises, `call_modality_describe` returns `None` and the caller proceeds.
 
-Test naming follows the repo's feature convention: `tests/test_modality_backends.py`, `tests/test_modality_atlas.py`. Ruff runs `--select E9,F63,F7,F82` only, so style will not gate; correctness will.
+Test naming follows the repo's feature convention: `tests/test_modality_backends.py`, `tests/test_modality_openai_compat.py`. Ruff runs `--select E9,F63,F7,F82` only, so style will not gate; correctness will.
 
 ---
 
@@ -242,7 +261,7 @@ Test naming follows the repo's feature convention: `tests/test_modality_backends
    │  modality_backends.py   call_modality_describe()   [THIS RFC]      │
    │  ─────────────────────────────────────────────────────────────     │
    │  1. host backend for modality      (set_modality_backend)          │
-   │  2. Atlas / OpenAI-compatible      (modality_atlas.py)             │
+   │  2. Any OpenAI-compatible endpoint  (modality_openai_compat.py)             │
    │  3. (reserved: local captioner)                                    │
    │  4. metadata-only  ->  understanding_status='unavailable'          │
    │     never raises, never blocks remember()                          │
@@ -273,11 +292,11 @@ Test naming follows the repo's feature convention: `tests/test_modality_backends
 | File | Purpose | Lines |
 |---|---|---|
 | `mnemosyne/core/modality_backends.py` | **new.** Protocol, dataclasses, registry | ~200 |
-| `mnemosyne/core/modality_atlas.py` | **new.** Atlas / OpenAI-compatible adapter | ~300 |
+| `mnemosyne/core/modality_openai_compat.py` | **new.** OpenAI-compatible vision adapter (Atlas, OpenRouter, vLLM, LM Studio, …) | ~300 |
 | `mnemosyne/core/llm_backends.py` | the pattern being copied. No change | 124 |
 | `mnemosyne/core/embeddings.py` | no change. Consumed as-is for moment text | 402 |
 | `mnemosyne/core/config.py` | 8 keys into `ENV_VAR_MAP` / `DEFAULTS` / `REQUIRES_RESTART` | +~15 |
-| `tests/conftest.py` | reset the new process-globals beside `:63-71` | +~8 |
+| `tests/conftest.py` | reset the new process-globals beside `:64-69` | +~8 |
 | `docs/integrations/atlas-cloud.md` | **new.** Configuration recipe | ~120 |
 
 ---

--- a/docs/rfc/0003-media-moments.md
+++ b/docs/rfc/0003-media-moments.md
@@ -28,7 +28,7 @@ Image and video come first. Audio and voice profiles reuse the same primitives w
 
 ### 1.1 There is no span model anywhere in the repo
 
-The only structured non-text metadata with real columns is wall-clock time: `event_date` and `event_date_precision`, added to both memory tables at `beam.py:1227` and `:1231` and indexed immediately after, populated by `core/temporal_parser.py`, consumed by `_temporal_voice` (`core/polyphonic_recall.py:617`).
+The only structured non-text metadata with real columns is wall-clock time: `event_date` and `event_date_precision`, added to both memory tables at `beam.py:1228` and `:1231` and indexed immediately after, populated by `core/temporal_parser.py`, consumed by `_temporal_voice` (`core/polyphonic_recall.py:617`).
 
 There is no offset, no duration-within-content, no page, no bounding box, no chunk table, and no parent-document linkage. Note that `chunk_memories_by_budget()` in `core/local_llm.py` is *not* content chunking: it groups whole memories into batches that fit an LLM context window. The nearest thing to provenance linking is `episodic_memory.summary_of` and `annotations.kind='has_source'`.
 
@@ -38,7 +38,7 @@ So the moment primitive is genuinely new. Nothing needs to be refactored to make
 
 `core/content_sanitizer.py` is a working content-addressed blob store: `_store_blob` at `:91` writes bytes to `~/.hermes/mnemosyne/blobs/<h[0:2]>/<h[0:4]>/<sha256>` under `_blob_root()` (`:32`, overridable via `MNEMOSYNE_BLOB_DIR`), and `sanitize_content` at `:103` replaces the row content with a text stub while recording `{"blob_ref": "blob://sha256/<hash>", ...}` into metadata.
 
-It is invoked from three places: `core/memory.py:358`, `core/beam.py:3249`, and `core/beam.py:3521`. **Nothing in the tree ever reads a blob back.** A grep for `blob_ref` or `blob://` outside `content_sanitizer.py` and `tests/` returns nothing. RFC 0004 gives it a reader.
+It is invoked from three places: `core/memory.py:358`, `core/beam.py:3251`, and `core/beam.py:3523`. **Nothing in the tree ever reads a blob back.** A grep for `blob_ref` or `blob://` outside `content_sanitizer.py` and `tests/` returns nothing. RFC 0004 gives it a reader.
 
 Two details that matter here:
 
@@ -52,30 +52,30 @@ Adding a vec0 virtual table costs edits in four hardcoded whitelists, each of wh
 | Location | Function | Purpose |
 |---|---|---|
 | `beam.py:552` | `_existing_vec_dim` | which tables to parse for the stored dimension |
-| `beam.py:1544` | `_vec_table_available` | availability probe |
-| `beam.py:2150` | `_vec_table_insert` | write dispatch |
-| `beam.py:2448` | `reindex_vectors` | recreate loop |
+| `beam.py:1546` | `_vec_table_available` | availability probe |
+| `beam.py:2152` | `_vec_table_insert` | write dispatch |
+| `beam.py:2450` | `reindex_vectors` | recreate loop |
 
-It also permanently enlarges the dimension-mismatch blast radius described in RFC 0002 §1.5, and it requires maintaining rowid alignment between the vec table and its parent (see `_store_working_embedding` at `beam.py:2214` and `_wm_vec_delete` at `:2204`).
+It also permanently enlarges the dimension-mismatch blast radius described in RFC 0002 §1.5, and it requires maintaining rowid alignment between the vec table and its parent (see `_store_working_embedding` at `beam.py:2216` and `_wm_vec_delete` at `:2204`).
 
-`vec_facts` (declared `beam.py:1218`, never written) is the proof of cost: `reindex_vectors` recreates it empty forever, with a comment at `beam.py:2445` explaining that this is so its declared dimension cannot mismatch a query.
+`vec_facts` (declared `beam.py:1220`, never written) is the proof of cost: `reindex_vectors` recreates it empty forever, with a comment at `beam.py:2448` explaining that this is so its declared dimension cannot mismatch a query.
 
 ### 1.4 First-class memory rows come with the whole engine attached
 
-`_store_working_embedding` (`beam.py:2214`) already writes both `memory_embeddings` and `vec_working` for any working-memory row. So a row placed in `working_memory` automatically receives:
+`_store_working_embedding` (`beam.py:2216`) already writes both `memory_embeddings` and `vec_working` for any working-memory row. So a row placed in `working_memory` automatically receives:
 
 - the dense vector voice and the lexical FTS voice
 - recency decay and tier degradation
 - sleep and consolidation into `episodic_memory`
 - the veracity multiplier
 - a `memory_events` row (`beam.py:745`) so deletion and mutation propagate through sync
-- `mnemosyne reindex` coverage (`reindex_vectors`, `beam.py:2392`)
+- `mnemosyne reindex` coverage (`reindex_vectors`, `beam.py:2394`)
 
 This is the argument for §3.2.
 
 ### 1.5 The recall filter pattern is established, and has six touch points
 
-`memory_type` is the template to copy. It was added as an additive column via plain `ALTER TABLE` wrapped in try/except at `beam.py:658` and `:662`, and its filter clauses appear at `beam.py:5693` (working memory) and `:6195` (episodic). `recall()` is at `beam.py:5449`; `_recall_polyphonic` at `:7233`; the enhanced-recall cache key at `:6715`.
+`memory_type` is the template to copy. It was added as an additive column via plain `ALTER TABLE` wrapped in try/except at `beam.py:658` and `:662`, and its filter clauses appear at `beam.py:5695` (working memory) and `:6195` (episodic). `recall()` is at `beam.py:5451`; `_recall_polyphonic` at `:7233`; the enhanced-recall cache key at `:6715`.
 
 ### 1.6 Schema conventions
 
@@ -87,7 +87,13 @@ This is the argument for §3.2.
 
 ## 2. Data model
 
-New module `mnemosyne/core/media.py`, following the `core/annotations.py` template exactly: an idempotent `_init_media_with_conn(conn)` called both from `init_beam` and from a `MediaStore(conn=...)` that reuses BeamMemory's thread-local connection.
+New module `mnemosyne/core/media.py`, following the `core/annotations.py` template: an idempotent `_init_media_with_conn(conn)` called from a `MediaStore(conn=...)` that reuses BeamMemory's thread-local connection.
+
+> **Correction (2026-07-30).** An earlier draft of this section said `_init_media_with_conn` is called "both from `init_beam` and from a `MediaStore(conn=...)`", and §5 budgeted "3 lines in `init_beam`". Both are wrong, and they misdescribe the precedent this RFC claims to follow. `init_annotations` is **not** called from `init_beam` — it is called from `BeamMemory._ensure_e6_schema_with_migration` (`beam.py:3091`). The closer precedent is `CanonicalStore`, constructed in `BeamMemory.__init__` at `beam.py:3043`, with its DDL owned entirely by `canonical.py:89-137`. `init_beam` (`beam.py:592`) contains only first-party DDL.
+>
+> **The correct wiring is therefore: construct `MediaStore(db_path=..., conn=self.conn)` in `BeamMemory.__init__` beside `self.canonical`, and let the store's own init run the idempotent DDL. Zero lines in `init_beam`.**
+>
+> This does not change the migration story. `BeamMemory.__init__` runs on every open and the DDL is all `CREATE TABLE/INDEX IF NOT EXISTS`, so existing banks acquire the tables on next open with no migration module — which is exactly how `canonical_facts` reached existing databases.
 
 ### 2.1 `media_assets`
 
@@ -121,7 +127,15 @@ CREATE TABLE IF NOT EXISTS media_assets (
 );
 ```
 
-`asset_id` is deterministic, never random: `sha256:<hash>` when the bytes were seen, otherwise `ref:<sha256(normalized_ref_value)>`. Determinism is what makes re-ingest and archive re-push idempotent without a lookup round trip.
+`asset_id` is deterministic, never random: `sha256:<hash>` when the bytes were seen, otherwise `ref:<sha256(ref_kind + "\x1f" + normalized_ref_value)>`. Determinism is what makes re-ingest and archive re-push idempotent without a lookup round trip.
+
+> **Correction (2026-07-30), two rules an earlier draft omitted.**
+>
+> **1. `ref_kind` must be inside the digest.** The draft specified `ref:<sha256(normalized_ref_value)>`. But uniqueness is `(ref_kind, ref_value)` — the same `ref_value` under two different kinds is two legal rows, and both would hash to the same `asset_id`, colliding on the PRIMARY KEY.
+>
+> **2. `asset_id` is assigned at first registration and is never rewritten.** Read literally, the rule above gives an asset first seen by reference (`ref:…`) and later seen with its bytes (`sha256:…`) a *new* id, orphaning every moment already written against the old one. The `sha256:` form is used only when the hash is known at first registration; a hash that arrives later fills in `content_hash` via `UPDATE` and leaves `asset_id` untouched.
+>
+> **Consequence for the two unique indexes below.** `idx_media_ref` says identity is the reference; `idx_media_hash` says identity is the bytes. One file reachable by both a URL and a local path, both resolving to the same known hash, cannot be two rows. Registering the second reference returns the **existing** `asset_id` and records the new reference under `metadata.alt_refs`, rather than raising `IntegrityError`.
 
 `understanding_status` is one of `pending | ok | partial | unavailable | refused`. `unavailable` is rung 4 of the RFC 0002 §3.3 degradation ladder and is a success state.
 
@@ -175,7 +189,29 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_moment_span
     ON media_moments(asset_id, kind, span_key);
 ```
 
-`span_key` is a canonical string form of whichever span columns are populated. Paired with `INSERT OR IGNORE`, the unique index makes re-ingest and archive re-push idempotent. This is deliberately the same contract `AnnotationStore.import_all` received in #538, where UNIQUE collisions on `(memory_id, kind, value)` are skipped rather than aborting the import.
+`span_key` is a canonical string form of whichever span columns are populated, **plus the speaker**. Paired with `INSERT OR IGNORE`, the unique index makes re-ingest and archive re-push idempotent. This is deliberately the same contract `AnnotationStore.import_all` received in #538, where UNIQUE collisions on `(memory_id, kind, value)` are skipped rather than aborting the import.
+
+> **Correction (2026-07-30): `speaker` must be part of `span_key`, or multi-speaker audio is silently lossy.**
+>
+> §2.3 below says an audio moment is `span_kind='time'` with `t_start_ms`, `t_end_ms`, **and `speaker`**. But an earlier draft defined `span_key` from the *geometric* span alone. Two speakers talking over the same window — a crosstalk segment, an interviewer and interviewee, any diarized overlap — then produce **identical** `span_key`s under the same `kind='transcript'`, and `INSERT OR IGNORE` drops the second one. No error, no warning, no count. The lossiness is invisible precisely in the case diarization exists to handle.
+>
+> This redefines `span_key` from "canonical form of the span" to **"canonical form of the span identity"**, which is a real semantic change and is why it is called out rather than quietly patched.
+
+**`span_key` format, normative.**
+
+```
+span_key := "v1:" <span_kind> [ ":" <payload> ] [ ":spk=" <speaker-slug> ]
+```
+
+| `span_kind` | payload | example |
+|---|---|---|
+| `whole` | omitted | `v1:whole` |
+| `time` | `{t_start_ms}-{t_end_ms or "na"}` | `v1:time:90000-96000` |
+| `page` | `{page_start}-{page_end or page_start}` | `v1:page:3-3` |
+| `char` | `{char_start}-{char_end}` | `v1:char:0-512` |
+| `box` | four normalized floats, `f"{v:.6f}"`, comma-joined | `v1:box:0.100000,0.200000,0.300000,0.400000` |
+
+Rules: the `v1:` prefix is **mandatory** — without a version tag, a future format change silently produces both old- and new-form rows for the same span and the unique index cannot tell them apart; with it, the duplication is greppable and a rewrite migration can scope itself. Integers are coerced with `int()` and `bool` is rejected explicitly (`True` would otherwise become `1`). Floats are never rendered with `str()`, which is repr- and locale-sensitive. An unparseable `bbox` falls back to `"h" + sha256(canonical_json)[:16]` so the function stays total. The speaker slug is whitespace-collapsed, case-folded, truncated to 64 chars, and appended **last**, so rows without a speaker are byte-identical to what the pre-correction format would have produced.
 
 ### 2.3 One column set, not one table per modality
 
@@ -186,11 +222,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_moment_span
 | Image (whole) | `whole` | none |
 | Image (region) | `box` | `bbox` |
 | Video | `time` | `t_start_ms`, `t_end_ms` |
-| Audio | `time` | `t_start_ms`, `t_end_ms`, `speaker` |
+| Audio | `time` | `t_start_ms`, `t_end_ms`, `speaker` (also folded into `span_key`, per §2.2) |
 | Document (page) | `page` | `page_start`, `page_end` |
 | Document (offset) | `char` | `char_start`, `char_end` |
 
-**Pros.** NULL columns are free in SQLite. The recall sub-select in §4.2 stays a single predicate. The in-repo precedent for a discriminated nullable field plus a precision qualifier is `event_date` / `event_date_precision` (`beam.py:1227`, `:1231`).
+**Pros.** NULL columns are free in SQLite. The recall sub-select in §4.2 stays a single predicate. The in-repo precedent for a discriminated nullable field plus a precision qualifier is `event_date` / `event_date_precision` (`beam.py:1228`, `:1231`).
 
 **Cons.** No database-level guarantee that a `time` moment has `t_start_ms` populated. Accepted, and enforced in `MediaStore.add_moments` instead, consistent with the application-layer integrity posture from §1.6.
 
@@ -198,13 +234,23 @@ Four per-modality tables would multiply the recall predicate, the filter touch p
 
 ### 2.4 Soft references, checked not enforced
 
-`media_moments.asset_id` and `.memory_id` are convention-only per §1.6. Writers use the existence guard already used by `_store_working_embedding` (`beam.py:2214`) rather than an FK:
+`media_moments.asset_id` and `.memory_id` are convention-only per §1.6. Writers use the existence guard already used by `_store_working_embedding` (`beam.py:2216`) rather than an FK:
 
 ```sql
 WHERE EXISTS (SELECT 1 FROM working_memory WHERE id = ?)
 ```
 
 Integrity is *reported*, not enforced: add an orphaned-moment count to `mnemosyne doctor` and to `mnemosyne_diagnose`.
+
+> **Correction (2026-07-30): the two orphan kinds are different health states and must not be reported alike.**
+>
+> A moment whose **`asset_id`** has no asset is real corruption — nothing in the design should ever produce it, and it warrants a Finding.
+>
+> A moment whose **`memory_id`** no longer resolves is the *expected steady state*. §3.3 Cost 2 says so itself: consolidation may summarize the memory row away, and `media_moments.text` remains authoritative. Working memory is also trimmed on a cap (`_trim_working_memory`, called from `remember`). Emitting a warning for these means `mnemosyne doctor` cries wolf at every healthy media user after their first `sleep()`, which trains people to ignore the check that catches the real corruption.
+>
+> **Count both; emit a Finding only for asset-orphans.**
+>
+> A second constraint the draft did not state: `mnemosyne doctor` opens the database **read-only** (`open_readonly_doctor_db`). The media inspection must therefore take a `not_configured` branch when the tables are absent — the same shape as the existing unverifiable-store branch — and must never attempt DDL on that connection.
 
 ---
 
@@ -235,13 +281,27 @@ Reusing `vec_facts` is rejected outright: it is the cautionary tale from §1.3, 
 **Cost 3: moments are misclassified.** `classify_memory` (`beam.py:3267`) will label a caption an "observation".
 *Mitigation:* see §3.4.
 
-### 3.4 Two prerequisite changes to the ingest path
+### 3.4 Three prerequisite changes to the ingest path
 
-**Prerequisite 1: `remember()` needs a `memory_type` override.** `BeamMemory.remember` (`beam.py:3210-3217`) accepts `content`, `source`, `importance`, `metadata`, `valid_until`, `scope`, `memory_id`, `extract_entities`, `extract`, `veracity`, and `trust_tier`. There is **no `memory_type` parameter**: the value is derived locally from `classify_memory` at `beam.py:3264-3268`. Add `memory_type: Optional[str] = None` as an explicit override so a moment can declare itself `artifact` (`core/typed_memory.py`, `MemoryType.ARTIFACT`, described as "references to documents, code, external resources"). The plumbing is already friendly: the dedup-update path uses `memory_type = COALESCE(?, memory_type)` at `beam.py:3299`.
+> **Correction (2026-07-30).** This section listed two prerequisites. There is a third, and it is the most dangerous of the three: see prerequisite 3. Line anchors throughout this section have also been corrected; they had drifted by two lines.
 
-*Estimated: ~5 lines in `beam.py`, plus the same parameter on the `core/memory.py` facade.*
+**Prerequisite 1: `remember()` needs a `memory_type` override.** `BeamMemory.remember` (`beam.py:3212`) accepts `content`, `source`, `importance`, `metadata`, `valid_until`, `scope`, `memory_id`, `extract_entities`, `extract`, `veracity`, and `trust_tier`. There is **no `memory_type` parameter**: the value is derived locally from `classify_memory` at `beam.py:3266-3272`. Add `memory_type: Optional[str] = None` as an explicit override so a moment can declare itself `artifact` (`core/typed_memory.py:51`, `MemoryType.ARTIFACT`, described as "references to documents, code, external resources" — verified present). The plumbing is already friendly: the dedup-update path uses `memory_type = COALESCE(?, memory_type)` at `beam.py:3301`.
 
-**Prerequisite 2: `remember_media()` must never route a URI through `content`.** Per §1.2, `sanitize_content` is invoked on the content string at `beam.py:3249`, and a `data:` URI is rewritten into a blob stub. The media reference therefore travels as a **parameter**, and the `content` of a moment row is always the moment's descriptive text. This is a hard API constraint, not a style preference, and deserves a regression test.
+An explicit value **wins outright and short-circuits the classifier**; an unrecognized label warns and falls back to classification rather than storing `NULL`, so a typo degrades to today's behaviour instead of stripping the type. Append the parameter at the **end** of the signature — positional callers exist throughout the test suite, and a `*` separator would break them.
+
+*Estimated: ~15 lines in `beam.py` including the label-clamping helper, plus the same parameter on the `core/memory.py` facade and per-item parity in `remember_batch`.*
+
+**Prerequisite 2: `remember_media()` must never route a URI through `content`.** Per §1.2, `sanitize_content` is invoked on the content string at `beam.py:3251`, and a `data:` URI is rewritten into a blob stub. The media reference therefore travels as a **parameter**, and the `content` of a moment row is always the moment's descriptive text. This is a hard API constraint, not a style preference, and deserves a regression test.
+
+A second, sharper reason the draft missed: **`metadata_json` is never sanitized.** `sanitize_content` only ever inspects `content` (`beam.py:3251`, `beam.py:3523`, `memory.py:358`). A `data:` URI that arrives as a reference and gets copied into `media_assets.ref_value` or into `metadata["media"]["ref"]` therefore writes megabytes of base64 into two uncapped `TEXT` columns, with no size cap and no entropy check — precisely the outcome the size-cap and entropy branches exist to prevent, reached by a path they do not watch. The fix is to convert a `data:` URI to a `blob://` reference **at the door**, before any storage. The regression test must assert not only that no `content` contains `data:`, but that no `metadata_json` contains `base64` and that every written `metadata_json` stays small.
+
+**Prerequisite 3: `remember()` needs a `dedupe` opt-out, or moments bind to the wrong asset.** `_find_duplicate` (`beam.py:3177`, called at `beam.py:3275`) matches on `(session_id, content)` exactly and returns the existing row's id. Moment captions collide on identical text far more often than prose does: "a black frame", "a screenshot of a terminal window", the same slide appearing in two recordings, any boilerplate title card. Two such moments **from different assets in one session** therefore produce **one** `working_memory` row, and the second `media_moments` row binds its `memory_id` to the **first asset's** memory.
+
+The consequences are all silent. Recall answers "which video mentioned X" with the wrong video. The §4.4 enrichment join returns two `media` blocks for one result with no way to choose between them. The §4.3 `asset_ref` filter matches the wrong asset. Nothing raises, nothing is logged, and the row counts all look correct.
+
+Add `dedupe: bool = True` and guard the `_find_duplicate` call with it; `remember_media()` passes `dedupe=False`. Note that `remember_batch` already bypasses dedup entirely (`beam.py:3531` generates an id unconditionally), so only the single-write path is exposed. Note also that leaving dedup on has a second-order hazard even when the collision is benign: the `COALESCE` at `beam.py:3301` means an explicit `memory_type='artifact'` **retypes the colliding row**, silently converting a user's conversational note into an artifact. `dedupe=False` removes both exposures at once.
+
+*This is the highest silent-wrong-answer risk in this RFC.* It ranks above the enhanced-recall cache key in §4.3, because the cache key produces a stale answer while this one produces a confidently wrong attribution.
 
 ---
 
@@ -249,7 +309,7 @@ Reusing `vec_facts` is rejected outright: it is the cautionary tale from §1.3, 
 
 ### 4.1 Media-internal time is not wall-clock time
 
-`t_start_ms` is relative to its asset. "t=90s" has no meaning without knowing which asset, so it is **not comparable across assets** and must never enter `event_date` or a date-range filter. `event_date` is indexed for range queries (`beam.py:1227-1231` and the indexes immediately following) and consumed by `_temporal_voice` (`polyphonic_recall.py:617`); polluting it with media offsets would corrupt temporal recall for every user.
+`t_start_ms` is relative to its asset. "t=90s" has no meaning without knowing which asset, so it is **not comparable across assets** and must never enter `event_date` or a date-range filter. `event_date` is indexed for range queries (`beam.py:1228-1231` and the indexes immediately following) and consumed by `_temporal_voice` (`polyphonic_recall.py:617`); polluting it with media offsets would corrupt temporal recall for every user.
 
 Three distinct times, never conflated:
 
@@ -265,9 +325,9 @@ The one legitimate bridge is `captured_at + t_start_ms -> event_date`, valid onl
 
 **Recommendation: add a fifth polyphonic voice, plus read-only enrichment on the linear path. Do not add a term to the linear scorer.**
 
-Rejected alternative, linear weight: `_normalize_weights` (`beam.py:1398`) normalizes vector, FTS, and importance weights to sum to 1.0, reading them straight from `os.environ`. A fourth term renormalizes the other three and shifts ranking for every existing user and every ranking test, to serve queries that are mostly not about media.
+Rejected alternative, linear weight: `_normalize_weights` (`beam.py:1400`) normalizes vector, FTS, and importance weights to sum to 1.0, reading them straight from `os.environ`. A fourth term renormalizes the other three and shifts ranking for every existing user and every ranking test, to serve queries that are mostly not about media.
 
-Rejected alternative, episodic bonus: the bonus ladder at `beam.py:6227-6301` (graph bonus capped at 0.08, fact bonus at 0.1) could host an additive media bonus, but it would fire for every artifact memory regardless of whether the query is about media. That is noise, not signal.
+Rejected alternative, episodic bonus: the bonus ladder at `beam.py:6237-6299` (graph bonus capped at 0.08, fact bonus at 0.1) could host an additive media bonus, but it would fire for every artifact memory regardless of whether the query is about media. That is noise, not signal.
 
 Polyphonic is the seam that was designed for this. `_combine_voices` (`polyphonic_recall.py:727`) fuses ranked lists with Reciprocal Rank Fusion at `RRF_K = 60` (`:734`), which absorbs a new list without renormalizing anything. `_env_disabled` (`:58`) provides a free kill switch. `PolyphonicResult.voice_scores` (`:83`) provides per-signal provenance at no cost.
 
@@ -295,17 +355,17 @@ EXISTS (SELECT 1
 
 | # | Touch point | Location | Note |
 |---|---|---|---|
-| 1 | `recall()` signature | `beam.py:5449` | add after `memory_type` |
-| 2 | Working-memory WHERE | `beam.py:5693` | the `memory_type` clause is the literal template |
-| 3 | Episodic WHERE | `beam.py:6195` | same shape |
-| 4 | `_recall_polyphonic` signature and call site | `beam.py:7233`, called from `:5531` | |
+| 1 | `recall()` signature | `beam.py:5451` | add after `memory_type` |
+| 2 | Working-memory WHERE | `beam.py:5695` | the `memory_type` clause is the literal template |
+| 3 | Episodic WHERE | `beam.py:6197` | same shape |
+| 4 | `_recall_polyphonic` signature and call site | `beam.py:7235`, called from `:5531` | |
 | 5 | Polyphonic post-filter | `beam.py` `_polyphonic_row_passes_filters` | **batch-prefetch** an `id -> modality` map before the loop; do not query per row |
-| 6 | Explain-trace `filters` dict | `beam.py:5556` | safe: `RecallExplainTrace` prunes `None` values |
-| 7 | Enhanced-recall cache key | `beam.py:6715` | **see the warning below** |
+| 6 | Explain-trace `filters` dict | `beam.py:5562` | safe: `RecallExplainTrace` prunes `None` values |
+| 7 | Enhanced-recall cache key | `beam.py:6717` | **see the warning below** |
 | 8 | MCP surface | `tool_schemas.py` `RECALL_SCHEMA`, `mcp_tools.py`, and **both** Hermes copies | `tests/test_hermes_provider_parity.py` fails otherwise |
 | 9 | Generated docs | `scripts/generate-docs.py` | it hand-duplicates the schemas as literals |
 
-**The highest silent-wrong-answer risk in this RFC is touch point 7.** `_enhanced_recall_cache_key` (`beam.py:6715`) canonicalizes `recall_kwargs` wholesale, so a new parameter enters the digest only if it arrives inside `kwargs` rather than as a named argument. Verify that plumbing, and **bump the key's version prefix regardless**. Without the bump, cache entries written before the filter existed will be served to modality-filtered queries, returning unfiltered results with no error. Note that `invalidate()` already calls `_invalidate_query_cache` (`beam.py:3993`) for both branches, so eviction on mutation is handled; this is purely about the schema of the key.
+**The highest silent-wrong-answer risk in this RFC is touch point 7.** `_enhanced_recall_cache_key` (`beam.py:6717`) canonicalizes `recall_kwargs` wholesale, so a new parameter enters the digest only if it arrives inside `kwargs` rather than as a named argument. Verify that plumbing, and **bump the key's version prefix regardless**. Without the bump, cache entries written before the filter existed will be served to modality-filtered queries, returning unfiltered results with no error. Note that `invalidate()` already calls `_invalidate_query_cache` (`beam.py:3995`) for both branches, so eviction on mutation is handled; this is purely about the schema of the key.
 
 ### 4.4 Read-only enrichment on every path
 
@@ -324,7 +384,7 @@ Fetched with one batched `WHERE memory_id IN (...)` query, following the batchin
 
 | Phase | Work | Est. LOC | Chief risk |
 |---|---|---|---|
-| **0** | `core/media.py` registry and `MediaStore`; 3 lines in `init_beam` near `beam.py:1227`; `mnemosyne doctor` orphan count | ~350 + ~250 tests | Near zero. No vec tables, no recall touch, nothing in a hot path |
+| **0** | `core/media.py` registry and `MediaStore`; `MediaStore` constructed in `BeamMemory.__init__` beside `self.canonical` (`beam.py:3043`), **not** in `init_beam` — see the correction in §2; `mnemosyne doctor` orphan count | ~420 + ~550 tests | Near zero. No vec tables, no recall touch, nothing in a hot path |
 | **1** | RFC 0002 provider protocol and Atlas adapter; `remember_media()`; `memory_type` override on `remember()` | ~640 | Process-global not reset in conftest; a socket opening when disabled; a URI leaking into `content` (§3.4) |
 | **2** | Read-only recall enrichment (§4.4) | ~80 | The result dict gains a key: audit every consumer, including both Hermes copies and the sync serializer |
 | **3** | `modality` / `asset_ref` filter across the nine touch points (§4.3) | ~150 | The cache key (§4.3); the generated-docs literals |
@@ -346,9 +406,29 @@ Therefore: media understanding is **synchronous inside the caller's `remember_me
 - **A `vec_facts` writer alongside media work.** Independent debts.
 - **Media-native embeddings in phases 0 through 4.** See RFC 0002 §2.
 
+### 5.2b Config keys this RFC introduces must be registered
+
+> **Correction (2026-07-30).** This RFC introduces two config keys — `MNEMOSYNE_MEDIA_TIME_BRIDGE` (§4.1) and `MNEMOSYNE_VOICE_MEDIA` (§4.2) — and tabulates neither. RFC 0002 §3.4's key table covers only the eight `MNEMOSYNE_MODALITY_*` keys, so a reader following either document alone will miss these.
+>
+> Each must be added to **`ENV_VAR_MAP` (`config.py:62`)**, **`DEFAULTS` (`config.py:192`)**, and **`CONFIG_DESCRIPTIONS` (`scripts/generate-docs.py`)**, then `docs/api/*.mdx` regenerated. A key absent from `ENV_VAR_MAP` is YAML-only and cannot be set from the environment at all; a key absent from `CONFIG_DESCRIPTIONS` **fails the `docs-check` CI job**. The Python type of the value in `DEFAULTS` drives environment-variable coercion, so both must be registered as `bool`, not `"false"`.
+>
+> Register each key in the phase that consumes it (the time bridge with phase 3, the media voice with phase 4), not upfront — declaring a key with no reader is the same anti-pattern as declaring an interface with no writer (RFC 0002 §1.4).
+
 ### 5.3 CI constraint
 
 CI runs `pytest tests/ -v` with `MNEMOSYNE_NO_EMBEDDINGS=1`. Every media test must pass with embeddings off. The caption-to-text design (RFC 0002 §2) satisfies this, because moments still land in FTS. Ruff runs `--select E9,F63,F7,F82` only.
+
+### 5.4 Known gaps this RFC does not close
+
+> **Added 2026-07-30.** Three gaps surfaced during implementation review that no section of this RFC addresses. They are recorded here rather than silently inherited. **All three should be resolved before phase 2**, because phase 2's enrichment join builds directly on top of them.
+
+**1. `media_assets` and `media_moments` do not sync.** `memory_events` (`beam.py:745`) is what propagates rows to peer devices, and nothing emits events for either media table. A synced peer therefore receives the caption *memory row* and none of its span data, `archive_locator`, or asset linkage. This directly contradicts §3.3 Cost 2, which calls `media_moments.text` "authoritative" and the memory row a mere "index entry": after a sync, the index entry arrives and the authority does not. It also weakens RFC 0004 invariant 5, which requires deletion to reach synced devices. The failure is silent and degraded rather than loud and broken — timestamps and deep links simply vanish on the second device — which is exactly the kind of gap that goes unreported for a long time.
+
+**2. `mnemosyne export` omits both tables.** Backups will silently exclude all media state. Same class of gap as (1), and it should be fixed in the same change.
+
+**3. Deletion and cascade semantics are unspecified.** RFC 0004 §4 invariant 5 requires `forget_asset(asset_id, cascade=True)` to remove moments, their memory rows, their `memory_embeddings` and `vec_working` entries, and to emit DELETE events. Neither RFC says what happens in the *other* direction: when a moment's `working_memory` row is forgotten by the user, evicted by `_trim_working_memory`, or summarized away by consolidation. §3.3 Cost 2 asserts moments are "rehydratable" and nothing implements rehydration.
+
+Implementations should **not** ship a `cascade=` parameter before there is an ingest path creating the bindings it would cascade over — that is a dead branch with a falsely reassuring test. Phase 0 ships sidecar-only deletion and says so in the docstring.
 
 ---
 
@@ -360,12 +440,12 @@ CI runs `pytest tests/ -v` with `MNEMOSYNE_NO_EMBEDDINGS=1`. Every media test mu
 |---|---|---|
 | Content-addressed byte storage | ⚠️ write-only | `core/content_sanitizer.py:91`, `:103` |
 | A `blob://` URI scheme | ⚠️ no reader | `content_sanitizer.py:126` |
-| Wall-clock event time with precision | ✅ | `beam.py:1227`, `:1231` |
+| Wall-clock event time with precision | ✅ | `beam.py:1228`, `:1231` |
 | Additive-column migration idiom | ✅ | `beam.py:658-662` |
 | Subsystem module with idempotent init | ✅ | `core/annotations.py:124` |
 | Partial unique index idiom | ✅ | `core/canonical.py:131-132` |
 | Idempotent-insert-on-unique contract | ✅ | `annotations.py:159` and #538 |
-| Recall filter template | ✅ | `beam.py:5693`, `:6195` |
+| Recall filter template | ✅ | `beam.py:5695`, `:6195` |
 | Pluggable recall voice with kill switch | ✅ | `polyphonic_recall.py:58`, `:727` |
 | A span or offset model | ❌ | nowhere |
 | A modality dimension | ❌ | nowhere |
@@ -423,7 +503,7 @@ CI runs `pytest tests/ -v` with `MNEMOSYNE_NO_EMBEDDINGS=1`. Every media test mu
    │  phase 2: enrichment  -> result["media"] = {ref, span, locator}  │
    │  phase 3: filter      -> EXISTS(...) correlated sub-select        │
    │  phase 4: _media_voice -> RRF k=60 (polyphonic_recall.py:734)     │
-   │  linear scorer weights UNTOUCHED (beam.py:1398)                   │
+   │  linear scorer weights UNTOUCHED (beam.py:1400)                   │
    └──────────────────────────────────────────────────────────────────┘
 
    TIME AXES, never conflated:

--- a/docs/rfc/0004-archive-boundary.md
+++ b/docs/rfc/0004-archive-boundary.md
@@ -62,29 +62,49 @@ class ContentResolver(Protocol):
     schemes: frozenset[str]          # {"blob"} | {"archive"} | {"file"} | ...
 
     def head(self, uri: str) -> Optional[ResolvedMeta]:
-        """Cheap existence and metadata probe. None if unresolvable."""
+        """Cheap existence and metadata probe.
+
+        None means "not my scheme, or not a URI I can parse".
+        ResolvedMeta(exists=False) means "mine, and gone".
+        """
 
     def open(self, uri: str) -> Optional[BinaryIO]:
         """Lazy byte stream. None if unavailable."""
 
-    def presign(self, uri: str, ttl_s: int) -> Optional[str]:
+    def presign(self, uri: str, *, ttl_s: int = 300) -> Optional[str]:
         """A short-lived URL a third party can fetch. None if unsupported."""
 ```
 
 `ResolvedMeta` carries `exists`, `byte_size`, `mime`, `content_hash`, `etag`.
 
+> **Correction (2026-07-30), two signature fixes.**
+>
+> **1. `head` must distinguish "not mine" from "gone".** The original docstring said only "None if unresolvable", collapsing two states that §3.2.1 depends on separating: `mnemosyne doctor` validating that a reference is still live needs "the file is missing" to be a *different answer* from "no resolver handles this scheme". `ResolvedMeta.exists` exists precisely to carry that, and returning `None` for both makes it unreachable.
+>
+> **2. `ttl_s` is keyword-only with a default.** As drafted it was positional, contradicting the `llm_backends` convention this section says it is copying — one positional argument, everything else keyword-only (`llm_backends.py:37-47`).
+
 **`presign` is the load-bearing method.** It is how a cloud vision provider (RFC 0002) reaches bytes that Mnemosyne does not want to read, buffer, or proxy. Without it, either the brain streams every megabyte through its own process to hand to a provider, or media understanding only works for local files. With it, "the archive is a separate product" becomes structurally true rather than aspirational: the archive serves bytes directly to whoever needs them, and the brain only ever passes URIs around.
 
 ### 2.3 Ship `BlobResolver` in the same change
 
-A `BlobResolver` over `content_sanitizer._blob_root()`, giving the existing blob store its first reader. Two details from §2.1 constrain `head`:
+A `BlobResolver` over `content_sanitizer._blob_root()`, giving the existing blob store its first reader. Two details constrain `head`:
 
-- `mime` is populated only on the `data:` URI branch (`content_sanitizer.py:128`). For size-cap and entropy blobs, `head` must sniff the bytes or return `mime=None`. It must not guess.
+- **`mime` is sniffed or `None`, on all three branches.** `head` must not guess.
 - `presign` returns `None`. Local files have no presignable URL. Callers must handle `None` by falling back to `open`, or by skipping the provider call.
+
+> **Correction (2026-07-30): the original wording of the first bullet was wrong, in a way that would send an implementer looking for something that does not exist.**
+>
+> It read: "`mime` is populated only on the `data:` URI branch (`content_sanitizer.py:128`). For size-cap and entropy blobs, `head` must sniff the bytes or return `mime=None`." That implies the data-URI branch gives `BlobResolver` a mime it can return. It does not. That mime is written into the **memory row's `metadata_json`** (`beam.py:3251-3256`, `memory.py:358-364`), not into anything addressable by `blob://sha256/<hash>`. The blob store on disk holds bare bytes at a hash path with no sidecar and no filename.
+>
+> So the rule is uniform: **sniff-or-`None` on all three branches.** Sniffing means reading a small prefix and matching magic bytes; it explicitly excludes `mimetypes.guess_type` (there is no filename to guess from — the path *is* the hash) and excludes defaulting to `application/octet-stream`, which is a guess wearing a disguise.
+>
+> A resolver that joined against `working_memory.metadata_json` to recover the declared mime is conceivable but out of scope: it would put a database dependency inside a filesystem resolver, and the two can disagree.
+
+**One thing this section does not say, and must.** Nothing here specifies **who registers `BlobResolver`**. Unaddressed, the forty lines that exist to close the "blobs are unreachable" bug close nothing, because no code path ever constructs one. The registry in §2.4 therefore resolves in two tiers: an explicit registration dict first, then a built-in default map containing `{"blob": BlobResolver}`. This makes byte access work with zero configuration, and it makes `clear_content_resolvers()` restore the built-in rather than *remove* blob access — which matters, because §2.4 mandates calling exactly that in `tests/conftest.py` before every test.
 
 ### 2.4 Registration and absence
 
-Process-global registry keyed by scheme: `set_content_resolver(resolver)`, `get_resolver(scheme)`, `clear_content_resolvers()`. Per RFC 0002 §5, these globals **must** be reset in `tests/conftest.py` beside the existing `llm_backends._backend` reset at `:63-71`.
+Process-global registry keyed by scheme: `set_content_resolver(resolver)`, `get_resolver(scheme)`, `clear_content_resolvers()`. Per RFC 0002 §5, these globals **must** be reset in `tests/conftest.py` beside the existing `llm_backends._backend` reset at `:64-69`.
 
 When no resolver is registered for a scheme, `get_resolver` returns `None` and every caller degrades:
 
@@ -147,7 +167,7 @@ The point of reference hashes and moment spans is to get the utility of media me
 | 2 | **No provider call without explicit opt-in.** | `MNEMOSYNE_MODALITY_ENABLED` defaults false (RFC 0002 §3.4). With it unset, a test asserts zero sockets opened and zero backend invocations |
 | 3 | **The brain never persists media bytes.** | `media_assets` has no BLOB column (RFC 0003 §2.1), and a test asserts the media ingest path never calls `content_sanitizer._store_blob` |
 | 4 | **Recall generates no outbound traffic.** | A test asserts no resolver method is called during `recall()` |
-| 5 | **Deletion is complete and propagates.** | `forget_asset(asset_id, cascade=True)` removes moments, their memory rows, their `memory_embeddings` and `vec_working` entries via `_wm_vec_delete` (`beam.py:2204`), and emits DELETE rows into `memory_events` (`beam.py:745`) so the deletion reaches synced devices |
+| 5 | **Deletion is complete and propagates.** | `forget_asset(asset_id, cascade=True)` removes moments, their memory rows, their `memory_embeddings` and `vec_working` entries via `_wm_vec_delete` (`beam.py:2206`), and emits DELETE rows into `memory_events` (`beam.py:745`) so the deletion reaches synced devices |
 | 6 | **The index is legible.** | Everything stored about an asset is human-readable text plus a reference, per RFC 0002 §2. No opaque media vectors |
 
 Invariant 6 is the substantive difference from tools like Microsoft Recall, and it is worth stating plainly in user-facing docs: what Mnemosyne knows about your media is a list of sentences you can read, search, edit, and delete.
@@ -210,7 +230,7 @@ These are the owner's calls and are deliberately left unresolved here.
 | Registry pattern to copy | ✅ | `core/llm_backends.py:24-123` |
 | Frontmatter parse and vault I/O | ⚠️ export-only | `integrations/obsidian-mnemosyne/main.ts:92` |
 | Source-plugin pattern for the archive to copy | ✅ | `core/importers/base.py:48`, `__init__.py:44` |
-| Deletion propagation through sync | ✅ | `beam.py:745`, `beam.py:2204` |
+| Deletion propagation through sync | ✅ | `beam.py:745`, `beam.py:2206` |
 | A resolver abstraction | ❌ | nowhere |
 | Any way to read a stored blob | ❌ | nowhere |
 | An index-handoff contract | ❌ | nowhere |
@@ -283,7 +303,7 @@ These are the owner's calls and are deliberately left unresolved here.
 | `mnemosyne/core/content_sanitizer.py` | unchanged. Read by `BlobResolver` | 169 |
 | `mnemosyne/core/media.py` | RFC 0003. Stores `archive_locator`, never parses it | ~350 |
 | `mnemosyne/tool_schemas.py`, `mcp_tools.py` | 2 media tools, plus **both** Hermes copies | +~120 |
-| `tests/conftest.py` | reset the resolver registry beside `:63-71` | +~6 |
+| `tests/conftest.py` | reset the resolver registry beside `:64-69` | +~6 |
 | `integrations/obsidian-mnemosyne/main.ts` | export-only today. Candidate prototype for Part 2 | 318 |
 | `mnemosyne/core/importers/base.py` | the plugin pattern the archive should copy | 250 |
 
@@ -297,6 +317,12 @@ Three gaps, in order of value per line of code:
 
 1. **Blobs are unreachable** and always have been. Roughly forty lines of `BlobResolver` fixes a live data-availability hole, and it is worth shipping on its own merits regardless of the rest of this document.
 2. **No seam for byte access**, which would otherwise force local-filesystem-only media support or byte proxying through the brain.
+
+> **Correction (2026-07-30): gap 2 is a blocker, not a nicety, and the sequencing below understates it.**
+>
+> This section recommends that `ContentResolver` plus `BlobResolver` "land with RFC 0003 phase 0, because they close an existing bug" — framing byte access as independently valuable but optional to the provider work. It is not optional. RFC 0002's `DescribeRequest` carries a URI and no bytes, so without a resolver to supply them the OpenAI-compatible adapter can describe **publicly fetchable URLs and nothing else** — no local file, no `blob://` reference. For a local-first memory system, that is close to describing nothing.
+>
+> **`ContentResolver` is therefore a hard prerequisite of the vision adapter**, and the adapter must not be scheduled before it. RFC 0002 §3.1's `DescribeRequest.fetch` field is the seam through which the two connect.
 3. **No index-handoff contract**, which is the gap that determines whether a two-product architecture is real or just a diagram.
 
 Recommended sequencing: `ContentResolver` plus `BlobResolver` land with RFC 0003 phase 0, because they close an existing bug. The MCP handoff tools land with phase 1. Part 2 begins only after the contract has one working implementation, which per §6 should probably be the Obsidian plugin learning to read.


### PR DESCRIPTION
Corrections to the multimodal RFCs (0002 modality providers, 0003 media moments, 0004 archive boundary), and removes vendor naming from the modality seam so the interface is described by the protocol rather than by any one provider.

Docs only. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This documentation-only PR corrects multimodal architecture guidance in RFCs 0002–0004. It changes no runtime code paths.

### Core memory architecture

- `MediaStore` now owns media initialization through `BeamMemory.__init__`.
- Asset identity now includes `ref_kind` and remains stable after registration.
- Moment deduplication now includes versioned speaker identity through `span_key`.
- Media ingest now supports `memory_type` overrides and requires an explicit `dedupe=False` path.
- Recall guidance now defines filter touch points, cache-key versioning, and media voice/filter sequencing.
- The RFCs document unresolved synchronization, export, and deletion/cascade semantics.

These corrections reduce risks of asset collisions, speaker-span collisions, and duplicate-caption misattribution. They do not change working, episodic, or BEAM memory behavior, retrieval code, consolidation, or veracity logic.

### Local-first and privacy posture

The design keeps media handling explicit and compatible with local-first deployments. It prevents media URIs from entering sanitized content or uncapped metadata. Lazy `DescribeRequest.fetch` avoids unnecessary byte retrieval.

The OpenAI-compatible adapter can use optional model-capability preflight with silent degradation. This supports compatible endpoints but can introduce remote processing when configured. The RFCs do not add a new privacy boundary or change data-sync behavior.

### Agent integration

The changes do not modify Hermes, MCP, or CLI interfaces. They clarify the provider seam and adapter input behavior for future integrations.

### Maintainability

Renaming `modality_atlas.py` to `modality_openai_compat.py` removes vendor-specific naming while retaining Atlas as the reference deployment and recipe. The generic contract, explicit refusal results, resolver semantics, registration requirements, and re-verified references improve maintainability.

Making `ContentResolver` a hard prerequisite for the vision adapter is the right call. Correct `head`, `presign`, and MIME-sniffing contracts reduce integration ambiguity.

### Scope and verification

The PR does not change the sync layer, benchmark methodology, tier behavior, consolidation pipeline, or veracity system. Documentation checks and reference verification pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->