### PR TITLE
feat(release): make release.py understand pre-releases, and stop blaming this repo for sibling drift

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -55,6 +55,20 @@ SITE = os.path.join(SIBLINGS, "mnemosyne-website")
 # can run the beta cycle RELEASING.md requires.
 VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?$")
 
+PRERELEASE_RE = re.compile(r"^\d+\.\d+\.\d+(?:a|b|rc)\d+$")
+
+
+def _is_prerelease(version: str) -> bool:
+    """True for 4.0.0b1, False for 4.0.0.
+
+    A pre-release ships to PyPI and gets a GitHub pre-release, but it is not
+    the release. It does not take its own dated CHANGELOG section, and it does
+    not move the docs or marketing sites, which advertise the version people
+    get from a plain `pip install`.
+    """
+    return bool(PRERELEASE_RE.match(version))
+
+
 
 # ---------------------------------------------------------------- helpers
 def _read(path: str) -> str:
@@ -128,6 +142,11 @@ def cmd_check(args: argparse.Namespace) -> int:
     sections = _changelog_sections()
     if version in sections:
         _ok(f"CHANGELOG has a [{version}] section")
+    elif _is_prerelease(version):
+        # Deliberate: a beta shares the entry with the release it precedes.
+        # Promoting per pre-release would leave a stale [4.0.0b1] heading
+        # beside [4.0.0] describing the same changes.
+        _ok(f"CHANGELOG keeps [Unreleased] for pre-release {version}")
     else:
         _bad(f"CHANGELOG has no [{version}] section (found: {', '.join(sections[:4])})")
         problems += 1
@@ -175,10 +194,26 @@ def cmd_check(args: argparse.Namespace) -> int:
 
     gen = subprocess.run([sys.executable, os.path.join(REPO, "scripts", "verify-docs.py")],
                          cwd=REPO, capture_output=True, text=True)
+    out = gen.stdout + gen.stderr
+    # verify-docs.py exits non-zero for canonical drift AND for sibling drift.
+    # Only the first is this repository's problem and only the first should
+    # block a release. Reporting them the same way sent you to run
+    # generate-docs.py for a file this repo does not own, and made a stale
+    # docs site look like stale generated output here.
+    canonical_drift = any(
+        line.strip().startswith("DRIFT:") for line in out.splitlines()
+    )
+    sibling_drift = "DRIFT (sibling)" in out
     if gen.returncode == 0:
         _ok("generated docs match the code")
-    else:
+    elif canonical_drift:
         _bad("generated docs are stale. Run: python3 scripts/generate-docs.py")
+        problems += 1
+    elif sibling_drift:
+        _warn("mnemosyne-docs content is behind this repo; `prepare` for a "
+              "final release regenerates it")
+    else:
+        _bad(f"verify-docs.py failed: {out.strip().splitlines()[-1] if out.strip() else gen.returncode}")
         problems += 1
 
     for name, path, probe in (
@@ -190,8 +225,12 @@ def cmd_check(args: argparse.Namespace) -> int:
         elif os.path.exists(probe):
             cur = _read(probe).strip() if probe.endswith(".txt") and "version" in probe else ""
             if probe.endswith("version.txt"):
-                _ok(f"{name} version.txt = {cur}") if cur == version else _warn(
-                    f"{name} version.txt = {cur}, will become {version} on prepare")
+                if cur == version:
+                    _ok(f"{name} version.txt = {cur}")
+                elif _is_prerelease(version):
+                    _ok(f"{name} version.txt = {cur}, unchanged for a pre-release")
+                else:
+                    _warn(f"{name} version.txt = {cur}, will become {version} on prepare")
             else:
                 _ok(f"{name} present")
 
@@ -278,7 +317,9 @@ def cmd_prepare(args: argparse.Namespace) -> int:
     # 3. Promote [Unreleased] into a dated section.
     cl = os.path.join(REPO, "CHANGELOG.md")
     s = _read(cl)
-    if f"## [{version}]" in s:
+    if _is_prerelease(version):
+        print(f"  CHANGELOG.md left on [Unreleased] ({version} is a pre-release)")
+    elif f"## [{version}]" in s:
         print(f"  CHANGELOG already has [{version}], leaving it alone")
     else:
         s2 = s.replace("## [Unreleased]",
@@ -287,34 +328,53 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         print(f"  CHANGELOG.md -> [{version}] - {today}")
 
     # 4. Regenerate the derived docs so they carry the new version.
-    subprocess.run([sys.executable, os.path.join(REPO, "scripts", "generate-docs.py")],
+    #
+    # For a pre-release use verify-docs.py --fix, which writes only this
+    # repository's canonical docs/api/*.mdx. generate-docs.py also writes into
+    # mnemosyne-docs, and those files carry the version in their frontmatter,
+    # so running it here would put a beta version on the published docs site
+    # even though step 5 deliberately leaves version.txt alone.
+    doc_script = "verify-docs.py" if _is_prerelease(version) else "generate-docs.py"
+    doc_args = ["--fix"] if _is_prerelease(version) else []
+    subprocess.run([sys.executable, os.path.join(REPO, "scripts", doc_script), *doc_args],
                    cwd=REPO, check=False)
 
-    # 5. Sibling repos.
-    vt = os.path.join(DOCS, "version.txt")
-    if os.path.isfile(vt):
-        _write(vt, version + "\n")
-        print(f"  mnemosyne-docs/version.txt -> {version}")
+    # 5. Sibling repos. A pre-release must not move them: the docs hero and
+    # the marketing site advertise what a plain `pip install` gives you, and
+    # that is still the previous release until the final ships.
+    if _is_prerelease(version):
+        print(f"  sibling repos left alone ({version} is a pre-release)")
     else:
-        print("  mnemosyne-docs not present, skipped")
+        vt = os.path.join(DOCS, "version.txt")
+        if os.path.isfile(vt):
+            _write(vt, version + "\n")
+            print(f"  mnemosyne-docs/version.txt -> {version}")
+        else:
+            print("  mnemosyne-docs not present, skipped")
 
-    llms = os.path.join(SITE, "public", "llms.txt")
-    if os.path.isfile(llms):
-        s = _read(llms)
-        s2 = re.sub(r"(Latest stable: mnemosyne-memory )\S+", rf"\g<1>{version}", s)
-        if s2 != s:
-            _write(llms, s2)
-            print(f"  mnemosyne-website/public/llms.txt -> {version}")
-    else:
-        print("  mnemosyne-website not present, skipped")
+        llms = os.path.join(SITE, "public", "llms.txt")
+        if os.path.isfile(llms):
+            s = _read(llms)
+            s2 = re.sub(r"(Latest stable: mnemosyne-memory )\S+", rf"\g<1>{version}", s)
+            if s2 != s:
+                _write(llms, s2)
+                print(f"  mnemosyne-website/public/llms.txt -> {version}")
+        else:
+            print("  mnemosyne-website not present, skipped")
 
     print()
     print("Next:")
-    print("  1. review the diffs in all three repos")
-    print(f"  2. python3 scripts/release.py announce {version}")
-    print("  3. commit and merge each repo")
-    print(f"  4. python3 scripts/release.py check {version}")
-    print(f"  5. python3 scripts/release.py tag {version}")
+    if _is_prerelease(version):
+        print("  1. review the diff in this repo")
+        print(f"  2. commit and merge, then: python3 scripts/release.py check {version}")
+        print(f"  3. python3 scripts/release.py tag {version}")
+        print("  4. announce nothing yet; a pre-release is not the release")
+    else:
+        print("  1. review the diffs in all three repos")
+        print(f"  2. python3 scripts/release.py announce {version}")
+        print("  3. commit and merge each repo")
+        print(f"  4. python3 scripts/release.py check {version}")
+        print(f"  5. python3 scripts/release.py tag {version}")
     return 0
 
 


### PR DESCRIPTION
#794 taught the tag format and the version regexes about pre-releases. Actually running `prepare 4.0.0b1` showed the rest of the script still treated a beta as a release, in four places.

**CHANGELOG.** `check` demanded a `[4.0.0b1]` section and `prepare` would have created one. A beta shares its entry with the release it precedes, so promoting per pre-release leaves a stale `[4.0.0b1]` heading beside `[4.0.0]` describing the same changes. Both now keep `[Unreleased]` for a pre-release.

**Sibling repos.** `prepare` would have written `mnemosyne-docs/version.txt` and `mnemosyne-website/public/llms.txt`. Those advertise what a plain `pip install` gives you, which during a beta is still the previous release. Now left alone.

**Generated docs.** Step 4 ran `generate-docs.py`, which writes into `mnemosyne-docs` unconditionally, and those files carry the version in their frontmatter. So a beta reached the published docs site through the back door even with `version.txt` skipped. A pre-release now runs `verify-docs.py --fix`, which touches only this repo's canonical `docs/api/*.mdx`.

**Sibling drift reporting.** `verify-docs.py` exits non-zero for canonical drift and sibling drift alike, and `check` reported both as "generated docs are stale. Run: generate-docs.py". That sent you to regenerate a file this repo does not own, made a stale docs site look like stale output here, and blocked the release gate on something that is not this repo's state. Canonical drift now blocks; sibling drift warns.

## Verified end to end

`prepare 4.0.0b1`:
```
  mnemosyne/__init__.py -> 4.0.0b1
  hermes_memory_provider/plugin.yaml -> 4.0.0b1
  CHANGELOG.md left on [Unreleased] (4.0.0b1 is a pre-release)
  sibling repos left alone (4.0.0b1 is a pre-release)
```

Both sibling repos: **0 changes**. `check 4.0.0b1` reports **READY**, and the build produces `mnemosyne_memory-4.0.0b1-py3-none-any.whl`.

A final release is unaffected: `check 4.0.0` still requires its dated CHANGELOG section and still reports that `prepare` will move the siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates release handling for pre-releases.
- Keeps pre-release changelogs on `[Unreleased]`.
- Prevents sibling repository changes during pre-release preparation.
- Regenerates only canonical local API documentation.
- Blocks checks for canonical documentation drift.
- Warns about sibling repository drift.
- Preserves existing final-release behavior.
- Improves release maintainability by separating local canonical state from sibling repository state.

## Mnemosyne Architecture Impact

- No changes to working, episodic, or BEAM memory tiers.
- No changes to retrieval, consolidation, veracity, or sync systems.
- No changes to privacy posture or local-first guarantees.
- No changes to Hermes, MCP, or CLI integration surfaces.
- No changes to benchmark methodology.
- The release workflow preserves local canonical documentation ownership. This is the right call for local-first maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->