### PR TITLE
fix(hermes): explain Windows symlink privilege recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Windows Hermes symlink installs now explain WinError 1314 recovery (#807).** When Windows denies symbolic-link creation because Developer Mode or the symbolic-link privilege is unavailable, the installer fails closed and prints a command-safe persistent wrapper retry using the resolved Hermes Python; it does not switch modes automatically.
 - **Hermes wrapper validation timeout is configurable (#804).** `mnemosyne-hermes install --mode wrapper` now accepts `--import-timeout SECONDS` (default: 60) for both selected-Python validation probes, rejects non-positive/non-finite values, and gives a retry command when validation times out.
 - **Committed memory invalidations no longer report failure when enhanced-recall cache eviction fails (#594).** The mutation remains successful and the cache error is logged for reconciliation.
 - **Hermes providers no longer clear the shared host LLM backend while another primary provider remains active (#551).**

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -87,6 +87,22 @@ class SkillInstallResult:
     message: str
 
 
+class _WindowsSymlinkPrivilegeError(RuntimeError):
+    """A Windows symlink failure for which the CLI has a safe retry."""
+
+
+def _is_windows_symlink_privilege_error(error: OSError) -> bool:
+    """Return whether ``error`` is Windows ERROR_PRIVILEGE_NOT_HELD (1314)."""
+    return getattr(error, "winerror", None) == 1314
+
+
+def _windows_wrapper_retry_command(hermes_python: Path) -> str:
+    """Format a Windows-command-line-safe wrapper retry for a selected Python."""
+    return subprocess.list2cmdline(
+        ["mnemosyne-hermes", "install", "--mode", "wrapper", "--python", str(hermes_python)]
+    )
+
+
 def hermes_home() -> Path:
     """Return the Hermes home directory used for user-installed plugins."""
     return Path(os.environ.get("HERMES_HOME") or "~/.hermes").expanduser()
@@ -1804,7 +1820,12 @@ def install_plugin(
         _write_profile_links_preference(link_profiles, hermes_home_path=hermes_home_path)
         try:
             _prepare_plugin_target(base, target, force=force)
-            os.symlink(str(source), str(target))
+            try:
+                os.symlink(str(source), str(target))
+            except OSError as error:
+                if _is_windows_symlink_privilege_error(error):
+                    raise _WindowsSymlinkPrivilegeError from error
+                raise
         except Exception:
             try:
                 _restore_profile_links_preference(preference_path, previous_preference)
@@ -2189,15 +2210,39 @@ def run_install(
         else:
             print(f"  Hermes' Python: mnemosyne-memory {hermes_core} OK")
 
-    target = install_plugin(
-        hermes_home_path=hermes_home_path,
-        force=force,
-        mode=mode,
-        python=python,
-        import_timeout=import_timeout,
-        migrate_wrapper_to_symlink=migrate_wrapper_to_symlink,
-        link_profiles=link_profiles,
-    )
+    try:
+        target = install_plugin(
+            hermes_home_path=hermes_home_path,
+            force=force,
+            mode=mode,
+            python=python,
+            import_timeout=import_timeout,
+            migrate_wrapper_to_symlink=migrate_wrapper_to_symlink,
+            link_profiles=link_profiles,
+        )
+    except _WindowsSymlinkPrivilegeError:
+        print(
+            "\n  ⚠ Windows symbolic-link privilege is unavailable (WinError 1314).\n"
+            "     Enable Developer Mode or run with an account granted the "
+            "symbolic-link privilege.\n"
+            "     The installer did not switch install modes automatically.\n",
+            file=sys.stderr,
+        )
+        if hermes_python is not None:
+            print(
+                "  Persistent no-symlink-privilege alternative:\n"
+                f"    {_windows_wrapper_retry_command(hermes_python)}\n",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "  A safe wrapper retry cannot be generated because Hermes' Python was "
+                "not resolved.\n"
+                "  Locate the Hermes interpreter, then re-run with --python "
+                "<path-to-hermes-python>.\n",
+                file=sys.stderr,
+            )
+        return 1
     skill_result = install_bundled_skill(
         hermes_home_path=hermes_home_path,
         force=force,

--- a/integrations/hermes/tests/test_windows_symlink_privilege.py
+++ b/integrations/hermes/tests/test_windows_symlink_privilege.py
@@ -1,0 +1,44 @@
+"""Regression coverage for Windows symlink-privilege install failures (#807)."""
+
+from pathlib import Path
+
+from mnemosyne_hermes import install
+
+
+class _WindowsSymlinkPrivilegeError(OSError):
+    """Cross-platform stand-in for Windows ERROR_PRIVILEGE_NOT_HELD (1314)."""
+
+    def __init__(self) -> None:
+        super().__init__("A required privilege is not held by the client")
+        self.winerror = 1314
+
+
+def test_run_install_explains_windows_symlink_privilege_and_safe_wrapper_retry(
+    tmp_path, monkeypatch, capsys
+):
+    """WinError 1314 must fail closed with a retry using the resolved Hermes Python."""
+    hermes_python = Path(r"C:\Program Files\Hermes\venv\Scripts\python.exe")
+    target = tmp_path / "plugins" / "mnemosyne"
+
+    monkeypatch.setattr(install, "check_mnemosyne_core", lambda: True)
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: hermes_python)
+    monkeypatch.setattr(install, "check_mnemosyne_core_for_hermes_python", lambda _: "4.0")
+    monkeypatch.setattr(
+        install.os,
+        "symlink",
+        lambda *_: (_ for _ in ()).throw(_WindowsSymlinkPrivilegeError()),
+    )
+
+    rc = install.run_install(hermes_home_path=tmp_path)
+    stderr = capsys.readouterr().err
+
+    assert rc == 1
+    assert "Windows symbolic-link privilege" in stderr
+    assert "Developer Mode" in stderr
+    assert "persistent no-symlink-privilege alternative" in stderr
+    assert (
+        'mnemosyne-hermes install --mode wrapper --python '
+        '"C:\\Program Files\\Hermes\\venv\\Scripts\\python.exe"'
+    ) in stderr
+    assert not target.exists()
+    assert not target.is_symlink()

--- a/integrations/hermes/tests/test_windows_symlink_privilege.py
+++ b/integrations/hermes/tests/test_windows_symlink_privilege.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from mnemosyne_hermes import install
 
 
@@ -11,6 +13,10 @@ class _WindowsSymlinkPrivilegeError(OSError):
     def __init__(self) -> None:
         super().__init__("A required privilege is not held by the client")
         self.winerror = 1314
+
+
+def _raise_symlink_privilege_error(*_args) -> None:
+    raise _WindowsSymlinkPrivilegeError()
 
 
 def test_run_install_explains_windows_symlink_privilege_and_safe_wrapper_retry(
@@ -23,11 +29,7 @@ def test_run_install_explains_windows_symlink_privilege_and_safe_wrapper_retry(
     monkeypatch.setattr(install, "check_mnemosyne_core", lambda: True)
     monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: hermes_python)
     monkeypatch.setattr(install, "check_mnemosyne_core_for_hermes_python", lambda _: "4.0")
-    monkeypatch.setattr(
-        install.os,
-        "symlink",
-        lambda *_: (_ for _ in ()).throw(_WindowsSymlinkPrivilegeError()),
-    )
+    monkeypatch.setattr(install.os, "symlink", _raise_symlink_privilege_error)
 
     rc = install.run_install(hermes_home_path=tmp_path)
     stderr = capsys.readouterr().err
@@ -35,10 +37,43 @@ def test_run_install_explains_windows_symlink_privilege_and_safe_wrapper_retry(
     assert rc == 1
     assert "Windows symbolic-link privilege" in stderr
     assert "Developer Mode" in stderr
-    assert "persistent no-symlink-privilege alternative" in stderr
+    assert "persistent no-symlink-privilege alternative" in stderr.lower()
     assert (
         'mnemosyne-hermes install --mode wrapper --python '
         '"C:\\Program Files\\Hermes\\venv\\Scripts\\python.exe"'
     ) in stderr
+    assert not target.exists()
+    assert not target.is_symlink()
+
+
+def test_run_install_does_not_offer_wrapper_without_a_resolved_hermes_python(
+    tmp_path, monkeypatch, capsys
+):
+    """The no-bootstrap path must not invent a wrapper interpreter retry."""
+    monkeypatch.setattr(install, "check_mnemosyne_core", lambda: True)
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: None)
+    monkeypatch.setattr(install.os, "symlink", _raise_symlink_privilege_error)
+
+    rc = install.run_install(hermes_home_path=tmp_path, no_bootstrap=True)
+    stderr = capsys.readouterr().err
+
+    assert rc == 1
+    assert "cannot be generated" in stderr
+    assert "Locate the Hermes interpreter" in stderr
+    assert "mnemosyne-hermes install --mode wrapper" not in stderr
+
+
+def test_non_1314_symlink_error_still_propagates_without_a_wrapper_fallback(tmp_path, monkeypatch):
+    """Only WinError 1314 changes CLI behavior; other symlink failures stay errors."""
+    target = tmp_path / "plugins" / "mnemosyne"
+
+    def raise_access_denied(*_args) -> None:
+        raise OSError("access denied")
+
+    monkeypatch.setattr(install.os, "symlink", raise_access_denied)
+
+    with pytest.raises(OSError, match="access denied"):
+        install.install_plugin(hermes_home_path=tmp_path)
+
     assert not target.exists()
     assert not target.is_symlink()


### PR DESCRIPTION
## Reproducer-first draft

Fixes #807.

### Reproduction

A focused installer-boundary regression simulates only `OSError.winerror == 1314` from the default symlink creation path. It currently fails on the selected base because that error propagates without an actionable recovery.

### Intended narrow fix

Keep symlink mode as the default. Fail closed only for Windows symbolic-link privilege error 1314 and print a command-safe persistent wrapper retry using the already resolved Hermes interpreter. No automatic junction, wrapper fallback, mode switch, privilege elevation, profile-link change, or handling of other `OSError` values.

### Before implementation proof

`PYTHONPATH=.:integrations/hermes/src uv run --no-sync --with pytest pytest integrations/hermes/tests/test_windows_symlink_privilege.py -q`

Fails on `a3e23c9a76390068fdb512d82b4d6e64c928c614` with the simulated WinError 1314 escaping `install_plugin()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Architecture and behavior

- This PR changes only Hermes Windows installer recovery for symbolic-link privilege failures.
- It does not change working, episodic, or BEAM memory tiers.
- It does not change retrieval, consolidation, veracity, synchronization, or benchmark methodology.
- The installer remains fail-closed when Windows returns `WinError 1314`.
- The installer does not switch modes, elevate privileges, or create junctions automatically.

## Local-first and privacy posture

- The change preserves local-first behavior.
- It adds no network access, telemetry, remote state, or data movement.
- It does not change Mnemosyne’s privacy posture or database state.
- Wrapper mode provides a persistent local alternative when symbolic-link privileges are unavailable.
- Users who require symlinks receive guidance to enable Developer Mode or effective symbolic-link privileges.

## Agent integration surfaces

- Hermes receives a targeted recovery message for `OSError.winerror == 1314`.
- The retry command uses the resolved Hermes Python path and remains safe when the path contains spaces.
- MCP and CLI behavior remain unchanged.
- The installer does not alter plugin metadata, profile links, or wrapper validation.

## Maintainability

- The narrow error handling preserves existing behavior for all other `OSError` values.
- Dedicated regression tests cover privilege failures, unrelated errors, cleanup, missing interpreters, and command quoting.
- Keeping symlink mode as the default and avoiding automatic fallback is the right call because it preserves explicit installation semantics.
- The focused implementation limits platform-specific behavior and reduces future maintenance risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->