### PR TITLE
feat(media): media asset registry and moment index (RFC 0003 phase 0)

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -3461,6 +3461,13 @@ class BeamMemory:
         from mnemosyne.core.canonical import CanonicalStore
         self.canonical = CanonicalStore(db_path=self.db_path, conn=self.conn)
 
+        # Media assets + moment index (RFC 0003 phase 0). Wired exactly like
+        # CanonicalStore above: the store owns its own idempotent DDL, so
+        # existing banks acquire the tables on next open with no migration
+        # module. Zero lines in init_beam, which holds only first-party DDL.
+        from mnemosyne.core.media import MediaStore
+        self.media = MediaStore(db_path=self.db_path, conn=self.conn)
+
         # Phase 3: Episodic graph (shared connection)
         self.episodic_graph = None
         if EpisodicGraph is not None:

--- a/mnemosyne/core/media.py
+++ b/mnemosyne/core/media.py
@@ -1,0 +1,1098 @@
+"""
+Mnemosyne MediaStore — media assets and the moment index (RFC 0003 phase 0)
+==========================================================================
+
+Two sidecar tables and one store:
+
+- ``media_assets``  — one row per referenced piece of media. **No BLOB column,
+  by design.** Mnemosyne records the *reference* and the *text*; the bytes stay
+  wherever they already live.
+- ``media_moments`` — one row per semantically tagged span within an asset
+  (a caption, a shot, a transcript segment, a page, an OCR region).
+
+A moment is *not* a new kind of memory. Each retained moment is an ordinary
+``working_memory`` row, with ``media_moments.memory_id`` bound to it, so it
+inherits recall, decay, consolidation, sync, and reindex with no new code.
+There is no ``vec_moments`` table and this module never creates one.
+
+Three invariants this module exists to hold:
+
+1. **Idempotency.** ``asset_id`` and ``span_key`` are deterministic, so
+   re-ingesting the same media or re-pushing an archive writes nothing new.
+   Paired with ``INSERT OR IGNORE`` and the unique indexes, a repeat is a
+   no-op rather than a duplicate.
+2. **Application-layer integrity.** No schema-level foreign keys (issue #503:
+   ``PRAGMA foreign_keys=ON`` broke 22 tests that intentionally create orphan
+   rows). ``add_moments`` validates; ``mnemosyne doctor`` reports.
+3. **No bytes.** Nothing here accepts, stores, or returns media bytes. The
+   byte path is ``core/content_sanitizer.py`` (write) and ``core/resolvers.py``
+   (read); this module only ever holds a reference to them.
+
+See ``docs/rfc/0003-media-moments.md`` for the design and the corrections
+this module implements.
+"""
+
+import hashlib
+import json
+import os
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+from urllib.parse import urlsplit, urlunsplit
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+#: Bumping this changes every ``span_key`` ever computed. Rows written under an
+#: older version remain in the table under their old keys, and the unique index
+#: cannot tell the two forms apart — so a bump REQUIRES a rewrite migration.
+#: The golden-string tests in ``tests/test_media_span_key.py`` exist to make
+#: that a deliberate act rather than an accident.
+SPAN_KEY_VERSION = "v1"
+
+REF_KINDS = frozenset({"sha256", "url", "youtube", "file", "blob", "archive"})
+MODALITIES = frozenset({"image", "video", "audio", "document"})
+MOMENT_KINDS = frozenset({
+    "caption", "shot", "transcript", "style", "ocr", "page", "summary",
+})
+SPAN_KINDS = frozenset({"whole", "time", "page", "char", "box"})
+
+#: ``unavailable`` is rung 4 of the RFC 0002 §3.3 degradation ladder and is a
+#: *success* state: the asset is registered and recallable by reference, the
+#: provider simply never described it.
+UNDERSTANDING_STATUSES = frozenset({
+    "pending", "ok", "partial", "unavailable", "refused",
+})
+
+#: Every span column, and which ``span_kind`` owns it. A moment carrying a
+#: column its kind does not own is rejected rather than silently dropped — see
+#: ``validate_span``.
+_SPAN_COLUMNS: Dict[str, Tuple[str, ...]] = {
+    "whole": (),
+    "time": ("t_start_ms", "t_end_ms"),
+    "page": ("page_start", "page_end"),
+    "char": ("char_start", "char_end"),
+    "box": ("bbox",),
+}
+
+_ALL_SPAN_COLUMNS: Tuple[str, ...] = (
+    "t_start_ms", "t_end_ms", "page_start", "page_end",
+    "char_start", "char_end", "bbox",
+)
+
+#: Columns without which a span has no identity at all.
+_REQUIRED_SPAN_COLUMNS: Dict[str, Tuple[str, ...]] = {
+    "whole": (),
+    "time": ("t_start_ms",),
+    "page": ("page_start",),
+    "char": ("char_start", "char_end"),
+    "box": ("bbox",),
+}
+
+_SPEAKER_MAX_LEN = 64
+
+
+# ---------------------------------------------------------------------------
+# Connection plumbing (mirrors core/canonical.py)
+# ---------------------------------------------------------------------------
+
+def _default_db_path() -> Path:
+    """Resolved at call time so ``MNEMOSYNE_DATA_DIR`` is honoured without
+    importing beam (which would be a circular import)."""
+    data_dir = os.environ.get("MNEMOSYNE_DATA_DIR")
+    base = Path(data_dir) if data_dir else (Path.home() / ".hermes" / "mnemosyne" / "data")
+    return base / "mnemosyne.db"
+
+
+def _get_conn(db_path: Optional[Path] = None) -> sqlite3.Connection:
+    path = Path(db_path) if db_path else _default_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_media(db_path: Optional[Path] = None) -> None:
+    """Create the media tables and indexes if absent.
+
+    Idempotent. Safe on databases that already have them. Opens and closes its
+    own connection; does not leak file descriptors.
+    """
+    conn = _get_conn(db_path)
+    try:
+        _init_media_with_conn(conn)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def _init_media_with_conn(conn: sqlite3.Connection) -> None:
+    """Run schema DDL on an existing connection. Caller owns conn lifetime.
+
+    All DDL is ``IF NOT EXISTS``, and ``BeamMemory.__init__`` runs on every
+    open, so existing banks acquire these tables on next open with no migration
+    module — exactly how ``canonical_facts`` reached existing databases.
+    """
+    cursor = conn.cursor()
+
+    # No BLOB column anywhere in this table, and that is load-bearing: the
+    # brain stores references and text, never media bytes (RFC 0004 invariant 3).
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS media_assets (
+            asset_id                TEXT PRIMARY KEY,
+            content_hash            TEXT,
+            ref_kind                TEXT NOT NULL,
+            ref_value               TEXT NOT NULL,
+            modality                TEXT NOT NULL,
+            mime                    TEXT,
+            byte_size               INTEGER,
+            duration_ms             INTEGER,
+            width                   INTEGER,
+            height                  INTEGER,
+            page_count              INTEGER,
+            title                   TEXT,
+            source                  TEXT,
+            session_id              TEXT,
+            scope                   TEXT,
+            captured_at             TEXT,
+            captured_at_precision   TEXT DEFAULT 'unknown',
+            understanding_status    TEXT DEFAULT 'pending',
+            provider                TEXT,
+            provider_model          TEXT,
+            archive_locator         TEXT,
+            metadata                TEXT DEFAULT '{}',
+            created_at              TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    # Identity is the reference...
+    cursor.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_media_ref "
+        "ON media_assets(ref_kind, ref_value)"
+    )
+    # ...and, when the bytes have been seen, the bytes. A PARTIAL unique index
+    # (the canonical.py:131-132 trick) is what lets many assets share a NULL
+    # content_hash — reference-only assets whose bytes were never fetched —
+    # while any *known* hash stays unique.
+    cursor.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_media_hash "
+        "ON media_assets(content_hash) WHERE content_hash IS NOT NULL"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_media_modality ON media_assets(modality)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_media_session "
+        "ON media_assets(session_id, created_at)"
+    )
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS media_moments (
+            moment_id       TEXT PRIMARY KEY,
+            asset_id        TEXT NOT NULL,
+            memory_id       TEXT,
+            kind            TEXT NOT NULL,
+            text            TEXT NOT NULL,
+            span_kind       TEXT NOT NULL,
+            t_start_ms      INTEGER,
+            t_end_ms        INTEGER,
+            page_start      INTEGER,
+            page_end        INTEGER,
+            char_start      INTEGER,
+            char_end        INTEGER,
+            bbox            TEXT,
+            speaker         TEXT,
+            confidence      REAL DEFAULT 1.0,
+            ordinal         INTEGER,
+            span_key        TEXT NOT NULL,
+            provider        TEXT,
+            provider_model  TEXT,
+            created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_moment_asset ON media_moments(asset_id, ordinal)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_moment_time ON media_moments(asset_id, t_start_ms)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_moment_memory ON media_moments(memory_id)"
+    )
+    # The idempotency contract. Paired with INSERT OR IGNORE, this is what makes
+    # re-ingest and archive re-push no-ops instead of duplicates. Same posture
+    # as AnnotationStore's (memory_id, kind, value) unique index from #538.
+    cursor.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_moment_span "
+        "ON media_moments(asset_id, kind, span_key)"
+    )
+
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Pure functions: reference normalization and asset identity
+# ---------------------------------------------------------------------------
+
+def normalize_ref(ref_kind: str, ref_value: str) -> Tuple[str, str]:
+    """Canonicalize a media reference to its ``(ref_kind, ref_value)`` form.
+
+    Normalization is deliberately conservative — it only folds differences that
+    are *definitionally* insignificant, because anything more aggressive would
+    make two genuinely different references collide on one ``asset_id``:
+
+    - ``ref_kind`` is stripped and lower-cased, and must be in :data:`REF_KINDS`.
+    - Hex digests (``sha256``, ``blob``) are lower-cased.
+    - URLs get a lower-cased scheme and host; path, query, and fragment are
+      left exactly as given. ``#t=90`` is meaningful for media and is kept.
+    - ``file`` paths are only stripped — POSIX paths are case-sensitive, and
+      the filesystem is never touched (no ``resolve()``, no ``stat()``).
+
+    Raises ``ValueError`` on an unknown kind or an empty value.
+    """
+    kind = str(ref_kind or "").strip().lower()
+    if kind not in REF_KINDS:
+        raise ValueError(
+            f"unknown ref_kind {ref_kind!r}; expected one of {sorted(REF_KINDS)}"
+        )
+
+    value = str(ref_value or "").strip()
+    if not value:
+        raise ValueError(f"ref_value must be a non-empty string for ref_kind={kind!r}")
+
+    if kind in {"sha256", "blob"}:
+        value = value.lower()
+    elif kind == "url":
+        parts = urlsplit(value)
+        if parts.scheme or parts.netloc:
+            value = urlunsplit((
+                parts.scheme.lower(),
+                parts.netloc.lower(),
+                parts.path,
+                parts.query,
+                parts.fragment,
+            ))
+
+    return kind, value
+
+
+def compute_asset_id(
+    ref_kind: str,
+    ref_value: str,
+    content_hash: Optional[str] = None,
+) -> str:
+    """Return the deterministic ``asset_id`` for a reference.
+
+    ``sha256:<hash>`` when the bytes were seen at first registration, otherwise
+    ``ref:<sha256(ref_kind + "\\x1f" + normalized_ref_value)>``. Determinism is
+    what makes re-ingest and archive re-push idempotent without a lookup round
+    trip.
+
+    Two rules the first draft of RFC 0003 omitted, both load-bearing:
+
+    1. **``ref_kind`` is inside the digest.** Uniqueness is ``(ref_kind,
+       ref_value)``, so the same value under two kinds is two legal rows —
+       hashing the value alone would collide them on the PRIMARY KEY.
+    2. **The id is assigned at first registration and never rewritten.** An
+       asset first seen by reference and later by bytes keeps its ``ref:`` id;
+       the hash arriving late fills in ``content_hash`` via UPDATE. Recomputing
+       would orphan every moment already written against the old id. This
+       function is therefore only ever called for a *first* registration —
+       :meth:`MediaStore.upsert_asset` looks up before it computes.
+    """
+    kind, value = normalize_ref(ref_kind, ref_value)
+    if content_hash:
+        return f"sha256:{str(content_hash).strip().lower()}"
+    digest = hashlib.sha256(f"{kind}\x1f{value}".encode("utf-8")).hexdigest()
+    return f"ref:{digest}"
+
+
+def compute_moment_id(asset_id: str, kind: str, span_key_value: str) -> str:
+    """Deterministic ``moment_id`` derived from the same triple as the unique
+    index, so the PRIMARY KEY and ``idx_moment_span`` can never disagree about
+    whether a moment is a duplicate."""
+    digest = hashlib.sha256(
+        f"{asset_id}\x1f{kind}\x1f{span_key_value}".encode("utf-8")
+    ).hexdigest()
+    return f"m:{digest[:32]}"
+
+
+# ---------------------------------------------------------------------------
+# Pure functions: span identity
+# ---------------------------------------------------------------------------
+
+def _as_int(value: Any) -> int:
+    """``int()`` that rejects ``bool``.
+
+    Without this, ``True`` renders as ``1`` and a boolean passed where an
+    offset belongs produces a plausible-looking key for a nonsense span.
+    """
+    if isinstance(value, bool):
+        raise TypeError("bool is not a valid span offset")
+    return int(value)
+
+
+def _parse_bbox(value: Any) -> List[float]:
+    """Coerce a bbox to exactly four floats. Accepts a sequence or its JSON
+    string form (the column is TEXT, so both shapes reach us in practice)."""
+    raw = value
+    if isinstance(raw, (str, bytes)):
+        raw = json.loads(raw)
+    if isinstance(raw, (str, bytes)) or not isinstance(raw, Sequence):
+        raise TypeError(f"bbox must be a sequence of four numbers, got {type(value)!r}")
+    if len(raw) != 4:
+        raise ValueError(f"bbox must have exactly four values, got {len(raw)}")
+    out: List[float] = []
+    for v in raw:
+        if isinstance(v, bool):
+            raise TypeError("bool is not a valid bbox coordinate")
+        f = float(v)
+        if f != f or f in (float("inf"), float("-inf")):
+            raise ValueError("bbox coordinates must be finite")
+        out.append(f)
+    return out
+
+
+def _digest_payload(values: Any) -> str:
+    """Total fallback payload for anything that cannot be rendered in the
+    canonical form. Keeps :func:`span_key` from ever raising — a span with a
+    weird shape still gets a stable, collision-resistant identity."""
+    try:
+        blob = json.dumps(values, sort_keys=True, default=str)
+    except Exception:
+        blob = repr(values)
+    return "h" + hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+def _speaker_slug(speaker: Optional[str]) -> str:
+    """Whitespace-collapsed, case-folded, truncated to 64 chars. Empty in,
+    empty out — an all-whitespace speaker is the same as no speaker."""
+    if speaker is None:
+        return ""
+    return " ".join(str(speaker).split()).casefold()[:_SPEAKER_MAX_LEN]
+
+
+def span_key(
+    span_kind: str,
+    *,
+    t_start_ms: Optional[int] = None,
+    t_end_ms: Optional[int] = None,
+    page_start: Optional[int] = None,
+    page_end: Optional[int] = None,
+    char_start: Optional[int] = None,
+    char_end: Optional[int] = None,
+    bbox: Any = None,
+    speaker: Optional[str] = None,
+) -> str:
+    """Return the canonical **span identity** string for a moment.
+
+    Format, normative::
+
+        span_key := "v1:" <span_kind> [ ":" <payload> ] [ ":spk=" <speaker-slug> ]
+
+    ==============  ===========================================  ==========================================
+    ``span_kind``   payload                                      example
+    ==============  ===========================================  ==========================================
+    ``whole``       omitted                                      ``v1:whole``
+    ``time``        ``{t_start_ms}-{t_end_ms or "na"}``          ``v1:time:90000-96000``
+    ``page``        ``{page_start}-{page_end or page_start}``    ``v1:page:3-3``
+    ``char``        ``{char_start}-{char_end}``                  ``v1:char:0-512``
+    ``box``         four floats, ``f"{v:.6f}"``, comma-joined    ``v1:box:0.100000,0.200000,0.300000,0.400000``
+    ==============  ===========================================  ==========================================
+
+    Three rules that are not cosmetic:
+
+    - **The ``v1:`` prefix is mandatory.** Without a version tag a future format
+      change silently produces both old- and new-form rows for the same span,
+      and the unique index cannot tell them apart. With it, the duplication is
+      greppable and a rewrite migration can scope itself.
+    - **``speaker`` is part of the identity, appended last.** RFC 0003 §2.3 puts
+      a diarized audio segment at ``span_kind='time'`` *with* a speaker, so two
+      speakers over one window would otherwise produce identical keys and
+      ``INSERT OR IGNORE`` would drop the second — silently, and precisely in
+      the case diarization exists to handle. Appending last keeps rows without a
+      speaker byte-identical to the pre-correction format.
+    - **This function is total.** It never raises. Anything unrenderable falls
+      back to a ``h<digest>`` payload, so a malformed span still gets a stable
+      identity instead of aborting a batch. Rejecting bad input is
+      :func:`validate_span`'s job, not this one's.
+    """
+    kind = str(span_kind or "").strip().lower()
+
+    try:
+        if kind == "whole":
+            payload = None
+        elif kind == "time":
+            start = _as_int(t_start_ms)
+            end = "na" if t_end_ms is None else str(_as_int(t_end_ms))
+            payload = f"{start}-{end}"
+        elif kind == "page":
+            start = _as_int(page_start)
+            end = start if page_end is None else _as_int(page_end)
+            payload = f"{start}-{end}"
+        elif kind == "char":
+            payload = f"{_as_int(char_start)}-{_as_int(char_end)}"
+        elif kind == "box":
+            # Never str(); it is repr- and locale-sensitive.
+            payload = ",".join(f"{v:.6f}" for v in _parse_bbox(bbox))
+        else:
+            payload = _digest_payload({
+                "span_kind": span_kind,
+                "t_start_ms": t_start_ms, "t_end_ms": t_end_ms,
+                "page_start": page_start, "page_end": page_end,
+                "char_start": char_start, "char_end": char_end,
+                "bbox": bbox,
+            })
+    except Exception:
+        payload = _digest_payload({
+            "span_kind": span_kind,
+            "t_start_ms": t_start_ms, "t_end_ms": t_end_ms,
+            "page_start": page_start, "page_end": page_end,
+            "char_start": char_start, "char_end": char_end,
+            "bbox": bbox,
+        })
+
+    key = f"{SPAN_KEY_VERSION}:{kind}" if payload is None else f"{SPAN_KEY_VERSION}:{kind}:{payload}"
+
+    slug = _speaker_slug(speaker)
+    if slug:
+        key = f"{key}:spk={slug}"
+    return key
+
+
+def validate_span(
+    span_kind: str,
+    values: Dict[str, Any],
+    speaker: Optional[str] = None,
+) -> None:
+    """Raise ``ValueError``/``TypeError`` if a span is not writable.
+
+    SQLite gives no guarantee that a ``time`` moment has ``t_start_ms``
+    populated (RFC 0003 §2.3 accepts this), so the guarantee lives here,
+    consistent with the application-layer integrity posture in §1.6.
+
+    The strict rule worth naming: **columns foreign to the span kind must be
+    ``None``.** A ``time`` moment that also carries ``page_start`` produces a
+    ``span_key`` blind to the page, so two such moments differing only by page
+    collapse to one key and the second is silently dropped by ``INSERT OR
+    IGNORE``. Rejecting is the only option that is not lossy.
+    """
+    kind = str(span_kind or "").strip().lower()
+    if kind not in SPAN_KINDS:
+        raise ValueError(
+            f"unknown span_kind {span_kind!r}; expected one of {sorted(SPAN_KINDS)}"
+        )
+
+    owned = set(_SPAN_COLUMNS[kind])
+    foreign = [
+        col for col in _ALL_SPAN_COLUMNS
+        if col not in owned and values.get(col) is not None
+    ]
+    if foreign:
+        raise ValueError(
+            f"span_kind={kind!r} does not own {sorted(foreign)}; "
+            "a span carrying foreign columns yields a span_key blind to them, "
+            "so near-duplicate moments would be silently dropped. Clear them "
+            "or use the matching span_kind."
+        )
+
+    for col in _REQUIRED_SPAN_COLUMNS[kind]:
+        if values.get(col) is None:
+            raise ValueError(f"span_kind={kind!r} requires {col!r}")
+
+    if kind == "time":
+        start = _as_int(values["t_start_ms"])
+        if start < 0:
+            raise ValueError("t_start_ms must be >= 0")
+        if values.get("t_end_ms") is not None:
+            end = _as_int(values["t_end_ms"])
+            if end < start:
+                raise ValueError(f"t_end_ms ({end}) precedes t_start_ms ({start})")
+    elif kind == "page":
+        start = _as_int(values["page_start"])
+        if start < 0:
+            raise ValueError("page_start must be >= 0")
+        if values.get("page_end") is not None:
+            end = _as_int(values["page_end"])
+            if end < start:
+                raise ValueError(f"page_end ({end}) precedes page_start ({start})")
+    elif kind == "char":
+        start = _as_int(values["char_start"])
+        end = _as_int(values["char_end"])
+        if start < 0:
+            raise ValueError("char_start must be >= 0")
+        if end < start:
+            raise ValueError(f"char_end ({end}) precedes char_start ({start})")
+    elif kind == "box":
+        coords = _parse_bbox(values["bbox"])
+        if any(c < 0.0 or c > 1.0 for c in coords):
+            raise ValueError(f"bbox coordinates must be normalized to [0, 1], got {coords}")
+
+    # RFC 0003 §2.3 gives `speaker` to time spans only. Permitting it elsewhere
+    # would put a speaker in the span_key of a span that has no time axis to
+    # attach it to.
+    if _speaker_slug(speaker) and kind != "time":
+        raise ValueError(f"speaker is only valid on span_kind='time', not {kind!r}")
+
+
+# ---------------------------------------------------------------------------
+# Drafts and results
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MomentDraft:
+    """An unwritten moment. Providers produce these; :meth:`MediaStore.add_moments`
+    validates and writes them."""
+
+    kind: str
+    text: str
+    span_kind: str = "whole"
+    t_start_ms: Optional[int] = None
+    t_end_ms: Optional[int] = None
+    page_start: Optional[int] = None
+    page_end: Optional[int] = None
+    char_start: Optional[int] = None
+    char_end: Optional[int] = None
+    bbox: Any = None
+    speaker: Optional[str] = None
+    confidence: float = 1.0
+    ordinal: Optional[int] = None
+    memory_id: Optional[str] = None
+    provider: Optional[str] = None
+    provider_model: Optional[str] = None
+
+    def span_values(self) -> Dict[str, Any]:
+        return {col: getattr(self, col) for col in _ALL_SPAN_COLUMNS}
+
+    def span_key(self) -> str:
+        return span_key(
+            self.span_kind,
+            t_start_ms=self.t_start_ms,
+            t_end_ms=self.t_end_ms,
+            page_start=self.page_start,
+            page_end=self.page_end,
+            char_start=self.char_start,
+            char_end=self.char_end,
+            bbox=self.bbox,
+            speaker=self.speaker,
+        )
+
+
+@dataclass(frozen=True)
+class AssetUpsert:
+    """Result of :meth:`MediaStore.upsert_asset`.
+
+    ``status`` is one of:
+
+    - ``created``  — a new asset row
+    - ``updated``  — an existing row matched by reference and gained new detail
+    - ``unchanged``— an existing row matched by reference, nothing to add
+    - ``aliased``  — an existing row matched by *content hash* under a different
+      reference; the new reference was recorded in ``metadata.alt_refs``
+    """
+
+    asset_id: str
+    status: str
+
+
+@dataclass(frozen=True)
+class MomentWriteResult:
+    """Result of :meth:`MediaStore.add_moments`."""
+
+    inserted: int = 0
+    #: Moments whose (kind, span_key) already existed for this asset. A repeat
+    #: ingest lands entirely here — that is the idempotency contract working.
+    duplicate: int = 0
+    #: Moments written with memory_id NULL because the referenced
+    #: working_memory row was gone. Legitimate: eviction and consolidation both
+    #: happen between drafting and insert.
+    unbound: int = 0
+    moment_ids: List[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+_ASSET_DETAIL_COLUMNS: Tuple[str, ...] = (
+    "content_hash", "mime", "byte_size", "duration_ms", "width", "height",
+    "page_count", "title", "source", "session_id", "scope", "captured_at",
+    "captured_at_precision", "provider", "provider_model", "archive_locator",
+)
+
+
+class MediaStore:
+    """Handle over ``media_assets`` and ``media_moments``.
+
+    Example::
+
+        >>> store = MediaStore(db_path=path)
+        >>> up = store.upsert_asset(ref_kind="file", ref_value="/tmp/a.png",
+        ...                         modality="image")
+        >>> store.add_moments(up.asset_id, [
+        ...     MomentDraft(kind="caption", text="a terminal window",
+        ...                 span_kind="whole"),
+        ... ]).inserted
+        1
+    """
+
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        conn: Optional[sqlite3.Connection] = None,
+    ):
+        """When ``conn`` is provided the store reuses it — this is how
+        ``BeamMemory`` shares its thread-local connection, avoiding a per-call
+        file-descriptor cost. The caller owns that connection's lifetime.
+        When ``conn`` is None the store opens its own."""
+        self.db_path = db_path or _default_db_path()
+        if conn is not None:
+            self.conn = conn
+            _init_media_with_conn(conn)
+        else:
+            init_media(self.db_path)
+            self.conn = _get_conn(self.db_path)
+
+    # ------------------------------------------------------------------
+    # Assets
+    # ------------------------------------------------------------------
+
+    def upsert_asset(
+        self,
+        *,
+        ref_kind: str,
+        ref_value: str,
+        modality: str,
+        content_hash: Optional[str] = None,
+        mime: Optional[str] = None,
+        byte_size: Optional[int] = None,
+        duration_ms: Optional[int] = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        page_count: Optional[int] = None,
+        title: Optional[str] = None,
+        source: Optional[str] = None,
+        session_id: Optional[str] = None,
+        scope: Optional[str] = None,
+        captured_at: Optional[str] = None,
+        captured_at_precision: str = "unknown",
+        understanding_status: str = "pending",
+        provider: Optional[str] = None,
+        provider_model: Optional[str] = None,
+        archive_locator: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> AssetUpsert:
+        """Register (or re-register) a media asset. Idempotent.
+
+        Resolution order, which is also the reason ``compute_asset_id`` is only
+        ever reached for a genuinely new asset:
+
+        1. **By reference.** ``(ref_kind, ref_value)`` already present → return
+           that ``asset_id`` and fill in any detail column that is currently
+           NULL. **Existing non-NULL values are never overwritten**, so a
+           re-registration cannot downgrade what we already know.
+        2. **By content hash.** A different reference resolving to the same
+           known bytes → return the existing ``asset_id`` and record the new
+           reference under ``metadata.alt_refs``. One file reachable by both a
+           URL and a local path is one asset, not two, and certainly not an
+           ``IntegrityError``.
+        3. **New row**, with a deterministic id.
+
+        ``asset_id`` is assigned once and never rewritten. A ``content_hash``
+        arriving later fills the column via UPDATE and leaves the id alone —
+        rewriting it would orphan every moment already bound to the asset.
+        """
+        kind, value = normalize_ref(ref_kind, ref_value)
+
+        modality_norm = str(modality or "").strip().lower()
+        if modality_norm not in MODALITIES:
+            raise ValueError(
+                f"unknown modality {modality!r}; expected one of {sorted(MODALITIES)}"
+            )
+
+        status_norm = str(understanding_status or "pending").strip().lower()
+        if status_norm not in UNDERSTANDING_STATUSES:
+            raise ValueError(
+                f"unknown understanding_status {understanding_status!r}; "
+                f"expected one of {sorted(UNDERSTANDING_STATUSES)}"
+            )
+
+        hash_norm = str(content_hash).strip().lower() if content_hash else None
+
+        detail = {
+            "content_hash": hash_norm,
+            "mime": mime,
+            "byte_size": byte_size,
+            "duration_ms": duration_ms,
+            "width": width,
+            "height": height,
+            "page_count": page_count,
+            "title": title,
+            "source": source,
+            "session_id": session_id,
+            "scope": scope,
+            "captured_at": captured_at,
+            "captured_at_precision": captured_at_precision,
+            "provider": provider,
+            "provider_model": provider_model,
+            "archive_locator": archive_locator,
+        }
+
+        cursor = self.conn.cursor()
+
+        # (1) Known reference.
+        row = cursor.execute(
+            "SELECT * FROM media_assets WHERE ref_kind = ? AND ref_value = ?",
+            (kind, value),
+        ).fetchone()
+        if row is not None:
+            changed = self._fill_asset_detail(row, detail)
+            return AssetUpsert(asset_id=row["asset_id"],
+                               status="updated" if changed else "unchanged")
+
+        # (2) Known bytes under a new reference.
+        if hash_norm:
+            row = cursor.execute(
+                "SELECT * FROM media_assets WHERE content_hash = ?", (hash_norm,)
+            ).fetchone()
+            if row is not None:
+                self._record_alt_ref(row, kind, value)
+                self._fill_asset_detail(row, detail)
+                return AssetUpsert(asset_id=row["asset_id"], status="aliased")
+
+        # (3) New asset.
+        asset_id = compute_asset_id(kind, value, hash_norm)
+        meta_json = json.dumps(metadata or {}, default=str)
+        cursor.execute(
+            """
+            INSERT INTO media_assets (
+                asset_id, content_hash, ref_kind, ref_value, modality, mime,
+                byte_size, duration_ms, width, height, page_count, title,
+                source, session_id, scope, captured_at, captured_at_precision,
+                understanding_status, provider, provider_model, archive_locator,
+                metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                asset_id, hash_norm, kind, value, modality_norm, mime,
+                byte_size, duration_ms, width, height, page_count, title,
+                source, session_id, scope, captured_at, captured_at_precision,
+                status_norm, provider, provider_model, archive_locator,
+                meta_json,
+            ),
+        )
+        self.conn.commit()
+        return AssetUpsert(asset_id=asset_id, status="created")
+
+    def _fill_asset_detail(self, row: sqlite3.Row, detail: Dict[str, Any]) -> bool:
+        """Fill NULL detail columns on an existing asset. Returns whether
+        anything changed. Non-NULL values are left alone: a second sighting of
+        an asset can add knowledge but must never remove it."""
+        updates = {
+            col: val for col, val in detail.items()
+            if val is not None and col in _ASSET_DETAIL_COLUMNS and row[col] is None
+        }
+        # 'unknown' is the column default, not real information.
+        if updates.get("captured_at_precision") == "unknown":
+            updates.pop("captured_at_precision", None)
+        if not updates:
+            return False
+        assignments = ", ".join(f"{col} = ?" for col in updates)
+        self.conn.execute(
+            f"UPDATE media_assets SET {assignments} WHERE asset_id = ?",
+            (*updates.values(), row["asset_id"]),
+        )
+        self.conn.commit()
+        return True
+
+    def _record_alt_ref(self, row: sqlite3.Row, kind: str, value: str) -> None:
+        """Append a second reference to the same bytes under
+        ``metadata.alt_refs``, deduped."""
+        try:
+            meta = json.loads(row["metadata"] or "{}")
+            if not isinstance(meta, dict):
+                meta = {}
+        except Exception:
+            meta = {}
+        alts = meta.get("alt_refs")
+        if not isinstance(alts, list):
+            alts = []
+        entry = {"ref_kind": kind, "ref_value": value}
+        if entry not in alts:
+            alts.append(entry)
+        meta["alt_refs"] = alts
+        self.conn.execute(
+            "UPDATE media_assets SET metadata = ? WHERE asset_id = ?",
+            (json.dumps(meta, default=str), row["asset_id"]),
+        )
+        self.conn.commit()
+
+    def get_asset(self, asset_id: str) -> Optional[Dict[str, Any]]:
+        row = self.conn.execute(
+            "SELECT * FROM media_assets WHERE asset_id = ?", (asset_id,)
+        ).fetchone()
+        return dict(row) if row else None
+
+    def find_asset_by_ref(self, ref_kind: str, ref_value: str) -> Optional[Dict[str, Any]]:
+        kind, value = normalize_ref(ref_kind, ref_value)
+        row = self.conn.execute(
+            "SELECT * FROM media_assets WHERE ref_kind = ? AND ref_value = ?",
+            (kind, value),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def set_understanding_status(
+        self,
+        asset_id: str,
+        status: str,
+        *,
+        provider: Optional[str] = None,
+        provider_model: Optional[str] = None,
+    ) -> bool:
+        """Move an asset along the degradation ladder. Returns whether a row
+        was updated."""
+        status_norm = str(status or "").strip().lower()
+        if status_norm not in UNDERSTANDING_STATUSES:
+            raise ValueError(
+                f"unknown understanding_status {status!r}; "
+                f"expected one of {sorted(UNDERSTANDING_STATUSES)}"
+            )
+        assignments = ["understanding_status = ?"]
+        params: List[Any] = [status_norm]
+        if provider is not None:
+            assignments.append("provider = ?")
+            params.append(provider)
+        if provider_model is not None:
+            assignments.append("provider_model = ?")
+            params.append(provider_model)
+        params.append(asset_id)
+        cursor = self.conn.execute(
+            f"UPDATE media_assets SET {', '.join(assignments)} WHERE asset_id = ?",
+            tuple(params),
+        )
+        self.conn.commit()
+        return cursor.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Moments
+    # ------------------------------------------------------------------
+
+    def add_moments(
+        self,
+        asset_id: str,
+        drafts: Sequence[MomentDraft],
+    ) -> MomentWriteResult:
+        """Write moments for an asset. Idempotent, all-or-nothing on validation.
+
+        **Everything is validated before anything is written.** A batch with one
+        bad draft writes zero rows and raises, rather than leaving a partial
+        span index behind that nothing knows is partial.
+
+        Three checks that are not obvious:
+
+        - *Foreign span columns are rejected*, not dropped — see
+          :func:`validate_span`.
+        - *Intra-batch duplicates are rejected*, naming both indices. Two drafts
+          with the same ``(kind, span_key)`` would otherwise have the second
+          silently swallowed by ``INSERT OR IGNORE``, which is right for a
+          *repeat ingest* and wrong for a *single batch* that believes it is
+          writing two distinct moments.
+        - *A ``memory_id`` with no live ``working_memory`` row is set NULL and
+          counted, not raised.* Eviction (``_trim_working_memory``) and
+          consolidation both legitimately remove the row between drafting and
+          insert, and ``media_moments.text`` remains authoritative either way.
+
+        Raises ``ValueError`` if the asset does not exist — a moment on a
+        non-existent asset is the one orphan kind that is real corruption.
+        """
+        if not drafts:
+            return MomentWriteResult()
+
+        if self.get_asset(asset_id) is None:
+            raise ValueError(
+                f"no media_assets row for asset_id={asset_id!r}; "
+                "register the asset before writing moments"
+            )
+
+        prepared: List[Tuple[MomentDraft, str, str]] = []
+        seen: Dict[Tuple[str, str], int] = {}
+
+        for index, draft in enumerate(drafts):
+            kind = str(draft.kind or "").strip().lower()
+            if kind not in MOMENT_KINDS:
+                raise ValueError(
+                    f"drafts[{index}]: unknown kind {draft.kind!r}; "
+                    f"expected one of {sorted(MOMENT_KINDS)}"
+                )
+            text = str(draft.text or "").strip()
+            if not text:
+                raise ValueError(f"drafts[{index}]: text must be a non-empty string")
+
+            try:
+                validate_span(draft.span_kind, draft.span_values(), draft.speaker)
+            except (ValueError, TypeError) as exc:
+                raise type(exc)(f"drafts[{index}]: {exc}") from exc
+
+            key = draft.span_key()
+            if (kind, key) in seen:
+                raise ValueError(
+                    f"drafts[{index}] duplicates drafts[{seen[(kind, key)]}]: "
+                    f"both resolve to kind={kind!r} span_key={key!r}. "
+                    "The unique index would silently drop the second; "
+                    "deduplicate the batch or give them distinct spans."
+                )
+            seen[(kind, key)] = index
+            prepared.append((draft, kind, key))
+
+        result_ids: List[str] = []
+        inserted = duplicate = unbound = 0
+        cursor = self.conn.cursor()
+
+        for draft, kind, key in prepared:
+            moment_id = compute_moment_id(asset_id, kind, key)
+            memory_id = draft.memory_id
+            if memory_id is not None and not self._memory_exists(memory_id):
+                memory_id = None
+                unbound += 1
+
+            bbox_text = None
+            if draft.bbox is not None:
+                bbox_text = json.dumps(
+                    [float(f"{v:.6f}") for v in _parse_bbox(draft.bbox)]
+                )
+
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO media_moments (
+                    moment_id, asset_id, memory_id, kind, text, span_kind,
+                    t_start_ms, t_end_ms, page_start, page_end,
+                    char_start, char_end, bbox, speaker, confidence, ordinal,
+                    span_key, provider, provider_model
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    moment_id, asset_id, memory_id, kind, draft.text,
+                    str(draft.span_kind).strip().lower(),
+                    draft.t_start_ms, draft.t_end_ms,
+                    draft.page_start, draft.page_end,
+                    draft.char_start, draft.char_end,
+                    bbox_text, draft.speaker, draft.confidence, draft.ordinal,
+                    key, draft.provider, draft.provider_model,
+                ),
+            )
+            if cursor.rowcount > 0:
+                inserted += 1
+            else:
+                duplicate += 1
+            result_ids.append(moment_id)
+
+        self.conn.commit()
+        return MomentWriteResult(
+            inserted=inserted,
+            duplicate=duplicate,
+            unbound=unbound,
+            moment_ids=result_ids,
+        )
+
+    def bind_moment_memory(self, moment_id: str, memory_id: str) -> bool:
+        """Bind a moment to its memory row, guarded by existence rather than an
+        FK (issue #503). Returns whether the binding was written.
+
+        This is the second half of the two-step ingest ordering: the moment row
+        is written first, then the memory row, then this. A crash between them
+        leaves a recoverable unbound moment that ``doctor`` counts; the reverse
+        order would leak a memory row nothing can trace back.
+        """
+        if not self._memory_exists(memory_id):
+            return False
+        cursor = self.conn.execute(
+            "UPDATE media_moments SET memory_id = ? WHERE moment_id = ?",
+            (memory_id, moment_id),
+        )
+        self.conn.commit()
+        return cursor.rowcount > 0
+
+    def get_moments(
+        self,
+        asset_id: str,
+        kind: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        sql = "SELECT * FROM media_moments WHERE asset_id = ?"
+        params: List[Any] = [asset_id]
+        if kind:
+            sql += " AND kind = ?"
+            params.append(str(kind).strip().lower())
+        sql += " ORDER BY ordinal IS NULL, ordinal, t_start_ms, moment_id"
+        return [dict(r) for r in self.conn.execute(sql, tuple(params)).fetchall()]
+
+    def moments_for_memory(self, memory_id: str) -> List[Dict[str, Any]]:
+        rows = self.conn.execute(
+            "SELECT * FROM media_moments WHERE memory_id = ?", (memory_id,)
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Integrity
+    # ------------------------------------------------------------------
+
+    def count_orphans(self) -> Dict[str, int]:
+        """Count both orphan kinds. **They are different health states.**
+
+        ``asset_orphans`` — a moment whose asset is gone. Real corruption;
+        nothing in the design should ever produce it.
+
+        ``memory_orphans`` — a moment whose memory row no longer resolves. The
+        *expected steady state*: consolidation summarizes the memory row away
+        and ``media_moments.text`` remains authoritative, and working memory is
+        trimmed on a cap. Reporting these as a problem would make the check cry
+        wolf at every healthy media user after their first ``sleep()``, which
+        trains people to ignore the check that catches the real corruption.
+        """
+        asset_orphans = self.conn.execute(
+            "SELECT COUNT(*) FROM media_moments m "
+            "WHERE NOT EXISTS (SELECT 1 FROM media_assets a WHERE a.asset_id = m.asset_id)"
+        ).fetchone()[0]
+
+        memory_orphans = 0
+        if self._has_table("working_memory"):
+            memory_orphans = self.conn.execute(
+                "SELECT COUNT(*) FROM media_moments m WHERE m.memory_id IS NOT NULL "
+                "AND NOT EXISTS (SELECT 1 FROM working_memory w WHERE w.id = m.memory_id)"
+            ).fetchone()[0]
+
+        return {"asset_orphans": asset_orphans, "memory_orphans": memory_orphans}
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _has_table(self, name: str) -> bool:
+        row = self.conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)
+        ).fetchone()
+        return row is not None
+
+    def _memory_exists(self, memory_id: str) -> bool:
+        """Existence guard in place of an FK.
+
+        When ``working_memory`` is absent entirely — a standalone MediaStore on
+        a database that is not a Beam bank — the binding cannot be verified, so
+        it is preserved as given rather than silently nulled. ``doctor`` will
+        count it if it is genuinely dangling.
+        """
+        if not self._has_table("working_memory"):
+            return True
+        row = self.conn.execute(
+            "SELECT 1 FROM working_memory WHERE id = ?", (memory_id,)
+        ).fetchone()
+        return row is not None

--- a/mnemosyne/doctor.py
+++ b/mnemosyne/doctor.py
@@ -85,6 +85,11 @@ _DOCTOR_TABLE_COLUMNS: dict[str, frozenset[str]] = {
     "graph_edges": frozenset({"source", "target"}),
     "canonical_facts": frozenset({"owner_id", "category", "name", "valid_until"}),
     "triples": frozenset({"valid_from", "valid_until"}),
+    # Media sidecars (RFC 0003). Only the two reference columns are approved --
+    # `text`, `speaker`, and the span columns are user content and must never
+    # reach a metric.
+    "media_assets": frozenset({"asset_id"}),
+    "media_moments": frozenset({"asset_id", "memory_id"}),
 }
 _DOCTOR_TABLES = tuple(_DOCTOR_TABLE_COLUMNS)
 
@@ -1300,6 +1305,7 @@ class ReferenceContractRegistry:
                 "episodic_memory",
                 "canonical_facts",
                 "triples",
+                "media_moments",
             )
         }
 
@@ -1405,7 +1411,79 @@ class ReferenceContractRegistry:
             findings,
         )
         self._inspect_unverifiable_stores(catalog, metrics)
+        self._inspect_media(catalog, live_union, metrics, findings)
         return AdapterResult(metrics=metrics, findings=findings, repair_candidates=candidates)
+
+    def _inspect_media(
+        self,
+        catalog: _CatalogResult,
+        live_union: str,
+        metrics: dict[str, Any],
+        findings: list[Finding],
+    ) -> None:
+        """Count both media orphan kinds; warn about only one of them.
+
+        A moment whose ``asset_id`` has no asset is real corruption — nothing in
+        RFC 0003 should ever produce it — so it gets a Finding.
+
+        A moment whose ``memory_id`` no longer resolves is the *expected* steady
+        state: consolidation summarizes the memory row away and
+        ``media_moments.text`` stays authoritative, and working memory is
+        trimmed on a cap. Warning about those would make this check cry wolf at
+        every healthy media user after their first ``sleep()``, which trains
+        people to ignore the half of it that catches the real corruption.
+
+        This runs on the read-only doctor connection, so the tables-absent case
+        must take the ``not_configured`` branch and never attempt DDL.
+        """
+        empty = {"status": "not_configured", "asset_orphans": 0, "memory_orphans": 0}
+        if not {"media_moments", "media_assets"}.issubset(catalog.tables):
+            metrics["media_moments"] = empty
+            return
+        columns = _table_columns(self.conn, "media_moments", self.scan_limit)
+        if columns.error_class:
+            metrics["media_moments"] = {"status": STATUS_UNKNOWN, "error_class": columns.error_class}
+            return
+        required = {"asset_id", "memory_id"}
+        if not required.issubset(columns.columns):
+            metrics["media_moments"] = (
+                {"status": STATUS_UNKNOWN, "columns_truncated": True}
+                if columns.truncated else empty
+            )
+            return
+
+        asset_orphans = _bounded_count(
+            self.conn,
+            "SELECT 1 FROM media_moments m WHERE NOT EXISTS "
+            "(SELECT 1 FROM media_assets a WHERE a.asset_id = m.asset_id)",
+            self.scan_limit,
+        )
+        if live_union:
+            memory_orphans = _bounded_count(
+                self.conn,
+                "SELECT 1 FROM media_moments m WHERE m.memory_id IS NOT NULL "
+                f"AND m.memory_id NOT IN ({live_union})",
+                self.scan_limit,
+            )
+            status = "checked"
+        else:
+            memory_orphans = _BoundedCount(value=0)
+            status = "unverifiable_contract"
+
+        metrics["media_moments"] = _with_counts(
+            status, {"asset_orphans": asset_orphans, "memory_orphans": memory_orphans}
+        )
+        if not asset_orphans.error_class and asset_orphans.value:
+            findings.append(Finding(
+                code="references.media_moment_orphan_asset",
+                status=STATUS_WARNING,
+                severity=SEVERITY_WARNING,
+                message=(
+                    "Media moments reference assets that no longer exist. "
+                    "Moments whose memory row is gone are expected after "
+                    "consolidation and are counted without a warning."
+                ),
+            ))
 
     def _inspect_graph(
         self,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -119,7 +119,7 @@ def test_open_readonly_doctor_db_rejects_schema_and_data_writes(tmp_path):
 
 
 def test_optional_sqlite_vec_load_keeps_doctor_connection_write_protected(tmp_path):
-    sqlite_vec = pytest.importorskip("sqlite_vec")
+    pytest.importorskip("sqlite_vec")
     db_path = tmp_path / "doctor.db"
     sqlite3.connect(db_path).close()
 
@@ -716,6 +716,7 @@ def test_adapter_catalog_errors_are_unknown_and_redacted():
         "episodic_memory",
         "canonical_facts",
         "triples",
+        "media_moments",
     }
     assert all(metric == {"status": STATUS_UNKNOWN, "error_class": "database_error"} for metric in result.metrics.values())
     assert "private body" not in json.dumps(result.metrics)

--- a/tests/test_media_doctor.py
+++ b/tests/test_media_doctor.py
@@ -1,0 +1,172 @@
+"""Doctor coverage for the media sidecar tables (RFC 0003 §2.4).
+
+The load-bearing behaviour: **both orphan kinds are counted, only one warns.**
+A moment whose asset is gone is real corruption. A moment whose memory row is
+gone is the expected steady state after consolidation -- warning about those
+would make the check cry wolf at every healthy media user after their first
+``sleep()``, which trains people to ignore the half that catches real damage.
+"""
+
+import sqlite3
+
+from mnemosyne.doctor import (
+    ReferenceContractRegistry,
+    STATUS_UNKNOWN,
+    open_readonly_doctor_db,
+)
+
+_BASE_DDL = """
+CREATE TABLE working_memory (id TEXT PRIMARY KEY);
+CREATE TABLE memory_embeddings (memory_id TEXT PRIMARY KEY, embedding_json TEXT);
+CREATE TABLE media_assets (asset_id TEXT PRIMARY KEY, ref_kind TEXT, ref_value TEXT);
+CREATE TABLE media_moments (
+  moment_id TEXT PRIMARY KEY, asset_id TEXT, memory_id TEXT,
+  kind TEXT, text TEXT, span_kind TEXT, span_key TEXT
+);
+INSERT INTO working_memory VALUES ('mem-live');
+INSERT INTO media_assets VALUES ('asset-live', 'url', 'http://x/1');
+"""
+
+
+def _fixture(tmp_path, ddl):
+    db_path = tmp_path / "media-doctor.db"
+    writable = sqlite3.connect(db_path)
+    writable.executescript(ddl)
+    writable.commit()
+    writable.close()
+    return open_readonly_doctor_db(db_path)
+
+
+def _moment(moment_id, asset_id, memory_id):
+    value = "NULL" if memory_id is None else f"'{memory_id}'"
+    return (
+        f"INSERT INTO media_moments VALUES "
+        f"('{moment_id}', '{asset_id}', {value}, 'caption', 'x', 'whole', 'v1:whole');"
+    )
+
+
+def _inspect(tmp_path, ddl):
+    conn = _fixture(tmp_path, ddl)
+    try:
+        return ReferenceContractRegistry(conn).inspect()
+    finally:
+        conn.close()
+
+
+def test_absent_tables_report_not_configured(tmp_path):
+    """The doctor connection is read-only, so the tables-absent case must take
+    this branch and never attempt DDL."""
+    result = _inspect(tmp_path, "CREATE TABLE working_memory (id TEXT PRIMARY KEY);")
+    assert result.metrics["media_moments"] == {
+        "status": "not_configured", "asset_orphans": 0, "memory_orphans": 0,
+    }
+
+
+def test_a_half_present_schema_reports_not_configured(tmp_path):
+    result = _inspect(
+        tmp_path,
+        "CREATE TABLE working_memory (id TEXT PRIMARY KEY);"
+        "CREATE TABLE media_moments (moment_id TEXT PRIMARY KEY, asset_id TEXT, memory_id TEXT);",
+    )
+    assert result.metrics["media_moments"]["status"] == "not_configured"
+
+
+def test_a_healthy_media_install_is_clean(tmp_path):
+    result = _inspect(tmp_path, _BASE_DDL + _moment("m1", "asset-live", "mem-live"))
+    assert result.metrics["media_moments"] == {
+        "status": "checked", "asset_orphans": 0, "memory_orphans": 0,
+    }
+    assert [f for f in result.findings if "media" in f.code] == []
+
+
+def test_a_consolidated_memory_is_counted_without_a_warning(tmp_path):
+    """The expected steady state: media_moments.text remains authoritative
+    after sleep() summarizes the memory row away."""
+    result = _inspect(tmp_path, _BASE_DDL + _moment("m1", "asset-live", "mem-gone"))
+    assert result.metrics["media_moments"] == {
+        "status": "checked", "asset_orphans": 0, "memory_orphans": 1,
+    }
+    assert [f for f in result.findings if "media" in f.code] == [], (
+        "memory-orphans must not warn -- doing so trains users to ignore the "
+        "asset-orphan finding that catches real corruption"
+    )
+
+
+def test_an_orphaned_asset_reference_raises_a_finding(tmp_path):
+    result = _inspect(tmp_path, _BASE_DDL + _moment("m1", "asset-gone", "mem-live"))
+    assert result.metrics["media_moments"] == {
+        "status": "checked", "asset_orphans": 1, "memory_orphans": 0,
+    }
+    codes = [f.code for f in result.findings]
+    assert "references.media_moment_orphan_asset" in codes
+
+
+def test_an_unbound_moment_is_not_an_orphan(tmp_path):
+    """A NULL memory_id is a moment awaiting binding, not a dangling one."""
+    result = _inspect(tmp_path, _BASE_DDL + _moment("m1", "asset-live", None))
+    assert result.metrics["media_moments"]["memory_orphans"] == 0
+
+
+def test_media_findings_never_become_repair_candidates(tmp_path):
+    """Deletion and cascade semantics are unspecified in v1 (RFC 0003 §5.4);
+    doctor reports, it does not offer to delete."""
+    result = _inspect(tmp_path, _BASE_DDL + _moment("m1", "asset-gone", "mem-gone"))
+    assert result.repair_candidates == []
+
+
+def test_media_metrics_leak_no_content(tmp_path):
+    import json
+
+    ddl = _BASE_DDL + (
+        "INSERT INTO media_moments VALUES "
+        "('m1', 'asset-live', 'mem-live', 'caption', 'private caption text', "
+        "'whole', 'v1:whole');"
+    )
+    result = _inspect(tmp_path, ddl)
+    assert "private caption text" not in json.dumps(result.metrics)
+
+
+def test_unknown_catalog_includes_the_media_key(tmp_path):
+    """Every metric name the adapter can emit must also appear in its unknown
+    fallback, or a corrupt catalog produces a report missing a key that
+    downstream renderers expect."""
+    conn = _fixture(tmp_path, _BASE_DDL)
+    try:
+        metrics = ReferenceContractRegistry._unknown_metrics("DatabaseError")
+    finally:
+        conn.close()
+    assert metrics["media_moments"] == {
+        "status": STATUS_UNKNOWN, "error_class": "DatabaseError",
+    }
+
+
+def test_counts_stay_bounded_by_the_scan_limit(tmp_path):
+    """A pathological database must not produce an unbounded report. The limit
+    has to clear media_moments' column count (8) so the column probe still
+    succeeds -- below that the adapter correctly reports it cannot tell."""
+    scan_limit = 8
+    ddl = _BASE_DDL + "".join(
+        _moment(f"m{i}", "asset-gone", "mem-gone") for i in range(20)
+    )
+    conn = _fixture(tmp_path, ddl)
+    try:
+        metrics = ReferenceContractRegistry(conn, scan_limit=scan_limit).inspect().metrics
+    finally:
+        conn.close()
+    media = metrics["media_moments"]
+    assert media["status"] == "scan_limited"
+    assert media["asset_orphans"] == scan_limit
+    assert media["asset_orphans_truncated"] is True
+
+
+def test_a_truncated_column_probe_reports_unknown_not_healthy(tmp_path):
+    """Below the column count the adapter cannot verify the contract, and must
+    say so rather than report zero orphans."""
+    conn = _fixture(tmp_path, _BASE_DDL + _moment("m1", "asset-gone", "mem-gone"))
+    try:
+        metrics = ReferenceContractRegistry(conn, scan_limit=1).inspect().metrics
+    finally:
+        conn.close()
+    assert metrics["media_moments"] == {
+        "status": STATUS_UNKNOWN, "columns_truncated": True,
+    }

--- a/tests/test_media_schema.py
+++ b/tests/test_media_schema.py
@@ -1,0 +1,252 @@
+"""Schema tests for media_assets / media_moments (RFC 0003 §2, §1.6)."""
+
+import sqlite3
+
+import pytest
+
+from mnemosyne.core.media import MediaStore, init_media
+
+
+def _tables(conn):
+    return {
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+
+
+def _indexes(conn):
+    return {
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        ).fetchall()
+    }
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "media.db"
+
+
+# ---------------------------------------------------------------------------
+# DDL
+# ---------------------------------------------------------------------------
+
+def test_init_creates_both_tables_and_every_index(db_path):
+    init_media(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        assert {"media_assets", "media_moments"}.issubset(_tables(conn))
+        assert {
+            "idx_media_ref", "idx_media_hash", "idx_media_modality",
+            "idx_media_session", "idx_moment_asset", "idx_moment_time",
+            "idx_moment_memory", "idx_moment_span",
+        }.issubset(_indexes(conn))
+    finally:
+        conn.close()
+
+
+def test_init_is_idempotent(db_path):
+    init_media(db_path)
+    init_media(db_path)
+    init_media(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        assert {"media_assets", "media_moments"}.issubset(_tables(conn))
+    finally:
+        conn.close()
+
+
+def test_init_does_not_leak_the_connection_it_opens(db_path):
+    """``init_media`` opens and closes its own connection. If it leaked one,
+    every BeamMemory open would cost a file descriptor forever."""
+    init_media(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA journal_mode = DELETE")
+        conn.execute("BEGIN EXCLUSIVE")
+        conn.execute("ROLLBACK")
+    finally:
+        conn.close()
+
+
+def test_no_column_is_a_blob(db_path):
+    """RFC 0004 invariant 3: the brain stores references and text, never bytes.
+
+    A BLOB column here would make byte storage possible by accident, which is
+    exactly how a memory system becomes an ambient recorder.
+    """
+    init_media(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        for table in ("media_assets", "media_moments"):
+            declared = [
+                (row[1], (row[2] or "").upper())
+                for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+            ]
+            assert declared, f"{table} has no columns"
+            offenders = [name for name, decl in declared if "BLOB" in decl]
+            assert offenders == [], (
+                f"{table} declares BLOB column(s) {offenders}; media bytes must "
+                "never live in the database (RFC 0004 invariant 3)"
+            )
+    finally:
+        conn.close()
+
+
+def test_no_schema_level_foreign_keys(db_path):
+    """Issue #503: ``PRAGMA foreign_keys=ON`` broke 22 tests that intentionally
+    create orphan rows. Integrity here is application-layer and reported by
+    ``doctor``, not enforced by SQLite."""
+    init_media(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        for table in ("media_assets", "media_moments"):
+            assert conn.execute(f"PRAGMA foreign_key_list({table})").fetchall() == []
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Constraints
+# ---------------------------------------------------------------------------
+
+def test_reference_uniqueness_is_enforced_by_index(db_path):
+    init_media(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO media_assets (asset_id, ref_kind, ref_value, modality) "
+            "VALUES ('a', 'url', 'http://x/1', 'image')"
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO media_assets (asset_id, ref_kind, ref_value, modality) "
+                "VALUES ('b', 'url', 'http://x/1', 'image')"
+            )
+    finally:
+        conn.close()
+
+
+def test_content_hash_uniqueness_is_partial_so_nulls_may_repeat(db_path):
+    """Reference-only assets whose bytes were never fetched all carry a NULL
+    content_hash; the partial index (canonical.py:131-132's trick) is what lets
+    many of them coexist while a *known* hash stays unique."""
+    init_media(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            "INSERT INTO media_assets (asset_id, ref_kind, ref_value, modality) "
+            "VALUES ('a', 'url', 'http://x/1', 'image');"
+            "INSERT INTO media_assets (asset_id, ref_kind, ref_value, modality) "
+            "VALUES ('b', 'url', 'http://x/2', 'image');"
+            "INSERT INTO media_assets (asset_id, content_hash, ref_kind, ref_value, modality) "
+            "VALUES ('c', 'deadbeef', 'url', 'http://x/3', 'image');"
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO media_assets (asset_id, content_hash, ref_kind, ref_value, modality) "
+                "VALUES ('d', 'deadbeef', 'url', 'http://x/4', 'image')"
+            )
+    finally:
+        conn.close()
+
+
+def test_span_uniqueness_is_per_asset_and_kind(db_path):
+    init_media(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        def insert(moment_id, asset_id, kind, key):
+            conn.execute(
+                "INSERT INTO media_moments "
+                "(moment_id, asset_id, kind, text, span_kind, span_key) "
+                "VALUES (?, ?, ?, 't', 'whole', ?)",
+                (moment_id, asset_id, kind, key),
+            )
+
+        insert("m1", "a", "caption", "v1:whole")
+        insert("m2", "b", "caption", "v1:whole")      # different asset — fine
+        insert("m3", "a", "ocr", "v1:whole")          # different kind — fine
+        with pytest.raises(sqlite3.IntegrityError):
+            insert("m4", "a", "caption", "v1:whole")
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration story
+# ---------------------------------------------------------------------------
+
+def test_existing_database_acquires_the_tables_with_no_migration_module(db_path):
+    """The destructive downgrade: prove "no migration module needed" rather
+    than assume it.
+
+    Build a database, drop the media tables as an older version would have left
+    it, then reopen. ``BeamMemory.__init__`` runs the store's DDL on every open
+    and every statement is ``IF NOT EXISTS``, so the tables come back -- which
+    is exactly how ``canonical_facts`` reached existing databases.
+    """
+    store = MediaStore(db_path=db_path)
+    up = store.upsert_asset(ref_kind="url", ref_value="http://x/1", modality="image")
+    assert up.status == "created"
+    store.conn.close()
+
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        "DROP TABLE media_moments; DROP TABLE media_assets;"
+    )
+    conn.commit()
+    assert not {"media_assets", "media_moments"} & _tables(conn)
+    conn.close()
+
+    reopened = MediaStore(db_path=db_path)
+    try:
+        assert {"media_assets", "media_moments"}.issubset(_tables(reopened.conn))
+        # The data is gone (it was dropped) but the schema is whole again.
+        assert reopened.get_asset(up.asset_id) is None
+        again = reopened.upsert_asset(
+            ref_kind="url", ref_value="http://x/1", modality="image"
+        )
+        assert again.asset_id == up.asset_id, "asset_id must be deterministic"
+    finally:
+        reopened.conn.close()
+
+
+def test_store_shares_a_caller_owned_connection(db_path):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        store = MediaStore(db_path=db_path, conn=conn)
+        assert store.conn is conn
+        assert {"media_assets", "media_moments"}.issubset(_tables(conn))
+    finally:
+        conn.close()
+
+
+def test_beam_exposes_media_on_the_shared_connection(tmp_path):
+    from mnemosyne.core.beam import BeamMemory
+
+    beam = BeamMemory(session_id="media-wiring", db_path=tmp_path / "beam.db")
+    try:
+        assert hasattr(beam, "media")
+        # Same connection object — no extra file descriptor per bank.
+        assert beam.media.conn is beam.conn
+        assert {"media_assets", "media_moments"}.issubset(_tables(beam.conn))
+    finally:
+        try:
+            beam.conn.close()
+        except Exception:
+            pass
+
+
+def test_no_vec_table_is_created(db_path):
+    """A moment is an ordinary working_memory row. A vec0 table would cost four
+    whitelist edits and a permanent rowid-alignment discipline (RFC 0003 §1.3)."""
+    init_media(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        names = _tables(conn) | _indexes(conn)
+        assert not any("moment" in n and n.startswith("vec") for n in names)
+        assert "vec_moments" not in names
+    finally:
+        conn.close()

--- a/tests/test_media_span_key.py
+++ b/tests/test_media_span_key.py
@@ -1,0 +1,263 @@
+"""Pure-function tests for span identity (RFC 0003 §2.2).
+
+``span_key`` is the idempotency contract for media ingest: it is what the
+``(asset_id, kind, span_key)`` unique index compares, so its format is a
+persisted data format, not an implementation detail.
+"""
+
+import pytest
+
+from mnemosyne.core.media import (
+    SPAN_KEY_VERSION,
+    compute_asset_id,
+    compute_moment_id,
+    normalize_ref,
+    span_key,
+    validate_span,
+)
+
+
+# ---------------------------------------------------------------------------
+# Golden strings
+# ---------------------------------------------------------------------------
+
+_GOLDEN = [
+    ("whole", {}, "v1:whole"),
+    ("time", {"t_start_ms": 90000, "t_end_ms": 96000}, "v1:time:90000-96000"),
+    ("time", {"t_start_ms": 0, "t_end_ms": None}, "v1:time:0-na"),
+    ("page", {"page_start": 3, "page_end": 3}, "v1:page:3-3"),
+    ("page", {"page_start": 3, "page_end": None}, "v1:page:3-3"),
+    ("char", {"char_start": 0, "char_end": 512}, "v1:char:0-512"),
+    ("box", {"bbox": [0.1, 0.2, 0.3, 0.4]},
+     "v1:box:0.100000,0.200000,0.300000,0.400000"),
+    ("time", {"t_start_ms": 1000, "t_end_ms": 2000, "speaker": "Alice Chen"},
+     "v1:time:1000-2000:spk=alice chen"),
+]
+
+
+@pytest.mark.parametrize("kind,kwargs,expected", _GOLDEN)
+def test_span_key_golden_strings(kind, kwargs, expected):
+    """These strings are written into ``media_moments.span_key`` and compared
+    by a UNIQUE index, so changing any of them changes stored data.
+
+    If this test fails you have changed a persisted format. Every existing row
+    keeps its old key, the unique index cannot tell the two forms apart, and
+    re-ingest silently produces duplicate moments. Bump ``SPAN_KEY_VERSION``
+    and ship a rewrite migration -- do not just update the expected string.
+    """
+    assert span_key(kind, **kwargs) == expected, (
+        "span_key format changed: this is a persisted data format. "
+        "Bump SPAN_KEY_VERSION and write a rewrite migration."
+    )
+
+
+def test_version_prefix_is_present_and_current():
+    """Without a version tag, a future format change produces both old- and
+    new-form rows for the same span with no way to tell them apart."""
+    assert SPAN_KEY_VERSION == "v1"
+    assert span_key("whole").startswith(f"{SPAN_KEY_VERSION}:")
+
+
+# ---------------------------------------------------------------------------
+# Speaker is part of the identity
+# ---------------------------------------------------------------------------
+
+def test_speaker_distinguishes_overlapping_time_spans():
+    """The correction that motivated folding speaker into the key: two
+    diarized speakers over one window must not collapse to one row."""
+    a = span_key("time", t_start_ms=1000, t_end_ms=2000, speaker="alice")
+    b = span_key("time", t_start_ms=1000, t_end_ms=2000, speaker="bob")
+    assert a != b
+
+
+def test_no_speaker_is_byte_identical_to_pre_correction_format():
+    """Appending the speaker *last* is what keeps existing speaker-less rows
+    valid under the corrected format."""
+    assert span_key("time", t_start_ms=1000, t_end_ms=2000) == "v1:time:1000-2000"
+    assert ":spk=" not in span_key("time", t_start_ms=1000, t_end_ms=2000)
+
+
+@pytest.mark.parametrize("speaker", ["  Alice   Chen  ", "ALICE CHEN", "alice chen"])
+def test_speaker_slug_is_collapsed_and_casefolded(speaker):
+    assert span_key("time", t_start_ms=0, speaker=speaker).endswith(":spk=alice chen")
+
+
+def test_speaker_slug_is_truncated_to_64_chars():
+    slug = span_key("time", t_start_ms=0, speaker="x" * 200).split(":spk=")[1]
+    assert len(slug) == 64
+
+
+def test_whitespace_only_speaker_is_no_speaker():
+    assert span_key("time", t_start_ms=0) == span_key("time", t_start_ms=0, speaker="   ")
+
+
+# ---------------------------------------------------------------------------
+# Coercion rules
+# ---------------------------------------------------------------------------
+
+def test_bool_is_rejected_as_an_offset_and_falls_back_to_a_digest():
+    """``True`` would otherwise render as ``1`` and produce a plausible key for
+    a nonsense span. The function stays total, so the rejection shows up as the
+    digest form rather than an exception."""
+    key = span_key("time", t_start_ms=True)
+    assert key.startswith("v1:time:h")
+    assert key != "v1:time:1-na"
+
+
+def test_numeric_strings_are_coerced():
+    assert span_key("time", t_start_ms="90000", t_end_ms="96000") == "v1:time:90000-96000"
+
+
+def test_bbox_floats_are_fixed_point_not_repr():
+    """``str(0.1 + 0.2)`` is locale- and repr-sensitive; fixed-point is not."""
+    assert span_key("box", bbox=[0.1 + 0.2, 0, 0, 0]).startswith("v1:box:0.300000,")
+
+
+def test_bbox_accepts_its_json_string_form():
+    assert span_key("box", bbox="[0.1, 0.2, 0.3, 0.4]") == span_key(
+        "box", bbox=[0.1, 0.2, 0.3, 0.4]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Totality
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad", [None, [], [1, 2], "not json", {"x": 1}, object()])
+def test_unparseable_bbox_falls_back_to_a_digest_and_never_raises(bad):
+    key = span_key("box", bbox=bad)
+    assert key.startswith("v1:box:h")
+
+
+def test_unknown_span_kind_still_produces_a_stable_key():
+    a = span_key("teleport", t_start_ms=5)
+    b = span_key("teleport", t_start_ms=5)
+    assert a == b and a.startswith("v1:teleport:h")
+
+
+def test_digest_fallback_is_stable_and_discriminating():
+    assert span_key("box", bbox=[1, 2]) == span_key("box", bbox=[1, 2])
+    assert span_key("box", bbox=[1, 2]) != span_key("box", bbox=[1, 3])
+
+
+# ---------------------------------------------------------------------------
+# validate_span
+# ---------------------------------------------------------------------------
+
+def _values(**kwargs):
+    base = {
+        "t_start_ms": None, "t_end_ms": None, "page_start": None,
+        "page_end": None, "char_start": None, "char_end": None, "bbox": None,
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_validate_accepts_the_canonical_shapes():
+    validate_span("whole", _values())
+    validate_span("time", _values(t_start_ms=0, t_end_ms=10))
+    validate_span("page", _values(page_start=1))
+    validate_span("char", _values(char_start=0, char_end=10))
+    validate_span("box", _values(bbox=[0.0, 0.0, 1.0, 1.0]))
+
+
+def test_foreign_span_columns_are_rejected_not_dropped():
+    """A time moment carrying page_start yields a span_key blind to the page,
+    so two such moments differing only by page collapse to one key and the
+    second is silently swallowed by INSERT OR IGNORE."""
+    with pytest.raises(ValueError, match="does not own"):
+        validate_span("time", _values(t_start_ms=0, page_start=3))
+
+
+def test_whole_rejects_every_span_column():
+    with pytest.raises(ValueError, match="does not own"):
+        validate_span("whole", _values(t_start_ms=0))
+
+
+def test_missing_required_column_is_rejected():
+    with pytest.raises(ValueError, match="requires 't_start_ms'"):
+        validate_span("time", _values())
+    with pytest.raises(ValueError, match="requires 'char_end'"):
+        validate_span("char", _values(char_start=0))
+
+
+def test_unknown_span_kind_is_rejected_by_the_validator():
+    """span_key stays total for a weird kind; the validator does not."""
+    with pytest.raises(ValueError, match="unknown span_kind"):
+        validate_span("teleport", _values())
+
+
+@pytest.mark.parametrize("values,message", [
+    (_values(t_start_ms=-1), "t_start_ms must be >= 0"),
+    (_values(t_start_ms=100, t_end_ms=50), "precedes"),
+    (_values(page_start=5, page_end=1), "precedes"),
+    (_values(char_start=10, char_end=1), "precedes"),
+])
+def test_ordering_and_range_are_enforced(values, message):
+    kind = "time" if values["t_start_ms"] is not None else (
+        "page" if values["page_start"] is not None else "char"
+    )
+    with pytest.raises(ValueError, match=message):
+        validate_span(kind, values)
+
+
+def test_bbox_must_be_normalized():
+    with pytest.raises(ValueError, match="normalized"):
+        validate_span("box", _values(bbox=[0, 0, 1920, 1080]))
+
+
+def test_speaker_is_time_only():
+    """RFC 0003 §2.3 gives speaker to time spans; anywhere else there is no
+    time axis to attach it to."""
+    validate_span("time", _values(t_start_ms=0), speaker="alice")
+    with pytest.raises(ValueError, match="only valid on span_kind='time'"):
+        validate_span("whole", _values(), speaker="alice")
+
+
+# ---------------------------------------------------------------------------
+# Reference normalization and asset identity
+# ---------------------------------------------------------------------------
+
+def test_normalize_lowercases_scheme_and_host_only():
+    kind, value = normalize_ref("url", "HTTPS://Example.COM/Path?Q=1#T=90")
+    assert (kind, value) == ("url", "https://example.com/Path?Q=1#T=90")
+
+
+def test_normalize_lowercases_hex_digests():
+    assert normalize_ref("sha256", "ABCDEF")[1] == "abcdef"
+    assert normalize_ref("blob", "blob://sha256/ABC")[1] == "blob://sha256/abc"
+
+
+def test_normalize_leaves_file_paths_case_intact():
+    """POSIX paths are case-sensitive; folding them would collide two files."""
+    assert normalize_ref("file", "  /tmp/Photo.PNG  ")[1] == "/tmp/Photo.PNG"
+
+
+@pytest.mark.parametrize("kind,value", [("nope", "x"), ("url", ""), ("url", "   ")])
+def test_normalize_rejects_bad_input(kind, value):
+    with pytest.raises(ValueError):
+        normalize_ref(kind, value)
+
+
+def test_asset_id_includes_ref_kind_in_the_digest():
+    """The same ref_value under two kinds is two legal rows (uniqueness is
+    ``(ref_kind, ref_value)``); hashing the value alone would collide them on
+    the PRIMARY KEY."""
+    assert compute_asset_id("url", "abc") != compute_asset_id("file", "abc")
+
+
+def test_asset_id_prefers_the_hash_form_when_bytes_are_known():
+    assert compute_asset_id("url", "http://x/y", content_hash="AB12") == "sha256:ab12"
+    assert compute_asset_id("url", "http://x/y").startswith("ref:")
+
+
+def test_asset_id_is_stable_across_equivalent_references():
+    assert compute_asset_id("url", "HTTP://X.COM/a") == compute_asset_id("url", "http://x.com/a")
+
+
+def test_moment_id_derives_from_the_same_triple_as_the_unique_index():
+    a = compute_moment_id("asset-1", "caption", "v1:whole")
+    assert a == compute_moment_id("asset-1", "caption", "v1:whole")
+    assert a != compute_moment_id("asset-2", "caption", "v1:whole")
+    assert a != compute_moment_id("asset-1", "ocr", "v1:whole")
+    assert a != compute_moment_id("asset-1", "caption", "v1:time:0-na")

--- a/tests/test_media_store.py
+++ b/tests/test_media_store.py
@@ -1,0 +1,353 @@
+"""Behavioural tests for MediaStore (RFC 0003 §2.1, §2.2, §2.4)."""
+
+import json
+import sqlite3
+
+import pytest
+
+from mnemosyne.core.media import MediaStore, MomentDraft
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = MediaStore(db_path=tmp_path / "media.db")
+    yield s
+    try:
+        s.conn.close()
+    except Exception:
+        pass
+
+
+def _asset(store, **kwargs):
+    params = {"ref_kind": "url", "ref_value": "http://x/1", "modality": "image"}
+    params.update(kwargs)
+    return store.upsert_asset(**params)
+
+
+# ---------------------------------------------------------------------------
+# Assets
+# ---------------------------------------------------------------------------
+
+def test_upsert_is_idempotent_by_reference(store):
+    first = _asset(store)
+    second = _asset(store)
+    assert first.asset_id == second.asset_id
+    assert (first.status, second.status) == ("created", "unchanged")
+    assert store.conn.execute("SELECT COUNT(*) FROM media_assets").fetchone()[0] == 1
+
+
+def test_equivalent_references_resolve_to_one_asset(store):
+    a = _asset(store, ref_value="HTTP://X.COM/a")
+    b = _asset(store, ref_value="http://x.com/a")
+    assert a.asset_id == b.asset_id
+
+
+def test_same_ref_value_under_two_kinds_is_two_assets(store):
+    a = _asset(store, ref_kind="url", ref_value="abc")
+    b = _asset(store, ref_kind="file", ref_value="abc")
+    assert a.asset_id != b.asset_id
+
+
+def test_asset_id_is_stable_when_the_hash_arrives_later(store):
+    """An asset first seen by reference and later by bytes keeps its id.
+    Recomputing it would orphan every moment already written against it."""
+    first = _asset(store)
+    assert first.asset_id.startswith("ref:")
+
+    store.add_moments(first.asset_id, [MomentDraft(kind="caption", text="a cat")])
+
+    second = _asset(store, content_hash="DEADBEEF")
+    assert second.asset_id == first.asset_id
+    assert second.status == "updated"
+    assert store.get_asset(first.asset_id)["content_hash"] == "deadbeef"
+    # The moment is still bound to a live asset.
+    assert len(store.get_moments(first.asset_id)) == 1
+
+
+def test_a_second_reference_to_known_bytes_aliases_rather_than_raising(store):
+    """One file reachable by both a URL and a local path is one asset -- not
+    two rows, and certainly not an IntegrityError on the partial hash index."""
+    first = _asset(store, content_hash="abc123")
+    second = _asset(store, ref_kind="file", ref_value="/tmp/a.png", content_hash="abc123")
+
+    assert second.asset_id == first.asset_id
+    assert second.status == "aliased"
+    assert store.conn.execute("SELECT COUNT(*) FROM media_assets").fetchone()[0] == 1
+
+    meta = json.loads(store.get_asset(first.asset_id)["metadata"])
+    assert meta["alt_refs"] == [{"ref_kind": "file", "ref_value": "/tmp/a.png"}]
+
+
+def test_alt_refs_are_deduped(store):
+    _asset(store, content_hash="abc123")
+    for _ in range(3):
+        _asset(store, ref_kind="file", ref_value="/tmp/a.png", content_hash="abc123")
+    meta = json.loads(store.find_asset_by_ref("url", "http://x/1")["metadata"])
+    assert len(meta["alt_refs"]) == 1
+
+
+def test_re_registration_adds_knowledge_but_never_removes_it(store):
+    first = _asset(store, title="Original", width=100)
+    _asset(store, title="Different", height=200)
+    row = store.get_asset(first.asset_id)
+    assert row["title"] == "Original", "a second sighting must not overwrite"
+    assert row["width"] == 100
+    assert row["height"] == 200, "but it may fill in what was NULL"
+
+
+def test_captured_at_precision_default_is_not_treated_as_knowledge(store):
+    first = _asset(store, captured_at="2026-01-01", captured_at_precision="exact")
+    _asset(store)  # defaults to 'unknown'
+    assert store.get_asset(first.asset_id)["captured_at_precision"] == "exact"
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"modality": "hologram"},
+    {"ref_kind": "carrier-pigeon"},
+    {"understanding_status": "vibes"},
+])
+def test_upsert_rejects_unknown_vocabulary(store, kwargs):
+    with pytest.raises(ValueError):
+        _asset(store, **kwargs)
+
+
+def test_understanding_status_transitions(store):
+    a = _asset(store)
+    assert store.get_asset(a.asset_id)["understanding_status"] == "pending"
+    assert store.set_understanding_status(
+        a.asset_id, "ok", provider="openai_compat", provider_model="qwen-vl"
+    )
+    row = store.get_asset(a.asset_id)
+    assert row["understanding_status"] == "ok"
+    assert row["provider_model"] == "qwen-vl"
+    assert not store.set_understanding_status("nope", "ok")
+    with pytest.raises(ValueError):
+        store.set_understanding_status(a.asset_id, "vibes")
+
+
+def test_unavailable_is_a_success_state_not_an_error(store):
+    """Rung 4 of the RFC 0002 §3.3 degradation ladder: the asset is registered
+    and recallable by reference even though nothing described it."""
+    a = _asset(store)
+    assert store.set_understanding_status(a.asset_id, "unavailable")
+    assert store.get_asset(a.asset_id)["understanding_status"] == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Moments
+# ---------------------------------------------------------------------------
+
+def test_moments_write_and_read_back(store):
+    a = _asset(store, modality="video")
+    result = store.add_moments(a.asset_id, [
+        MomentDraft(kind="shot", text="a wide shot", span_kind="time",
+                    t_start_ms=0, t_end_ms=5000, ordinal=0),
+        MomentDraft(kind="shot", text="a close-up", span_kind="time",
+                    t_start_ms=5000, t_end_ms=9000, ordinal=1),
+    ])
+    assert (result.inserted, result.duplicate, result.unbound) == (2, 0, 0)
+    moments = store.get_moments(a.asset_id)
+    assert [m["text"] for m in moments] == ["a wide shot", "a close-up"]
+    assert [m["span_key"] for m in moments] == ["v1:time:0-5000", "v1:time:5000-9000"]
+
+
+def test_re_ingest_is_a_no_op(store):
+    """The idempotency contract: an archive re-push writes nothing new."""
+    a = _asset(store)
+    drafts = [MomentDraft(kind="caption", text="a terminal window")]
+    first = store.add_moments(a.asset_id, drafts)
+    second = store.add_moments(a.asset_id, drafts)
+
+    assert (first.inserted, first.duplicate) == (1, 0)
+    assert (second.inserted, second.duplicate) == (0, 1)
+    assert second.moment_ids == first.moment_ids
+    assert len(store.get_moments(a.asset_id)) == 1
+
+
+def test_two_speakers_over_one_window_are_two_moments(store):
+    """The correction that motivated folding speaker into span_key. Without it
+    INSERT OR IGNORE drops the second -- silently, and precisely in the case
+    diarization exists to handle."""
+    a = _asset(store, modality="audio")
+    result = store.add_moments(a.asset_id, [
+        MomentDraft(kind="transcript", text="so I said", span_kind="time",
+                    t_start_ms=1000, t_end_ms=2000, speaker="Alice"),
+        MomentDraft(kind="transcript", text="no you didn't", span_kind="time",
+                    t_start_ms=1000, t_end_ms=2000, speaker="Bob"),
+    ])
+    assert result.inserted == 2
+    assert len(store.get_moments(a.asset_id)) == 2
+
+
+def test_intra_batch_duplicates_are_rejected_not_swallowed(store):
+    """INSERT OR IGNORE is right for a *repeat ingest* and wrong for a single
+    batch that believes it is writing two distinct moments."""
+    a = _asset(store)
+    with pytest.raises(ValueError, match=r"drafts\[1\] duplicates drafts\[0\]"):
+        store.add_moments(a.asset_id, [
+            MomentDraft(kind="caption", text="one"),
+            MomentDraft(kind="caption", text="two"),  # same span, same kind
+        ])
+    assert store.get_moments(a.asset_id) == []
+
+
+def test_validation_writes_nothing_at_all(store):
+    """A batch with one bad draft must not leave a partial span index behind
+    that nothing knows is partial."""
+    a = _asset(store)
+    with pytest.raises(ValueError, match=r"drafts\[2\]"):
+        store.add_moments(a.asset_id, [
+            MomentDraft(kind="caption", text="good", span_kind="whole"),
+            MomentDraft(kind="ocr", text="also good", span_kind="char",
+                        char_start=0, char_end=10),
+            MomentDraft(kind="shot", text="bad", span_kind="time"),  # no t_start_ms
+        ])
+    assert store.get_moments(a.asset_id) == []
+
+
+@pytest.mark.parametrize("draft,match", [
+    (MomentDraft(kind="vibe", text="x"), "unknown kind"),
+    (MomentDraft(kind="caption", text="   "), "non-empty"),
+    (MomentDraft(kind="shot", text="x", span_kind="time", t_start_ms=0, page_start=1),
+     "does not own"),
+    (MomentDraft(kind="caption", text="x", span_kind="whole", speaker="alice"),
+     "only valid on span_kind='time'"),
+])
+def test_draft_validation_names_the_offending_index(store, draft, match):
+    a = _asset(store)
+    with pytest.raises(ValueError, match=match) as exc:
+        store.add_moments(a.asset_id, [draft])
+    assert "drafts[0]" in str(exc.value)
+
+
+def test_moments_on_a_nonexistent_asset_are_refused(store):
+    """The one orphan kind that is real corruption -- refuse to create it."""
+    with pytest.raises(ValueError, match="no media_assets row"):
+        store.add_moments("ghost", [MomentDraft(kind="caption", text="x")])
+
+
+def test_bbox_is_stored_in_the_same_precision_the_span_key_uses(store):
+    a = _asset(store)
+    store.add_moments(a.asset_id, [
+        MomentDraft(kind="ocr", text="LOGIN", span_kind="box",
+                    bbox=[0.1 + 0.2, 0.2, 0.3, 0.4]),
+    ])
+    moment = store.get_moments(a.asset_id)[0]
+    assert json.loads(moment["bbox"]) == [0.3, 0.2, 0.3, 0.4]
+    assert moment["span_key"] == "v1:box:0.300000,0.200000,0.300000,0.400000"
+
+
+def test_empty_batch_is_a_no_op(store):
+    a = _asset(store)
+    result = store.add_moments(a.asset_id, [])
+    assert (result.inserted, result.duplicate, result.moment_ids) == (0, 0, [])
+
+
+# ---------------------------------------------------------------------------
+# Soft references (§2.4)
+# ---------------------------------------------------------------------------
+
+def _with_working_memory(store):
+    store.conn.execute("CREATE TABLE working_memory (id TEXT PRIMARY KEY)")
+    store.conn.execute("INSERT INTO working_memory VALUES ('mem-live')")
+    store.conn.commit()
+
+
+def test_a_dead_memory_id_is_nulled_and_counted_not_raised(store):
+    """Eviction (_trim_working_memory) and consolidation both legitimately
+    remove the row between drafting and insert."""
+    _with_working_memory(store)
+    a = _asset(store)
+    result = store.add_moments(a.asset_id, [
+        MomentDraft(kind="caption", text="bound", memory_id="mem-live"),
+        MomentDraft(kind="ocr", text="unbound", memory_id="mem-gone"),
+    ])
+    assert (result.inserted, result.unbound) == (2, 1)
+    by_text = {m["text"]: m["memory_id"] for m in store.get_moments(a.asset_id)}
+    assert by_text == {"bound": "mem-live", "unbound": None}
+
+
+def test_binding_is_guarded_by_existence_rather_than_a_foreign_key(store):
+    _with_working_memory(store)
+    a = _asset(store)
+    moment_id = store.add_moments(
+        a.asset_id, [MomentDraft(kind="caption", text="x")]
+    ).moment_ids[0]
+
+    assert not store.bind_moment_memory(moment_id, "mem-gone")
+    assert store.get_moments(a.asset_id)[0]["memory_id"] is None
+    assert store.bind_moment_memory(moment_id, "mem-live")
+    assert store.get_moments(a.asset_id)[0]["memory_id"] == "mem-live"
+    assert [m["text"] for m in store.moments_for_memory("mem-live")] == ["x"]
+
+
+def test_a_standalone_store_preserves_bindings_it_cannot_verify(store):
+    """Without a working_memory table there is nothing to check against;
+    nulling the binding would be a silent data loss, so it is kept and left for
+    doctor to count."""
+    a = _asset(store)
+    result = store.add_moments(
+        a.asset_id, [MomentDraft(kind="caption", text="x", memory_id="mem-elsewhere")]
+    )
+    assert result.unbound == 0
+    assert store.get_moments(a.asset_id)[0]["memory_id"] == "mem-elsewhere"
+
+
+def test_count_orphans_separates_the_two_kinds(store):
+    _with_working_memory(store)
+    a = _asset(store)
+    store.add_moments(a.asset_id, [
+        MomentDraft(kind="caption", text="ok", memory_id="mem-live"),
+    ])
+    assert store.count_orphans() == {"asset_orphans": 0, "memory_orphans": 0}
+
+    # Consolidation summarized the memory row away -- the expected steady state.
+    store.conn.execute("DELETE FROM working_memory WHERE id = 'mem-live'")
+    # ...and a genuinely corrupt row, which nothing in the design produces.
+    store.conn.execute(
+        "INSERT INTO media_moments "
+        "(moment_id, asset_id, kind, text, span_kind, span_key) "
+        "VALUES ('m-orphan', 'ghost-asset', 'caption', 'x', 'whole', 'v1:whole')"
+    )
+    store.conn.commit()
+    assert store.count_orphans() == {"asset_orphans": 1, "memory_orphans": 1}
+
+
+# ---------------------------------------------------------------------------
+# No bytes, ever
+# ---------------------------------------------------------------------------
+
+def test_the_store_never_reaches_for_the_blob_writer(store, monkeypatch):
+    """MediaStore holds references and text. Byte handling belongs to
+    content_sanitizer (write) and resolvers (read), never here."""
+    from mnemosyne.core import content_sanitizer
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("MediaStore must never store blobs")
+
+    monkeypatch.setattr(content_sanitizer, "_store_blob", _explode)
+
+    a = _asset(store, ref_kind="blob", ref_value="blob://sha256/" + "ab" * 32)
+    store.add_moments(a.asset_id, [MomentDraft(kind="caption", text="a chart")])
+    assert store.get_moments(a.asset_id)[0]["text"] == "a chart"
+
+
+def test_stored_values_are_text_not_bytes(store):
+    a = _asset(store)
+    store.add_moments(a.asset_id, [MomentDraft(kind="caption", text="x")])
+    for table in ("media_assets", "media_moments"):
+        for row in store.conn.execute(f"SELECT * FROM {table}").fetchall():
+            assert not any(isinstance(v, (bytes, bytearray)) for v in tuple(row))
+
+
+def test_store_survives_a_shared_connection_being_reused(tmp_path):
+    """The BeamMemory wiring shape: one connection, several stores."""
+    conn = sqlite3.connect(tmp_path / "shared.db")
+    conn.row_factory = sqlite3.Row
+    try:
+        one = MediaStore(db_path=tmp_path / "shared.db", conn=conn)
+        two = MediaStore(db_path=tmp_path / "shared.db", conn=conn)
+        a = one.upsert_asset(ref_kind="url", ref_value="http://x/1", modality="image")
+        assert two.get_asset(a.asset_id) is not None
+    finally:
+        conn.close()


### PR DESCRIPTION
Phase 0 of RFC 0003. Adds the media asset registry and the moment index that the later phases build on.

No ingest path yet: this is the storage and indexing substrate only. `remember_media()` arrives in a follow-up.

Rebased onto current main. Full suite green under CI conditions (`MNEMOSYNE_NO_EMBEDDINGS=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds `media_assets` and `media_moments` sidecar tables and initializes them idempotently through `BeamMemory`.
- Adds `MediaStore` with deterministic asset and moment identities, span validation, duplicate handling, memory binding, and orphan reporting.
- Links media moments to existing `working_memory` rows. This reuses current recall, decay, consolidation, synchronization, and reindex behavior.
- Stores references and metadata only. The design adds no media bytes, BLOB columns, vector tables, provider calls, or ingest path.
- Supports existing databases that acquire the schema on reopen.

## Architecture impact

- **Tiered memory:** Adds media indexing beside `working_memory`. It does not change working, episodic, or BEAM tier behavior.
- **Retrieval:** Adds no media-specific retrieval strategy. Existing memory retrieval remains the integration path.
- **Consolidation and veracity:** Adds no changes to consolidation, veracity checks, or memory scoring.
- **Synchronization:** Reuses existing synchronization behavior through ordinary memory rows.
- **Local-first and privacy:** Preserves the local-first design. No remote service or provider call is introduced. Media content is not stored.
- **Agent integration:** Adds no Hermes, MCP, or CLI surface. Future integrations can use `MediaStore` without changing current agent interfaces.
- **Maintainability:** Separates media metadata from memory content. Deterministic IDs, versioned span keys, application-level validation, bounded doctor checks, and idempotent initialization support stable evolution.

## Architectural assessment

Using sidecar tables and linking moments to `working_memory` is the right call for phase 0. It avoids duplicate recall and lifecycle pipelines. It also avoids premature storage of sensitive media content.

The implementation does not erode local-first guarantees. It provides storage and indexing infrastructure only. Benchmark methodology is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->