### PR TITLE
fix(hermes): discover native Windows venv Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Native Windows Hermes venv discovery now finds `Scripts/python.exe` (#809).** Implicit `mnemosyne-hermes install` discovery now supports validated native Windows virtual-environment layouts through launcher siblings, known Hermes roots, the active prefix, and `VIRTUAL_ENV`; explicit `--python` remains authoritative.
 - **Windows Hermes symlink installs now explain WinError 1314 recovery (#807).** When Windows denies symbolic-link creation because Developer Mode or the symbolic-link privilege is unavailable, the installer fails closed and prints a command-safe persistent wrapper retry using the resolved Hermes Python; it does not switch modes automatically.
 - **Hermes wrapper validation timeout is configurable (#804).** `mnemosyne-hermes install --mode wrapper` now accepts `--import-timeout SECONDS` (default: 60) for both selected-Python validation probes, rejects non-positive/non-finite values, and gives a retry command when validation times out.
 - **Committed memory invalidations no longer report failure when enhanced-recall cache eviction fails (#594).** The mutation remains successful and the cache error is logged for reconciliation.

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -857,14 +857,33 @@ def _resolve_hermes_bin(hermes_bin: str) -> Path | None:
     return None
 
 
+def _is_windows_platform() -> bool:
+    """Return whether the installer is running on native Windows."""
+    return os.name == "nt"
+
+
+def _venv_python_candidates(venv_root: Path) -> tuple[Path, ...]:
+    """Return supported interpreter paths in platform-appropriate order.
+
+    Native Windows virtual environments keep their interpreter in
+    ``Scripts/python.exe``. POSIX layouts remain ``bin/python`` followed by
+    ``bin/python3``. The predicate that consumes these candidates still requires
+    the adjacent ``pyvenv.cfg`` marker and executability.
+    """
+    posix = (venv_root / "bin" / "python", venv_root / "bin" / "python3")
+    if _is_windows_platform():
+        return (venv_root / "Scripts" / "python.exe", *posix)
+    return posix
+
+
 def _is_venv_bin_dir(bin_dir: Path) -> bool:
-    """Return whether ``bin_dir`` is the ``bin/`` of a real virtual environment.
+    """Return whether ``bin_dir`` is an interpreter directory of a real venv.
 
     ``pyvenv.cfg`` is what separates a venv from a directory that merely holds
     executables. It is the only cheap signal that discriminates the #618 case:
     ``~/.local/bin`` holds both a ``hermes`` launcher and an unrelated
     ``python``, so "the launcher sits next to a python" proves nothing on its
-    own.
+    own. The same marker applies to native Windows ``Scripts/`` layouts.
     """
     return (bin_dir.parent / "pyvenv.cfg").is_file()
 
@@ -951,9 +970,7 @@ def _find_hermes_python(explicit_python: str | Path | None = None) -> Optional[P
     if hermes_bin:
         resolved = _resolve_hermes_bin(hermes_bin)
         if resolved:
-            bin_dir = resolved.parent
-            for py_name in ("python", "python3"):
-                candidate = bin_dir / py_name
+            for candidate in _venv_python_candidates(resolved.parent.parent):
                 if _is_validated_venv_python(candidate):
                     return candidate
 
@@ -971,18 +988,18 @@ def _find_hermes_python(explicit_python: str | Path | None = None) -> Optional[P
         Path("/usr/lib/hermes-agent"),
     ]:
         for venv_name in ("venv", ".venv"):
-            candidate = root / venv_name / "bin" / "python"
-            if _is_validated_venv_python(candidate):
-                return candidate
+            for candidate in _venv_python_candidates(root / venv_name):
+                if _is_validated_venv_python(candidate):
+                    return candidate
 
     # 3. Check if we're running inside Hermes' venv ourselves.
     #    `sys.prefix != sys.base_prefix` says the *running* interpreter is in a
     #    venv; it says nothing about the bin/python being asked for here, which
     #    can be absent or non-executable in a partially built environment.
     if sys.prefix != sys.base_prefix:
-        venv_python = Path(sys.prefix) / "bin" / "python"
-        if _is_validated_venv_python(venv_python):
-            return venv_python
+        for candidate in _venv_python_candidates(Path(sys.prefix)):
+            if _is_validated_venv_python(candidate):
+                return candidate
 
     # 4. Check VIRTUAL_ENV env var (uv-managed or explicit).
     #    This is an ordinary environment variable, not an assertion that a venv
@@ -991,9 +1008,9 @@ def _find_hermes_python(explicit_python: str | Path | None = None) -> Optional[P
     #    this function exists to prevent.
     ve = os.environ.get("VIRTUAL_ENV")
     if ve:
-        candidate = Path(ve) / "bin" / "python"
-        if _is_validated_venv_python(candidate):
-            return candidate
+        for candidate in _venv_python_candidates(Path(ve)):
+            if _is_validated_venv_python(candidate):
+                return candidate
 
     # Nothing validated. Better to stop and let the caller ask for --python
     # than to bootstrap into an interpreter that only looked plausible.

--- a/integrations/hermes/tests/test_find_hermes_python.py
+++ b/integrations/hermes/tests/test_find_hermes_python.py
@@ -750,3 +750,109 @@ def test_run_install_honours_explicit_python(hermes_world, tmp_path, monkeypatch
 
     assert rc == 0
     assert bootstrapped == [chosen]
+
+
+def _make_windows_venv(root: Path) -> Path:
+    """Create a native Windows venv layout without changing ``os.name``."""
+    scripts = root / "Scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    (root / "pyvenv.cfg").write_text("home = C:/Python\n", encoding="utf-8")
+    return _write_executable(scripts / "python.exe", "#!/bin/sh\nexit 0\n")
+
+
+def _isolate_windows_discovery(tmp_path, monkeypatch):
+    """Neutralize every implicit route; each test enables one route explicitly."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "empty-home"))
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", sys.base_prefix)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "user-home"))
+    # Keep the simulated layout local to the installer module. In particular,
+    # changing process-global ``os.name`` would make pathlib and shutil act as
+    # though this Linux test process were Windows.
+    monkeypatch.setattr(install, "_is_windows_platform", lambda: True, raising=False)
+
+
+def test_windows_launcher_sibling_discovers_scripts_python_exe(tmp_path, monkeypatch):
+    """Route 1: a native launcher sibling must find its validated Windows venv."""
+    _isolate_windows_discovery(tmp_path, monkeypatch)
+    venv = tmp_path / "launcher-venv"
+    python = _make_windows_venv(venv)
+    launcher = _write_executable(venv / "Scripts" / "hermes.exe", "#!/bin/sh\nexit 0\n")
+    monkeypatch.setattr(install.shutil, "which", lambda _: str(launcher))
+
+    assert install._find_hermes_python() == python
+
+
+def test_windows_known_root_discovers_scripts_python_exe(tmp_path, monkeypatch):
+    """Route 2: a known Hermes install root must support ``Scripts/python.exe``."""
+    _isolate_windows_discovery(tmp_path, monkeypatch)
+    home = tmp_path / "hermes-home"
+    python = _make_windows_venv(home / "hermes-agent" / "venv")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert install._find_hermes_python() == python
+
+
+def test_windows_active_prefix_discovers_scripts_python_exe(tmp_path, monkeypatch):
+    """Route 3: the active venv prefix must find its native Windows runtime."""
+    _isolate_windows_discovery(tmp_path, monkeypatch)
+    prefix = tmp_path / "active-venv"
+    python = _make_windows_venv(prefix)
+    monkeypatch.setattr(sys, "prefix", str(prefix))
+
+    assert install._find_hermes_python() == python
+
+
+def test_windows_virtual_env_discovers_scripts_python_exe(tmp_path, monkeypatch):
+    """Route 4: VIRTUAL_ENV must find its validated native Windows runtime."""
+    _isolate_windows_discovery(tmp_path, monkeypatch)
+    venv = tmp_path / "virtual-env"
+    python = _make_windows_venv(venv)
+    monkeypatch.setenv("VIRTUAL_ENV", str(venv))
+
+    assert install._find_hermes_python() == python
+
+
+@pytest.mark.parametrize("kind", ["missing", "nonexecutable", "unrelated"])
+def test_windows_known_root_rejects_invalid_scripts_candidates(tmp_path, monkeypatch, kind):
+    """Windows-shaped candidates retain the existing marker and executable checks."""
+    _isolate_windows_discovery(tmp_path, monkeypatch)
+    home = tmp_path / "hermes-home"
+    root = home / "hermes-agent" / "venv"
+    candidate = root / "Scripts" / "python.exe"
+    if kind == "nonexecutable":
+        _make_windows_venv(root).chmod(0o644)
+    elif kind == "unrelated":
+        _write_executable(candidate, "#!/bin/sh\nexit 0\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    assert install._find_hermes_python() is None
+
+
+def test_windows_explicit_python_still_precedes_implicit_discovery(tmp_path, monkeypatch):
+    """An explicit path remains authoritative over a valid Windows route."""
+    _isolate_windows_discovery(tmp_path, monkeypatch)
+    discovered = _make_windows_venv(tmp_path / "virtual-env")
+    chosen = tmp_path / "chosen" / "python.exe"
+    monkeypatch.setenv("VIRTUAL_ENV", str(discovered.parent.parent))
+
+    assert install._find_hermes_python(explicit_python=chosen) == chosen
+
+
+def test_posix_known_root_precedence_stays_python_then_python3(tmp_path, monkeypatch):
+    """Windows support does not alter the established POSIX candidate order."""
+    home = tmp_path / "hermes-home"
+    venv = home / "hermes-agent" / "venv"
+    python = _make_venv(venv)
+    python3 = _write_executable(venv / "bin" / "python3", "#!/bin/sh\nexit 0\n")
+    windows_python = _make_windows_venv(venv)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(sys, "prefix", sys.base_prefix)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "user-home"))
+    monkeypatch.setattr(install, "_is_windows_platform", lambda: False, raising=False)
+
+    assert install._find_hermes_python() == python
+    assert python != python3 != windows_python


### PR DESCRIPTION
## Problem

`mnemosyne-hermes install` implicitly discovers only POSIX `bin/python` layouts. A standard native Windows Hermes venv at `Scripts/python.exe` is missed across launcher sibling, known install root, active prefix, and `VIRTUAL_ENV` routes.

## Reproducer first

The first commit adds route-level simulated native-Windows layout tests without changing process-global `os.name`. On the selected green base `b33eb128e6461c97e7e9693fb2e2adc82803db3f`, the four route tests fail because discovery returns `None`; validation-negative and POSIX-order controls pass.

## Intended scope

Add the smallest platform-aware candidate-layout support while preserving:

- explicit `--python` precedence;
- existing `pyvenv.cfg` and executable validation;
- existing POSIX candidate order;
- all installer lifecycle behavior.

No changes to Windows symlink privilege recovery, wrapper behavior, profiles, config, or database behavior.

## Verification planned

- focused route reproducer and full discovery/installer tests;
- package wheel plus fresh-venv CLI help/install sanity;
- lint, compile, diff checks, and independent current-head review.

Native Windows runtime verification remains a manual release smoke because this PR is developed on Linux.

Fixes #809


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds native Windows Hermes interpreter discovery through `Scripts/python.exe`.
- Covers launcher siblings, known install roots, active `sys.prefix`, and `VIRTUAL_ENV`.
- Preserves explicit `--python` precedence, candidate validation, security checks, and POSIX candidate order.
- Adds route-level Windows regression tests and POSIX regression coverage.

## Architecture and privacy impact

- This change affects the Hermes agent integration surface only.
- It does not change Mnemosyne’s working, episodic, or BEAM memory tiers.
- It does not change retrieval, consolidation, veracity, sync, MCP, database, profiles, or wrappers.
- It does not change privacy posture or local-first guarantees.
- It keeps interpreter discovery local and validates candidates before use.
- Shared candidate-generation logic improves long-term maintainability and reduces route-specific behavior.

## Verification

- Tests cover missing, non-executable, and unrelated Windows candidates.
- Native Windows runtime verification remains a manual release smoke test.
- No benchmark methodology changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->