### PR TITLE
feat(beam): let remember() take an explicit memory_type and opt out of dedupe

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -188,6 +188,31 @@ def _source_to_trust_tier(source: str) -> str:
     # Conservative default: treat as direct user input
     return "STATED"
 
+
+def _clamp_memory_type(value: Optional[str]) -> Optional[str]:
+    """Validate an explicit memory_type label, or return None.
+
+    None passes through, which is the signal to fall back to the content
+    classifier. An unrecognized label also returns None, with a WARNING: a
+    typo should degrade to classification, not strip the type off the row.
+
+    Mirrors the posture of clamp_veracity -- validate at the lowest public
+    ingest path rather than trusting callers, since the value reaches a
+    column that recall filters on.
+    """
+    if value is None:
+        return None
+    if MemoryType is None:  # typed_memory unavailable; nothing to validate against
+        return None
+    candidate = str(value).strip().lower()
+    if candidate in {m.value for m in MemoryType}:
+        return candidate
+    logger.warning(
+        "remember: unknown memory_type %r; falling back to the classifier", value
+    )
+    return None
+
+
 try:
     import numpy as np
 except ImportError:
@@ -3635,7 +3660,9 @@ class BeamMemory:
                  extract_entities: bool = False,
                  extract: bool = False,
                  veracity: str = "unknown",
-                 trust_tier: str = None) -> str:
+                 trust_tier: str = None,
+                 memory_type: str = None,
+                 dedupe: bool = True) -> str:
         """Store into working_memory. Deduplicates exact content matches.
 
         When called from the legacy-compatible Mnemosyne.remember() path,
@@ -3657,6 +3684,29 @@ class BeamMemory:
             veracity: Confidence level -- 'stated', 'inferred', 'tool', 'imported', 'unknown'.
                 Non-canonical labels are clamped to 'unknown' with a WARNING
                 (mirrors the C12.b clamp at the hermes_memory_provider boundary).
+            memory_type: Optional explicit MemoryType value (e.g. 'artifact').
+                Overrides the content classifier entirely -- the classifier is
+                not consulted when this is supplied. Unrecognized labels log a
+                WARNING and fall back to classification, so a typo degrades to
+                default behaviour rather than stripping the type. Callers that
+                *know* what they are writing (a media caption is an artifact,
+                whatever its words look like) should set this.
+            dedupe: When False, skip the exact-content duplicate check and
+                always write a new row.
+
+                Callers writing programmatically-generated text need this. The
+                dedup key is (session_id, content), and generated text collides
+                far more readily than prose -- "a black frame", "a screenshot
+                of a terminal window", a repeated slide. Two such rows
+                describing *different* sources would otherwise collapse into
+                one, and any sidecar table binding to the returned id would
+                bind the second source's row to the first source's memory.
+                Nothing raises and the counts all look right, which is what
+                makes it worth an explicit opt-out.
+
+                Leaving dedupe on has a second effect worth knowing: the
+                dedup-update path applies memory_type via COALESCE, so an
+                explicit type on a colliding write retypes the existing row.
         """
         # Clamp veracity at the BeamMemory.remember entry too -- the
         # method is the lowest-level public ingest path under BeamMemory,
@@ -3683,8 +3733,12 @@ class BeamMemory:
             trust_tier = "STATED"
 
         # --- Typed memory classification (Phase 1 -- zero overhead) ---
-        memory_type = None
-        if classify_memory is not None:
+        # An explicit memory_type wins outright and short-circuits the
+        # classifier: a caller that declares the type knows something the
+        # content does not say. An unrecognized label degrades to
+        # classification rather than to NULL.
+        memory_type = _clamp_memory_type(memory_type)
+        if memory_type is None and classify_memory is not None:
             try:
                 result = classify_memory(content)
                 memory_type = result.memory_type.value
@@ -3692,7 +3746,7 @@ class BeamMemory:
                 pass  # Classifier failures are non-blocking
 
         # --- Deduplication: exact match ---
-        existing_id = self._find_duplicate(content)
+        existing_id = self._find_duplicate(content) if dedupe else None
         if existing_id:
             cursor = self.conn.cursor()
             # Dedup-update clears consolidated_at so a re-remembered row
@@ -3957,8 +4011,11 @@ class BeamMemory:
             memory_id = _generate_id(item["content"])
             ids.append(memory_id)
             # Typed memory classification
-            item_type = None
-            if classify_memory is not None:
+            # Per-item explicit type wins and short-circuits the classifier,
+            # matching remember(). There is no method-level default: a batch
+            # is heterogeneous by nature.
+            item_type = _clamp_memory_type(item.get("memory_type"))
+            if item_type is None and classify_memory is not None:
                 try:
                     result = classify_memory(item["content"])
                     item_type = result.memory_type.value

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -387,7 +387,9 @@ class Mnemosyne:
                  extract_entities: bool = False,
                  extract: bool = False,
                  veracity: str = "unknown",
-                 trust_tier: str = None) -> str:
+                 trust_tier: str = None,
+                 memory_type: str = None,
+                 dedupe: bool = True) -> str:
         """
         Store a memory directly to SQLite.
         Writes to both BEAM working_memory and legacy memories table.
@@ -402,10 +404,20 @@ class Mnemosyne:
             trust_tier: Trust classification for prompt-injection defense.
                 None = use beam default ('STATED'). 'EXTERNAL_WRITE' for MCP
                 tool calls, 'IMPORTED' for bulk imports.
+            memory_type: Optional explicit MemoryType value; overrides the
+                content classifier. See BeamMemory.remember.
+            dedupe: When False, always write a new row instead of folding into
+                an exact content match. See BeamMemory.remember.
 
         Returns:
             memory_id on success, or None if the content was filtered by
             the write classifier (noise pattern or secret detection).
+
+        Note for programmatic writers: this facade can return None, because
+        the write filter below may veto the content outright. It also does not
+        accept a caller-supplied memory_id. Callers that must observe every
+        write and control its id -- media ingest, importers -- should call
+        BeamMemory.remember directly rather than going through here.
         """
         # --- Core-level write filter (issues #406, #428) ---
         # Placed here so ALL entry points (Hermes provider, MCP server, SDK,
@@ -458,6 +470,8 @@ class Mnemosyne:
                 extract_entities=extract_entities, extract=extract,
                 veracity=veracity,
                 trust_tier=trust_tier,
+                memory_type=memory_type,
+                dedupe=dedupe,
             )
             timestamp = datetime.now().isoformat()
 

--- a/tests/test_memory_type_override.py
+++ b/tests/test_memory_type_override.py
@@ -1,0 +1,237 @@
+"""Explicit memory_type and the dedupe opt-out on remember().
+
+Two prerequisites for writing programmatically-generated memories:
+
+1. A caller that knows what it is writing must be able to say so. The content
+   classifier reads words, and generated text ("a screenshot of a terminal")
+   does not describe what it actually is.
+
+2. A caller writing generated text must be able to opt out of content dedup.
+   The dedup key is (session_id, content); generated text collides where prose
+   would not, and folding two rows into one silently misattributes anything
+   that binds to the returned id.
+"""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mnemosyne.core import beam as beam_module
+from mnemosyne.core.beam import BeamMemory, _clamp_memory_type
+from mnemosyne.core.typed_memory import MemoryType
+
+
+@pytest.fixture
+def temp_db():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir) / "test.db"
+
+
+def _memory_type_of(db_path: Path, memory_id: str):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT memory_type FROM working_memory WHERE id = ?", (memory_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, f"no working_memory row for {memory_id}"
+    return row[0]
+
+
+# --- _clamp_memory_type -----------------------------------------------------
+
+
+def test_clamp_passes_through_none():
+    assert _clamp_memory_type(None) is None
+
+
+@pytest.mark.parametrize("label", [m.value for m in MemoryType])
+def test_clamp_accepts_every_declared_type(label):
+    assert _clamp_memory_type(label) == label
+
+
+@pytest.mark.parametrize("given,expected", [("ARTIFACT", "artifact"), ("  Artifact  ", "artifact")])
+def test_clamp_normalizes_case_and_whitespace(given, expected):
+    assert _clamp_memory_type(given) == expected
+
+
+def test_clamp_rejects_unknown_label_with_a_warning(caplog):
+    with caplog.at_level("WARNING"):
+        assert _clamp_memory_type("definitely-not-a-type") is None
+    assert "unknown memory_type" in caplog.text
+
+
+# --- explicit type beats the classifier ------------------------------------
+
+
+def test_explicit_type_wins_over_classifier(temp_db, monkeypatch):
+    """The classifier must not merely be overridden afterwards -- it must not
+    run at all. Monkeypatching it to raise proves the short-circuit."""
+
+    def explode(_content):
+        raise AssertionError("classify_memory must not be called")
+
+    monkeypatch.setattr(beam_module, "classify_memory", explode)
+
+    beam = BeamMemory(session_id="mt-explicit", db_path=temp_db)
+    # Content the classifier would confidently label a preference.
+    mid = beam.remember("I prefer dark mode", memory_type="artifact")
+
+    assert _memory_type_of(temp_db, mid) == "artifact"
+
+
+def test_classifier_still_runs_when_no_type_is_given(temp_db, monkeypatch):
+    monkeypatch.setattr(
+        beam_module,
+        "classify_memory",
+        lambda content: type("R", (), {"memory_type": MemoryType.PREFERENCE})(),
+    )
+    beam = BeamMemory(session_id="mt-default", db_path=temp_db)
+    mid = beam.remember("I prefer dark mode")
+    assert _memory_type_of(temp_db, mid) == "preference"
+
+
+def test_unknown_type_falls_back_to_the_classifier(temp_db, monkeypatch):
+    """A typo should degrade to today's behaviour, not strip the type."""
+    monkeypatch.setattr(
+        beam_module,
+        "classify_memory",
+        lambda content: type("R", (), {"memory_type": MemoryType.PREFERENCE})(),
+    )
+    beam = BeamMemory(session_id="mt-typo", db_path=temp_db)
+    mid = beam.remember("I prefer dark mode", memory_type="artifcat")
+    assert _memory_type_of(temp_db, mid) == "preference"
+
+
+def test_classifier_failure_is_still_non_blocking(temp_db, monkeypatch):
+    def explode(_content):
+        raise RuntimeError("classifier is broken")
+
+    monkeypatch.setattr(beam_module, "classify_memory", explode)
+    beam = BeamMemory(session_id="mt-broken", db_path=temp_db)
+    mid = beam.remember("some content")  # must not raise
+    assert _memory_type_of(temp_db, mid) is None
+
+
+# --- dedupe -----------------------------------------------------------------
+
+
+def test_dedupe_on_by_default_folds_identical_content(temp_db):
+    beam = BeamMemory(session_id="dedupe-default", db_path=temp_db)
+    first = beam.remember("a screenshot of a terminal window")
+    second = beam.remember("a screenshot of a terminal window")
+    assert first == second
+
+
+def test_dedupe_false_writes_a_distinct_row(temp_db):
+    """The regression this exists to prevent: two captions of the same text
+    describing different sources must remain two rows, so anything binding to
+    the returned id binds to the right one."""
+    beam = BeamMemory(session_id="dedupe-off", db_path=temp_db)
+    first = beam.remember("a black frame", dedupe=False)
+    second = beam.remember("a black frame", dedupe=False)
+
+    assert first != second
+
+    conn = sqlite3.connect(str(temp_db))
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM working_memory WHERE content = ?", ("a black frame",)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 2
+
+
+def test_dedupe_false_avoids_retyping_a_colliding_row(temp_db):
+    """With dedup on, an explicit type reaches the COALESCE in the update path
+    and retypes whatever row it collided with. dedupe=False is what keeps a
+    generated write from mutating a user's existing memory."""
+    beam = BeamMemory(session_id="dedupe-retype", db_path=temp_db)
+    original = beam.remember("meeting notes", memory_type="event")
+    assert _memory_type_of(temp_db, original) == "event"
+
+    beam.remember("meeting notes", memory_type="artifact", dedupe=False)
+
+    # The original row is untouched.
+    assert _memory_type_of(temp_db, original) == "event"
+
+
+def test_dedupe_on_does_retype_via_coalesce(temp_db):
+    """Documents the behaviour the flag exists to opt out of, so a future
+    change to the COALESCE path fails loudly here."""
+    beam = BeamMemory(session_id="dedupe-coalesce", db_path=temp_db)
+    original = beam.remember("meeting notes", memory_type="event")
+    again = beam.remember("meeting notes", memory_type="artifact")
+
+    assert again == original
+    assert _memory_type_of(temp_db, original) == "artifact"
+
+
+# --- remember_batch parity --------------------------------------------------
+
+
+def test_remember_batch_honors_per_item_memory_type(temp_db, monkeypatch):
+    def explode(_content):
+        raise AssertionError("classify_memory must not be called for typed items")
+
+    monkeypatch.setattr(beam_module, "classify_memory", explode)
+
+    beam = BeamMemory(session_id="batch-typed", db_path=temp_db)
+    ids = beam.remember_batch(
+        [
+            {"content": "I prefer dark mode", "memory_type": "artifact"},
+            {"content": "I prefer light mode", "memory_type": "artifact"},
+        ]
+    )
+
+    assert len(ids) == 2
+    for mid in ids:
+        assert _memory_type_of(temp_db, mid) == "artifact"
+
+
+def test_remember_batch_unknown_type_falls_back(temp_db, monkeypatch):
+    monkeypatch.setattr(
+        beam_module,
+        "classify_memory",
+        lambda content: type("R", (), {"memory_type": MemoryType.PREFERENCE})(),
+    )
+    beam = BeamMemory(session_id="batch-typo", db_path=temp_db)
+    ids = beam.remember_batch([{"content": "x", "memory_type": "nope"}])
+    assert _memory_type_of(temp_db, ids[0]) == "preference"
+
+
+# --- facade parity ----------------------------------------------------------
+
+
+def test_facade_passes_both_parameters_through(temp_db, monkeypatch):
+    from mnemosyne.core.memory import Mnemosyne
+
+    seen = {}
+    m = Mnemosyne(db_path=temp_db, session_id="facade")
+
+    real = m.beam.remember
+
+    def spy(content, **kwargs):
+        seen.update(kwargs)
+        return real(content, **kwargs)
+
+    monkeypatch.setattr(m.beam, "remember", spy)
+    m.remember("a caption", memory_type="artifact", dedupe=False)
+
+    assert seen["memory_type"] == "artifact"
+    assert seen["dedupe"] is False
+
+
+# --- positional-call compatibility -----------------------------------------
+
+
+def test_existing_positional_callers_are_unaffected(temp_db):
+    """The new parameters are appended, not inserted, and there is no `*`
+    separator -- positional calls are common throughout the suite."""
+    beam = BeamMemory(session_id="positional", db_path=temp_db)
+    mid = beam.remember("content", "conversation", 0.7, {"k": "v"})
+    assert mid


### PR DESCRIPTION
`remember()` gains two parameters:

- `memory_type`, an explicit `MemoryType` that overrides the content classifier
- `dedupe=False`, which always writes a new row instead of folding into an exact content match

Both default to current behaviour, so existing callers are unaffected. Media ingest needs both: a caption's type is known at ingest time rather than inferred, and two frames can legitimately produce identical description text without being the same memory.

Rebased onto current main. The rebase resolved one conflict against #760, which wrapped this write path in `_deferred_commits`; both changes are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- `remember()` now accepts explicit `memory_type` and `dedupe` controls.
- Valid `memory_type` values bypass classification. Unknown values trigger a warning and use classification.
- `dedupe=False` creates a new row for identical content. This prevents identical media captions from merging across frames.
- `remember_batch()` supports per-item memory-type overrides.
- `Mnemosyne.remember()` forwards both parameters through the facade.
- Existing defaults and positional callers remain compatible.
- Writes remain protected by `_deferred_commits`.

## Architectural impact

This change improves the BEAM write path for media ingestion. It does not change working memory, episodic memory, retrieval strategies, consolidation, veracity processing, or the sync layer.

The explicit type override is the right call when ingestion already knows the content type. The deduplication opt-out is the right call when identical descriptions represent distinct assets.

The change does not alter privacy behavior or local-first guarantees. It adds no external service dependency and keeps writes in the existing local transaction flow.

No changes affect Hermes, MCP, or CLI integration surfaces. These integrations can use the new behavior through the existing memory facade.

The test suite reports 2404 passed and 2 skipped tests. Ruff and documentation checks pass. The tests cover validation, fallback behavior, classifier bypass, deduplication, batch behavior, facade forwarding, and positional compatibility.

## Maintainability

The API appends optional parameters to preserve compatibility. Centralized memory-type validation keeps invalid input behavior explicit. The new tests document the expected behavior across direct, batch, and facade entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->