### PR TITLE
docs(releasing): make RELEASING.md the whole pipeline, and fix two wrong claims

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -105,14 +105,55 @@ PyPI project show that exact version.
 
 ## Core Release Process
 
-### 1. Bump the version
+### 0. Audit what is going out
 
 ```bash
-# Only file that holds the canonical version:
-# mnemosyne/__init__.py  →  __version__ = "3.1.2"
+git tag -l 'v*' | sort -V | tail -1
+git log --oneline vLAST..HEAD --no-merges
 ```
 
-Update it, commit. PR the version bump separately from code changes.
+Classify by Conventional Commits: `feat:` is MINOR, `fix:` / `chore:` /
+`docs:` / `perf:` / `test:` are PATCH, `BREAKING CHANGE` or a `!` after the
+type is MAJOR.
+
+**The prefix is not sufficient on its own.** 4.0.0 exists because a `fix:`
+commit (#521) carried a breaking environment-variable change and shipped a
+MINOR bump. Also grep the `[Unreleased]` section for `Breaking` and
+`Behavior change` markers, and let those win over the prefix.
+
+Two more checks before you touch anything:
+
+- **Is it already bumped?** A contributor PR may have done it. Check
+  `pip index versions mnemosyne-memory` and `git tag -l 'vX.Y*'`. PyPI is
+  immutable, so check it first, always.
+- **Audit both packages.** Run the audit over `mnemosyne/` and over
+  `integrations/hermes/`. If either changed, both ship.
+
+### 1. Bump the version
+
+Use the script. It is the whole point of the script.
+
+```bash
+python3 scripts/release.py check 4.0.0      # read-only. run this first, always
+python3 scripts/release.py prepare 4.0.0    # writes every surface it knows about
+```
+
+Two files in this repository carry the core version, and `prepare` writes
+both:
+
+- `mnemosyne/__init__.py` (`__version__`), the canonical value
+- `hermes_memory_provider/plugin.yaml` (`version`), which `check` gates on
+
+`prepare` also promotes `[Unreleased]` into a dated section, regenerates
+`docs/api/*.mdx`, and writes `mnemosyne-docs/version.txt` and
+`mnemosyne-website/public/llms.txt`.
+
+**Do not run `prepare` for a version correction that is not a release.** A
+dated heading for a version that has not shipped is the exact drift this
+tooling exists to stop. Bump the two version files by hand and leave
+`[Unreleased]` alone.
+
+PR the version bump separately from code changes.
 
 ### 2. Tag and push
 
@@ -138,6 +179,142 @@ The auto-generated notes from `generate_release_notes: true` are a starting poin
 - Thank first-time contributors by name/PR
 - Link to the relevant issues each PR fixes
 - Note any env var changes or config migrations
+
+## CHANGELOG and UPDATING.md
+
+The step that is always underdone. Reconstruct it from git rather than from
+memory:
+
+```bash
+git log --reverse --format='COMMIT %h%nAuthor: %an%nMessage: %B---' vLAST..HEAD
+git show vLAST:CHANGELOG.md | tail -n +9        # then prepend; never overwrite
+```
+
+Cover every commit since the last tag, not only your own, and name every
+external contributor. Forty commits and four bullets means the entry is
+already wrong.
+
+Cross-check the tags against the headings with
+`grep -E '^## \[' CHANGELOG.md`. Drift happens; surface it rather than paper
+over it. If the CHANGELOG date and the tag date differ by more than a day,
+ask before publishing.
+
+`UPDATING.md` needs new environment variables, migration paths, schema
+changes, rollback commands, and its intro link moved from the old version to
+the new one.
+
+## Downstream surfaces
+
+`prepare` covers two of these. The rest are still manual, tracked in #790.
+
+**`mnemosyne-website`**
+
+- `messages/*.json` sets `home.version`, formatted `"vX.Y.Z: Short Tagline"`.
+  Three to five words, and do not reuse the previous tagline.
+- `src/data/changelog.json` sets `latest.version`.
+- `public/data/changelog.json` must be an identical copy of it.
+- `public/llms.txt` carries the latest stable version. `prepare` writes this.
+
+The i18n JSON is mixed-format. Use `json.load` and `json.dump(indent=2)`,
+never a regex. A `changelog.json` entry wants eight to twelve substantive
+items; a bare version number is a lie detector.
+
+**`mnemosyne-docs`**
+
+- `version.txt` drives the landing hero. `prepare` writes this.
+- MDX content carries hardcoded version references. The 3.12.0 release left 42
+  of them across 17 files.
+
+```bash
+find content -name "*.mdx" -exec sed -i 's/vOLD/vNEW/g' {} +
+grep -rn "vOLD" content/ --include="*.mdx"      # must return nothing
+```
+
+Touch current-facing pages only: getting-started, installation, quick-start,
+tool-schema, and the `src/app/page.tsx` tagline. Leave comparisons, benchmarks
+and migration guides alone; those are historical records.
+
+**Standalone plugin**, if `integrations/hermes/` changed. Four files carry the
+version and they drift. Patch each with exact strings, because YAML versions
+are not safe for bulk regex:
+
+- `integrations/hermes/pyproject.toml`, the source of truth
+- `integrations/hermes/plugin.yaml`
+- `integrations/hermes/src/mnemosyne_hermes/plugin.yaml`
+- `integrations/hermes/src/mnemosyne_hermes/__init__.py`, the one that gets
+  forgotten. v3.14.0 caught this.
+
+Ground truth is `pip index versions mnemosyne-hermes`, not git tags. Tagless
+manual uploads have happened.
+
+## Build verification
+
+Both Next.js sites must build clean before Vercel deploys them:
+
+```bash
+cd ../mnemosyne-docs && npm run build
+cd ../mnemosyne-website && npm run build
+```
+
+## Announcement
+
+Release announcements are written and posted by the maintainer, and are held
+until the release is verified installable. `python3 scripts/release.py announce
+X.Y.Z` drafts the blog, X and Discord copy from the changelog section. It
+drafts only; it never posts.
+
+## Verify every exit
+
+```bash
+curl -sL https://mnemosyne.site | grep 'vX.Y'
+curl -sL https://docs.mnemosyne.site | grep 'X.Y'
+pip index versions mnemosyne-memory
+pip index versions mnemosyne-hermes
+```
+
+If a live site still shows the old version it is usually the Vercel CDN rather
+than the code. Check `curl -sI <url> | grep -i x-vercel-cache`. A `HIT` with a
+high age means the deploy did not re-trigger; push an empty commit to fire the
+webhook.
+
+## Security patch releases
+
+A CVE fix differs from a normal release in five ways.
+
+1. Single purpose. The fix and its tests, nothing else. No bundling with
+   feature work.
+2. The fix must already be on `origin/main`, not a feature branch. Verify
+   before tagging.
+3. Core bump, GHSA and PyPI are the minimum. Skip the multi-repo cycle unless
+   the vulnerability touches those repos.
+4. **PyPI before GHSA.** Tag, push, let the release workflow finish, confirm
+   the version is installable, and only then publish the advisory:
+   `gh api repos/OWNER/REPO/security-advisories/<GHSA> -X PATCH -f state=published`.
+   The disclosure window must not open before the fix is reachable.
+5. Thirty-day embargo per `SECURITY.md`. Coordinate with the reporter. Discord
+   gets the upgrade line only.
+
+Check advisory state with
+`gh api repos/mnemosyne-oss/mnemosyne/security-advisories`. A draft advisory at
+critical severity means stop and escalate.
+
+## Recurring failure modes
+
+Observed on real releases. Read this list before you start.
+
+- **Stopping at the core tag.** The release is CHANGELOG plus plugin plus
+  website plus docs plus announcement. Skipping one gets noticed.
+- **A thin CHANGELOG.** Reconstruct from `git log` first, every time.
+- **The plugin `__init__.py` version.** It is the fourth file and it is the one
+  that gets missed.
+- **Lightweight tags.** `--follow-tags` pushes annotated tags only. Always
+  `git tag -a`.
+- **The pre-push hook on plugin tags.** It validates plugin tags against the
+  core version, so plugin tags need `git push --no-verify`. Never skip the hook
+  for a core tag.
+- **PyPI trusted publishing mismatch.** If the registered publisher and the
+  repository owner disagree, a tag push fails with `invalid-publisher`. This
+  happens after an ownership or org move. Fix it in PyPI settings, not in CI.
 
 ## Git Hook (auto-enforced)
 


### PR DESCRIPTION
The operational half of a Mnemosyne release lived outside the repository. `RELEASING.md` covered versioning policy and the core tag flow; everything downstream of the tag lived in an agent's working knowledge. Predictably, the two drifted.

This folds the contributor-facing half in, so the pipeline ships with the code and has one owner. Announcement mechanics and anything naming a host, path or account are deliberately out of scope here and stay with the maintainer.

**Two things already in the file were wrong:**

- It said `mnemosyne/__init__.py` is the "only file that holds the canonical version". `hermes_memory_provider/plugin.yaml` carries it too, and `release.py` both bumps it in `prepare` and fails on it in `check`.
- The bump step described a hand edit, while `release.py check` / `prepare` has been the supported path since it was written. Its own docstring says doing this by hand is what produced the historical drift.

**Added:** the pre-bump audit; CHANGELOG reconstruction from `git log` rather than memory; `UPDATING.md`; the downstream website, docs and plugin surfaces with the correct repository named for each; build verification; exit verification including the Vercel CDN trap; the security-patch variant with PyPI before GHSA; and the recurring failure modes from real releases.

One refinement worth calling out: classifying a release by Conventional Commits prefix alone is not enough. 4.0.0 exists because a `fix:` commit carried a breaking environment-variable change and shipped as a MINOR. The audit section now says to grep `[Unreleased]` for `Breaking` markers and let those win.

The downstream section states plainly that `prepare` covers two of those surfaces and the rest are still manual, tracked in #790.

Docs only. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Expanded `RELEASING.md` with the complete Mnemosyne release workflow.
- Documented version synchronization across the core package and `hermes_memory_provider/plugin.yaml`.
- Added procedures for changelog reconstruction, downstream surfaces, build checks, post-release verification, security releases, and recurring failures.
- Clarified breaking-change classification and use of `scripts/release.py check` and `prepare`.

## Architecture and maintainability impact

- No changes affect tiered memory, retrieval, consolidation, veracity, sync, benchmarks, privacy, or local-first guarantees.
- No Hermes, MCP, or CLI integration code changes.
- The documented release checks improve long-term maintainability and reduce version-drift risk across agent integration surfaces.
- Keeping announcement details maintainer-owned preserves operational control without changing the local-first design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->