### PR TITLE
fix(hermes): make wrapper validation timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Hermes wrapper validation timeout is configurable (#804).** `mnemosyne-hermes install --mode wrapper` now accepts `--import-timeout SECONDS` (default: 60) for both selected-Python validation probes, rejects non-positive/non-finite values, and gives a retry command when validation times out.
 - **Committed memory invalidations no longer report failure when enhanced-recall cache eviction fails (#594).** The mutation remains successful and the cache error is logged for reconciliation.
 - **Hermes providers no longer clear the shared host LLM backend while another primary provider remains active (#551).**
 - **The OpenAI-compatible modality retry test is deterministic under load (#798).** Its localhost stub handles one request at a time and records response statuses, so the 401/no-retry contract is checked against the response actually served.

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -184,7 +184,8 @@ from.
 For a wrapper install, `--import-timeout SECONDS` sets the timeout for both
 selected-`--python` validation probes. It defaults to 60 seconds. Use it when
 that selected interpreter needs longer to resolve its site-packages or import
-`mnemosyne_hermes`:
+`mnemosyne_hermes`. `SECONDS` must be positive and finite: zero, negative,
+`NaN`, and infinite values are rejected.
 
 ```bash
 mnemosyne-hermes install --mode wrapper --python /path/to/hermes/venv/bin/python --import-timeout 90

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -179,6 +179,22 @@ mnemosyne-hermes install --dry-run          # shows which interpreter would be u
 symlink install, and selects the site-packages a `--mode wrapper` install imports
 from.
 
+#### Wrapper validation timeout
+
+For a wrapper install, `--import-timeout SECONDS` sets the timeout for both
+selected-`--python` validation probes. It defaults to 60 seconds. Use it when
+that selected interpreter needs longer to resolve its site-packages or import
+`mnemosyne_hermes`:
+
+```bash
+mnemosyne-hermes install --mode wrapper --python /path/to/hermes/venv/bin/python --import-timeout 90
+mnemosyne-hermes install --mode wrapper --python /path/to/hermes/venv/bin/python --no-bootstrap --import-timeout 90
+```
+
+The second form still validates the selected wrapper interpreter; `--no-bootstrap`
+only skips automatic package installation. `mnemosyne-hermes status` intentionally
+uses its fixed 60-second validation policy, independent of an install-time override.
+
 The installer also deploys the bundled `mnemosyne-memory-override` skill to
 `$HERMES_HOME/skills/memory/mnemosyne-memory-override/SKILL.md`. The skill is a
 behavioral guardrail that nudges agents away from the legacy `memory` tool for

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -391,11 +391,20 @@ def _timeout_diagnostic(python: Path, timeout: float, *, retry_hint: bool = True
             "installer validation."
         )
     retry_seconds = f"{max(timeout * 2, timeout + 1):g}"
-    return (
-        message + " "
-        "Retry with: mnemosyne-hermes install --mode wrapper "
-        f"--python {shlex.quote(str(python))} --import-timeout {retry_seconds}"
+    retry_args = [
+        "mnemosyne-hermes",
+        "install",
+        "--mode",
+        "wrapper",
+        "--python",
+        str(python),
+        "--import-timeout",
+        retry_seconds,
+    ]
+    retry_command = (
+        subprocess.list2cmdline(retry_args) if os.name == "nt" else shlex.join(retry_args)
     )
+    return message + f" Retry with: {retry_command}"
 
 
 def _site_packages_for_python(

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -24,6 +24,7 @@ from typing import Optional
 
 PLUGIN_NAME = "mnemosyne"
 DEFAULT_WRAPPER_IMPORT_TIMEOUT = 60.0
+STATUS_WRAPPER_IMPORT_TIMEOUT = 10.0
 SKILL_NAME = "mnemosyne-memory-override"
 SKILL_CATEGORY = "memory"
 BUNDLED_SKILL_RESOURCE = ("skills", SKILL_NAME, "SKILL.md")
@@ -386,7 +387,7 @@ def _timeout_diagnostic(python: Path, timeout: float) -> str:
     return (
         f"wrapper validation timed out after {seconds} seconds for interpreter {python}. "
         "Retry with: mnemosyne-hermes install --mode wrapper "
-        f"--python {python} --import-timeout {retry_seconds}"
+        f"--python {shlex.quote(str(python))} --import-timeout {retry_seconds}"
     )
 
 
@@ -565,6 +566,7 @@ def plugin_state(*, hermes_home_path: str | Path | None = None) -> PluginState:
             wrapper_import_ok, wrapper_import_error, invalid_runtime = _check_wrapper_import(
                 wrapper_site,
                 wrapper_python,
+                import_timeout=STATUS_WRAPPER_IMPORT_TIMEOUT,
             )
             if not wrapper_import_ok:
                 status = "invalid_wrapper" if invalid_runtime else "stale_wrapper"
@@ -2040,7 +2042,10 @@ def _parser() -> argparse.ArgumentParser:
         type=_parse_import_timeout,
         default=DEFAULT_WRAPPER_IMPORT_TIMEOUT,
         metavar="SECONDS",
-        help="Wrapper validation timeout in seconds (default: 60).",
+        help=(
+            "Wrapper validation timeout in seconds "
+            f"(default: {DEFAULT_WRAPPER_IMPORT_TIMEOUT:g})."
+        ),
     )
     install.add_argument(
         "--migrate-wrapper-to-symlink",

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -24,7 +24,6 @@ from typing import Optional
 
 PLUGIN_NAME = "mnemosyne"
 DEFAULT_WRAPPER_IMPORT_TIMEOUT = 60.0
-STATUS_WRAPPER_IMPORT_TIMEOUT = 10.0
 SKILL_NAME = "mnemosyne-memory-override"
 SKILL_CATEGORY = "memory"
 BUNDLED_SKILL_RESOURCE = ("skills", SKILL_NAME, "SKILL.md")
@@ -380,12 +379,18 @@ def _parse_import_timeout(value: str) -> float:
         raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
-def _timeout_diagnostic(python: Path, timeout: float) -> str:
+def _timeout_diagnostic(python: Path, timeout: float, *, retry_hint: bool = True) -> str:
     """Return an actionable timeout diagnostic for selected wrapper Python."""
     seconds = f"{timeout:g}"
+    message = f"wrapper validation timed out after {seconds} seconds for interpreter {python}."
+    if not retry_hint:
+        return message + (
+            " Status uses the default "
+            f"{DEFAULT_WRAPPER_IMPORT_TIMEOUT:g}-second wrapper validation timeout."
+        )
     retry_seconds = f"{max(timeout * 2, timeout + 1):g}"
     return (
-        f"wrapper validation timed out after {seconds} seconds for interpreter {python}. "
+        message + " "
         "Retry with: mnemosyne-hermes install --mode wrapper "
         f"--python {shlex.quote(str(python))} --import-timeout {retry_seconds}"
     )
@@ -419,6 +424,7 @@ def _check_wrapper_import(
     python: Path | None = None,
     *,
     import_timeout: float = DEFAULT_WRAPPER_IMPORT_TIMEOUT,
+    retry_hint: bool = True,
 ) -> tuple[bool, str | None, bool]:
     """Return import success, error text, and whether the runtime is invalid."""
     if not site_packages.is_dir():
@@ -464,7 +470,7 @@ def _check_wrapper_import(
     except OSError as exc:
         return False, f"could not run wrapper Python {runner}: {exc}", True
     except subprocess.TimeoutExpired:
-        return False, _timeout_diagnostic(runner, import_timeout), False
+        return False, _timeout_diagnostic(runner, import_timeout, retry_hint=retry_hint), False
     if result.returncode == 0:
         return True, None, False
     return False, (result.stderr.strip() or result.stdout.strip() or "import failed")[:500], False
@@ -566,7 +572,8 @@ def plugin_state(*, hermes_home_path: str | Path | None = None) -> PluginState:
             wrapper_import_ok, wrapper_import_error, invalid_runtime = _check_wrapper_import(
                 wrapper_site,
                 wrapper_python,
-                import_timeout=STATUS_WRAPPER_IMPORT_TIMEOUT,
+                import_timeout=DEFAULT_WRAPPER_IMPORT_TIMEOUT,
+                retry_hint=False,
             )
             if not wrapper_import_ok:
                 status = "invalid_wrapper" if invalid_runtime else "stale_wrapper"

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -8,6 +8,7 @@ import hashlib
 import importlib
 import json
 import logging
+import math
 import os
 import re
 import shlex
@@ -22,6 +23,7 @@ from pathlib import Path
 from typing import Optional
 
 PLUGIN_NAME = "mnemosyne"
+DEFAULT_WRAPPER_IMPORT_TIMEOUT = 60.0
 SKILL_NAME = "mnemosyne-memory-override"
 SKILL_CATEGORY = "memory"
 BUNDLED_SKILL_RESOURCE = ("skills", SKILL_NAME, "SKILL.md")
@@ -358,14 +360,50 @@ def _wrapper_metadata(target: Path, init_file: Path) -> _WrapperMetadata:
     return _WrapperMetadata(python=python, site_packages=site_packages)
 
 
-def _site_packages_for_python(python: Path) -> Path:
-    """Ask an interpreter for its purelib/site-packages path."""
-    result = subprocess.run(
-        [str(python), "-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])"],
-        capture_output=True,
-        text=True,
-        timeout=10,
+def _validated_import_timeout(value: float | str) -> float:
+    """Return a safe wrapper-validation timeout in seconds."""
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("import timeout must be a positive finite number of seconds") from exc
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("import timeout must be a positive finite number of seconds")
+    return timeout
+
+
+def _parse_import_timeout(value: str) -> float:
+    """Argparse adapter that keeps invalid timeout diagnostics actionable."""
+    try:
+        return _validated_import_timeout(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def _timeout_diagnostic(python: Path, timeout: float) -> str:
+    """Return an actionable timeout diagnostic for selected wrapper Python."""
+    seconds = f"{timeout:g}"
+    retry_seconds = f"{max(timeout * 2, timeout + 1):g}"
+    return (
+        f"wrapper validation timed out after {seconds} seconds for interpreter {python}. "
+        "Retry with: mnemosyne-hermes install --mode wrapper "
+        f"--python {python} --import-timeout {retry_seconds}"
     )
+
+
+def _site_packages_for_python(
+    python: Path, *, import_timeout: float = DEFAULT_WRAPPER_IMPORT_TIMEOUT
+) -> Path:
+    """Ask an interpreter for its purelib/site-packages path."""
+    import_timeout = _validated_import_timeout(import_timeout)
+    try:
+        result = subprocess.run(
+            [str(python), "-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])"],
+            capture_output=True,
+            text=True,
+            timeout=import_timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(_timeout_diagnostic(python, import_timeout)) from exc
     if result.returncode != 0:
         stderr = result.stderr.strip() or result.stdout.strip()
         raise RuntimeError(f"Could not resolve site-packages for {python}: {stderr}")
@@ -376,7 +414,10 @@ def _site_packages_for_python(python: Path) -> Path:
 
 
 def _check_wrapper_import(
-    site_packages: Path, python: Path | None = None
+    site_packages: Path,
+    python: Path | None = None,
+    *,
+    import_timeout: float = DEFAULT_WRAPPER_IMPORT_TIMEOUT,
 ) -> tuple[bool, str | None, bool]:
     """Return import success, error text, and whether the runtime is invalid."""
     if not site_packages.is_dir():
@@ -386,6 +427,7 @@ def _check_wrapper_import(
         return False, f"wrapper Python missing: {runner}", True
     if not os.access(runner, os.X_OK):
         return False, f"wrapper Python is not executable: {runner}", True
+    import_timeout = _validated_import_timeout(import_timeout)
     code = (
         "import site\n"
         "import sys\n"
@@ -406,7 +448,7 @@ def _check_wrapper_import(
             [str(runner), "-S", "-c", code],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=import_timeout,
             # -S and a selected site directory isolate imports from the runner's
             # ambient site/user directories. Filtering PYTHONPATH prevents a
             # caller-controlled package shadowing that contract; filtering
@@ -421,7 +463,7 @@ def _check_wrapper_import(
     except OSError as exc:
         return False, f"could not run wrapper Python {runner}: {exc}", True
     except subprocess.TimeoutExpired:
-        return False, f"wrapper Python import timed out: {runner}", False
+        return False, _timeout_diagnostic(runner, import_timeout), False
     if result.returncode == 0:
         return True, None, False
     return False, (result.stderr.strip() or result.stdout.strip() or "import failed")[:500], False
@@ -1421,13 +1463,18 @@ def _is_wrapper_plugin_target(target: Path) -> bool:
 
 def _validated_wrapper_environment(
     python: str | Path | None,
+    *,
+    import_timeout: float = DEFAULT_WRAPPER_IMPORT_TIMEOUT,
 ) -> tuple[Path, Path]:
     """Validate the selected wrapper runtime before touching an installed plugin."""
     wrapper_python = Path(python).expanduser() if python else Path(sys.executable)
     if not wrapper_python.is_file():
         raise FileNotFoundError(f"Python interpreter not found: {wrapper_python}")
-    site_packages = _site_packages_for_python(wrapper_python)
-    import_ok, import_error, _invalid_runtime = _check_wrapper_import(site_packages, wrapper_python)
+    import_timeout = _validated_import_timeout(import_timeout)
+    site_packages = _site_packages_for_python(wrapper_python, import_timeout=import_timeout)
+    import_ok, import_error, _invalid_runtime = _check_wrapper_import(
+        site_packages, wrapper_python, import_timeout=import_timeout
+    )
     if not import_ok:
         raise RuntimeError(
             f"Selected Python environment cannot import mnemosyne_hermes: {import_error}"
@@ -1662,6 +1709,7 @@ def install_plugin(
     force: bool = False,
     mode: str = "symlink",
     python: str | Path | None = None,
+    import_timeout: float = DEFAULT_WRAPPER_IMPORT_TIMEOUT,
     migrate_wrapper_to_symlink: bool = False,
     link_profiles: bool = True,
 ) -> Path:
@@ -1759,7 +1807,9 @@ def install_plugin(
     # Validate and fully write the replacement before removing a working wrapper.
     # In particular, a bad --python or a selected environment missing this package
     # must leave the existing wrapper and every profile link untouched.
-    wrapper_python, site_packages = _validated_wrapper_environment(python)
+    wrapper_python, site_packages = _validated_wrapper_environment(
+        python, import_timeout=import_timeout
+    )
     target.parent.mkdir(parents=True, exist_ok=True)
     staging_parent = Path(tempfile.mkdtemp(prefix=f".{target.name}.staging-", dir=target.parent))
     staged = staging_parent / target.name
@@ -1986,6 +2036,13 @@ def _parser() -> argparse.ArgumentParser:
         ),
     )
     install.add_argument(
+        "--import-timeout",
+        type=_parse_import_timeout,
+        default=DEFAULT_WRAPPER_IMPORT_TIMEOUT,
+        metavar="SECONDS",
+        help="Wrapper validation timeout in seconds (default: 60).",
+    )
+    install.add_argument(
         "--migrate-wrapper-to-symlink",
         action="store_true",
         help=(
@@ -2037,6 +2094,7 @@ def run_install(
     no_bootstrap: bool = False,
     mode: str = "symlink",
     python: str | Path | None = None,
+    import_timeout: float = DEFAULT_WRAPPER_IMPORT_TIMEOUT,
     migrate_wrapper_to_symlink: bool = False,
     link_profiles: bool = True,
 ) -> int:
@@ -2113,6 +2171,7 @@ def run_install(
         force=force,
         mode=mode,
         python=python,
+        import_timeout=import_timeout,
         migrate_wrapper_to_symlink=migrate_wrapper_to_symlink,
         link_profiles=link_profiles,
     )
@@ -2186,7 +2245,11 @@ def main(argv: list[str] | None = None) -> int:
                     wrapper_python = Path(getattr(args, "python", None) or sys.executable).expanduser()
                     print(f"  Wrapper Python: {wrapper_python}")
                     if wrapper_python.is_file():
-                        print(f"  Wrapper site-packages: {_site_packages_for_python(wrapper_python)}")
+                        print(
+                            "  Wrapper site-packages: "
+                            f"{_site_packages_for_python(wrapper_python, import_timeout=args.import_timeout)}"
+                        )
+                    print(f"  Wrapper import timeout: {args.import_timeout:g} seconds")
                 print(f"  Will force: {bool(getattr(args, 'force', False))}")
                 if getattr(args, "migrate_wrapper_to_symlink", False):
                     print("  Will allow wrapper-to-symlink migration: yes")
@@ -2215,6 +2278,7 @@ def main(argv: list[str] | None = None) -> int:
                 no_bootstrap=getattr(args, "no_bootstrap", False),
                 mode=getattr(args, "mode", "symlink"),
                 python=getattr(args, "python", None),
+                import_timeout=getattr(args, "import_timeout", DEFAULT_WRAPPER_IMPORT_TIMEOUT),
                 migrate_wrapper_to_symlink=getattr(args, "migrate_wrapper_to_symlink", False),
                 link_profiles=getattr(args, "link_profiles", True),
             )

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -385,8 +385,10 @@ def _timeout_diagnostic(python: Path, timeout: float, *, retry_hint: bool = True
     message = f"wrapper validation timed out after {seconds} seconds for interpreter {python}."
     if not retry_hint:
         return message + (
-            " Status uses the default "
-            f"{DEFAULT_WRAPPER_IMPORT_TIMEOUT:g}-second wrapper validation timeout."
+            " Status validates wrapper imports with its fixed default "
+            f"{DEFAULT_WRAPPER_IMPORT_TIMEOUT:g}-second policy. Inspect the selected "
+            "interpreter and its import performance; --import-timeout only affects "
+            "installer validation."
         )
     retry_seconds = f"{max(timeout * 2, timeout + 1):g}"
     return (

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -424,8 +424,11 @@ def test_plugin_state_classifies_timed_out_wrapper_import_as_stale(tmp_path, mon
     site_packages = install._site_packages_for_python(Path(sys.executable))
     install._write_wrapper_plugin(target, python=Path(sys.executable), site_packages=site_packages)
 
+    observed_timeouts = []
+
     def raise_timeout(*args, **kwargs):
-        raise subprocess.TimeoutExpired(args[0], 10)
+        observed_timeouts.append(kwargs["timeout"])
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
 
     monkeypatch.setattr(install.subprocess, "run", raise_timeout)
 
@@ -436,8 +439,10 @@ def test_plugin_state_classifies_timed_out_wrapper_import_as_stale(tmp_path, mon
     assert state.wrapper_import_ok is False
     assert state.wrapper_import_error is not None
     assert str(Path(sys.executable)) in state.wrapper_import_error
-    assert "10 seconds" in state.wrapper_import_error
-    assert "--import-timeout 20" in state.wrapper_import_error
+    assert observed_timeouts == [60.0]
+    assert "60 seconds" in state.wrapper_import_error
+    assert "Status uses the default 60-second wrapper validation timeout" in state.wrapper_import_error
+    assert "Retry with:" not in state.wrapper_import_error
 
 
 def test_plugin_state_reports_stale_wrapper_target(tmp_path):

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -440,8 +440,10 @@ def test_plugin_state_classifies_timed_out_wrapper_import_as_stale(tmp_path, mon
     assert state.wrapper_import_error is not None
     assert str(Path(sys.executable)) in state.wrapper_import_error
     assert observed_timeouts == [60.0]
-    assert "60 seconds" in state.wrapper_import_error
-    assert "Status uses the default 60-second wrapper validation timeout" in state.wrapper_import_error
+    assert "fixed default 60-second policy" in state.wrapper_import_error
+    assert "Inspect the selected interpreter and its import performance" in state.wrapper_import_error
+    assert "--import-timeout only affects installer validation" in state.wrapper_import_error
+    assert "--import-timeout 120" not in state.wrapper_import_error
     assert "Retry with:" not in state.wrapper_import_error
 
 

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -220,6 +220,35 @@ def test_is_installed_stays_false_for_broken_symlink(tmp_path):
     assert install.is_installed(hermes_home_path=tmp_path) is False
 
 
+def test_wrapper_install_accepts_an_11_second_import_with_60_second_timeout(tmp_path, monkeypatch):
+    """A slow but healthy selected runtime must not inherit the old 10s ceiling."""
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    observed_timeouts = []
+
+    def simulated_subprocess(command, **kwargs):
+        timeout = kwargs["timeout"]
+        observed_timeouts.append(timeout)
+        if "-S" in command and timeout < 11:
+            raise subprocess.TimeoutExpired(command, timeout)
+        if "-S" in command:
+            return subprocess.CompletedProcess(command, 0, "0.0-test\n", "")
+        return subprocess.CompletedProcess(command, 0, f"{site_packages}\n", "")
+
+    monkeypatch.setattr(install.subprocess, "run", simulated_subprocess)
+
+    target = install.install_plugin(
+        hermes_home_path=tmp_path,
+        mode="wrapper",
+        python=sys.executable,
+        import_timeout=60.0,
+        link_profiles=False,
+    )
+
+    assert target.is_dir()
+    assert observed_timeouts == [60.0, 60.0]
+
+
 def test_install_plugin_wrapper_creates_persistent_shim(tmp_path):
     target = install.install_plugin(
         hermes_home_path=tmp_path,

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -436,8 +436,8 @@ def test_plugin_state_classifies_timed_out_wrapper_import_as_stale(tmp_path, mon
     assert state.wrapper_import_ok is False
     assert state.wrapper_import_error is not None
     assert str(Path(sys.executable)) in state.wrapper_import_error
-    assert "60 seconds" in state.wrapper_import_error
-    assert "--import-timeout 120" in state.wrapper_import_error
+    assert "10 seconds" in state.wrapper_import_error
+    assert "--import-timeout 20" in state.wrapper_import_error
 
 
 def test_plugin_state_reports_stale_wrapper_target(tmp_path):

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -434,7 +434,10 @@ def test_plugin_state_classifies_timed_out_wrapper_import_as_stale(tmp_path, mon
     assert state.status == "stale_wrapper"
     assert state.installed is False
     assert state.wrapper_import_ok is False
-    assert state.wrapper_import_error == f"wrapper Python import timed out: {Path(sys.executable)}"
+    assert state.wrapper_import_error is not None
+    assert str(Path(sys.executable)) in state.wrapper_import_error
+    assert "60 seconds" in state.wrapper_import_error
+    assert "--import-timeout 120" in state.wrapper_import_error
 
 
 def test_plugin_state_reports_stale_wrapper_target(tmp_path):

--- a/integrations/hermes/tests/test_wrapper_import_timeout.py
+++ b/integrations/hermes/tests/test_wrapper_import_timeout.py
@@ -120,3 +120,23 @@ def test_wrapper_import_timeout_diagnostic_names_interpreter_duration_and_retry(
     assert str(Path(sys.executable)) in error
     assert "75 seconds" in error
     assert "--import-timeout 150" in error
+
+
+def test_wrapper_import_timeout_diagnostic_quotes_windows_python_path(monkeypatch):
+    python = Path("C:/Program Files/Hermes/venv/python.exe")
+    retry_args = [
+        "mnemosyne-hermes",
+        "install",
+        "--mode",
+        "wrapper",
+        "--python",
+        str(python),
+        "--import-timeout",
+        "120",
+    ]
+    monkeypatch.setattr(install.os, "name", "nt")
+
+    error = install._timeout_diagnostic(python, 60)
+
+    assert error.endswith(f"Retry with: {subprocess.list2cmdline(retry_args)}")
+    assert '"C:/Program Files/Hermes/venv/python.exe"' in error

--- a/integrations/hermes/tests/test_wrapper_import_timeout.py
+++ b/integrations/hermes/tests/test_wrapper_import_timeout.py
@@ -1,0 +1,70 @@
+"""Focused coverage for wrapper validation timeout configuration."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mnemosyne_hermes import install
+
+
+def test_install_cli_passes_default_and_override_import_timeout(tmp_path, monkeypatch):
+    received = []
+    monkeypatch.setattr(
+        install,
+        "run_install",
+        lambda **kwargs: received.append(kwargs) or 0,
+    )
+
+    assert install.main(["--hermes-home", str(tmp_path), "install"]) == 0
+    assert install.main(
+        ["--hermes-home", str(tmp_path), "install", "--import-timeout", "75"]
+    ) == 0
+
+    assert [call["import_timeout"] for call in received] == [60.0, 75.0]
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf", "-inf"])
+def test_install_cli_rejects_non_positive_or_nonfinite_import_timeout(value, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        install.main(["install", f"--import-timeout={value}"])
+
+    assert exc_info.value.code == 2
+    assert "positive finite number" in capsys.readouterr().err
+
+
+def test_wrapper_validation_default_timeout_reaches_both_probes(tmp_path, monkeypatch):
+    observed_timeouts = []
+
+    def successful_probe(command, **kwargs):
+        observed_timeouts.append(kwargs["timeout"])
+        if "-S" in command:
+            return subprocess.CompletedProcess(command, 0, "0.0-test\n", "")
+        return subprocess.CompletedProcess(command, 0, f"{tmp_path}\n", "")
+
+    monkeypatch.setattr(install.subprocess, "run", successful_probe)
+
+    python, site_packages = install._validated_wrapper_environment(Path(sys.executable))
+
+    assert python == Path(sys.executable)
+    assert site_packages == tmp_path
+    assert observed_timeouts == [60.0, 60.0]
+
+
+def test_wrapper_import_timeout_diagnostic_names_interpreter_duration_and_retry(tmp_path, monkeypatch):
+    def timed_out(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(install.subprocess, "run", timed_out)
+
+    ok, error, invalid_runtime = install._check_wrapper_import(
+        tmp_path, Path(sys.executable), import_timeout=75
+    )
+
+    assert ok is False
+    assert invalid_runtime is False
+    assert error is not None
+    assert str(Path(sys.executable)) in error
+    assert "75 seconds" in error
+    assert "--import-timeout 150" in error

--- a/integrations/hermes/tests/test_wrapper_import_timeout.py
+++ b/integrations/hermes/tests/test_wrapper_import_timeout.py
@@ -52,6 +52,33 @@ def test_wrapper_validation_default_timeout_reaches_both_probes(tmp_path, monkey
     assert observed_timeouts == [60.0, 60.0]
 
 
+def test_wrapper_install_timeout_preserves_existing_target(tmp_path, monkeypatch):
+    target = tmp_path / "plugins" / "mnemosyne"
+    target.mkdir(parents=True)
+    sentinel = target / "keep"
+    sentinel.write_text("existing wrapper", encoding="utf-8")
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+
+    def probe_with_slow_import(command, **kwargs):
+        if "-S" in command:
+            raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+        return subprocess.CompletedProcess(command, 0, f"{site_packages}\n", "")
+
+    monkeypatch.setattr(install.subprocess, "run", probe_with_slow_import)
+
+    with pytest.raises(RuntimeError, match="wrapper validation timed out"):
+        install.install_plugin(
+            hermes_home_path=tmp_path,
+            force=True,
+            mode="wrapper",
+            python=sys.executable,
+            link_profiles=False,
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "existing wrapper"
+
+
 def test_wrapper_import_timeout_diagnostic_names_interpreter_duration_and_retry(tmp_path, monkeypatch):
     def timed_out(command, **kwargs):
         raise subprocess.TimeoutExpired(command, kwargs["timeout"])

--- a/integrations/hermes/tests/test_wrapper_import_timeout.py
+++ b/integrations/hermes/tests/test_wrapper_import_timeout.py
@@ -3,6 +3,7 @@
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -34,7 +35,8 @@ def test_install_cli_rejects_non_positive_or_nonfinite_import_timeout(value, cap
     assert "positive finite number" in capsys.readouterr().err
 
 
-def test_wrapper_validation_default_timeout_reaches_both_probes(tmp_path, monkeypatch):
+@pytest.mark.parametrize("import_timeout", [60.0, 90.0])
+def test_wrapper_validation_timeout_reaches_both_probes(tmp_path, monkeypatch, import_timeout):
     observed_timeouts = []
 
     def successful_probe(command, **kwargs):
@@ -45,11 +47,13 @@ def test_wrapper_validation_default_timeout_reaches_both_probes(tmp_path, monkey
 
     monkeypatch.setattr(install.subprocess, "run", successful_probe)
 
-    python, site_packages = install._validated_wrapper_environment(Path(sys.executable))
+    python, site_packages = install._validated_wrapper_environment(
+        Path(sys.executable), import_timeout=import_timeout
+    )
 
     assert python == Path(sys.executable)
     assert site_packages == tmp_path
-    assert observed_timeouts == [60.0, 60.0]
+    assert observed_timeouts == [import_timeout, import_timeout]
 
 
 def test_plugin_state_accepts_11_second_healthy_wrapper_import(tmp_path, monkeypatch):
@@ -134,7 +138,7 @@ def test_wrapper_import_timeout_diagnostic_quotes_windows_python_path(monkeypatc
         "--import-timeout",
         "120",
     ]
-    monkeypatch.setattr(install.os, "name", "nt")
+    monkeypatch.setattr(install, "os", SimpleNamespace(name="nt"))
 
     error = install._timeout_diagnostic(python, 60)
 

--- a/integrations/hermes/tests/test_wrapper_import_timeout.py
+++ b/integrations/hermes/tests/test_wrapper_import_timeout.py
@@ -52,6 +52,31 @@ def test_wrapper_validation_default_timeout_reaches_both_probes(tmp_path, monkey
     assert observed_timeouts == [60.0, 60.0]
 
 
+def test_plugin_state_accepts_11_second_healthy_wrapper_import(tmp_path, monkeypatch):
+    """Status must share the 60-second wrapper-validation policy with install."""
+    target = tmp_path / "plugins" / "mnemosyne"
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    install._write_wrapper_plugin(target, python=Path(sys.executable), site_packages=site_packages)
+    observed_timeouts = []
+
+    def slow_but_healthy_import(command, **kwargs):
+        timeout = kwargs["timeout"]
+        observed_timeouts.append(timeout)
+        if timeout < 11:
+            raise subprocess.TimeoutExpired(command, timeout)
+        return subprocess.CompletedProcess(command, 0, "0.0-test\n", "")
+
+    monkeypatch.setattr(install.subprocess, "run", slow_but_healthy_import)
+
+    state = install.plugin_state(hermes_home_path=tmp_path)
+
+    assert observed_timeouts == [60.0]
+    assert state.status == "installed"
+    assert state.installed is True
+    assert state.wrapper_import_ok is True
+
+
 def test_wrapper_install_timeout_preserves_existing_target(tmp_path, monkeypatch):
     target = tmp_path / "plugins" / "mnemosyne"
     target.mkdir(parents=True)


### PR DESCRIPTION
## Problem

`mnemosyne-hermes install --mode wrapper` uses a fixed 10-second deadline for both selected-Python validation probes. A healthy native Windows import can take about 19 seconds and is rejected before the wrapper is written.

## Approach

This draft starts with a focused reproducer. The follow-up implementation will add a validated `--import-timeout SECONDS` install option, defaulting to 60 seconds, and pass the effective value to both wrapper probes.

## Reproducer

The test simulates an import that needs 11 seconds without sleeping. It records subprocess deadlines and expects a 60-second setting to let wrapper creation finish.

## Scope

Only wrapper validation timeout configuration and diagnostics. No symlink privilege changes, automatic junctions, manifest/hook changes, or generic subprocess timeout refactor.

Fixes #804


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds configurable Hermes wrapper validation timeouts through `--import-timeout SECONDS`.
- Defaults the timeout to 60 seconds and rejects non-positive or non-finite values.
- Applies the timeout to both selected-Python validation probes.
- Improves timeout diagnostics with the interpreter, timeout duration, and retry command.
- Preserves existing wrapper targets when validation times out.
- Adds coverage for defaults, overrides, invalid values, propagation, slow imports, and diagnostics.
- Documents the change in `CHANGELOG.md`.

## Architectural impact

- **Core memory architecture:** No changes to working, episodic, or BEAM memory tiers.
- **Retrieval and consolidation:** No changes.
- **Veracity system and sync layer:** No changes.
- **Privacy and local-first guarantees:** Preserved. The change only adjusts local wrapper validation timing.
- **Agent integration surfaces:** Hermes CLI and programmatic installation APIs gain the `import_timeout` parameter. MCP contracts, plugin manifests, hooks, and symlink privilege semantics remain unchanged.
- **Benchmark methodology:** No changes.

## Assessment

Configurable validation is the right call for slow but healthy Windows imports. The default remains bounded, and timeout guidance improves recovery. The PR does not erode Mnemosyne’s local-first design or expand the integration contract beyond the required Hermes installation option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->