### PR TITLE
feat(core): give the blob store a reader via ContentResolver and BlobResolver

### DIFF
--- a/mnemosyne/core/resolvers.py
+++ b/mnemosyne/core/resolvers.py
@@ -1,0 +1,405 @@
+"""
+Mnemosyne Content Resolver Registry
+===================================
+Resolves an opaque content URI to metadata or bytes.
+
+Mnemosyne stores *references* to heavy content, never the content itself:
+``core/content_sanitizer.py`` extracts oversized or binary-shaped payloads to
+a content-addressed blob store and leaves a ``blob://sha256/<hash>`` reference
+behind. Until this module existed, that store had no reader at all -- bytes
+extracted by the size-cap and high-entropy rules were unreachable by any code
+path in the repository.
+
+This module gives references a read side, and generalizes the idea: a resolver
+claims one or more URI *schemes* and answers three questions about a URI --
+does it exist and what is it (``head``), give me the bytes (``open``), and give
+me a short-lived URL a third party can fetch (``presign``).
+
+``presign`` is the load-bearing one. It is how a remote vision provider reaches
+bytes that Mnemosyne does not want to read, buffer, or proxy through its own
+process. It is also what makes "the archive is a separate product" structurally
+true rather than aspirational: the archive serves bytes directly to whoever
+needs them, and Mnemosyne only ever passes URIs around.
+
+Absence is a supported state, not an error. When no resolver handles a scheme,
+``get_resolver`` returns None and every caller degrades: a client shows a
+reference without a preview, and memories recall perfectly, because their text
+is local. Nothing raises. This mirrors ``embeddings.available()``.
+
+    Losing the archive costs you previews, not memories.
+
+See RFC 0004 (docs/rfc/0004-archive-boundary.md) for the full contract.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Callable, Dict, Iterable, Optional, Protocol
+
+__all__ = [
+    "BlobResolver",
+    "CallableContentResolver",
+    "ContentResolver",
+    "ResolvedMeta",
+    "clear_content_resolvers",
+    "get_resolver",
+    "resolve_head",
+    "resolve_open",
+    "resolve_presign",
+    "scheme_of",
+    "set_content_resolver",
+]
+
+
+# --- Shapes -----------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResolvedMeta:
+    """What a resolver knows about a URI without transferring its bytes.
+
+    ``exists=False`` is a meaningful answer: the resolver recognized the URI
+    and the content is gone. That is different from ``head()`` returning None,
+    which means "not my scheme". ``mnemosyne doctor`` needs to tell a dead
+    reference apart from an unconfigured one.
+
+    Every field except ``exists`` is optional, because a resolver must never
+    guess. A blob on disk has no filename and no sidecar, so its mime type is
+    either sniffed from magic bytes or left as None.
+    """
+
+    exists: bool
+    byte_size: Optional[int] = None
+    mime: Optional[str] = None
+    content_hash: Optional[str] = None
+    etag: Optional[str] = None
+
+
+class ContentResolver(Protocol):
+    """Resolves an opaque content URI to metadata or bytes.
+
+    Implementations claim one or more schemes and answer for those only.
+    Like :class:`~mnemosyne.core.llm_backends.LLMBackend`, the interface is
+    deliberately tiny and failure is a return value rather than an exception.
+    """
+
+    name: str
+    schemes: frozenset  # e.g. {"blob"} | {"archive"} | {"file"}
+
+    def head(self, uri: str) -> Optional[ResolvedMeta]:
+        """Cheap existence and metadata probe.
+
+        None means "not my scheme, or not a URI I can parse".
+        ``ResolvedMeta(exists=False)`` means "mine, and gone".
+        """
+        ...
+
+    def open(self, uri: str) -> Optional[BinaryIO]:
+        """Lazy byte stream, or None if unavailable. The caller owns the handle."""
+        ...
+
+    def presign(self, uri: str, *, ttl_s: int = 300) -> Optional[str]:
+        """A short-lived URL a third party can fetch, or None if unsupported."""
+        ...
+
+
+@dataclass
+class CallableContentResolver:
+    """Wrap plain functions as a :class:`ContentResolver`. Useful for tests.
+
+    Any method whose function is None returns None, so a resolver that only
+    knows how to ``head`` is a legal resolver.
+    """
+
+    name: str
+    schemes: frozenset
+    head_func: Optional[Callable[[str], Optional[ResolvedMeta]]] = None
+    open_func: Optional[Callable[[str], Optional[BinaryIO]]] = None
+    presign_func: Optional[Callable[..., Optional[str]]] = None
+
+    def head(self, uri: str) -> Optional[ResolvedMeta]:
+        return self.head_func(uri) if self.head_func is not None else None
+
+    def open(self, uri: str) -> Optional[BinaryIO]:
+        return self.open_func(uri) if self.open_func is not None else None
+
+    def presign(self, uri: str, *, ttl_s: int = 300) -> Optional[str]:
+        if self.presign_func is None:
+            return None
+        return self.presign_func(uri, ttl_s=ttl_s)
+
+
+# --- URI helpers ------------------------------------------------------------
+
+_SCHEME_RE = re.compile(r"^(?P<scheme>[a-zA-Z][a-zA-Z0-9+.\-]*)://")
+
+
+def scheme_of(uri: str) -> Optional[str]:
+    """Return the lowercased scheme of a ``scheme://rest`` URI, or None.
+
+    Deliberately stricter than ``urllib.parse``: a bare word, an empty string,
+    or a leading ``://`` is not a URI we will dispatch on.
+    """
+    if not uri or not isinstance(uri, str):
+        return None
+    m = _SCHEME_RE.match(uri)
+    return m.group("scheme").lower() if m else None
+
+
+# --- BlobResolver -----------------------------------------------------------
+
+# blob://sha256/<64 lowercase hex>. Anything else is not ours.
+_BLOB_URI_RE = re.compile(r"^blob://(?P<algo>sha256)/(?P<hash>[0-9a-f]{64})$")
+
+# Magic-byte prefixes, longest-first where prefixes overlap. Deliberately
+# short: this exists to answer "is this a PNG" for a preview, not to be a
+# general-purpose file identifier.
+_MAGIC: tuple = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+    (b"%PDF-", "application/pdf"),
+    (b"OggS", "audio/ogg"),
+    (b"ID3", "audio/mpeg"),
+    (b"\xff\xfb", "audio/mpeg"),
+    (b"fLaC", "audio/flac"),
+    (b"PK\x03\x04", "application/zip"),
+    (b"\x1a\x45\xdf\xa3", "video/webm"),
+)
+
+_SNIFF_BYTES = 512
+
+
+def _sniff_mime(head_bytes: bytes) -> Optional[str]:
+    """Identify a mime type from magic bytes, or return None.
+
+    Returns None rather than ``application/octet-stream`` on no match. A blob
+    path is a hash, so there is no filename to infer from and
+    ``mimetypes.guess_type`` would be worse than useless here. An unrecognized
+    type is unknown, and saying so is more useful to a caller than a default
+    that looks like an answer.
+    """
+    if not head_bytes:
+        return None
+    for prefix, mime in _MAGIC:
+        if head_bytes.startswith(prefix):
+            return mime
+    # RIFF containers carry their real type at offset 8.
+    if head_bytes.startswith(b"RIFF") and len(head_bytes) >= 12:
+        fourcc = head_bytes[8:12]
+        if fourcc == b"WEBP":
+            return "image/webp"
+        if fourcc == b"WAVE":
+            return "audio/wav"
+        if fourcc == b"AVI ":
+            return "video/x-msvideo"
+    # ISO base media (mp4/mov/heic) puts 'ftyp' at offset 4.
+    if len(head_bytes) >= 12 and head_bytes[4:8] == b"ftyp":
+        brand = head_bytes[8:12]
+        if brand in (b"heic", b"heix", b"hevc", b"heim"):
+            return "image/heic"
+        if brand == b"qt  ":
+            return "video/quicktime"
+        return "video/mp4"
+    return None
+
+
+class BlobResolver:
+    """Reader for the content-addressed blob store written by ``content_sanitizer``.
+
+    This is the first reader that store has ever had. Bytes extracted by the
+    size-cap rule and the high-entropy rule were previously unreachable.
+
+    ``presign`` always returns None: a local path is not a URL, and inventing a
+    ``file://`` one would hand a remote provider something it cannot fetch
+    while looking like success.
+    """
+
+    name = "blob"
+    schemes = frozenset({"blob"})
+
+    def __init__(self, root: Optional[Path] = None) -> None:
+        # Stored, not resolved. _blob_root() reads MNEMOSYNE_BLOB_DIR at call
+        # time, and tests set that variable after this module is imported --
+        # caching the root here would silently resolve against the wrong
+        # directory for the life of the process.
+        self._root = Path(root) if root is not None else None
+
+    def _blob_root(self) -> Path:
+        if self._root is not None:
+            return self._root
+        from mnemosyne.core.content_sanitizer import _blob_root
+
+        return _blob_root()
+
+    def _path_for(self, uri: str) -> Optional[Path]:
+        """Map a blob URI to its on-disk path, or None if the URI is not ours."""
+        m = _BLOB_URI_RE.match(uri or "")
+        if m is None:
+            return None
+        digest = m.group("hash")
+        root = self._blob_root()
+        # Layout must match content_sanitizer._store_blob exactly.
+        path = root / digest[:2] / digest[:4] / digest
+        # Defense in depth. The 64-hex pattern already makes traversal
+        # unreachable; this makes that guarantee explicit rather than implied
+        # by a regex somebody may later loosen.
+        try:
+            if not path.resolve().is_relative_to(root.resolve()):
+                return None
+        except (OSError, ValueError):
+            return None
+        return path
+
+    def head(self, uri: str) -> Optional[ResolvedMeta]:
+        path = self._path_for(uri)
+        if path is None:
+            return None
+        digest = uri.rsplit("/", 1)[-1]
+        try:
+            size = path.stat().st_size
+        except OSError:
+            # Ours, and gone. Distinct from "not mine" above.
+            return ResolvedMeta(exists=False, content_hash=digest)
+        mime = None
+        try:
+            with path.open("rb") as fh:
+                mime = _sniff_mime(fh.read(_SNIFF_BYTES))
+        except OSError:
+            pass
+        # The store is content-addressed, so the hash IS the strongest possible
+        # etag and it costs nothing to provide.
+        return ResolvedMeta(
+            exists=True,
+            byte_size=size,
+            mime=mime,
+            content_hash=digest,
+            etag=digest,
+        )
+
+    def open(self, uri: str) -> Optional[BinaryIO]:
+        path = self._path_for(uri)
+        if path is None:
+            return None
+        try:
+            return path.open("rb")
+        except OSError:
+            return None
+
+    def presign(self, uri: str, *, ttl_s: int = 300) -> Optional[str]:
+        """Always None. A local filesystem path has no presignable URL.
+
+        Callers handle None by falling back to ``open`` and sending bytes
+        themselves, or by skipping the remote call entirely. Do not "fix" this
+        by returning a ``file://`` URL -- no third party can fetch one.
+        """
+        return None
+
+
+# --- Registry ---------------------------------------------------------------
+
+_resolvers: Dict[str, ContentResolver] = {}
+
+# Built-in fallbacks, consulted only when nothing is explicitly registered.
+# Without this, nothing would ever construct a BlobResolver and the bug this
+# module exists to fix would remain open. Keeping them out of `_resolvers`
+# means clear_content_resolvers() restores byte access rather than removing it,
+# which matters because tests/conftest.py calls it before every test.
+_DEFAULT_RESOLVER_FACTORIES: Dict[str, Callable[[], ContentResolver]] = {
+    "blob": BlobResolver,
+}
+
+
+def set_content_resolver(
+    resolver: Optional[ContentResolver],
+    *,
+    schemes: Optional[Iterable[str]] = None,
+) -> None:
+    """Register (or unregister) a resolver for its declared schemes.
+
+    Hosts call this from their initialize/shutdown hooks. By default the
+    resolver claims every scheme in its own ``schemes`` attribute; pass
+    ``schemes`` to override. Last registration wins per scheme.
+
+    Pass ``resolver=None`` together with ``schemes`` to unregister those
+    schemes, which restores the built-in default for any scheme that has one.
+    """
+    if resolver is None:
+        if schemes is None:
+            raise ValueError("set_content_resolver(None) requires schemes=")
+        for s in schemes:
+            _resolvers.pop(str(s).lower(), None)
+        return
+
+    claimed = schemes if schemes is not None else getattr(resolver, "schemes", ()) or ()
+    for s in claimed:
+        _resolvers[str(s).lower()] = resolver
+
+
+def get_resolver(scheme_or_uri: str) -> Optional[ContentResolver]:
+    """Return the resolver for a scheme (or for a URI's scheme), or None.
+
+    Explicit registrations win; otherwise a built-in default is constructed on
+    demand. Returns None for a scheme nobody handles -- the supported absence
+    path, not an error.
+    """
+    if not scheme_or_uri:
+        return None
+    key = scheme_of(scheme_or_uri) or str(scheme_or_uri).lower()
+    found = _resolvers.get(key)
+    if found is not None:
+        return found
+    factory = _DEFAULT_RESOLVER_FACTORIES.get(key)
+    return factory() if factory is not None else None
+
+
+def clear_content_resolvers() -> None:
+    """Drop all explicit registrations.
+
+    Built-in defaults survive, so blob access still works afterwards. Tests
+    call this between cases so a registration cannot bleed into the next one.
+    """
+    _resolvers.clear()
+
+
+# --- Convenience wrappers ---------------------------------------------------
+#
+# These mirror call_host_llm (llm_backends.py:95): look up, call, swallow
+# anything the resolver raises. A resolver talking to a network archive will
+# raise eventually, and no caller of recall or doctor should have to care.
+
+
+def resolve_head(uri: str) -> Optional[ResolvedMeta]:
+    """Probe a URI's existence and metadata. None if unresolvable."""
+    resolver = get_resolver(uri)
+    if resolver is None:
+        return None
+    try:
+        return resolver.head(uri)
+    except Exception:
+        return None
+
+
+def resolve_open(uri: str) -> Optional[BinaryIO]:
+    """Open a URI's bytes. None if unavailable. The caller owns the handle."""
+    resolver = get_resolver(uri)
+    if resolver is None:
+        return None
+    try:
+        return resolver.open(uri)
+    except Exception:
+        return None
+
+
+def resolve_presign(uri: str, *, ttl_s: int = 300) -> Optional[str]:
+    """Get a short-lived third-party-fetchable URL. None if unsupported."""
+    resolver = get_resolver(uri)
+    if resolver is None:
+        return None
+    try:
+        return resolver.presign(uri, ttl_s=ttl_s)
+    except Exception:
+        return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,15 @@ def _close_cached_connections():
     except Exception:
         pass
 
+    # Same reasoning for the content-resolver registry. Note this clears only
+    # explicit registrations: the built-in blob resolver survives, so tests
+    # that read blobs still work after the reset.
+    try:
+        from mnemosyne.core import resolvers as _resolvers_mod
+        _resolvers_mod.clear_content_resolvers()
+    except Exception:
+        pass
+
 
 @pytest.fixture(autouse=True)
 def _reset_thread_local_connections():

--- a/tests/test_blob_resolver.py
+++ b/tests/test_blob_resolver.py
@@ -1,0 +1,192 @@
+"""BlobResolver: the first reader the content-addressed blob store ever had.
+
+The round-trip tests are the real regression tests. Before this resolver
+existed, `sanitize_content` would extract oversized and high-entropy payloads
+to disk and nothing in the repository could ever read them back -- the bytes
+were written, referenced in metadata, and permanently unreachable.
+"""
+
+import base64
+import os
+
+import pytest
+
+from mnemosyne.core import content_sanitizer
+from mnemosyne.core.resolvers import BlobResolver, resolve_head, resolve_open
+
+
+@pytest.fixture(autouse=True)
+def blob_dir(tmp_path, monkeypatch):
+    """Point the blob store at a temp dir. Read at call time by _blob_root()."""
+    root = tmp_path / "blobs"
+    monkeypatch.setenv("MNEMOSYNE_BLOB_DIR", str(root))
+    return root
+
+
+def _extract(content: str) -> str:
+    """Run content through the sanitizer and return its blob:// reference."""
+    _stub, meta = content_sanitizer.sanitize_content(content)
+    assert meta, "expected sanitize_content to extract this payload"
+    return meta["blob_ref"]
+
+
+# --- round trips through all three extraction branches ----------------------
+
+
+def test_round_trip_size_cap_branch():
+    """Rule 2: content over 1 MB. Previously unreachable once written."""
+    original = "x" * (content_sanitizer.SIZE_HARD_CAP + 1)
+    ref = _extract(original)
+
+    with resolve_open(ref) as fh:
+        assert fh.read().decode("utf-8") == original
+
+
+def test_round_trip_high_entropy_branch():
+    """Rule 3: base64-shaped payload over 100 KB. Also previously unreachable."""
+    original = base64.b64encode(os.urandom(200_000)).decode("ascii")
+    ref = _extract(original)
+
+    with resolve_open(ref) as fh:
+        assert fh.read().decode("utf-8") == original
+
+
+def test_round_trip_data_uri_branch():
+    """Rule 1: a data: URI. Here the blob holds the *decoded* bytes."""
+    raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+    ref = _extract("data:image/png;base64," + base64.b64encode(raw).decode("ascii"))
+
+    with resolve_open(ref) as fh:
+        assert fh.read() == raw
+
+
+# --- head() ----------------------------------------------------------------
+
+
+def test_head_reports_size_hash_and_etag():
+    original = "y" * (content_sanitizer.SIZE_HARD_CAP + 1)
+    ref = _extract(original)
+
+    meta = resolve_head(ref)
+    assert meta is not None
+    assert meta.exists is True
+    assert meta.byte_size == len(original.encode("utf-8"))
+    assert meta.content_hash == ref.rsplit("/", 1)[-1]
+    # Content-addressed storage makes the hash the strongest available etag.
+    assert meta.etag == meta.content_hash
+
+
+def test_head_mime_is_none_for_text_blobs():
+    """The 'must not guess' rule. A size-cap blob is UTF-8 text with no magic
+    bytes and no filename; the honest answer is None, not
+    application/octet-stream."""
+    ref = _extract("z" * (content_sanitizer.SIZE_HARD_CAP + 1))
+    assert resolve_head(ref).mime is None
+
+
+def test_head_mime_is_sniffed_from_magic_bytes():
+    raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+    ref = _extract("data:image/png;base64," + base64.b64encode(raw).decode("ascii"))
+
+    # Sniffed from the bytes on disk -- NOT read back from the mime that
+    # sanitize_content recorded in the memory row's metadata, which the blob
+    # store has no access to. See the RFC 0004 §2.3 correction.
+    assert resolve_head(ref).mime == "image/png"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (b"\xff\xd8\xff\xe0" + b"\x00" * 16, "image/jpeg"),
+        (b"GIF89a" + b"\x00" * 16, "image/gif"),
+        (b"%PDF-1.7\n" + b"\x00" * 16, "application/pdf"),
+        (b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 8, "image/webp"),
+        (b"RIFF\x00\x00\x00\x00WAVE" + b"\x00" * 8, "audio/wav"),
+        (b"\x00\x00\x00\x20ftypisom" + b"\x00" * 8, "video/mp4"),
+        (b"OggS" + b"\x00" * 16, "audio/ogg"),
+        (b"not a known magic number at all", None),
+    ],
+)
+def test_head_mime_sniffing_table(raw, expected):
+    ref = "blob://sha256/" + content_sanitizer._store_blob(raw)
+    assert resolve_head(ref).mime == expected
+
+
+def test_head_missing_blob_reports_exists_false_not_none():
+    """'Mine, and gone' must be distinguishable from 'not my scheme'.
+    mnemosyne doctor needs that distinction to report a dead reference."""
+    meta = resolve_head("blob://sha256/" + "a" * 64)
+    assert meta is not None
+    assert meta.exists is False
+    assert meta.content_hash == "a" * 64
+    assert meta.byte_size is None
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "blob://sha256/tooshort",
+        "blob://md5/" + "a" * 64,
+        "blob://sha256/" + "A" * 64,  # uppercase hex is not what we write
+        "blob://sha256/" + "a" * 63,
+        "blob://sha256/" + "g" * 64,  # not hex
+        "http://example.com/x",
+        "",
+    ],
+)
+def test_head_returns_none_for_uris_that_are_not_ours(uri):
+    assert BlobResolver().head(uri) is None
+    assert BlobResolver().open(uri) is None
+
+
+def test_traversal_is_rejected():
+    hostile = "blob://sha256/../../../../../../etc/passwd"
+    assert BlobResolver().head(hostile) is None
+    assert BlobResolver().open(hostile) is None
+
+
+# --- presign ---------------------------------------------------------------
+
+
+def test_presign_returns_none():
+    """A local path has no presignable URL. Returning a file:// URL would hand
+    a remote provider something it cannot fetch, while looking like success."""
+    ref = _extract("q" * (content_sanitizer.SIZE_HARD_CAP + 1))
+    assert BlobResolver().presign(ref) is None
+    assert BlobResolver().presign(ref, ttl_s=900) is None
+
+
+# --- root resolution -------------------------------------------------------
+
+
+def test_root_is_read_at_call_time_not_construction(tmp_path, monkeypatch):
+    """Constructing the resolver must not freeze MNEMOSYNE_BLOB_DIR. Tests set
+    that variable after import, and a cached root would resolve against the
+    wrong directory for the life of the process."""
+    resolver = BlobResolver()
+
+    later = tmp_path / "later-blobs"
+    monkeypatch.setenv("MNEMOSYNE_BLOB_DIR", str(later))
+    digest = content_sanitizer._store_blob(b"stored after construction")
+
+    with resolver.open("blob://sha256/" + digest) as fh:
+        assert fh.read() == b"stored after construction"
+
+
+def test_explicit_root_overrides_the_environment(tmp_path, monkeypatch):
+    explicit = tmp_path / "explicit"
+    monkeypatch.setenv("MNEMOSYNE_BLOB_DIR", str(explicit))
+    digest = content_sanitizer._store_blob(b"in the explicit root")
+
+    monkeypatch.setenv("MNEMOSYNE_BLOB_DIR", str(tmp_path / "somewhere-else"))
+    with BlobResolver(root=explicit).open("blob://sha256/" + digest) as fh:
+        assert fh.read() == b"in the explicit root"
+
+
+def test_layout_matches_store_blob_exactly():
+    """If _store_blob's sharding ever changes, this fails loudly rather than
+    the resolver quietly returning 'gone' for every blob."""
+    digest = content_sanitizer._store_blob(b"layout check")
+    expected = content_sanitizer._blob_root() / digest[:2] / digest[:4] / digest
+    assert expected.exists()
+    assert BlobResolver()._path_for("blob://sha256/" + digest) == expected

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -1,0 +1,192 @@
+"""Registry semantics for mnemosyne.core.resolvers.
+
+These cover the contract independent of any filesystem: scheme dispatch,
+registration lifecycle, the built-in default, and the promise that a failing
+resolver degrades to None rather than raising into a caller.
+
+Blob-reading behaviour lives in tests/test_blob_resolver.py.
+"""
+
+import pytest
+
+from mnemosyne.core.resolvers import (
+    BlobResolver,
+    CallableContentResolver,
+    ResolvedMeta,
+    clear_content_resolvers,
+    get_resolver,
+    resolve_head,
+    resolve_open,
+    resolve_presign,
+    scheme_of,
+    set_content_resolver,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Belt and braces: conftest already clears this, but these tests register
+    aggressively and should not depend on the global fixture's ordering."""
+    clear_content_resolvers()
+    yield
+    clear_content_resolvers()
+
+
+def _archive_resolver(**kwargs):
+    return CallableContentResolver(name="fake-archive", schemes=frozenset({"archive"}), **kwargs)
+
+
+# --- scheme_of --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "uri,expected",
+    [
+        ("blob://sha256/abc", "blob"),
+        ("archive://host/thing", "archive"),
+        ("HTTPS://Example.com/x", "https"),
+        ("s3+custom://bucket/key", "s3+custom"),
+        ("", None),
+        ("noscheme", None),
+        ("://missing", None),
+        ("/plain/path", None),
+        (None, None),
+    ],
+)
+def test_scheme_of(uri, expected):
+    assert scheme_of(uri) == expected
+
+
+# --- registration lifecycle -------------------------------------------------
+
+
+def test_get_resolver_returns_none_for_unhandled_scheme():
+    """The supported absence path: no resolver, no error, no exception."""
+    assert get_resolver("archive") is None
+    assert get_resolver("archive://anything") is None
+    assert resolve_head("archive://anything") is None
+    assert resolve_open("archive://anything") is None
+    assert resolve_presign("archive://anything") is None
+
+
+def test_set_and_get_by_scheme_and_by_uri():
+    r = _archive_resolver()
+    set_content_resolver(r)
+    assert get_resolver("archive") is r
+    assert get_resolver("archive://host/thing") is r
+
+
+def test_schemes_override_claims_extra_schemes():
+    r = _archive_resolver()
+    set_content_resolver(r, schemes=["archive", "vault"])
+    assert get_resolver("vault://x") is r
+
+
+def test_last_registration_wins():
+    first = _archive_resolver()
+    second = _archive_resolver()
+    set_content_resolver(first)
+    set_content_resolver(second)
+    assert get_resolver("archive") is second
+
+
+def test_set_none_unregisters_named_schemes():
+    r = _archive_resolver()
+    set_content_resolver(r)
+    set_content_resolver(None, schemes=["archive"])
+    assert get_resolver("archive") is None
+
+
+def test_set_none_without_schemes_is_an_error():
+    """Silently clearing everything would be a nasty way to spell 'unregister'."""
+    with pytest.raises(ValueError):
+        set_content_resolver(None)
+
+
+# --- the built-in default ---------------------------------------------------
+
+
+def test_blob_resolver_is_available_with_zero_configuration():
+    """The whole point of the two-tier registry: nobody has to register
+    BlobResolver for the blob store to become readable."""
+    assert isinstance(get_resolver("blob"), BlobResolver)
+    assert isinstance(get_resolver("blob://sha256/" + "a" * 64), BlobResolver)
+
+
+def test_explicit_registration_overrides_the_builtin():
+    custom = CallableContentResolver(name="custom-blob", schemes=frozenset({"blob"}))
+    set_content_resolver(custom)
+    assert get_resolver("blob") is custom
+
+
+def test_clear_restores_builtin_rather_than_removing_blob_access():
+    """conftest calls clear_content_resolvers() before every test. If clearing
+    dropped the built-in, that reset would silently disable blob reads for the
+    entire suite -- so this asserts the reset is safe to run."""
+    custom = CallableContentResolver(name="custom-blob", schemes=frozenset({"blob"}))
+    set_content_resolver(custom)
+    assert get_resolver("blob") is custom
+
+    clear_content_resolvers()
+
+    restored = get_resolver("blob")
+    assert restored is not custom
+    assert isinstance(restored, BlobResolver)
+
+
+# --- failure degrades to None ----------------------------------------------
+
+
+def test_wrappers_swallow_resolver_exceptions():
+    """A resolver talking to a network archive will raise eventually. No caller
+    of recall or doctor should have to care. Mirrors call_host_llm."""
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("archive unreachable")
+
+    set_content_resolver(
+        _archive_resolver(head_func=boom, open_func=boom, presign_func=boom)
+    )
+
+    assert resolve_head("archive://x") is None
+    assert resolve_open("archive://x") is None
+    assert resolve_presign("archive://x") is None
+
+
+def test_callable_resolver_methods_default_to_none():
+    """A resolver that only knows how to head is a legal resolver."""
+    set_content_resolver(
+        _archive_resolver(head_func=lambda uri: ResolvedMeta(exists=True))
+    )
+    assert resolve_head("archive://x") == ResolvedMeta(exists=True)
+    assert resolve_open("archive://x") is None
+    assert resolve_presign("archive://x") is None
+
+
+def test_presign_ttl_is_forwarded():
+    seen = {}
+
+    def presign(uri, *, ttl_s):
+        seen["uri"] = uri
+        seen["ttl_s"] = ttl_s
+        return "https://example.invalid/signed"
+
+    set_content_resolver(_archive_resolver(presign_func=presign))
+    assert resolve_presign("archive://x", ttl_s=60) == "https://example.invalid/signed"
+    assert seen == {"uri": "archive://x", "ttl_s": 60}
+
+
+# --- cross-test isolation ---------------------------------------------------
+# These two run in definition order within the file and together assert that
+# the autouse reset actually works.
+
+
+def test_isolation_a_registers_a_resolver():
+    set_content_resolver(
+        CallableContentResolver(name="leaky", schemes=frozenset({"leak"}))
+    )
+    assert get_resolver("leak") is not None
+
+
+def test_isolation_b_does_not_see_the_previous_registration():
+    assert get_resolver("leak") is None


### PR DESCRIPTION
The blob store could write but not read, so nothing downstream could get content back out of it.

Adds the `ContentResolver` interface and the `BlobResolver` implementation that satisfies it. Media ingest depends on this to turn a stored reference back into bytes.

Rebased onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds `ContentResolver`, `BlobResolver`, and resolver registry APIs for reading stored blob references as bytes.
- Supports metadata lookup, MIME detection from magic bytes, traversal protection, and per-call `MNEMOSYNE_BLOB_DIR` resolution.
- Preserves local-first behavior. Blob content remains on the local filesystem, with no new configuration or remote service.
- Provides a clean integration surface for Hermes, MCP, and CLI consumers through `resolve_head()`, `resolve_open()`, and `resolve_presign()`.
- Keeps presigning unsupported for local blobs and returns safe fallback results for unsupported URIs or resolver failures.

## Architectural impact

This change strengthens the blob layer of the core memory architecture. It enables media ingest and downstream consumers to resolve stored references into content.

It does not change working, episodic, or BEAM memory tiers. It does not change retrieval, consolidation, veracity, synchronization, or benchmark methodology.

## Design assessment

The resolver protocol and scheme-based dispatch are the right call. They provide a narrow extension point for future content sources without coupling memory consumers to blob-storage details.

The built-in `blob` fallback, registry isolation, traversal protection, and call-time root lookup support maintainability and safe local deployment.

No change erodes the local-first design. The implementation adds no network dependency, remote storage requirement, or new configuration key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->