### PR TITLE
chore(release): bump the pending version to 4.0.0b1 for the beta cycle

### DIFF
--- a/docs/api/configuration.mdx
+++ b/docs/api/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-version: 4.0.0
+version: 4.0.0b1
 config_key_count: 114
 env_only_count: 44
 generated_at: "auto"

--- a/docs/api/tool-schema.mdx
+++ b/docs/api/tool-schema.mdx
@@ -1,13 +1,13 @@
 ---
 title: "MCP Tool Schema"
-version: 4.0.0
+version: 4.0.0b1
 tool_count: 37
 mcp_tool_count: 29
 plugin_only_tool_count: 8
 generated_at: "auto"
 ---
 
-# MCP Tool Schema (v4.0.0)
+# MCP Tool Schema (v4.0.0b1)
 
 > **Generated file. Do not edit by hand.**
 > Source: `mnemosyne/tool_schemas.py` and `mnemosyne/mcp_tools.py`.

--- a/hermes_memory_provider/plugin.yaml
+++ b/hermes_memory_provider/plugin.yaml
@@ -1,5 +1,5 @@
 name: mnemosyne
-version: 4.0.0
+version: 4.0.0b1
 description: "Native local memory for Hermes — SQLite with vector search, FTS5 hybrid ranking, episodic consolidation, temporal triples, and bidirectional sync with optional client-side encryption. Zero cloud. Zero latency."
 author: Abdias J
 provides_tools:

--- a/mnemosyne/__init__.py
+++ b/mnemosyne/__init__.py
@@ -10,7 +10,7 @@ Example:
     >>> results = recall("user preferences")
 """
 
-__version__ = "4.0.0"
+__version__ = "4.0.0b1"
 __author__ = "Abdias J"
 __license__ = "MIT"
 


### PR DESCRIPTION
`RELEASING.md` requires at least one beta for a major, and 4.0.0 carries the multimodal stack plus a breaking change to embedding-dimension resolution.

Written by `release.py prepare 4.0.0b1`. For a pre-release that bumps only the two version surfaces and regenerates this repository's canonical docs:

```
  mnemosyne/__init__.py -> 4.0.0b1
  hermes_memory_provider/plugin.yaml -> 4.0.0b1
  CHANGELOG.md left on [Unreleased] (4.0.0b1 is a pre-release)
  sibling repos left alone (4.0.0b1 is a pre-release)
```

Verified after running it: `mnemosyne-docs` and `mnemosyne-website` both at **0 changes**.

The CHANGELOG stays on `[Unreleased]` because a beta shares its entry with the release it precedes. The standalone plugin stays at 0.7.0; it versions on its own `v0.*` line and is not part of the core pre-release.

`release.py check 4.0.0b1` reports **READY**.

Next after this merges is the `v4.0.0b1` tag, which publishes to PyPI as a pre-release that only `pip install --pre` resolves, flagged so it never becomes the repository's "Latest release". No announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Bumps Mnemosyne and the Hermes plugin version to `4.0.0b1`.
- Updates generated MCP documentation metadata to `4.0.0b1`.
- Keeps the changelog under `[Unreleased]`.
- Leaves the standalone plugin at `0.7.0` and sibling repositories unchanged.
- `release.py check 4.0.0b1` reports `READY`.

## Architecture and compatibility impact

- No changes affect working, episodic, or BEAM memory tiers.
- No changes affect retrieval, consolidation, veracity, or sync behavior.
- No changes affect privacy posture or local-first guarantees.
- No changes affect Hermes, MCP, or CLI behavior.
- No changes affect benchmark methodology.
- The version-only scope is the right call for the beta release cycle. It limits release risk and preserves long-term maintainability.
- Canonical documentation regeneration produced no additional changes.

The next release step is to create the `v4.0.0b1` tag for PyPI pre-release publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->