### PR TITLE
docs(releasing): define how a beta cycle ends

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -100,6 +100,80 @@ pip install --pre mnemosyne-memory
 The GitHub release is flagged as a pre-release automatically, so a beta never
 becomes the repository's "Latest release".
 
+### Beta lifecycle
+
+The mechanics above say how to cut a beta. This says how one ends, which is the
+part that drifts if nobody writes it down.
+
+**Name the questions at tag time.** A beta exists to answer specific doubts. Write
+them into the release notes when you cut `bN`, because a beta whose questions were
+never stated cannot be shown to have finished. For `4.0.0b1` they are:
+
+1. Does the embedding-dimension guard break people in ways we did not predict, and
+   is `MNEMOSYNE_EMBEDDING_DIM=<N>` actually sufficient to recover?
+2. Is the multimodal surface (`remember_media()`, the modality seam, the media
+   store) the right shape? New API is expensive to unship, and a beta is the last
+   cheap moment to change a signature.
+
+**A beta with no users is not a beta.** `pip install --pre` is opt-in, so silence is
+the default outcome, not a good one. Announce the beta and ask for one specific
+thing to be tried. If nobody opts in, promoting to final is a delayed release with
+extra steps and no evidence, so say that plainly rather than treating the quiet as
+a pass.
+
+#### What blocks promotion
+
+A **beta blocker** is any of:
+
+- A regression against the previous stable line in documented behavior.
+- A data-integrity or data-loss defect.
+- The documented migration does not work, or is incomplete.
+- A crash at import or first call in a supported configuration.
+
+Everything else ships in the final and is fixed in the following patch. A bug in a
+brand-new feature is not automatically a blocker; a thing that worked in 3.15.1 and
+no longer works always is.
+
+#### Weak signals, do not promote on these
+
+- **Time elapsed.** Two weeks measures nothing.
+- **Zero bug reports.** Usually means zero users, not zero bugs.
+- **Download counts.** `--pre` traffic is mostly CI and mirrors.
+
+#### Strong signals to promote
+
+- **Someone hit the breaking change and recovered using only the documented
+  migration.** This is the strongest single signal available, because it is the
+  specific risk the beta exists for. One real report beats a thousand silent
+  installs.
+- **Someone who did not write the new surface used it against their own data, and
+  the shape held.** If the first external use forces a signature change, the beta
+  did its job and you owe it another round.
+- **No issue opened during the window is a regression from the previous stable
+  line.** New-feature bugs are expected; regressions are the thing being tested for.
+
+#### The progression
+
+```
+bN   -> bN+1    a beta blocker was fixed. Evidence-based, not scheduled.
+bN   -> rc1     zero open blockers, no API signature change in the last beta,
+                and the migration exercised by someone other than you.
+rc1  -> final   the rc sat with no new blockers, and every downstream surface
+                in "Downstream surfaces" is updated and verified.
+```
+
+`b` and `rc` are a contract, not decoration: **`b` means the API may still change,
+`rc` means it will not.** Any API change after `rc1` forces `rc2` and resets the
+promise. If you would not defend that distinction to a user who pinned `rc1`, do
+not cut the rc yet.
+
+#### The failure mode
+
+The beta that never ends. It happens when promotion is left to feel finished rather
+than to a written test. If you cannot state which of the strong signals you have
+observed, you are not ready to promote, and the honest move is to say what evidence
+is still missing rather than to ship on fatigue.
+
 ### When to release
 
 - **Patches:** As soon as CI is green on main. Bug fixes don't wait.


### PR DESCRIPTION
## Description

`### Pre-releases` covers the mechanics of cutting a beta: tag format, PEP 440 ordering, `--pre`, the GitHub pre-release flag. It says nothing about how one **finishes**. That is the half that drifts, because promotion ends up decided by fatigue rather than by evidence.

Adds `### Beta lifecycle`:

**Name the questions at tag time.** A beta exists to answer specific doubts, and one whose questions were never written down cannot later be shown to have finished. For `4.0.0b1` they are the embedding-dimension guard's migration, and whether the multimodal surface is the right shape while changing a signature is still cheap.

**A beta with no users is not a beta.** `--pre` is opt-in, so silence is the default outcome, not a pass. If nobody opts in, promoting is a delayed release with extra steps and no evidence.

**Blocker definition.** Regression against the previous stable line, data integrity, a migration that does not work, or a crash at import. A bug in a brand-new feature is not automatically a blocker; something that worked in 3.15.1 and no longer does always is.

**Weak signals** that should not drive promotion: elapsed time, absence of bug reports, download counts. Each of the three usually measures the absence of users rather than the absence of defects.

**Strong signals** that should: someone hit the breaking change and recovered using only the documented migration; someone outside the authors used the new surface and its shape held; no issue opened in the window is a regression.

**The progression**, with the contract that makes the labels mean something: `b` may still change API, `rc` may not, and any API change after `rc1` forces `rc2`.

## Related Issue

No issue. Written while preparing the `v4.0.0b1` tag, since the policy is needed before the tag, not after.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Existing tests still pass (`pytest tests/ -v`)
- [ ] New tests added for any new functionality
- [x] Manual verification (describe what you tested)

`tests/test_release_gates.py`: 11 passed. Documentation only; no code path changes.

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py`
- [ ] `CHANGELOG.md` updated with a brief entry
- [ ] README updated if user-facing behavior changed
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency

No version bump and no CHANGELOG entry: this documents process, not shipped behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2pLMWfZENtNZYZW4oVsxN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds a `### Beta lifecycle` section to `RELEASING.md`.
- Defines evidence-based criteria for beta promotion, release candidates, and final releases.
- Documents blocker criteria, API stability requirements, and weak versus strong promotion signals.
- Documents the risks of promotion without sufficient evidence.

## Architectural impact

- Does not change Mnemosyne’s core memory architecture.
- Does not change tiered memory, retrieval, consolidation, veracity, sync, or benchmark systems.
- Does not change privacy posture or local-first guarantees.
- Does not change Hermes, MCP, or CLI integration surfaces.
- Improves long-term maintainability by defining repeatable release decisions and requiring user evidence.
- The documentation-only approach is the right call. No architectural or local-first risks are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->