### PR TITLE
feat(release): support PEP 440 pre-release tags so a major can have a beta

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -119,11 +119,14 @@ PY
 }
 
 for tag in "${refs[@]}"; do
-    # Validate format: vMAJOR.MINOR.PATCH
-    if ! echo "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-        echo "ERROR: Tag '$tag' must match format vMAJOR.MINOR.PATCH (e.g. v3.1.2)"
+    # Validate format: vMAJOR.MINOR.PATCH, optionally with a PEP 440
+    # pre-release suffix (aN / bN / rcN), so a major can run the beta cycle
+    # RELEASING.md requires.
+    if ! echo "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$'; then
+        echo "ERROR: Tag '$tag' must match vMAJOR.MINOR.PATCH with an optional"
+        echo "       PEP 440 pre-release suffix"
         echo "  Got:      $tag"
-        echo "  Expected: vMAJOR.MINOR.PATCH"
+        echo "  Expected: v3.1.2, or v4.0.0b1 / v4.0.0rc1 for a pre-release"
         exit 1
     fi
 
@@ -150,11 +153,32 @@ for tag in "${refs[@]}"; do
     fi
 
     # Compare only releases in the selected package namespace.
+    #
+    # `sort -V` cannot do this. It orders 4.0.0 BEFORE 4.0.0b1, comparing the
+    # empty suffix against "b1" lexically, so once a beta is tagged the real
+    # release would be rejected as "behind". PEP 440 says the opposite: a
+    # pre-release precedes its final. Compare in Python instead, stdlib only,
+    # so the hook never depends on `packaging` being installed.
     if [ -n "$latest_existing" ]; then
         latest_ver="${latest_existing#v}"
-        if [ "$(printf '%s\n' "$tag_version" "$latest_ver" | sort -V | head -1)" = "$tag_version" ] && [ "$tag_version" != "$latest_ver" ]; then
-            echo "ERROR: Tag '$tag_version' is behind existing $tag_namespace tag '$latest_existing'"
+        if ! TAG_VER="$tag_version" LATEST_VER="$latest_ver" python3 - <<'PEP440'
+import os, re, sys
+
+def key(v):
+    m = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?", v)
+    if not m:
+        sys.exit("unparseable version: " + repr(v))
+    major, minor, patch, kind, num = m.groups()
+    # A final release outranks every pre-release of the same X.Y.Z.
+    stage = {None: 3, "a": 0, "b": 1, "rc": 2}[kind]
+    return (int(major), int(minor), int(patch), stage, int(num or 0))
+
+sys.exit(0 if key(os.environ["TAG_VER"]) > key(os.environ["LATEST_VER"]) else 1)
+PEP440
+        then
+            echo "ERROR: Tag '$tag_version' is not ahead of existing $tag_namespace tag '$latest_existing'"
             echo "  New tag must be greater than the latest existing tag in that namespace."
+            echo "  Pre-release order: 4.0.0a1 < 4.0.0b1 < 4.0.0rc1 < 4.0.0"
             exit 1
         fi
     fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           files: dist/*
           generate_release_notes: true
+          # A pre-release tag must not become the repository's "Latest release".
+          prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,6 +71,35 @@ Mnemosyne follows **strict SemVer** (MAJOR.MINOR.PATCH).
 - Altered env var semantics (not just adding new ones)
 - Changed Python version requirements
 
+### Pre-releases
+
+A major needs a beta cycle, so the tag format accepts a PEP 440 pre-release
+suffix: `aN`, `bN` or `rcN`. `v4.0.0b1` is valid; `v4.0.0-beta.1` is not.
+
+`__version__` carries the same string, so a beta is `4.0.0b1` in
+`mnemosyne/__init__.py` and `hermes_memory_provider/plugin.yaml`, exactly as
+`release.py prepare 4.0.0b1` writes it.
+
+Ordering is PEP 440, not `sort -V`:
+
+```
+4.0.0a1  <  4.0.0b1  <  4.0.0rc1  <  4.0.0
+```
+
+The pre-push hook enforces that ordering in Python rather than with `sort -V`,
+which gets it backwards: `sort -V` places `4.0.0` before `4.0.0b1`, so with it
+the real release would be rejected as behind its own beta.
+
+pip will not install a pre-release unless asked, so a beta reaches only the
+people who opt in:
+
+```bash
+pip install --pre mnemosyne-memory
+```
+
+The GitHub release is flagged as a pre-release automatically, so a beta never
+becomes the repository's "Latest release".
+
 ### When to release
 
 - **Patches:** As soon as CI is green on main. Bug fixes don't wait.
@@ -143,7 +172,9 @@ The auto-generated notes from `generate_release_notes: true` are a starting poin
 
 A pre-push hook in <code>.githooks/pre-push</code> validates each pushed tag:
 
-1. Tag format: `vMAJOR.MINOR.PATCH` (e.g. `v3.1.2`, not `v3.1` or `v3.1.2-beta`)
+1. Tag format: `vMAJOR.MINOR.PATCH`, with an optional PEP 440 pre-release
+   suffix (e.g. `v3.1.2`, `v4.0.0b1`, `v4.0.0rc1`; not `v3.1` or
+   `v4.0.0-beta.1`)
 2. A `v0.*` standalone tag matches `[project].version` in
    <code>integrations/hermes/pyproject.toml</code>; other tags match
    <code>__version__</code> in <code>mnemosyne/__init__.py</code> (without `v`)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -51,7 +51,9 @@ SIBLINGS = os.path.dirname(REPO)
 DOCS = os.path.join(SIBLINGS, "mnemosyne-docs")
 SITE = os.path.join(SIBLINGS, "mnemosyne-website")
 
-VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+# MAJOR.MINOR.PATCH with an optional PEP 440 pre-release suffix, so a major
+# can run the beta cycle RELEASING.md requires.
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?$")
 
 
 # ---------------------------------------------------------------- helpers
@@ -142,7 +144,17 @@ def cmd_check(args: argparse.Namespace) -> int:
     tags = set(_git("tag", "--list").split())
 
     def _parts(v: str) -> tuple:
-        return tuple(int(x) for x in re.findall(r"\d+", v))
+        """Sort key honouring PEP 440 pre-release order.
+
+        A naive digit sweep reads "4.0.0b1" as (4, 0, 0, 1) and ranks it above
+        "4.0.0", which is backwards: a pre-release precedes its final release.
+        """
+        m = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?", v.lstrip("v"))
+        if not m:
+            return tuple(int(x) for x in re.findall(r"\d+", v))
+        major, minor, patch, kind, num = m.groups()
+        stage = {None: 3, "a": 0, "b": 1, "rc": 2}[kind]
+        return (int(major), int(minor), int(patch), stage, int(num or 0))
 
     tagged = sorted((_parts(t) for t in tags if VERSION_RE.match(t.lstrip("v"))), reverse=True)
     newest_tag = tagged[0] if tagged else (0,)
@@ -298,9 +310,9 @@ def cmd_prepare(args: argparse.Namespace) -> int:
 
     print()
     print("Next:")
-    print(f"  1. review the diffs in all three repos")
+    print("  1. review the diffs in all three repos")
     print(f"  2. python3 scripts/release.py announce {version}")
-    print(f"  3. commit and merge each repo")
+    print("  3. commit and merge each repo")
     print(f"  4. python3 scripts/release.py check {version}")
     print(f"  5. python3 scripts/release.py tag {version}")
     return 0
@@ -435,7 +447,7 @@ Full changelog: <https://github.com/mnemosyne-oss/mnemosyne/releases/tag/v{versi
 
     print(f"Drafts written to dist-announce/ for {version}:\n")
     print(f"  {slug}.mdx          blog post -> mnemosyne-website/content/blog/")
-    print(f"                          verified to build; renders one page per locale (7)")
+    print("                          verified to build; renders one page per locale (7)")
     print(f"  {slug}-x.txt        X post ({len(x_post)} chars)")
     print(f"  {slug}-discord.md   Discord announcement")
     print()
@@ -464,7 +476,7 @@ def cmd_tag(args: argparse.Namespace) -> int:
     print()
     print("Then, once PyPI shows the new version:")
     print("    merge the version bumps in mnemosyne-docs and mnemosyne-website")
-    print(f"    publish the drafts from dist-announce/")
+    print("    publish the drafts from dist-announce/")
     return 0
 
 


### PR DESCRIPTION
`RELEASING.md` requires "at least one beta cycle" for a major, and the tooling could not produce one. Both gates rejected any pre-release string:

```
.githooks/pre-push:  ^v[0-9]+\.[0-9]+\.[0-9]+$
scripts/release.py:  VERSION_RE = ^\d+\.\d+\.\d+$
```

Nobody had hit it because there had never been a major. 4.0.0 hits it.

## The part that would have bitten later

`sort -V` cannot order pre-releases. It places `4.0.0` **before** `4.0.0b1`, because it compares an empty suffix against `b1` lexically. So the beta tag would push fine and then the real `v4.0.0` would be rejected as "behind existing tag v4.0.0b1", after the beta had already shipped.

The monotonic check now compares in Python, stdlib only so the hook never depends on `packaging` being installed. Verified across seven orderings including that one:

| tag | vs latest | ahead? |
|---|---|---|
| 4.0.0b1 | 3.15.1 | yes |
| 4.0.0 | 4.0.0b1 | yes |
| 4.0.0b1 | 4.0.0 | no |
| 4.0.0b2 | 4.0.0b1 | yes |
| 4.0.0b1 | 4.0.0b1 | no |
| 4.0.0rc1 | 4.0.0b9 | yes |
| 3.15.1 | 4.0.0b1 | no |

`release.py` had the same class of bug in its own sort key: `_parts()` swept digits, reading `4.0.0b1` as `(4, 0, 0, 1)` and ranking it above `4.0.0`.

## Everything else

- The release workflow marks a pre-release tag as a GitHub pre-release, so a beta never becomes the repository's "Latest release".
- Tag routing is unchanged. `v4.0.0b1` does not start with `v0.`, so it still goes to the core job.
- Format gate accepts `v4.0.0b1`, `v4.0.0rc1`, `v4.0.0a2`; still rejects `v4.0.0-beta.1`, `v4.0`, `v4.0.0beta1`, `v4.0.0b`.
- `RELEASING.md` documents the format, the ordering, and that pip needs `--pre`.
- Nothing changes for a normal release.

Also fixes four pre-existing F541s in `release.py`, since CI lints whole changed files and they would otherwise fail this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates release tooling to support PEP 440 alpha, beta, and release-candidate tags.

- Validates `aN`, `bN`, and `rcN` tag suffixes.
- Orders pre-releases before final releases with Python-based comparison.
- Marks pre-release GitHub releases correctly.
- Documents tag formats, ordering, installation requirements, and release behavior.
- Fixes four F541 lint issues in `scripts/release.py`.
- Preserves existing tag routing and normal-release behavior.

## Mnemosyne Architecture Impact

This PR does not change Mnemosyne’s core memory architecture, privacy posture, or local-first guarantees.

It does not modify:

- Working, episodic, or BEAM memory tiers.
- Retrieval strategies.
- The consolidation pipeline.
- The veracity system.
- The sync layer.
- Hermes, MCP, or CLI integration surfaces.
- Benchmark methodology.

The changes affect release validation and publishing only. They do not add external runtime dependencies or change data handling.

## Maintainability

Python-based version comparison provides clearer and more reliable release ordering than `sort -V` and digit extraction. Explicit documentation improves release-process maintainability.

Supporting beta and other pre-release cycles is the right call for major releases. No change erodes the local-first design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->