### PR TITLE
feat(modality): vendor-neutral provider seam for describing non-text content

### DIFF
--- a/docs/api/configuration.mdx
+++ b/docs/api/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration"
 version: 4.0.0
-config_key_count: 106
+config_key_count: 114
 env_only_count: 44
 generated_at: "auto"
 ---
@@ -23,13 +23,13 @@ and `wm_max_items` are equivalent.
 Keys marked **restart** are read once at startup. Changing them at runtime warns
 and does not take effect until the process restarts.
 
-There are **106 configuration keys**. A further
+There are **114 configuration keys**. A further
 **44 environment variables** are read directly from the
 environment and are **not** settable in `config.yaml`; they are listed separately below.
 
 ---
 
-## Configuration keys (106)
+## Configuration keys (114)
 
 | Config key | Environment variable | Default | Restart | Description |
 |------------|----------------------|---------|---------|-------------|
@@ -80,6 +80,14 @@ environment and are **not** settable in `config.yaml`; they are listed separatel
 | `llm_n_threads` | `MNEMOSYNE_LLM_N_THREADS` | `4` | no | CPU threads for local GGUF inference. |
 | `llm_repo` | `MNEMOSYNE_LLM_REPO` | *(unset)* | **yes** | Hugging Face repo holding the local GGUF model. |
 | `llm_timeout` | `MNEMOSYNE_LLM_TIMEOUT` | `60` | no | Per-request timeout in seconds for LLM calls. |
+| `modality_api_key` | `MNEMOSYNE_MODALITY_API_KEY` | *(unset)* | no | API key for the modality endpoint. |
+| `modality_audio_model` | `MNEMOSYNE_MODALITY_AUDIO_MODEL` | *(unset)* | **yes** | Model used to transcribe or describe audio. |
+| `modality_base_url` | `MNEMOSYNE_MODALITY_BASE_URL` | *(unset)* | **yes** | Base URL of an OpenAI-compatible vision endpoint. Any provider that speaks the protocol works. |
+| `modality_enabled` | `MNEMOSYNE_MODALITY_ENABLED` | `false` | no | Allow outbound calls to describe non-text media. Off by default; nothing is sent until this is set. |
+| `modality_max_moments` | `MNEMOSYNE_MODALITY_MAX_MOMENTS` | `12` | no | Maximum moments retained per media asset. |
+| `modality_timeout` | `MNEMOSYNE_MODALITY_TIMEOUT` | `60` | no | Timeout in seconds for a modality describe call. |
+| `modality_video_model` | `MNEMOSYNE_MODALITY_VIDEO_MODEL` | *(unset)* | **yes** | Model used to describe video. |
+| `modality_vision_model` | `MNEMOSYNE_MODALITY_VISION_MODEL` | *(unset)* | **yes** | Model used to describe images and documents. |
 | `no_embeddings` | `MNEMOSYNE_NO_EMBEDDINGS` | `false` | no | Disable dense retrieval entirely. Recall degrades to lexical FTS5. |
 | `persona_daily_sync_hour` | `MNEMOSYNE_PERSONA_DAILY_SYNC_HOUR` | `3` | no | Local hour at which the daily persona sync runs. |
 | `persona_enabled` | `MNEMOSYNE_PERSONA_ENABLED` | `true` | no | Inject L3 persona facts into the system prompt. |

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -14,6 +14,19 @@ Mnemosyne runs everywhere. Pick your platform:
 | [Zero](zero.md) | Plugin (tools + hooks) | `.zero/plugins/mnemosyne/` |
 | [OpenClaw](openclaw.md) | Native plugin | `pip install mnemosyne-memory[openclaw]` |
 
+## Model providers
+
+Mnemosyne's outbound surfaces all speak the OpenAI-compatible protocol, so any
+provider that implements it works with environment variables alone.
+
+| Provider | Surfaces | Config |
+|----------|----------|--------|
+| [Any OpenAI-compatible vision endpoint](openai-compatible-vision.md) | Vision | `MNEMOSYNE_MODALITY_*` |
+| [Atlas Cloud](atlas-cloud.md) | Chat, embeddings, vision | `MNEMOSYNE_LLM_*`, `MNEMOSYNE_EMBEDDING_*`, `MNEMOSYNE_MODALITY_*` |
+
+Media understanding is **off by default** — `MNEMOSYNE_MODALITY_ENABLED`
+must be set before Mnemosyne makes any outbound call to describe a file.
+
 ## Quick Start (any MCP client)
 
 ```json

--- a/docs/integrations/atlas-cloud.md
+++ b/docs/integrations/atlas-cloud.md
@@ -1,0 +1,107 @@
+# Atlas Cloud
+
+[Atlas Cloud](https://atlascloud.ai) is an OpenAI-compatible model aggregator
+and a Mnemosyne sponsor. This page is a **configuration recipe** — there is no
+Atlas-specific code in Mnemosyne, and there is not meant to be. Everything below
+is environment variables against interfaces Mnemosyne already speaks, which is
+why the same three blocks work against OpenRouter, vLLM, or a local server with
+only the URLs changed.
+
+Atlas covers all three of Mnemosyne's outbound surfaces.
+
+| Surface | Config | Notes |
+|---|---|---|
+| Chat — consolidation, extraction, conflict detection | `MNEMOSYNE_LLM_*` | Works today, no new code |
+| Embeddings | `MNEMOSYNE_EMBEDDING_*` | Works today, one gotcha below |
+| Vision | `MNEMOSYNE_MODALITY_*` | See [OpenAI-Compatible Vision](openai-compatible-vision.md) |
+
+Two base URLs, and they are not interchangeable:
+
+- `https://api.atlascloud.ai/v1` — OpenAI-compatible chat, embeddings, vision.
+  **This is the one Mnemosyne uses.**
+- `https://api.atlascloud.ai/api/v1` — Atlas's own image/video generation and
+  `uploadMedia` endpoints. Mnemosyne does not call these.
+
+---
+
+## Chat
+
+Drives sleep-time consolidation, fact extraction, and conflict detection.
+
+```bash
+export MNEMOSYNE_LLM_BASE_URL=https://api.atlascloud.ai/v1
+export MNEMOSYNE_LLM_API_KEY=...
+export MNEMOSYNE_LLM_MODEL=...
+```
+
+---
+
+## Embeddings
+
+```bash
+export MNEMOSYNE_EMBEDDING_API_URL=https://api.atlascloud.ai/v1
+export MNEMOSYNE_EMBEDDING_API_KEY=...
+export MNEMOSYNE_EMBEDDING_MODEL=...
+export MNEMOSYNE_EMBEDDINGS_VIA_API=1   # <- do not omit this
+```
+
+**The gotcha.** Mnemosyne decides between the local ONNX embedder and a remote
+endpoint using a name heuristic: a model routes to the API when its name starts
+with `openai/` or contains `text-embedding`. A hosted BGE model has the same
+vendor-prefix shape as the *local* default (`BAAI/bge-small-en-v1.5`), so
+inference guesses "local" and quietly ignores your endpoint. Set
+`MNEMOSYNE_EMBEDDINGS_VIA_API=1` explicitly rather than relying on the heuristic.
+
+**Dimensions must match what is already stored.** Switching embedding providers
+mid-database is a reindex, not a config change — check
+`MNEMOSYNE_EMBEDDING_DIM` against your existing vec tables before you switch,
+or run `mnemosyne reindex` after.
+
+---
+
+## Vision
+
+```bash
+export MNEMOSYNE_MODALITY_ENABLED=1
+export MNEMOSYNE_MODALITY_BASE_URL=https://api.atlascloud.ai/v1
+export MNEMOSYNE_MODALITY_API_KEY=...
+export MNEMOSYNE_MODALITY_VISION_MODEL=qwen/qwen3-vl-235b-a22b-thinking
+```
+
+> **If Mnemosyne has already run on this machine**, exporting these does
+> nothing: `config.yaml` was seeded on first run and takes precedence over the
+> environment. Use `mnemosyne config set modality_enabled true` and the
+> matching `modality_*` keys instead, or `mnemosyne config migrate` to import
+> your current variables. See
+> [OpenAI-compatible vision](openai-compatible-vision.md#configyaml-wins-over-these-variables).
+
+
+Atlas aggregates vision models from several vendors, so the model name is the
+only thing you pick here. `GET https://api.atlascloud.ai/v1/models` lists what is
+available along with each model's `input_modalities`; Mnemosyne can use that to
+warn you if you configure a text-only model. See
+[OpenAI-Compatible Vision](openai-compatible-vision.md) for the full surface.
+
+---
+
+## Keys
+
+Every value above is a secret. Keep them in your environment or a secret
+manager — never in `config.yaml` committed to a repository, and never in a
+shell history file you sync. If a key has been pasted anywhere it should not
+be, rotate it; that is cheaper than auditing where it went.
+
+---
+
+## Why there is no `modality_atlas.py`
+
+Mnemosyne's partnership policy is that sponsored work benefits the whole
+ecosystem rather than privileging one provider, so core modules are named after
+protocols, not vendors. The evidence agreed with the policy: Atlas serves 123
+models, 30 of them vision-capable, and **every one belongs to another vendor**.
+Atlas is an aggregator of the OpenAI-compatible protocol — there was never an
+Atlas-specific API to adapt to.
+
+So Atlas is the **reference deployment**: the configuration we verify against,
+documented here as one worked example among several. The acceptance test is that
+switching to any other endpoint requires changing environment variables only.

--- a/docs/integrations/openai-compatible-vision.md
+++ b/docs/integrations/openai-compatible-vision.md
@@ -1,0 +1,220 @@
+# OpenAI-Compatible Vision
+
+Mnemosyne can ask an external model to describe an image, and store the
+description as ordinary, recallable memory. This page is the primary guide for
+configuring that.
+
+The seam speaks one protocol — `POST {base_url}/chat/completions` with
+`image_url` content parts — so **any** endpoint that implements it works. There
+is no provider-specific code path, and switching providers is an environment
+change, never a code change.
+
+> **Nothing is sent until you say so.** `modality_enabled` defaults to `false`.
+> With it unset, Mnemosyne makes no outbound call to describe media, opens no
+> socket, and never reads the bytes of a local file. Turning it on is a
+> deliberate, one-time act.
+
+---
+
+## What it does
+
+Point Mnemosyne at a piece of media and it records:
+
+- an **asset row** — the reference (URL, file path, or content hash), plus what
+  it knows about the media. The bytes are never copied into the database.
+- zero or more **moments** — captions, shots, transcript segments, OCR regions.
+  Each retained moment becomes an ordinary memory row, so it is recalled,
+  decayed, consolidated, and synced by the machinery that already exists.
+
+If no provider is configured, or the provider is unreachable, or it declines,
+the asset is still registered by reference. That is a **success state**, not an
+error: you get a searchable record that you referenced a given file, which is
+strictly more than you had before.
+
+---
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `MNEMOSYNE_MODALITY_ENABLED` | `false` | Master switch. Nothing happens until this is on. |
+| `MNEMOSYNE_MODALITY_BASE_URL` | *(unset)* | Base URL of the endpoint, including `/v1` if the provider uses one. |
+| `MNEMOSYNE_MODALITY_API_KEY` | *(unset)* | Bearer token. Required — a base URL alone is treated as an unfinished config. |
+| `MNEMOSYNE_MODALITY_VISION_MODEL` | *(unset)* | Model for images and documents. |
+| `MNEMOSYNE_MODALITY_VIDEO_MODEL` | *(unset)* | Model for video. |
+| `MNEMOSYNE_MODALITY_AUDIO_MODEL` | *(unset)* | Model for audio. |
+| `MNEMOSYNE_MODALITY_TIMEOUT` | `60` | Per-call timeout, seconds. |
+| `MNEMOSYNE_MODALITY_MAX_MOMENTS` | `12` | Cap on moments retained per asset. |
+| `MNEMOSYNE_MODALITY_PROMPT` | *(built-in)* | Override the description prompt. `{modality}` and `{max_moments}` are substituted. |
+
+`MNEMOSYNE_MODALITY_BASE_URL` and the three model keys are read once when the
+client is constructed, so changing them needs a restart. The rest apply
+immediately.
+
+### config.yaml wins over these variables
+
+Read this before using the examples below. Mnemosyne resolves settings in the
+order **`config.yaml` > environment variable > built-in default**, and
+*presence* in the file decides it, not the value. Once a key exists in
+`config.yaml`, the matching variable is never consulted again.
+
+That matters here because `config.yaml` is seeded with every known key the
+first time Mnemosyne runs. The seed copies whatever variables are already
+exported, so:
+
+* Export these variables **before Mnemosyne has ever run**, and the seeded file
+  captures them. The examples below work as written.
+* Export them **after** a config already exists, and they are silently ignored,
+  because the file already contains `modality_enabled: false` and an empty
+  `modality_base_url`.
+
+If Mnemosyne has run before, set the values instead of exporting them:
+
+```bash
+mnemosyne config set modality_enabled true
+mnemosyne config set modality_base_url https://your-endpoint/v1
+mnemosyne config set modality_api_key ...
+mnemosyne config set modality_vision_model your/model
+```
+
+`mnemosyne config migrate` re-exports your current variables into the file in
+one step, which is the quickest way to adopt an existing shell setup.
+
+The env-var form in the examples below stays correct for containers and
+ephemeral filesystems, where the variables are set before the first run every
+time.
+
+---
+
+## Worked examples
+
+Each block below is complete. Nothing but these variables changes between them.
+
+### Atlas Cloud
+
+```bash
+export MNEMOSYNE_MODALITY_ENABLED=1
+export MNEMOSYNE_MODALITY_BASE_URL=https://api.atlascloud.ai/v1
+export MNEMOSYNE_MODALITY_API_KEY=...
+export MNEMOSYNE_MODALITY_VISION_MODEL=qwen/qwen3-vl-235b-a22b-thinking
+```
+
+See [Atlas Cloud](atlas-cloud.md) for the full recipe, which also covers chat
+and embeddings.
+
+### OpenRouter
+
+```bash
+export MNEMOSYNE_MODALITY_ENABLED=1
+export MNEMOSYNE_MODALITY_BASE_URL=https://openrouter.ai/api/v1
+export MNEMOSYNE_MODALITY_API_KEY=sk-or-...
+export MNEMOSYNE_MODALITY_VISION_MODEL=google/gemini-2.0-flash-001
+```
+
+### vLLM (self-hosted)
+
+```bash
+export MNEMOSYNE_MODALITY_ENABLED=1
+export MNEMOSYNE_MODALITY_BASE_URL=http://localhost:8000/v1
+export MNEMOSYNE_MODALITY_API_KEY=whatever-you-configured
+export MNEMOSYNE_MODALITY_VISION_MODEL=Qwen/Qwen2-VL-7B-Instruct
+```
+
+vLLM does not require a key by default, but Mnemosyne does — set
+`--api-key` on the server and match it here, rather than leaving both blank.
+
+### LM Studio (local, no cloud)
+
+```bash
+export MNEMOSYNE_MODALITY_ENABLED=1
+export MNEMOSYNE_MODALITY_BASE_URL=http://localhost:1234/v1
+export MNEMOSYNE_MODALITY_API_KEY=lm-studio
+export MNEMOSYNE_MODALITY_VISION_MODEL=qwen2-vl-7b-instruct
+```
+
+This is the configuration to use if you want media understanding with no
+network egress at all.
+
+---
+
+## How local files are sent
+
+For a public `https://` URL, Mnemosyne passes the URL through and the provider
+fetches it. **No bytes are read locally and nothing new leaves your machine.**
+
+For anything else — a local path, a `blob://` reference — Mnemosyne reads the
+bytes and sends them inline as a base64 data part. This is the only way an
+OpenAI-compatible vision endpoint can see content it cannot fetch itself.
+
+If you are not comfortable with that for a given file, do not ingest it: there
+is no ambient capture, so nothing is described that you did not name.
+
+---
+
+## Checking your model can actually see
+
+Some endpoints publish per-model input modalities on `GET {base_url}/models`.
+When yours does, Mnemosyne uses it to warn if the configured model is text-only.
+When it does not, nothing is reported and everything still works — the check is
+strictly optional and degrades to silence.
+
+```python
+from mnemosyne.core.modality_openai_compat import warn_if_model_cannot_see
+
+warn_if_model_cannot_see("some/model", "https://your-endpoint/v1", "your-key")
+```
+
+---
+
+## Degradation ladder
+
+In order:
+
+1. A host-registered backend for this modality.
+2. This adapter, when a base URL and key are configured.
+3. *(reserved: a local captioner — not implemented.)*
+4. Metadata-only registration.
+
+Rung 4 is a success. The asset is registered, `understanding_status` is set to
+`unavailable`, zero moments are written, and nothing raises.
+
+A provider that *declines* on safety grounds is recorded separately, as
+`refused` — it will decline again, whereas a failure is worth retrying.
+
+---
+
+## Bringing your own backend
+
+The adapter is one implementation of a small protocol. A host that has its own
+authenticated vision client can register it directly and skip HTTP entirely:
+
+```python
+from mnemosyne.core.modality_backends import (
+    CallableModalityBackend, DescribeResult, DescribedMoment, set_modality_backend,
+)
+
+def describe(request):
+    text = my_client.caption(request.uri)
+    return DescribeResult(
+        summary=text,
+        moments=[DescribedMoment(kind="caption", text=text)],
+        provider="my-host",
+    )
+
+set_modality_backend(
+    CallableModalityBackend(name="my-host", func=describe,
+                            modalities=frozenset({"image"})),
+)
+```
+
+The opt-in gate still applies: with `MNEMOSYNE_MODALITY_ENABLED` unset, a
+registered backend is never called.
+
+---
+
+## See also
+
+- [Atlas Cloud recipe](atlas-cloud.md) — all three surfaces in one place
+- `docs/rfc/0002-modality-providers.md` — why the seam looks like this
+- `docs/rfc/0003-media-moments.md` — where the text ends up
+- `docs/rfc/0004-archive-boundary.md` — why the bytes do not

--- a/mnemosyne/core/config.py
+++ b/mnemosyne/core/config.py
@@ -55,6 +55,11 @@ REQUIRES_RESTART: Set[str] = {
     "sync_host",
     "sync_port",
     "sync_remote",
+    # Read once at client construction, same reason embedding_model is here.
+    "modality_base_url",
+    "modality_vision_model",
+    "modality_video_model",
+    "modality_audio_model",
 }
 
 # Mapping from config key (snake_case, no MNEMOSYNE_ prefix) to env var name.
@@ -130,6 +135,17 @@ ENV_VAR_MAP: Dict[str, str] = {
     "host_llm_provider": "MNEMOSYNE_HOST_LLM_PROVIDER",
     "host_llm_model": "MNEMOSYNE_HOST_LLM_MODEL",
     "host_llm_n_ctx": "MNEMOSYNE_HOST_LLM_N_CTX",
+    # Modality providers (RFC 0002). Vendor-neutral by design: these name the
+    # OpenAI-compatible protocol, not any provider, so switching endpoints is
+    # an environment change and never a code change.
+    "modality_enabled": "MNEMOSYNE_MODALITY_ENABLED",
+    "modality_base_url": "MNEMOSYNE_MODALITY_BASE_URL",
+    "modality_api_key": "MNEMOSYNE_MODALITY_API_KEY",
+    "modality_vision_model": "MNEMOSYNE_MODALITY_VISION_MODEL",
+    "modality_video_model": "MNEMOSYNE_MODALITY_VIDEO_MODEL",
+    "modality_audio_model": "MNEMOSYNE_MODALITY_AUDIO_MODEL",
+    "modality_timeout": "MNEMOSYNE_MODALITY_TIMEOUT",
+    "modality_max_moments": "MNEMOSYNE_MODALITY_MAX_MOMENTS",
     # Conflict detection
     "llm_conflict_detection": "MNEMOSYNE_LLM_CONFLICT_DETECTION",
     "conflict_llm_base_url": "MNEMOSYNE_CONFLICT_LLM_BASE_URL",
@@ -260,6 +276,18 @@ DEFAULTS: Dict[str, Any] = {
     "host_llm_provider": "",
     "host_llm_model": "",
     "host_llm_n_ctx": 2048,
+    # Modality providers (RFC 0002). `modality_enabled` defaults to False:
+    # Mnemosyne makes no outbound call to describe media until the operator has
+    # said yes, once, explicitly. The default's Python type drives env coercion,
+    # so the two ints below must stay ints.
+    "modality_enabled": False,
+    "modality_base_url": "",
+    "modality_api_key": "",
+    "modality_vision_model": "",
+    "modality_video_model": "",
+    "modality_audio_model": "",
+    "modality_timeout": 60,
+    "modality_max_moments": 12,
     # Conflict detection
     "llm_conflict_detection": False,
     "conflict_llm_base_url": "",

--- a/mnemosyne/core/modality_backends.py
+++ b/mnemosyne/core/modality_backends.py
@@ -1,0 +1,245 @@
+"""
+Mnemosyne Modality Backend Registry
+===================================
+Pluggable adapter for turning non-text content into text.
+
+A structural mirror of ``core/llm_backends.py``: one method, request-shaped,
+returning result-or-None; the caller owns the prompt, the backend owns the
+routing; failure is a return value, not an exception; and a callable test seam
+ships with it.
+
+Two things differ, both deliberately:
+
+1. **The registry is keyed by modality.** A local Whisper install for audio
+   alongside a remote endpoint for vision is a realistic configuration, and a
+   single global slot cannot express it.
+2. **There is an explicit opt-in gate, checked before the registry.** Mnemosyne
+   must not make an outbound call to describe media until the operator has said
+   yes, once, explicitly (RFC 0002 §3.4, restated as a testable invariant in
+   RFC 0004 §3). Checking the gate *before* the lookup means a host that
+   registered a backend for a user who never opted in makes no call at all.
+
+Nothing here stores anything, and nothing here reads bytes on its own. Bytes,
+when a provider needs them, arrive through :attr:`DescribeRequest.fetch`, which
+the caller wires from ``core/resolvers.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+MODALITIES: FrozenSet[str] = frozenset({"image", "video", "audio", "document"})
+
+
+def modality_enabled() -> bool:
+    """Whether the operator has opted in to outbound modality calls.
+
+    **Read at call time, never cached in a module constant.** ``local_llm.py:54``
+    reads ``MNEMOSYNE_HOST_LLM_ENABLED`` at import, which makes it impossible to
+    monkeypatch and therefore impossible to test honestly. Repeating that here
+    would fail in the worst direction: the privacy test passes (the flag was
+    unset at import) while production dials out (the operator set it later).
+
+    Defaults to **false**. A missing or unreadable config is a "no".
+    """
+    try:
+        from mnemosyne.core import config as _config
+        return _config.get_bool("modality_enabled", False)
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Wire shapes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DescribeRequest:
+    """What the caller asks a provider to describe.
+
+    ``fetch`` is the field that makes this usable for anything but a public URL.
+    An OpenAI-compatible vision call needs a base64 data part for a local file
+    or a ``blob://`` reference — which is to say, for essentially everything a
+    privacy-first local memory system actually holds. It is **lazy and
+    optional**: a backend describing a publicly fetchable ``https://`` URL never
+    calls it, and no bytes are read. The caller supplies it from the
+    ``core/resolvers.py`` registry.
+    """
+
+    modality: str
+    uri: str
+    mime: Optional[str] = None
+    content_hash: Optional[str] = None
+    #: The caller's prompt. Same division of labour as ``LLMBackend.complete``:
+    #: the caller owns the prompt, the backend owns the routing.
+    hint: Optional[str] = None
+    max_moments: int = 12
+    span_hint: Optional[str] = None
+    timeout: float = 60.0
+    detail: str = "auto"
+    fetch: Optional[Callable[[], Optional[bytes]]] = None
+
+
+@dataclass
+class DescribedMoment:
+    """One span a provider proposes.
+
+    This is the *provider wire shape*: what a backend is allowed to say. It is
+    deliberately **not** ``media.MomentDraft``, the storage shape — a provider
+    must not be able to set ``memory_id``, and identity and binding belong to
+    the store. ``remember_media`` maps one onto the other.
+
+    (RFC 0002 §3.1 and RFC 0003 §2.2 both called their type ``MomentDraft``;
+    the two names collided, so the provider-side one is renamed here.)
+    """
+
+    kind: str
+    text: str
+    t_start_ms: Optional[int] = None
+    t_end_ms: Optional[int] = None
+    page_start: Optional[int] = None
+    page_end: Optional[int] = None
+    char_start: Optional[int] = None
+    char_end: Optional[int] = None
+    bbox: Any = None
+    speaker: Optional[str] = None
+    confidence: float = 1.0
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DescribeResult:
+    """What a provider returns.
+
+    ``refused`` is distinct from failure. RFC 0003 §2.1 declares
+    ``understanding_status='refused'`` as a valid asset state, and a provider
+    that declines on safety grounds is meaningfully different from one that
+    timed out — the first will decline again, the second is worth retrying. The
+    distinction has to survive into the asset row or it is lost.
+    """
+
+    summary: Optional[str] = None
+    moments: List[DescribedMoment] = field(default_factory=list)
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    warnings: List[str] = field(default_factory=list)
+    refused: bool = False
+
+
+class ModalityBackend(Protocol):
+    """A provider that turns non-text content into text moments."""
+
+    name: str
+    modalities: FrozenSet[str]
+
+    def describe(self, request: DescribeRequest) -> Optional[DescribeResult]:
+        ...
+
+
+@dataclass
+class CallableModalityBackend:
+    """Wrap a callable as a :class:`ModalityBackend`. For tests and one-off callers."""
+
+    name: str
+    func: Callable[[DescribeRequest], Optional[DescribeResult]]
+    modalities: FrozenSet[str] = MODALITIES
+
+    def describe(self, request: DescribeRequest) -> Optional[DescribeResult]:
+        return self.func(request)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_backends: Dict[str, ModalityBackend] = {}
+_default: Optional[ModalityBackend] = None
+
+
+def set_modality_backend(
+    backend: Optional[ModalityBackend],
+    modalities: Optional[FrozenSet[str]] = None,
+) -> None:
+    """Register (or clear) a modality backend.
+
+    With ``modalities``, the backend is registered for exactly those modalities.
+    Without, it becomes the default for anything it declares it can serve.
+    Passing ``backend=None`` clears the default; pass ``modalities`` alongside
+    it to clear only those entries.
+    """
+    global _default
+    if backend is None:
+        if modalities:
+            for modality in modalities:
+                _backends.pop(str(modality).strip().lower(), None)
+        else:
+            _default = None
+        return
+
+    if modalities:
+        for modality in modalities:
+            _backends[str(modality).strip().lower()] = backend
+    else:
+        _default = backend
+
+
+def get_modality_backend(modality: str) -> Optional[ModalityBackend]:
+    """Return the backend that can serve ``modality``, or None.
+
+    The default is only returned when it *declares* it serves this modality.
+    Without that check, an image model gets handed an mp3 and asked to describe
+    it — and the failure mode is not an error but a confident, wrong caption,
+    which is worse than no caption at all.
+    """
+    key = str(modality or "").strip().lower()
+    explicit = _backends.get(key)
+    if explicit is not None:
+        return explicit
+    if _default is not None and key in getattr(_default, "modalities", frozenset()):
+        return _default
+    return None
+
+
+def clear_modality_backends() -> None:
+    """Reset the registry. Called from ``tests/conftest.py`` — the registry is a
+    process-global, and a test that forgets to unregister would otherwise bleed
+    into the next."""
+    global _default
+    _backends.clear()
+    _default = None
+
+
+def call_modality_describe(request: DescribeRequest) -> Optional[DescribeResult]:
+    """Describe content via the registered backend, or return None.
+
+    Returns ``None`` — never raises — when modality support is disabled, no
+    backend serves the modality, or the backend itself fails. Rung 4 of the
+    RFC 0002 §3.3 degradation ladder depends on this: the caller registers the
+    asset by reference regardless, so a missing provider costs the user nothing
+    they had before.
+
+    The gate is checked **first**, before the registry is even consulted, so
+    that "no outbound traffic when disabled" holds even on a host that
+    registered a backend eagerly.
+    """
+    if not modality_enabled():
+        return None
+
+    backend = get_modality_backend(request.modality)
+    if backend is None:
+        return None
+
+    try:
+        return backend.describe(request)
+    except Exception:
+        # Never raise into remember(). Provenance belongs at the call site, and
+        # the request must not be logged — it can carry a file path.
+        logger.info(
+            "modality backend %r failed for modality %r",
+            getattr(backend, "name", "?"), request.modality, exc_info=True,
+        )
+        return None

--- a/mnemosyne/core/modality_openai_compat.py
+++ b/mnemosyne/core/modality_openai_compat.py
@@ -1,0 +1,521 @@
+"""
+OpenAI-Compatible Vision Adapter
+================================
+The reference :class:`~mnemosyne.core.modality_backends.ModalityBackend`.
+
+This module speaks the OpenAI-compatible ``POST {base_url}/chat/completions``
+shape with ``image_url`` content parts. That shape is served by Atlas Cloud,
+OpenRouter, Together, Groq, vLLM, LM Studio, Ollama, and a local ``llama.cpp``
+server alike, which is why the module is named after the **protocol** and not
+after any provider. Switching endpoints must require changing environment
+variables only; if it ever requires changing code, something in here has
+acquired a vendor assumption and should be removed.
+
+Three policies are borrowed rather than reinvented:
+
+- Transport and timeout follow ``_call_remote_llm_with_model``
+  (``core/local_llm.py:458``): httpx when present, ``urllib`` otherwise.
+- Retry and backoff follow ``_embed_api`` (``core/embeddings.py:286-318``),
+  with the rate-limit classifier ``_is_rate_limit_error``
+  (``core/embeddings.py:247``). A third retry policy in one codebase is a
+  third thing to get wrong.
+- JSON tolerance follows ``core/extraction.py:80-105``: strict JSON, then
+  partial salvage, then give up and return ``None``.
+
+Nothing here raises into ``remember()``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import random
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, FrozenSet, List, Optional, Tuple
+
+from mnemosyne.core.modality_backends import (
+    DescribedMoment,
+    DescribeRequest,
+    DescribeResult,
+)
+
+logger = logging.getLogger(__name__)
+
+NAME = "openai_compat"
+
+_MAX_ATTEMPTS = 3
+_PUBLIC_URL_RE = re.compile(r"^https?://", re.IGNORECASE)
+
+DEFAULT_PROMPT = (
+    "Describe this {modality} for a searchable memory index. "
+    "Reply with JSON only, no prose and no code fences, in exactly this shape:\n"
+    '{{"summary": "one or two sentences", "moments": '
+    '[{{"kind": "caption", "text": "what is shown"}}]}}\n'
+    "Use at most {max_moments} moments. Describe only what is actually present; "
+    "do not guess at anything you cannot see."
+)
+
+
+# ---------------------------------------------------------------------------
+# Configuration (read at call time, never cached at import)
+# ---------------------------------------------------------------------------
+
+def _cfg_str(key: str, default: str = "") -> str:
+    try:
+        from mnemosyne.core import config as _config
+        return _config.get_str(key, default)
+    except Exception:
+        return default
+
+
+def _cfg_int(key: str, default: int) -> int:
+    try:
+        from mnemosyne.core import config as _config
+        return _config.get_int(key, default)
+    except Exception:
+        return default
+
+
+def model_for(modality: str) -> str:
+    """The configured model for a modality, or ``""``."""
+    return _cfg_str({
+        "image": "modality_vision_model",
+        "document": "modality_vision_model",
+        "video": "modality_video_model",
+        "audio": "modality_audio_model",
+    }.get(str(modality or "").strip().lower(), "modality_vision_model"))
+
+
+def is_configured(modality: str = "image") -> bool:
+    """Whether this adapter has what it needs to make a call.
+
+    Both a base URL and an API key are required, per RFC 0002 §3.2 — a base URL
+    alone is more likely a half-finished config than a deliberately
+    unauthenticated endpoint, and guessing wrong means an outbound call the
+    operator did not intend.
+    """
+    return bool(_cfg_str("modality_base_url")) and bool(_cfg_str("modality_api_key"))
+
+
+# ---------------------------------------------------------------------------
+# Payload construction
+# ---------------------------------------------------------------------------
+
+def _image_part(request: DescribeRequest) -> Optional[Dict[str, Any]]:
+    """Build the ``image_url`` content part, fetching bytes only when needed.
+
+    A publicly fetchable URL is passed through as-is and ``fetch`` is never
+    called — no bytes are read and nothing leaves the machine that was not
+    already public. Anything else (a local file, a ``blob://`` reference) needs
+    a base64 data URI, which is the whole reason ``DescribeRequest.fetch``
+    exists.
+    """
+    if _PUBLIC_URL_RE.match(request.uri or ""):
+        return {
+            "type": "image_url",
+            "image_url": {"url": request.uri, "detail": request.detail},
+        }
+
+    if request.fetch is None:
+        return None
+    try:
+        raw = request.fetch()
+    except Exception:
+        logger.info("modality fetch failed", exc_info=True)
+        return None
+    if not raw:
+        return None
+
+    mime = request.mime or "application/octet-stream"
+    encoded = base64.b64encode(raw).decode("ascii")
+    return {
+        "type": "image_url",
+        "image_url": {
+            "url": f"data:{mime};base64,{encoded}",
+            "detail": request.detail,
+        },
+    }
+
+
+def build_prompt(request: DescribeRequest) -> str:
+    """The instruction sent alongside the content.
+
+    ``request.hint`` wins when the caller supplies one — the caller owns the
+    prompt, per ``llm_backends.py:30-33``. Otherwise
+    ``MNEMOSYNE_MODALITY_PROMPT`` overrides the default, the same affordance
+    ``core/extraction.py`` provides via ``MNEMOSYNE_EXTRACTION_PROMPT``.
+    """
+    if request.hint:
+        return request.hint
+    template = os.environ.get("MNEMOSYNE_MODALITY_PROMPT") or DEFAULT_PROMPT
+    try:
+        return template.format(
+            modality=request.modality,
+            max_moments=request.max_moments,
+        )
+    except Exception:
+        # A malformed operator-supplied template must not break ingest.
+        return template
+
+
+# ---------------------------------------------------------------------------
+# Response parsing — the extraction.py tolerance ladder
+# ---------------------------------------------------------------------------
+
+def _strip_fences(raw: str) -> str:
+    text = (raw or "").strip()
+    if text.startswith("```"):
+        text = text.removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+    return text
+
+
+def parse_response(raw: str, max_moments: int) -> Optional[Tuple[Optional[str], List[DescribedMoment]]]:
+    """Parse a provider reply into ``(summary, moments)``, or None.
+
+    Rung 1: strict JSON. Rung 2: salvage — a truncated reply that still contains
+    recognizable text is worth something, and a vision model that ran out of
+    tokens mid-array is a routine occurrence rather than an error. Rung 3: give
+    up. Returning ``None`` is a supported outcome all the way up the stack.
+    """
+    text = _strip_fences(raw)
+    if not text:
+        return None
+
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        parsed = None
+
+    if isinstance(parsed, dict):
+        summary = parsed.get("summary")
+        moments: List[DescribedMoment] = []
+        raw_moments = parsed.get("moments")
+        if isinstance(raw_moments, list):
+            for item in raw_moments:
+                moment = _coerce_moment(item)
+                if moment is not None:
+                    moments.append(moment)
+                if len(moments) >= max_moments:
+                    break
+        if summary or moments:
+            return (str(summary) if summary else None, moments)
+        return None
+
+    # Salvage: pull quoted strings long enough to be descriptions rather than
+    # JSON keys. Deliberately crude -- it is a floor, not a parser.
+    salvaged = [s for s in re.findall(r'"([^"]{16,})"', text)]
+    if salvaged:
+        return (salvaged[0], [
+            DescribedMoment(kind="caption", text=s)
+            for s in salvaged[:max_moments]
+        ])
+    return None
+
+
+_MOMENT_INT_FIELDS = ("t_start_ms", "t_end_ms", "page_start", "page_end",
+                      "char_start", "char_end")
+
+
+def _coerce_moment(item: Any) -> Optional[DescribedMoment]:
+    """Turn one provider-supplied dict into a moment, or drop it.
+
+    Providers hallucinate span fields with some regularity. Anything that does
+    not coerce cleanly is dropped rather than guessed at: a caption with no span
+    is useful, a caption with a fabricated timestamp is a wrong answer that
+    looks right.
+    """
+    if not isinstance(item, dict):
+        if isinstance(item, str) and item.strip():
+            return DescribedMoment(kind="caption", text=item.strip())
+        return None
+
+    text = str(item.get("text") or "").strip()
+    if not text:
+        return None
+
+    moment = DescribedMoment(kind=str(item.get("kind") or "caption").strip().lower(), text=text)
+
+    for field_name in _MOMENT_INT_FIELDS:
+        value = item.get(field_name)
+        if value is None or isinstance(value, bool):
+            continue
+        try:
+            setattr(moment, field_name, int(value))
+        except (TypeError, ValueError):
+            continue
+
+    bbox = item.get("bbox")
+    if isinstance(bbox, (list, tuple)) and len(bbox) == 4:
+        try:
+            moment.bbox = [float(v) for v in bbox]
+        except (TypeError, ValueError):
+            moment.bbox = None
+
+    speaker = item.get("speaker")
+    if speaker:
+        moment.speaker = str(speaker)
+
+    try:
+        moment.confidence = float(item.get("confidence", 1.0))
+    except (TypeError, ValueError):
+        moment.confidence = 1.0
+
+    return moment
+
+
+_REFUSAL_MARKERS = (
+    "i can't help", "i cannot help", "i can't assist", "i cannot assist",
+    "i'm unable to", "i am unable to", "content policy", "safety policy",
+    "i won't", "i will not",
+)
+
+
+def _looks_refused(raw: str) -> bool:
+    """A provider declining is not the same as a provider failing.
+
+    The first will decline again; the second is worth retrying. The distinction
+    survives into ``media_assets.understanding_status`` as ``refused``.
+    """
+    lowered = (raw or "").strip().lower()[:400]
+    return any(marker in lowered for marker in _REFUSAL_MARKERS)
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+def _retry_delay(attempt: int) -> float:
+    """Same curve as ``embeddings._embed_api``."""
+    return 0.5 * (2 ** attempt) + random.uniform(0, 0.5)
+
+
+def _is_rate_limit_error(exc: BaseException) -> bool:
+    """Delegate to the one classifier that already exists, with a local copy of
+    its rule as a fallback so an import failure cannot turn a transient 429 into
+    a permanent give-up."""
+    try:
+        from mnemosyne.core.embeddings import _is_rate_limit_error as _classify
+        return _classify(exc)
+    except Exception:
+        msg = str(exc).lower()
+        return ("429" in msg or "too many requests" in msg
+                or "rate limit" in msg or "rate-limit" in msg)
+
+
+def _post_chat(
+    url: str,
+    headers: Dict[str, str],
+    payload: Dict[str, Any],
+    timeout: float,
+) -> Tuple[Optional[str], Optional[int], Optional[BaseException]]:
+    """One HTTP round trip. Returns ``(text, status, exc)``, never raises.
+
+    Same return contract as ``local_llm._call_remote_llm_with_model`` so the
+    retry decision above can be made on status alone.
+    """
+    try:
+        import httpx
+        has_httpx = True
+    except ImportError:
+        has_httpx = False
+
+    try:
+        if has_httpx:
+            with httpx.Client(timeout=timeout) as client:
+                response = client.post(url, json=payload, headers=headers)
+                status = response.status_code
+                if status >= 400:
+                    try:
+                        response.raise_for_status()
+                    except Exception as exc:
+                        return (None, status, exc)
+                data = response.json()
+        else:
+            import urllib.error
+            import urllib.request
+            request = urllib.request.Request(
+                url,
+                data=json.dumps(payload).encode(),
+                headers=headers,
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=timeout) as resp:
+                    status = getattr(resp, "status", 200)
+                    data = json.loads(resp.read().decode())
+            except urllib.error.HTTPError as exc:
+                return (None, exc.code, exc)
+            except Exception as exc:
+                return (None, None, exc)
+
+        choices = data.get("choices", []) if isinstance(data, dict) else []
+        if choices:
+            content = (choices[0] or {}).get("message", {}).get("content")
+            if content:
+                return (str(content), status, None)
+        return (None, status, None)
+    except Exception as exc:
+        return (None, None, exc)
+
+
+# ---------------------------------------------------------------------------
+# Optional capability preflight
+# ---------------------------------------------------------------------------
+
+def probe_model_modalities(base_url: str, api_key: str, timeout: float = 10.0) -> Dict[str, List[str]]:
+    """Best-effort map of model id → declared input modalities.
+
+    ``GET {base_url}/models`` exposes ``input_modalities`` per model on Atlas and
+    OpenRouter alike — an aggregator convention, not a vendor extension. It is
+    **strictly optional**: an endpoint that omits it, or exposes a different
+    shape, must still work. Returns ``{}`` on anything unexpected. Degrade to
+    silence, never to failure.
+    """
+    try:
+        import httpx
+    except ImportError:
+        return {}
+    try:
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        with httpx.Client(timeout=timeout) as client:
+            response = client.get(f"{base_url.rstrip('/')}/models", headers=headers)
+            if response.status_code >= 400:
+                return {}
+            data = response.json()
+    except Exception:
+        return {}
+
+    out: Dict[str, List[str]] = {}
+    entries = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(entries, list):
+        return {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        model_id = entry.get("id")
+        modalities = (
+            entry.get("input_modalities")
+            or (entry.get("architecture") or {}).get("input_modalities")
+        )
+        if model_id and isinstance(modalities, list):
+            out[str(model_id)] = [str(m) for m in modalities]
+    return out
+
+
+def warn_if_model_cannot_see(model: str, base_url: str, api_key: str) -> Optional[str]:
+    """Warn when the configured model declares no image input. Returns the
+    warning text, or None when there is nothing to say — including when the
+    endpoint does not publish capabilities at all."""
+    capabilities = probe_model_modalities(base_url, api_key)
+    declared = capabilities.get(model)
+    if not declared:
+        return None
+    if "image" in {d.lower() for d in declared}:
+        return None
+    message = (
+        f"configured modality model {model!r} declares input modalities "
+        f"{sorted(declared)} and may not accept images"
+    )
+    logger.warning("%s", message)
+    return message
+
+
+# ---------------------------------------------------------------------------
+# The backend
+# ---------------------------------------------------------------------------
+
+@dataclass
+class OpenAICompatModalityBackend:
+    """Describe content via any OpenAI-compatible vision endpoint."""
+
+    name: str = NAME
+    modalities: FrozenSet[str] = frozenset({"image", "document"})
+
+    def describe(self, request: DescribeRequest) -> Optional[DescribeResult]:
+        base_url = _cfg_str("modality_base_url").rstrip("/")
+        api_key = _cfg_str("modality_api_key")
+        if not base_url or not api_key:
+            return None
+
+        model = model_for(request.modality)
+        if not model:
+            logger.info(
+                "no modality model configured for %r; skipping", request.modality
+            )
+            return None
+
+        part = _image_part(request)
+        if part is None:
+            # No bytes and no public URL: nothing to send. Rung 4 of the ladder
+            # -- the caller still registers the asset by reference.
+            return None
+
+        timeout = float(request.timeout or _cfg_int("modality_timeout", 60))
+        max_moments = int(request.max_moments or _cfg_int("modality_max_moments", 12))
+
+        payload = {
+            "model": model,
+            "messages": [{
+                "role": "user",
+                "content": [{"type": "text", "text": build_prompt(request)}, part],
+            }],
+            "temperature": 0.2,
+            "stream": False,
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        }
+        url = f"{base_url}/chat/completions"
+
+        text = None
+        for attempt in range(_MAX_ATTEMPTS):
+            text, status, exc = _post_chat(url, headers, payload, timeout)
+            if text is not None:
+                break
+            transient = (
+                (status is not None and (status == 429 or 500 <= status < 600))
+                or (exc is not None and _is_rate_limit_error(exc))
+                or (status is None and exc is not None)
+            )
+            if transient and attempt < _MAX_ATTEMPTS - 1:
+                time.sleep(_retry_delay(attempt))
+                continue
+            break
+
+        if text is None:
+            return None
+
+        if _looks_refused(text):
+            return DescribeResult(
+                provider=self.name, model=model, refused=True,
+                warnings=["provider declined to describe this content"],
+            )
+
+        parsed = parse_response(text, max_moments)
+        if parsed is None:
+            return None
+        summary, moments = parsed
+        return DescribeResult(
+            summary=summary,
+            moments=moments[:max_moments],
+            provider=self.name,
+            model=model,
+        )
+
+
+def register_if_configured() -> bool:
+    """Register this adapter as the default backend when configured.
+
+    Returns whether it registered. Deliberately **not** called at import: a
+    module import must never have the side effect of arming an outbound path.
+    """
+    if not is_configured():
+        return False
+    from mnemosyne.core.modality_backends import set_modality_backend
+    set_modality_backend(OpenAICompatModalityBackend())
+    return True

--- a/scripts/generate-docs.py
+++ b/scripts/generate-docs.py
@@ -307,6 +307,16 @@ CONFIG_DESCRIPTIONS = {
     "host_llm_model": "Model override passed to the host backend.",
     "host_llm_n_ctx": "Context budget assumed for the host backend.",
 
+    # Modality providers (RFC 0002)
+    "modality_enabled": "Allow outbound calls to describe non-text media. Off by default; nothing is sent until this is set.",
+    "modality_base_url": "Base URL of an OpenAI-compatible vision endpoint. Any provider that speaks the protocol works.",
+    "modality_api_key": "API key for the modality endpoint.",
+    "modality_vision_model": "Model used to describe images and documents.",
+    "modality_video_model": "Model used to describe video.",
+    "modality_audio_model": "Model used to transcribe or describe audio.",
+    "modality_timeout": "Timeout in seconds for a modality describe call.",
+    "modality_max_moments": "Maximum moments retained per media asset.",
+
     # Conflict detection
     "llm_conflict_detection": "Enable LLM-based contradiction detection during sleep.",
     "conflict_llm_base_url": "Base URL for the conflict detection endpoint.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,16 @@ def _close_cached_connections():
     except Exception:
         pass
 
+    # Same reasoning for the modality registry, which is also a process-global.
+    # This reset ships in the PR that introduces the registry: a later one is
+    # one bled-through global away from a flaky matrix, and the symptom would be
+    # a privacy test passing for the wrong reason.
+    try:
+        from mnemosyne.core import modality_backends as _modality_mod
+        _modality_mod.clear_modality_backends()
+    except Exception:
+        pass
+
     # Same reasoning for the content-resolver registry. Note this clears only
     # explicit registrations: the built-in blob resolver survives, so tests
     # that read blobs still work after the reset.

--- a/tests/test_modality_backends.py
+++ b/tests/test_modality_backends.py
@@ -1,0 +1,269 @@
+"""Registry, gate, and degradation tests for the modality seam (RFC 0002 §3.1).
+
+The load-bearing assertion in this file is negative: **with the flag unset,
+nothing happens.** Not "an error is returned" -- nothing is called, nothing is
+sent, and the caller carries on.
+"""
+
+import pytest
+
+from mnemosyne.core import modality_backends as mb
+from mnemosyne.core.modality_backends import (
+    CallableModalityBackend,
+    DescribedMoment,
+    DescribeRequest,
+    DescribeResult,
+    call_modality_describe,
+    clear_modality_backends,
+    get_modality_backend,
+    modality_enabled,
+    set_modality_backend,
+)
+
+
+@pytest.fixture
+def enabled(monkeypatch, tmp_path):
+    """Opt in the way a real operator must.
+
+    Setting only ``MNEMOSYNE_MODALITY_ENABLED`` is not enough. ``config.yaml``
+    wins over env vars, and presence beats value: once a key exists in the
+    file, the variable is never consulted. A seeded config carries
+    ``modality_enabled: false``, so an env-only fixture passes on a machine
+    whose config predates the key and fails on a fresh one, which is exactly
+    how this slipped through locally and failed in CI.
+
+    Pointing ``MNEMOSYNE_DATA_DIR`` at a fresh directory makes the seed honour
+    the variables, which is the same path a new install takes.
+    """
+    from mnemosyne.core.config import MnemosyneConfig
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "cfg-enabled"))
+    monkeypatch.setenv("MNEMOSYNE_MODALITY_ENABLED", "1")
+    MnemosyneConfig.reset_instance()
+    yield
+    MnemosyneConfig.reset_instance()
+
+
+def _request(modality="image", uri="https://example.test/a.png", **kwargs):
+    return DescribeRequest(modality=modality, uri=uri, **kwargs)
+
+
+def _recording_backend(name="stub", modalities=mb.MODALITIES, result=None):
+    calls = []
+
+    def _describe(request):
+        calls.append(request)
+        return result if result is not None else DescribeResult(
+            summary="a stub", moments=[DescribedMoment(kind="caption", text="a stub")],
+            provider=name,
+        )
+
+    return CallableModalityBackend(name=name, func=_describe, modalities=modalities), calls
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+def test_disabled_by_default():
+    """Mnemosyne makes no outbound call to describe media until the operator
+    has said yes, once, explicitly."""
+    assert modality_enabled() is False
+
+
+def test_nothing_is_called_when_disabled():
+    """Not 'an error is returned' -- the backend is never invoked at all, even
+    though it is registered. A host that registers eagerly must not be able to
+    dial out on behalf of a user who never opted in."""
+    backend, calls = _recording_backend()
+    set_modality_backend(backend)
+    assert call_modality_describe(_request()) is None
+    assert calls == [], "the gate must be checked before the registry"
+
+
+def test_the_gate_is_read_at_call_time_not_import_time(monkeypatch, tmp_path):
+    """``local_llm.py:54`` reads its flag at import, which makes it
+    untestable. Repeating that here would fail in the direction where the
+    privacy test passes and production dials out.
+
+    Each phase gets its own data directory. A config is seeded on first read,
+    and presence in the file beats the env var from then on, so flipping the
+    variable inside one directory would prove nothing.
+    """
+    from mnemosyne.core.config import MnemosyneConfig
+
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "off"))
+    MnemosyneConfig.reset_instance()
+    assert modality_enabled() is False
+
+    monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / "on"))
+    monkeypatch.setenv("MNEMOSYNE_MODALITY_ENABLED", "1")
+    MnemosyneConfig.reset_instance()
+    try:
+        assert modality_enabled() is True
+    finally:
+        MnemosyneConfig.reset_instance()
+
+
+def test_an_unreadable_config_is_a_no(monkeypatch):
+    """Failing closed: if the flag cannot be read, it is off."""
+    def _explode(*args, **kwargs):
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr("mnemosyne.core.config.get_bool", _explode)
+    assert modality_enabled() is False
+
+
+def test_describe_runs_once_enabled(enabled):
+    backend, calls = _recording_backend()
+    set_modality_backend(backend)
+    result = call_modality_describe(_request())
+    assert result is not None and result.summary == "a stub"
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+def test_per_modality_registration_wins_over_the_default(enabled):
+    default, default_calls = _recording_backend("default")
+    audio, audio_calls = _recording_backend("audio-only", modalities=frozenset({"audio"}))
+    set_modality_backend(default)
+    set_modality_backend(audio, modalities=frozenset({"audio"}))
+
+    call_modality_describe(_request("audio"))
+    call_modality_describe(_request("image"))
+
+    assert len(audio_calls) == 1
+    assert len(default_calls) == 1
+    assert audio_calls[0].modality == "audio"
+
+
+def test_a_default_is_never_handed_a_modality_it_does_not_declare(enabled):
+    """The failure mode this prevents is not an error -- it is an image model
+    confidently captioning an mp3."""
+    vision, calls = _recording_backend("vision", modalities=frozenset({"image"}))
+    set_modality_backend(vision)
+
+    assert get_modality_backend("image") is vision
+    assert get_modality_backend("audio") is None
+    assert call_modality_describe(_request("audio")) is None
+    assert calls == []
+
+
+def test_modality_lookup_is_case_and_whitespace_insensitive(enabled):
+    backend, calls = _recording_backend(modalities=frozenset({"image"}))
+    set_modality_backend(backend, modalities=frozenset({"IMAGE"}))
+    assert get_modality_backend("  Image ") is backend
+
+
+def test_clearing_the_default(enabled):
+    backend, _ = _recording_backend()
+    set_modality_backend(backend)
+    set_modality_backend(None)
+    assert get_modality_backend("image") is None
+
+
+def test_clearing_specific_modalities_leaves_the_default(enabled):
+    default, _ = _recording_backend("default")
+    audio, _ = _recording_backend("audio", modalities=frozenset({"audio"}))
+    set_modality_backend(default)
+    set_modality_backend(audio, modalities=frozenset({"audio"}))
+
+    set_modality_backend(None, modalities=frozenset({"audio"}))
+    assert get_modality_backend("audio") is default
+
+
+def test_clear_resets_everything(enabled):
+    backend, _ = _recording_backend()
+    set_modality_backend(backend)
+    set_modality_backend(backend, modalities=frozenset({"audio"}))
+    clear_modality_backends()
+    assert get_modality_backend("image") is None
+    assert get_modality_backend("audio") is None
+
+
+def test_the_registry_does_not_leak_between_tests():
+    """Guards the conftest reset. If this fails, an earlier test's backend is
+    still armed and every privacy assertion in the suite is suspect."""
+    assert get_modality_backend("image") is None
+    assert mb._default is None
+    assert mb._backends == {}
+
+
+# ---------------------------------------------------------------------------
+# Degradation
+# ---------------------------------------------------------------------------
+
+def test_a_raising_backend_degrades_to_none(enabled):
+    """Rung 4 of the ladder depends on this: the caller registers the asset by
+    reference regardless, so a broken provider costs the user nothing."""
+    def _explode(request):
+        raise RuntimeError("provider on fire")
+
+    set_modality_backend(CallableModalityBackend(name="broken", func=_explode))
+    assert call_modality_describe(_request()) is None
+
+
+def test_a_backend_returning_none_is_not_an_error(enabled):
+    set_modality_backend(CallableModalityBackend(name="quiet", func=lambda r: None))
+    assert call_modality_describe(_request()) is None
+
+
+def test_no_backend_is_not_an_error(enabled):
+    assert call_modality_describe(_request()) is None
+
+
+def test_backend_failures_do_not_log_the_request(enabled, caplog):
+    """A request carries a URI, which can be a local file path."""
+    def _explode(request):
+        raise RuntimeError("provider on fire")
+
+    set_modality_backend(CallableModalityBackend(name="broken", func=_explode))
+    with caplog.at_level("DEBUG"):
+        call_modality_describe(_request(uri="/home/someone/private/photo.png"))
+    assert "/home/someone/private" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Wire shapes
+# ---------------------------------------------------------------------------
+
+def test_fetch_is_lazy_and_optional(enabled):
+    """A backend describing a public URL never reads bytes."""
+    fetched = []
+
+    def _fetch():
+        fetched.append(True)
+        return b"bytes"
+
+    backend, calls = _recording_backend()
+    set_modality_backend(backend)
+    call_modality_describe(_request(fetch=_fetch))
+
+    assert fetched == [], "the registry must not call fetch itself"
+    assert calls[0].fetch is _fetch, "but it must pass it through"
+
+
+def test_refused_is_distinct_from_failure(enabled):
+    """A provider that declines will decline again; one that failed is worth
+    retrying. Collapsing them loses that."""
+    refusal = DescribeResult(provider="p", refused=True)
+    set_modality_backend(CallableModalityBackend(name="p", func=lambda r: refusal))
+    result = call_modality_describe(_request())
+    assert result is not None and result.refused is True
+    assert result.moments == []
+
+
+def test_describe_result_defaults_are_empty_not_none():
+    result = DescribeResult()
+    assert (result.moments, result.warnings, result.refused) == ([], [], False)
+
+
+def test_described_moment_is_not_the_storage_shape():
+    """The provider wire shape must not let a backend set identity or binding
+    -- those belong to the store."""
+    fields = set(DescribedMoment(kind="caption", text="x").__dict__)
+    assert "memory_id" not in fields
+    assert "moment_id" not in fields
+    assert "extra" in fields

--- a/tests/test_modality_openai_compat.py
+++ b/tests/test_modality_openai_compat.py
@@ -1,0 +1,541 @@
+"""Tests for the OpenAI-compatible vision adapter (RFC 0002 §3.2).
+
+Every network test runs against a stub HTTP server on localhost. The live
+endpoint is never contacted: verification against a real provider is a manual,
+opt-in step gated on ``MNEMOSYNE_MODALITY_API_KEY`` being set in the operator's
+own environment, and no key is ever committed.
+
+The vendor-neutrality assertion lives here too, and it is mechanical rather than
+aspirational: point the adapter at a second stub on a different port with only
+environment variables changed, and it must work unmodified.
+"""
+
+import base64
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from mnemosyne.core import modality_openai_compat as adapter
+from mnemosyne.core.modality_backends import DescribeRequest
+
+
+# ---------------------------------------------------------------------------
+# Stub endpoint
+# ---------------------------------------------------------------------------
+
+class _Stub:
+    """A minimal OpenAI-compatible endpoint that records what it was sent."""
+
+    def __init__(self, replies, models_payload=None):
+        self.replies = list(replies)
+        self.models_payload = models_payload
+        self.requests = []
+        self.model_probes = 0
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def do_GET(self):
+                if not self.path.endswith("/models") or outer.models_payload is None:
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                outer.model_probes += 1
+                body = json.dumps(outer.models_payload).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                raw = self.rfile.read(length)
+                outer.requests.append(json.loads(raw.decode()))
+
+                status, content = outer.replies.pop(0) if outer.replies else (200, "{}")
+                if status >= 400:
+                    body = json.dumps({"error": content}).encode()
+                else:
+                    body = json.dumps(
+                        {"choices": [{"message": {"content": content}}]}
+                    ).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def base_url(self):
+        host, port = self.server.server_address[:2]
+        return f"http://{host}:{port}/v1"
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+@pytest.fixture
+def stub():
+    made = []
+
+    def _make(replies, models_payload=None):
+        s = _Stub(replies, models_payload)
+        made.append(s)
+        return s
+
+    yield _make
+    for s in made:
+        s.close()
+
+
+@pytest.fixture
+def configured(monkeypatch, tmp_path):
+    """Point the adapter at a stub. Everything is an environment variable --
+    that is the whole vendor-neutrality claim, made testable.
+
+    The variables only reach the adapter through a config that was seeded
+    while they were set: ``config.yaml`` wins over the environment, and
+    presence beats value. Each call gets a fresh data directory so the seed
+    picks them up, which is the path a new install takes.
+    """
+    from mnemosyne.core.config import MnemosyneConfig
+
+    calls = {"n": 0}
+
+    def _configure(base_url, **extra):
+        calls["n"] += 1
+        monkeypatch.setenv("MNEMOSYNE_DATA_DIR", str(tmp_path / f"cfg-{calls['n']}"))
+        monkeypatch.setenv("MNEMOSYNE_MODALITY_ENABLED", "1")
+        monkeypatch.setenv("MNEMOSYNE_MODALITY_BASE_URL", base_url)
+        monkeypatch.setenv("MNEMOSYNE_MODALITY_API_KEY", "test-key-not-real")
+        monkeypatch.setenv("MNEMOSYNE_MODALITY_VISION_MODEL", "some/vision-model")
+        for key, value in extra.items():
+            monkeypatch.setenv(key, value)
+        MnemosyneConfig.reset_instance()
+
+    yield _configure
+    MnemosyneConfig.reset_instance()
+
+
+def _request(**kwargs):
+    kwargs.setdefault("modality", "image")
+    kwargs.setdefault("uri", "https://example.test/a.png")
+    return DescribeRequest(**kwargs)
+
+
+_OK_REPLY = json.dumps({
+    "summary": "a terminal window",
+    "moments": [{"kind": "caption", "text": "a terminal window showing a test run"}],
+})
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+def test_describes_a_public_url(stub, configured):
+    server = stub([(200, _OK_REPLY)])
+    configured(server.base_url)
+
+    result = adapter.OpenAICompatModalityBackend().describe(_request())
+
+    assert result is not None
+    assert result.summary == "a terminal window"
+    assert [m.text for m in result.moments] == ["a terminal window showing a test run"]
+    assert (result.provider, result.model) == ("openai_compat", "some/vision-model")
+
+    sent = server.requests[0]
+    assert sent["model"] == "some/vision-model"
+    parts = sent["messages"][0]["content"]
+    assert parts[1]["image_url"]["url"] == "https://example.test/a.png"
+
+
+def test_a_public_url_never_reads_bytes(stub, configured):
+    """Nothing leaves the machine that was not already public, and no local
+    read happens for a URL the provider can fetch itself."""
+    server = stub([(200, _OK_REPLY)])
+    configured(server.base_url)
+    fetched = []
+
+    adapter.OpenAICompatModalityBackend().describe(
+        _request(fetch=lambda: fetched.append(True) or b"bytes")
+    )
+    assert fetched == []
+
+
+def test_local_content_is_sent_as_a_base64_data_part(stub, configured):
+    """The reason ``DescribeRequest.fetch`` exists: without it the adapter could
+    describe public URLs and nothing else -- which is to say none of the media a
+    local-first memory system actually holds."""
+    server = stub([(200, _OK_REPLY)])
+    configured(server.base_url)
+
+    result = adapter.OpenAICompatModalityBackend().describe(
+        _request(uri="blob://sha256/" + "ab" * 32, mime="image/png",
+                 fetch=lambda: b"\x89PNG fake")
+    )
+    assert result is not None
+
+    url = server.requests[0]["messages"][0]["content"][1]["image_url"]["url"]
+    assert url.startswith("data:image/png;base64,")
+    assert base64.b64decode(url.split(",", 1)[1]) == b"\x89PNG fake"
+
+
+def test_local_content_without_a_fetcher_degrades_to_none(stub, configured):
+    server = stub([(200, _OK_REPLY)])
+    configured(server.base_url)
+    assert adapter.OpenAICompatModalityBackend().describe(
+        _request(uri="/tmp/local.png")
+    ) is None
+    assert server.requests == [], "no call should be attempted with nothing to send"
+
+
+def test_a_failing_fetcher_degrades_to_none(stub, configured):
+    server = stub([(200, _OK_REPLY)])
+    configured(server.base_url)
+
+    def _explode():
+        raise OSError("disk gone")
+
+    assert adapter.OpenAICompatModalityBackend().describe(
+        _request(uri="/tmp/local.png", fetch=_explode)
+    ) is None
+
+
+# ---------------------------------------------------------------------------
+# Vendor neutrality
+# ---------------------------------------------------------------------------
+
+def test_switching_endpoints_is_an_environment_change_only(stub, configured):
+    """The acceptance test for vendor neutrality: same code, same call, second
+    endpoint, only env vars changed."""
+    first = stub([(200, _OK_REPLY)])
+    second = stub([(200, json.dumps({"summary": "from the other provider"}))])
+    backend = adapter.OpenAICompatModalityBackend()
+
+    configured(first.base_url)
+    assert backend.describe(_request()).summary == "a terminal window"
+
+    configured(second.base_url, MNEMOSYNE_MODALITY_VISION_MODEL="other/model")
+    assert backend.describe(_request()).summary == "from the other provider"
+
+    assert len(first.requests) == 1 and len(second.requests) == 1
+    assert second.requests[0]["model"] == "other/model"
+
+
+def test_no_module_in_core_is_named_after_a_provider():
+    """Sponsorship gets a recipe doc and a reference deployment; it does not get
+    its name in ``mnemosyne/core/``."""
+    import pathlib
+
+    core = pathlib.Path(adapter.__file__).parent
+    names = [p.name.lower() for p in core.glob("*.py")]
+    for vendor in ("atlas", "openrouter", "together", "groq", "anthropic", "openai_only"):
+        assert not any(vendor in n for n in names), f"core module named after {vendor}"
+
+
+# ---------------------------------------------------------------------------
+# Configuration gating
+# ---------------------------------------------------------------------------
+
+def test_unconfigured_makes_no_call(monkeypatch):
+    from mnemosyne.core.config import MnemosyneConfig
+
+    monkeypatch.setenv("MNEMOSYNE_MODALITY_BASE_URL", "")
+    monkeypatch.setenv("MNEMOSYNE_MODALITY_API_KEY", "")
+    MnemosyneConfig.reset_instance()
+    try:
+        assert adapter.is_configured() is False
+        assert adapter.OpenAICompatModalityBackend().describe(_request()) is None
+    finally:
+        MnemosyneConfig.reset_instance()
+
+
+def test_a_base_url_without_a_key_is_not_configured(monkeypatch, stub):
+    """More likely a half-finished config than a deliberately unauthenticated
+    endpoint; guessing wrong means an outbound call nobody asked for."""
+    from mnemosyne.core.config import MnemosyneConfig
+
+    server = stub([(200, _OK_REPLY)])
+    monkeypatch.setenv("MNEMOSYNE_MODALITY_BASE_URL", server.base_url)
+    monkeypatch.setenv("MNEMOSYNE_MODALITY_API_KEY", "")
+    MnemosyneConfig.reset_instance()
+    try:
+        assert adapter.is_configured() is False
+        assert adapter.OpenAICompatModalityBackend().describe(_request()) is None
+    finally:
+        MnemosyneConfig.reset_instance()
+    assert server.requests == []
+
+
+def test_a_missing_model_makes_no_call(stub, configured):
+    server = stub([(200, _OK_REPLY)])
+    configured(server.base_url, MNEMOSYNE_MODALITY_VISION_MODEL="")
+    assert adapter.OpenAICompatModalityBackend().describe(_request()) is None
+    assert server.requests == []
+
+
+def test_registration_is_never_an_import_side_effect(monkeypatch, stub):
+    """Importing a module must not arm an outbound path."""
+    from mnemosyne.core.config import MnemosyneConfig
+    from mnemosyne.core.modality_backends import get_modality_backend
+
+    assert get_modality_backend("image") is None
+
+    monkeypatch.setenv("MNEMOSYNE_MODALITY_BASE_URL", "")
+    monkeypatch.setenv("MNEMOSYNE_MODALITY_API_KEY", "")
+    MnemosyneConfig.reset_instance()
+    try:
+        assert adapter.register_if_configured() is False
+        assert get_modality_backend("image") is None
+    finally:
+        MnemosyneConfig.reset_instance()
+
+
+def test_registration_when_configured(stub, configured):
+    from mnemosyne.core.modality_backends import get_modality_backend
+
+    server = stub([(200, _OK_REPLY)])
+    configured(server.base_url)
+    assert adapter.register_if_configured() is True
+    assert get_modality_backend("image") is not None
+    assert get_modality_backend("audio") is None, "this adapter does not claim audio"
+
+
+def test_model_selection_is_per_modality(stub, configured):
+    server = stub([(200, _OK_REPLY)])
+    configured(server.base_url, MNEMOSYNE_MODALITY_VIDEO_MODEL="some/video-model")
+    assert adapter.model_for("image") == "some/vision-model"
+    assert adapter.model_for("document") == "some/vision-model"
+    assert adapter.model_for("video") == "some/video-model"
+
+
+# ---------------------------------------------------------------------------
+# The JSON tolerance ladder
+# ---------------------------------------------------------------------------
+
+def test_strict_json_is_rung_one():
+    parsed = adapter.parse_response(_OK_REPLY, max_moments=12)
+    assert parsed is not None
+    summary, moments = parsed
+    assert summary == "a terminal window"
+    assert len(moments) == 1
+
+
+def test_code_fences_are_tolerated():
+    parsed = adapter.parse_response(f"```json\n{_OK_REPLY}\n```", max_moments=12)
+    assert parsed is not None and parsed[0] == "a terminal window"
+
+
+def test_truncated_json_is_salvaged():
+    """A vision model running out of tokens mid-array is routine, and a partial
+    answer beats none."""
+    truncated = '{"summary": "a long description of the scene", "moments": [{"text": "a'
+    parsed = adapter.parse_response(truncated, max_moments=12)
+    assert parsed is not None
+    assert "a long description of the scene" in parsed[0]
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "no json here", "[]", "null"])
+def test_unparseable_output_gives_up_cleanly(raw):
+    assert adapter.parse_response(raw, max_moments=12) is None
+
+
+def test_moments_are_capped():
+    payload = json.dumps({
+        "summary": "s",
+        "moments": [{"kind": "caption", "text": f"moment {i}"} for i in range(50)],
+    })
+    _, moments = adapter.parse_response(payload, max_moments=3)
+    assert len(moments) == 3
+
+
+def test_span_fields_are_coerced_and_bad_ones_dropped():
+    """A caption with no span is useful; a caption with a fabricated timestamp
+    is a wrong answer that looks right."""
+    payload = json.dumps({"moments": [{
+        "kind": "shot", "text": "a shot",
+        "t_start_ms": "1000", "t_end_ms": "not a number",
+        "bbox": [0.1, 0.2, 0.3, 0.4], "speaker": "Alice", "confidence": "0.5",
+    }]})
+    _, moments = adapter.parse_response(payload, max_moments=12)
+    moment = moments[0]
+    assert moment.t_start_ms == 1000
+    assert moment.t_end_ms is None
+    assert moment.bbox == [0.1, 0.2, 0.3, 0.4]
+    assert moment.speaker == "Alice"
+    assert moment.confidence == 0.5
+
+
+def test_a_malformed_bbox_is_dropped_not_guessed():
+    payload = json.dumps({"moments": [
+        {"text": "a", "bbox": [1, 2]},
+        {"text": "b", "bbox": ["x", "y", "z", "w"]},
+    ]})
+    _, moments = adapter.parse_response(payload, max_moments=12)
+    assert [m.bbox for m in moments] == [None, None]
+
+
+def test_textless_moments_are_dropped():
+    payload = json.dumps({"summary": "s", "moments": [{"kind": "caption"}, {"text": "  "}]})
+    _, moments = adapter.parse_response(payload, max_moments=12)
+    assert moments == []
+
+
+def test_bare_strings_in_the_moments_array_become_captions():
+    payload = json.dumps({"summary": "s", "moments": ["a plain string"]})
+    _, moments = adapter.parse_response(payload, max_moments=12)
+    assert [(m.kind, m.text) for m in moments] == [("caption", "a plain string")]
+
+
+# ---------------------------------------------------------------------------
+# Refusal, retry, and failure
+# ---------------------------------------------------------------------------
+
+def test_a_refusal_is_reported_as_refused_not_as_failure(stub, configured):
+    server = stub([(200, "I can't help with identifying people in images.")])
+    configured(server.base_url)
+
+    result = adapter.OpenAICompatModalityBackend().describe(_request())
+    assert result is not None
+    assert result.refused is True
+    assert result.moments == []
+    assert result.warnings
+
+
+def test_rate_limits_are_retried(stub, configured, monkeypatch):
+    monkeypatch.setattr(adapter.time, "sleep", lambda _s: None)
+    server = stub([(429, "slow down"), (200, _OK_REPLY)])
+    configured(server.base_url)
+
+    result = adapter.OpenAICompatModalityBackend().describe(_request())
+    assert result is not None and result.summary == "a terminal window"
+    assert len(server.requests) == 2
+
+
+def test_server_errors_are_retried_then_given_up_on(stub, configured, monkeypatch):
+    monkeypatch.setattr(adapter.time, "sleep", lambda _s: None)
+    server = stub([(500, "boom"), (503, "boom"), (500, "boom")])
+    configured(server.base_url)
+
+    assert adapter.OpenAICompatModalityBackend().describe(_request()) is None
+    assert len(server.requests) == 3, "bounded at three attempts"
+
+
+def test_client_errors_are_not_retried(stub, configured, monkeypatch):
+    """A 401 will be a 401 again. Retrying it just triples the log noise."""
+    monkeypatch.setattr(adapter.time, "sleep", lambda _s: None)
+    server = stub([(401, "bad key"), (200, _OK_REPLY)])
+    configured(server.base_url)
+
+    assert adapter.OpenAICompatModalityBackend().describe(_request()) is None
+    assert len(server.requests) == 1
+
+
+def test_an_unreachable_endpoint_degrades_to_none(configured, monkeypatch):
+    monkeypatch.setattr(adapter.time, "sleep", lambda _s: None)
+    configured("http://127.0.0.1:1/v1")
+    assert adapter.OpenAICompatModalityBackend().describe(_request()) is None
+
+
+def test_the_adapter_never_raises(stub, configured, monkeypatch):
+    """Nothing here may raise into remember()."""
+    monkeypatch.setattr(adapter.time, "sleep", lambda _s: None)
+    server = stub([(200, "not json at all"), (200, "{}")])
+    configured(server.base_url)
+    backend = adapter.OpenAICompatModalityBackend()
+
+    assert backend.describe(_request()) is None
+    assert backend.describe(_request()) is None
+
+
+def test_rate_limit_classification_matches_the_existing_one():
+    assert adapter._is_rate_limit_error(RuntimeError("HTTP 429")) is True
+    assert adapter._is_rate_limit_error(RuntimeError("rate limit exceeded")) is True
+    assert adapter._is_rate_limit_error(RuntimeError("rate limit detection failed")) is True
+    assert adapter._is_rate_limit_error(RuntimeError("connection reset")) is False
+
+
+# ---------------------------------------------------------------------------
+# Prompting
+# ---------------------------------------------------------------------------
+
+def test_the_caller_owns_the_prompt():
+    assert adapter.build_prompt(_request(hint="describe the colours only")) == (
+        "describe the colours only"
+    )
+
+
+def test_the_prompt_is_env_overridable(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_MODALITY_PROMPT", "custom for {modality}")
+    assert adapter.build_prompt(_request()) == "custom for image"
+
+
+def test_a_malformed_prompt_template_does_not_break_ingest(monkeypatch):
+    monkeypatch.setenv("MNEMOSYNE_MODALITY_PROMPT", "unbalanced {brace")
+    assert adapter.build_prompt(_request()) == "unbalanced {brace"
+
+
+def test_the_default_prompt_renders():
+    prompt = adapter.build_prompt(_request(max_moments=4))
+    assert "image" in prompt and "4" in prompt and "{" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Optional capability preflight
+# ---------------------------------------------------------------------------
+
+_MODELS_PAYLOAD = {"data": [
+    {"id": "some/vision-model", "input_modalities": ["text", "image"]},
+    {"id": "some/text-model", "input_modalities": ["text"]},
+    {"id": "nested/model", "architecture": {"input_modalities": ["text", "image"]}},
+]}
+
+
+def test_preflight_reads_input_modalities(stub):
+    server = stub([], models_payload=_MODELS_PAYLOAD)
+    caps = adapter.probe_model_modalities(server.base_url, "k")
+    assert caps["some/vision-model"] == ["text", "image"]
+    assert caps["nested/model"] == ["text", "image"]
+
+
+def test_preflight_warns_only_about_a_text_only_model(stub):
+    server = stub([], models_payload=_MODELS_PAYLOAD)
+    assert adapter.warn_if_model_cannot_see("some/vision-model", server.base_url, "k") is None
+    warning = adapter.warn_if_model_cannot_see("some/text-model", server.base_url, "k")
+    assert warning is not None and "may not accept images" in warning
+
+
+def test_preflight_is_silent_on_an_endpoint_that_does_not_publish_capabilities(stub):
+    """It must stay strictly optional. Degrade to silence, never to failure."""
+    server = stub([])  # no /models route at all
+    assert adapter.probe_model_modalities(server.base_url, "k") == {}
+    assert adapter.warn_if_model_cannot_see("anything", server.base_url, "k") is None
+
+
+def test_preflight_tolerates_an_unexpected_shape(stub):
+    server = stub([], models_payload={"models": "not the expected shape"})
+    assert adapter.probe_model_modalities(server.base_url, "k") == {}
+
+
+def test_preflight_tolerates_an_unreachable_endpoint():
+    assert adapter.probe_model_modalities("http://127.0.0.1:1/v1", "k", timeout=1.0) == {}
+
+
+def test_describe_does_not_preflight(stub, configured):
+    """The preflight is an operator-facing diagnostic, not a per-call tax."""
+    server = stub([(200, _OK_REPLY)], models_payload=_MODELS_PAYLOAD)
+    configured(server.base_url)
+    adapter.OpenAICompatModalityBackend().describe(_request())
+    assert server.model_probes == 0


### PR DESCRIPTION
The provider seam for describing non-text content, plus an OpenAI-compatible backend that implements it.

Named after the protocol rather than any vendor, so a second backend does not have to inherit the first one's name.

Stacked on `feat/content-resolvers` (#778); that PR should merge first. The diff against main includes its commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds an opt-in, vendor-neutral modality seam for image, video, audio, and document description.
- Adds an OpenAI-compatible backend with configurable endpoints, models, retries, refusal handling, JSON parsing, and lazy media retrieval.
- Preserves local-first behavior by disabling modality processing by default. Public URLs remain lazy, and local content is fetched only when required.
- Protects privacy by avoiding URI logging and by degrading safely when configuration, input, or provider responses are unavailable.
- Adds modality-keyed backend registration and request/result types for future providers and custom integrations.
- Adds configuration defaults, generated documentation, OpenAI-compatible vision guidance, and Atlas Cloud integration guidance.
- Adds registry isolation and localhost-based tests for gating, privacy, retries, parsing, registration, and failure behavior.

## Architecture Impact

- **Core memory architecture:** Extends content description without changing existing memory ownership. Provider results use `DescribedMoment` without assigning store-owned identity.
- **Tiered memory:** No direct changes to working, episodic, or BEAM memory tiers.
- **Retrieval and consolidation:** No changes to retrieval strategies or the consolidation pipeline.
- **Veracity system:** No direct changes to veracity handling. Provider refusal is represented separately from transient failure.
- **Sync layer:** No changes to synchronization behavior.
- **Agent integration:** No direct changes to Hermes, MCP, or CLI surfaces. The backend registry provides an integration seam for future agent-facing workflows.
- **Benchmark methodology:** No benchmark changes. Validation adds focused tests and reports 2,487 passing tests, 2 skipped tests, clean Ruff checks, and clean documentation checks.

## Design Assessment

- The default-disabled modality path is the right call for local-first operation and predictable privacy behavior.
- The vendor-neutral backend protocol and modality-keyed registry improve long-term maintainability.
- Call-time configuration reads support runtime test isolation and reduce stale configuration state.
- Retry classification, bounded retries, and nonfatal degradation limit provider failures.
- External provider use introduces an optional privacy boundary when users enable modality processing and send media to a configured endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->