### PR TITLE
fix: preserve committed mutations when cache invalidation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Committed memory invalidations no longer report failure when enhanced-recall cache eviction fails (#594).** The mutation remains successful and the cache error is logged for reconciliation.
 - **Hermes providers no longer clear the shared host LLM backend while another primary provider remains active (#551).**
 - **The OpenAI-compatible modality retry test is deterministic under load (#798).** Its localhost stub handles one request at a time and records response statuses, so the 401/no-retry contract is checked against the response actually served.
 - **Raw dialog no longer starves distilled facts out of the dense recall voice (#696).** Conversational capture (`source='conversation'`, and legacy `honcho_*` imports) is topically identical to the queries that retrieve it, so those rows saturated the nearest-N working-memory vector pool and pushed distilled facts beyond it. An affected fact surfaced with `dense_score=0.0` or did not surface at all. Dialog sources are now excluded from the working-memory dense candidate pool while remaining fully reachable through FTS. #608 widened the candidate neighbourhood, which helps a shallow flood; this is what makes that capacity effective against the flood itself.

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4603,7 +4603,10 @@ class BeamMemory:
             else:
                 invalidated = validate_and_invalidate()
             if invalidated:
-                self._invalidate_query_cache_after_commit("invalidate")
+                if owns_transaction:
+                    self._invalidate_query_cache_after_commit("invalidate")
+                else:
+                    self._invalidate_query_cache()
             return invalidated
 
         now = datetime.now(timezone.utc).isoformat()
@@ -4927,6 +4930,7 @@ class BeamMemory:
         # uncommitted on the connection for a later unrelated commit to
         # silently include.
         cursor = self.conn.cursor()
+        owns_transaction = not self.conn.in_transaction
         with _guarded_transaction(self.conn):
             authorized_row = cursor.execute(
                 "SELECT rowid FROM working_memory WHERE id = ? AND (session_id = ? OR scope = 'global')",
@@ -4951,7 +4955,10 @@ class BeamMemory:
                     cursor.execute("DELETE FROM gists WHERE memory_id = ?", (memory_id,))
         forgotten = wm_rows > 0
         if forgotten:
-            self._invalidate_query_cache_after_commit("forget_working")
+            if owns_transaction:
+                self._invalidate_query_cache_after_commit("forget_working")
+            else:
+                self._invalidate_query_cache()
         return forgotten
 
     # ------------------------------------------------------------------

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4618,7 +4618,10 @@ class BeamMemory:
         """, (now, replacement_id, memory_id, self.session_id))
         if cursor.rowcount > 0:
             self.conn.commit()
-            self._invalidate_query_cache_after_commit("invalidate")
+            if self.conn.in_transaction:
+                self._invalidate_query_cache()
+            else:
+                self._invalidate_query_cache_after_commit("invalidate")
             return True
         # Try episodic_memory
         cursor.execute("""
@@ -4629,7 +4632,10 @@ class BeamMemory:
         invalidated = cursor.rowcount > 0
         self.conn.commit()
         if invalidated:
-            self._invalidate_query_cache_after_commit("invalidate")
+            if self.conn.in_transaction:
+                self._invalidate_query_cache()
+            else:
+                self._invalidate_query_cache_after_commit("invalidate")
         return invalidated
 
     def _detect_conflicts(self, rows: List[Dict], similarity_threshold: float = 0.88) -> List[tuple]:

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4603,7 +4603,7 @@ class BeamMemory:
             else:
                 invalidated = validate_and_invalidate()
             if invalidated:
-                self._invalidate_query_cache()
+                self._invalidate_query_cache_after_commit("invalidate")
             return invalidated
 
         now = datetime.now(timezone.utc).isoformat()
@@ -4615,7 +4615,7 @@ class BeamMemory:
         """, (now, replacement_id, memory_id, self.session_id))
         if cursor.rowcount > 0:
             self.conn.commit()
-            self._invalidate_query_cache()
+            self._invalidate_query_cache_after_commit("invalidate")
             return True
         # Try episodic_memory
         cursor.execute("""
@@ -4626,7 +4626,7 @@ class BeamMemory:
         invalidated = cursor.rowcount > 0
         self.conn.commit()
         if invalidated:
-            self._invalidate_query_cache()
+            self._invalidate_query_cache_after_commit("invalidate")
         return invalidated
 
     def _detect_conflicts(self, rows: List[Dict], similarity_threshold: float = 0.88) -> List[tuple]:
@@ -4951,7 +4951,7 @@ class BeamMemory:
                     cursor.execute("DELETE FROM gists WHERE memory_id = ?", (memory_id,))
         forgotten = wm_rows > 0
         if forgotten:
-            self._invalidate_query_cache()
+            self._invalidate_query_cache_after_commit("forget_working")
         return forgotten
 
     # ------------------------------------------------------------------

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -4609,6 +4609,10 @@ class BeamMemory:
                     self._invalidate_query_cache()
             return invalidated
 
+        # The no-replacement path mutates a single row directly.  Snapshot
+        # ownership before its first UPDATE: a caller-owned transaction must
+        # retain both its commit boundary and cache-failure rollback behavior.
+        owns_transaction = not self.conn.in_transaction
         now = datetime.now(timezone.utc).isoformat()
         # Try working_memory first
         cursor.execute("""
@@ -4617,11 +4621,11 @@ class BeamMemory:
             WHERE id = ? AND (session_id = ? OR scope = 'global')
         """, (now, replacement_id, memory_id, self.session_id))
         if cursor.rowcount > 0:
-            self.conn.commit()
-            if self.conn.in_transaction:
-                self._invalidate_query_cache()
-            else:
+            if owns_transaction:
+                self.conn.commit()
                 self._invalidate_query_cache_after_commit("invalidate")
+            else:
+                self._invalidate_query_cache()
             return True
         # Try episodic_memory
         cursor.execute("""
@@ -4630,12 +4634,13 @@ class BeamMemory:
             WHERE id = ? AND (session_id = ? OR scope = 'global')
         """, (now, replacement_id, memory_id, self.session_id))
         invalidated = cursor.rowcount > 0
-        self.conn.commit()
+        if owns_transaction:
+            self.conn.commit()
         if invalidated:
-            if self.conn.in_transaction:
-                self._invalidate_query_cache()
-            else:
+            if owns_transaction:
                 self._invalidate_query_cache_after_commit("invalidate")
+            else:
+                self._invalidate_query_cache()
         return invalidated
 
     def _detect_conflicts(self, rows: List[Dict], similarity_threshold: float = 0.88) -> List[tuple]:

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -782,6 +782,34 @@ def test_mutations_keep_cache_invalidation_errors_before_caller_commit(
         _close_memory(memory)
 
 
+def test_invalidate_keeps_cache_invalidation_error_during_deferred_commit(
+    monkeypatch, tmp_path: Path
+):
+    """A deferred batch has not committed when invalidate() returns."""
+    memory = BeamMemory(session_id="session-a", db_path=tmp_path / "memories.db")
+
+    def fail_invalidation():
+        raise RuntimeError("cache unavailable")
+
+    try:
+        memory_id = memory.remember("issue 594 deferred invalidate sentinel", source="test")
+        monkeypatch.setattr(memory, "_invalidate_query_cache", fail_invalidation)
+
+        with pytest.raises(RuntimeError, match="cache unavailable"):
+            with beam_module._deferred_commits(memory.conn):
+                assert memory.invalidate(memory_id) is True
+
+        row = memory.conn.execute(
+            "SELECT valid_until FROM working_memory WHERE id = ?", (memory_id,)
+        ).fetchone()
+        assert row is not None
+        assert row["valid_until"] is None
+    finally:
+        if memory.conn.in_transaction:
+            memory.conn.rollback()
+        _close_memory(memory)
+
+
 def test_successful_invalidate_episodic_memory_invalidates_enhanced_recall_cache(
     monkeypatch, tmp_path: Path
 ):

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -782,6 +782,49 @@ def test_mutations_keep_cache_invalidation_errors_before_caller_commit(
         _close_memory(memory)
 
 
+@pytest.mark.parametrize("memory_store", ["working", "episodic"])
+def test_invalidate_without_replacement_keeps_cache_failure_in_caller_transaction(
+    monkeypatch, tmp_path: Path, memory_store: str
+):
+    """#594: caller-owned invalidations must remain rollbackable on cache failure."""
+    memory = BeamMemory(session_id="session-a", db_path=tmp_path / "memories.db")
+
+    def fail_invalidation():
+        raise RuntimeError("cache unavailable")
+
+    try:
+        if memory_store == "working":
+            memory_id = memory.remember(
+                "issue 594 caller transaction working invalidation sentinel", source="test"
+            )
+            table = "working_memory"
+        else:
+            memory_id = memory.consolidate_to_episodic(
+                "issue 594 caller transaction episodic invalidation sentinel",
+                source_wm_ids=[],
+                source="test",
+            )
+            table = "episodic_memory"
+
+        monkeypatch.setattr(memory, "_invalidate_query_cache", fail_invalidation)
+        memory.conn.execute("BEGIN")
+
+        with pytest.raises(RuntimeError, match="cache unavailable"):
+            memory.invalidate(memory_id)
+
+        assert memory.conn.in_transaction
+        memory.conn.rollback()
+        row = memory.conn.execute(
+            f"SELECT valid_until FROM {table} WHERE id = ?", (memory_id,)
+        ).fetchone()
+        assert row is not None
+        assert row["valid_until"] is None
+    finally:
+        if memory.conn.in_transaction:
+            memory.conn.rollback()
+        _close_memory(memory)
+
+
 def test_invalidate_keeps_cache_invalidation_error_during_deferred_commit(
     monkeypatch, tmp_path: Path
 ):

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -740,6 +740,48 @@ def test_post_commit_mutations_survive_query_cache_invalidation_failure(
         _close_memory(memory)
 
 
+@pytest.mark.parametrize("operation", ["invalidate", "forget_working"])
+def test_mutations_keep_cache_invalidation_errors_before_caller_commit(
+    monkeypatch, tmp_path: Path, operation: str
+):
+    """#594's warning-only contract starts only after this instance commits."""
+    memory = BeamMemory(session_id="session-a", db_path=tmp_path / "memories.db")
+
+    def fail_invalidation():
+        raise RuntimeError("cache unavailable")
+
+    try:
+        memory_id = memory.remember(
+            f"issue 594 {operation} caller transaction sentinel", source="test"
+        )
+        replacement_id = memory.remember(
+            "issue 594 caller transaction replacement sentinel", source="test"
+        )
+        monkeypatch.setattr(memory, "_invalidate_query_cache", fail_invalidation)
+        memory.conn.execute("BEGIN")
+
+        with pytest.raises(RuntimeError, match="cache unavailable"):
+            if operation == "invalidate":
+                memory.invalidate(memory_id, replacement_id=replacement_id)
+            else:
+                memory.forget_working(memory_id)
+
+        assert memory.conn.in_transaction
+        memory.conn.rollback()
+        if operation == "invalidate":
+            row = memory.conn.execute(
+                "SELECT valid_until FROM working_memory WHERE id = ?", (memory_id,)
+            ).fetchone()
+            assert row is not None
+            assert row["valid_until"] is None
+        else:
+            assert memory.get(memory_id) is not None
+    finally:
+        if memory.conn.in_transaction:
+            memory.conn.rollback()
+        _close_memory(memory)
+
+
 def test_successful_invalidate_episodic_memory_invalidates_enhanced_recall_cache(
     monkeypatch, tmp_path: Path
 ):

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -701,6 +701,45 @@ def test_dedup_remember_write_survives_post_commit_cache_invalidation_failure(
         _close_memory(memory)
 
 
+@pytest.mark.parametrize("operation", ["invalidate", "forget_working"])
+def test_post_commit_mutations_survive_query_cache_invalidation_failure(
+    monkeypatch, tmp_path: Path, caplog, operation: str
+):
+    """#594: a committed public mutation is never reported as a cache failure."""
+    memory = BeamMemory(session_id="session-a", db_path=tmp_path / "memories.db")
+
+    def fail_invalidation():
+        raise RuntimeError("cache unavailable")
+
+    try:
+        memory_id = memory.remember(
+            f"issue 594 {operation} cache invalidation failure sentinel", source="test"
+        )
+        monkeypatch.setattr(memory, "_invalidate_query_cache", fail_invalidation)
+
+        with caplog.at_level(logging.WARNING, logger=beam_module.__name__):
+            if operation == "invalidate":
+                assert memory.invalidate(memory_id) is True
+                row = memory.conn.execute(
+                    "SELECT valid_until FROM working_memory WHERE id = ?", (memory_id,)
+                ).fetchone()
+                assert row is not None
+                assert row["valid_until"] is not None
+            else:
+                assert memory.forget_working(memory_id) is True
+                row = memory.conn.execute(
+                    "SELECT 1 FROM working_memory WHERE id = ?", (memory_id,)
+                ).fetchone()
+                assert row is None
+
+        assert (
+            f"{operation}: query-cache invalidation failed after commit "
+            "(RuntimeError): cache unavailable"
+        ) in caplog.text
+    finally:
+        _close_memory(memory)
+
+
 def test_successful_invalidate_episodic_memory_invalidates_enhanced_recall_cache(
     monkeypatch, tmp_path: Path
 ):


### PR DESCRIPTION
## Summary

Fixes #594.

A cache invalidation failure after a mutation has committed must be warning-only: callers keep the mutation success result and the durable database state remains authoritative.

## Contract and scope

- **Boundary:** only direct post-commit cache calls in `BeamMemory.invalidate()` and `BeamMemory.forget_working()`.
- **Non-goal:** no cache-publication or concurrent stale-publication behavior changes (#552 remains out of scope).
- **Why this boundary:** these methods currently commit/delete first and then let `_invalidate_query_cache()` escape, producing a false failure after durable state changes.

## Reproducer

`uv run pytest tests/test_enhanced_recall_cache.py -k post_commit_mutations_survive_query_cache_invalidation_failure -q` currently fails on this draft head: the selected mutation raises `RuntimeError` after the row was committed/changed.

The next commit will make that post-commit invalidation warning-only and retain the existing normal invalidation coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserves committed `invalidate()` and `forget_working()` mutations when enhanced-recall cache invalidation fails after commit.
- Treats post-commit cache failures as warning-only for transaction-owning operations.
- Retains cache errors for caller-owned and deferred transactions, so failures can still roll back uncommitted mutations.
- Keeps the durable database authoritative and records cache failures for later reconciliation.

## Architectural impact

- Improves the local-first guarantee by preserving durable memory mutations despite secondary cache failures.
- Does not change working, episodic, or BEAM memory tiers.
- Does not change retrieval, consolidation, veracity, sync, Hermes, MCP, or CLI integration surfaces.
- Does not change privacy behavior or introduce external services.
- Does not address cache publication or concurrent stale-publication races.

## Maintainability

- Adds regression coverage for post-commit, caller-owned, and deferred transaction paths.
- Documents the cache invalidation failure contract in `CHANGELOG.md`.
- Separating transaction-owned invalidation from nested invalidation is the right call. It makes commit semantics explicit and prevents cache errors from falsely reporting successful durable mutations as failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->