### PR TITLE
chore(hermes): bump the standalone plugin to 0.7.0 and stop pinning the version in tests

### DIFF
--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-mnemosyne
-version: 0.6.0
+version: 0.7.0
 description: "Native local memory for Hermes - SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, and temporal triples. Zero cloud. Zero latency. Pipx-installable via `pipx install mnemosyne-hermes`."
 author: Abdias J
 pip_dependencies:

--- a/integrations/hermes/pyproject.toml
+++ b/integrations/hermes/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mnemosyne-hermes"
-version = "0.6.0"
+version = "0.7.0"
 description = "Mnemosyne memory provider for Hermes Agent — local-first, zero-cloud memory"
 readme = "README.md"
 license = "MIT"

--- a/integrations/hermes/src/mnemosyne_hermes/__init__.py
+++ b/integrations/hermes/src/mnemosyne_hermes/__init__.py
@@ -136,7 +136,7 @@ except Exception as _persona_import_exc:  # pragma: no cover - graceful import f
         def _with_persona_block(self, base: str) -> str:
             return base
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 logger = logging.getLogger(__name__)
 

--- a/integrations/hermes/src/mnemosyne_hermes/plugin.yaml
+++ b/integrations/hermes/src/mnemosyne_hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-mnemosyne
-version: 0.6.0
+version: 0.7.0
 description: "Native local memory for Hermes — SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, temporal triples, and bidirectional sync with optional client-side encryption. Zero cloud. Zero latency."
 author: Abdias J
 provides_tools:

--- a/tests/test_plugin_manifest_versions.py
+++ b/tests/test_plugin_manifest_versions.py
@@ -140,7 +140,14 @@ def test_package_metadata_uses_the_same_version_contract():
     )
 
 
-def test_standalone_hermes_release_source_surfaces_are_ready_for_0_6_0():
+def test_standalone_hermes_release_source_surfaces_agree():
+    """All four standalone version surfaces must carry the same value.
+
+    The version itself is read from pyproject.toml, which RELEASING.md names as
+    the source of truth, rather than hardcoded. Pinning a literal here meant
+    every plugin release had to rename this test, and a rename is easy to do
+    without re-reading what it asserts.
+    """
     hermes_root = ROOT / "integrations" / "hermes"
     distribution_version = _project_version(hermes_root / "pyproject.toml")
     runtime_version = _assignment_version(
@@ -151,14 +158,17 @@ def test_standalone_hermes_release_source_surfaces_are_ready_for_0_6_0():
         hermes_root / "src" / "mnemosyne_hermes" / "plugin.yaml"
     )
 
-    assert distribution_version == "0.6.0"
+    assert distribution_version, "pyproject.toml declares no [project].version"
     assert runtime_version == distribution_version
     assert source_manifest_version == distribution_version
     assert packaged_manifest_version == distribution_version
 
 
-def test_standalone_hermes_release_wheel_is_ready_for_0_6_0(tmp_path):
-    wheel = _build_standalone_wheel(ROOT / "integrations" / "hermes", tmp_path)
+def test_standalone_hermes_release_wheel_matches_the_declared_version(tmp_path):
+    """The built wheel must carry the version pyproject.toml declares."""
+    hermes_root = ROOT / "integrations" / "hermes"
+    expected = _project_version(hermes_root / "pyproject.toml")
+    wheel = _build_standalone_wheel(hermes_root, tmp_path)
 
     with zipfile.ZipFile(wheel) as archive:
         metadata = BytesParser(policy=policy.default).parsebytes(
@@ -168,5 +178,5 @@ def test_standalone_hermes_release_wheel_is_ready_for_0_6_0(tmp_path):
 
         assert manifest_path in archive.namelist()
         assert metadata["Name"] == "mnemosyne-hermes"
-        assert metadata["Version"] == "0.6.0"
-        assert _manifest_version_from_wheel(archive, manifest_path) == "0.6.0"
+        assert metadata["Version"] == expected
+        assert _manifest_version_from_wheel(archive, manifest_path) == expected

--- a/tests/test_release_gates.py
+++ b/tests/test_release_gates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import re
 import subprocess
 from pathlib import Path
 
@@ -74,16 +75,31 @@ def _release_repo(
     return repo
 
 
-def test_standalone_0_6_0_tag_succeeds_against_actual_repo_state():
-    result = _run_hook(ROOT, "v0.6.0")
+def _declared_standalone_version() -> str:
+    """The standalone version this repo would release, from its source of truth."""
+    text = (ROOT / "integrations" / "hermes" / "pyproject.toml").read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match, "integrations/hermes/pyproject.toml declares no [project].version"
+    return match.group(1)
+
+
+def test_standalone_tag_for_the_declared_version_succeeds_against_actual_repo_state():
+    """Read the version rather than pinning it, so a plugin bump does not
+    require renaming this test to keep it honest."""
+    result = _run_hook(ROOT, f"v{_declared_standalone_version()}")
 
     assert result.returncode == 0, result.stderr + result.stdout
     assert "integrations/hermes/pyproject.toml" in result.stdout
 
 
 @pytest.mark.skipif(PYTHON310 is None, reason="python3.10 is unavailable for hook compatibility coverage")
-def test_standalone_0_6_0_tag_succeeds_with_python_3_10(tmp_path):
-    result = _run_hook(ROOT, "v0.6.0", python310=PYTHON310, tmp_path=tmp_path)
+def test_standalone_tag_for_the_declared_version_succeeds_with_python_3_10(tmp_path):
+    result = _run_hook(
+        ROOT,
+        f"v{_declared_standalone_version()}",
+        python310=PYTHON310,
+        tmp_path=tmp_path,
+    )
 
     assert result.returncode == 0, result.stderr + result.stdout
     assert "ModuleNotFoundError" not in result.stderr


### PR DESCRIPTION
`integrations/hermes/` has **20 non-merge commits since v3.15.1**, so the standalone package ships alongside core 4.0.0.

## Why 0.7.0 and not 0.6.0

It was already sitting at 0.6.0 across all four files, but **0.6.0 never shipped**. The newest `v0.*` tag is `v0.5.0` and PyPI's newest is `0.5.0`. #667 prepared 0.6.0, it was never tagged, and then 20 more fixes landed on top of it. The declared version no longer described what would go out.

0.6.0 joins 3.16.0 as a version that was prepared and never released. No changelog entry anywhere referenced it, so nothing needed retitling.

All four surfaces patched with exact per-file strings, since YAML versions are not safe for bulk regex:

- `integrations/hermes/pyproject.toml` (source of truth)
- `integrations/hermes/plugin.yaml`
- `integrations/hermes/src/mnemosyne_hermes/plugin.yaml`
- `integrations/hermes/src/mnemosyne_hermes/__init__.py` (the one that gets missed)

## The test change

Three tests failed on the bump because they hardcoded `0.6.0` in their assertions **and in their names**, so every plugin release had to rename them. A rename is easy to do without re-reading what the test asserts, which defeats the point of having it.

They now read the expected version from `pyproject.toml` and assert the actual invariant: all four surfaces agree, the built wheel carries the declared version, and the pre-push hook accepts the tag for it. No renaming needed at the next bump.

Verified the de-pinned assertion is not vacuous: setting one surface to `0.6.9` fails the test, restoring it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates the standalone Hermes plugin version from `0.6.0` to `0.7.0` in all four declarations.
- Updates release tests to read the expected version from `pyproject.toml` and validate source surfaces, wheel metadata, packaged manifests, and release tags.
- Uses the release documentation as the source of truth for release-related validation.

## Architecture and design impact

- No changes affect tiered memory, retrieval, consolidation, veracity, synchronization, or benchmark methodology.
- No changes affect Mnemosyne's privacy posture or local-first guarantees.
- No changes affect MCP, CLI, or Hermes integration behavior beyond the Hermes package version.
- Dynamic version checks improve long-term maintainability by reducing hard-coded release values.
- The version consistency checks are the right call for preventing mismatched Hermes release artifacts.
- The PR does not erode the local-first design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->