### PR TITLE
docs: add native Windows Hermes recovery guide

### DIFF
--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -202,6 +202,105 @@ pip install -e "integrations/hermes[dev]"
 >
 > **Never symlink a profile directly to `site-packages/mnemosyne_hermes`.** That bypasses the wrapper's `sys.path` bootstrap and can leave fresh Hermes profiles unable to import the provider.
 
+### Native Windows local install and recovery
+
+This section is for a **native Windows** Hermes installation, not Docker, WSL, or
+another user's Hermes home. Run it as the Windows user and in the Hermes profile
+that will use Mnemosyne. Do not copy a path from another account: select that
+Hermes installation's Python as `<hermes-python>`. If discovery cannot identify
+it, the explicit `--python` form below is authoritative.
+
+`mnemosyne-hermes` requires the standard local semantic-search dependency set,
+`mnemosyne-memory[embeddings]`. A Hermes-managed virtual environment can lack
+`pip`; check it first. In a fresh PowerShell, set the selected Hermes home and
+interpreter. `$HermesHome` must be the active user's intended Hermes home or
+profile home; it prevents this install from using another profile. Use its
+adjacent Scripts directory for the installer:
+
+```powershell
+$HermesHome = '<selected-hermes-home-or-profile-home>'
+$env:HERMES_HOME = $HermesHome
+$HermesPython = '<hermes-python>'
+$MnemosyneHermes = Join-Path (Split-Path -Parent $HermesPython) 'mnemosyne-hermes.exe'
+
+& $HermesPython -m pip --version
+if ($LASTEXITCODE -ne 0) {
+    uv pip install --python $HermesPython "mnemosyne-memory[embeddings]" mnemosyne-hermes
+} else {
+    & $HermesPython -m pip install "mnemosyne-memory[embeddings]" mnemosyne-hermes
+}
+
+# Symlink is the normal local install mode. --python is the safe fallback when
+# discovery is not applicable to this Hermes layout.
+& $MnemosyneHermes install --python $HermesPython --no-profile-links
+```
+
+`[embeddings]` is the standard local semantic-search profile. `mnemosyne-memory[all]`
+also adds local-LLM consolidation dependencies. On Windows, its local LLM
+dependencies can require compatible wheels (including `llama-cpp-python`) or a
+native build toolchain such as MSVC, NMake, and Visual Studio Build Tools; do
+not assume they will build universally. Start with `[embeddings]` unless local
+LLM consolidation is required.
+
+The installer discovers native Windows `Scripts/python.exe` layouts when using
+implicit discovery. An explicit `--python` remains the authoritative, safer
+choice for an unusual layout.
+
+#### Windows WinError 1314 recovery
+
+If the normal symlink install fails specifically with **WinError 1314**, the
+current process lacks effective symbolic-link privilege. Enable Windows Developer
+Mode or use an account that has that effective privilege; administrator-group
+membership alone does not guarantee it. The installer intentionally does not
+switch modes automatically, and this guide does not use junctions as a workaround.
+
+A wrapper retry avoids the plugin symlink and records the selected interpreter.
+Use the same selected Hermes Python:
+
+```powershell
+& $MnemosyneHermes install --mode wrapper --python $HermesPython --import-timeout 60 --no-profile-links
+```
+
+`--import-timeout` is the wrapper validation timeout and currently defaults to
+60 seconds; the explicit value above makes that retry policy visible. Wrapper
+mode is appropriate for a persistent side virtual environment in deployments
+where that side environment is retained across Hermes updates. It does **not**
+make a direct install into a Hermes-managed virtual environment survive a Hermes
+venv rebuild or replacement. After changing a wrapper, restart or refresh the
+actual local Hermes process before checking provider state.
+
+#### Enable and verify
+
+If Hermes reports the Mnemosyne plugin as disabled, enable it without requesting
+any built-in-tool override, then select it as the memory provider:
+
+```powershell
+hermes plugins enable mnemosyne --no-allow-tool-override
+hermes config set memory.provider mnemosyne
+```
+
+Restart or start a new local Hermes session, then verify the installer and active
+provider in the same user/profile scope:
+
+```powershell
+& $MnemosyneHermes status
+hermes memory status
+```
+
+The current documented Hermes CLI contract does not provide a `hermes plugins
+doctor mnemosyne` command, so do not substitute an unverified plugin-doctor
+command. Likewise, this guide does not prescribe a direct store/recall/delete
+smoke command: use the provider's runtime tools only after the two status checks
+succeed.
+
+| Symptom | Bounded recovery |
+|---|---|
+| `No module named pip` from `<hermes-python>` | Use `uv pip install --python "<hermes-python>" "mnemosyne-memory[embeddings]" mnemosyne-hermes`, then repeat the normal installer command. |
+| `[all]` fails while installing local-LLM dependencies | Keep `[embeddings]` for local semantic search, or resolve compatible wheels/build-toolchain requirements before retrying `[all]`. |
+| WinError 1314 during symlink install | Enable Developer Mode/effective symlink privilege, or retry wrapper mode with the selected Hermes Python. Do not use a junction or expect an automatic mode switch. |
+| Wrapper validation times out | `--import-timeout` defaults to 60 and affects installer validation only. A larger positive finite value can retry that install probe, but `mnemosyne-hermes status` always validates with its fixed 60-second policy; investigate the selected interpreter if status still fails. |
+| Hermes update or venv replacement leaves a missing/stale provider | Reinstall into the replacement Hermes interpreter for a symlink install. For a persistent-side-venv wrapper, refresh the wrapper against its retained selected interpreter, then restart Hermes and rerun both status commands. |
+
 ### Step 2: Link the plugin in a local mutable environment
 
 For a non-Docker local installation, the supported installer default is symlink mode:


### PR DESCRIPTION
## Summary
- add a focused native-Windows local Hermes installation and recovery section to the canonical Hermes guide
- document the pip-absent `uv pip --python` path, native `Scripts/python.exe` discovery, scoped `--no-profile-links` installs, and WinError 1314 wrapper retry
- clarify wrapper timeout/status behavior and managed-venv update limits

## Why this is narrow
This is documentation only. It records the current contracts from #805, #808, and #811 without changing installer behavior, plugin loading, packaging, or CI.

## Non-goals
- no Docker/Compose procedure changes
- no junction workaround, automatic mode switch, config hand-editing, or privileged built-in-tool override
- no unverified `hermes plugins doctor` or direct runtime smoke instructions
- no changes to the legacy LLM installation guide or release notes

## Verification
- `python scripts/verify-docs.py`
- source/parser help check for `mnemosyne-hermes install` (`--mode`, `--python`, `--import-timeout`, `--no-profile-links`) and `status`
- live Hermes help check for plugin enable (without tool override), config set, and memory status
- `git diff --check`
- independent current-head diff review: PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds native Windows Hermes installation and recovery guidance to the canonical guide.
- Documents local interpreter discovery, `uv pip --python`, scoped profile installation, WinError 1314 retries, wrapper timeouts, status checks, and managed-environment limits.
- Improves Hermes agent integration for Windows without changing installer behavior, plugin loading, packaging, CLI behavior, MCP integration, or CI.

## Architecture and guarantees

- Does not change working, episodic, or BEAM memory tiers.
- Does not change retrieval, consolidation, veracity, sync, or benchmark methodology.
- Preserves the local-first design because the documented Hermes setup remains local.
- Does not change the privacy posture or introduce a remote dependency.
- Improves long-term maintainability by centralizing Windows procedures in the canonical Hermes guide.
- This is the right call for documentation coverage. It avoids platform-specific installer changes while making local recovery behavior explicit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->