### PR TITLE
fix(modality): honor known HTTP statuses for retry decisions

### DIFF
--- a/mnemosyne/core/modality_openai_compat.py
+++ b/mnemosyne/core/modality_openai_compat.py
@@ -317,6 +317,7 @@ def _post_chat(
     Same return contract as ``local_llm._call_remote_llm_with_model`` so the
     retry decision above can be made on status alone.
     """
+    status: Optional[int] = None
     try:
         import httpx
         has_httpx = True
@@ -350,7 +351,7 @@ def _post_chat(
             except urllib.error.HTTPError as exc:
                 return (None, exc.code, exc)
             except Exception as exc:
-                return (None, None, exc)
+                return (None, status, exc)
 
         choices = data.get("choices", []) if isinstance(data, dict) else []
         if choices:
@@ -359,7 +360,7 @@ def _post_chat(
                 return (str(content), status, None)
         return (None, status, None)
     except Exception as exc:
-        return (None, None, exc)
+        return (None, status, exc)
 
 
 # ---------------------------------------------------------------------------

--- a/mnemosyne/core/modality_openai_compat.py
+++ b/mnemosyne/core/modality_openai_compat.py
@@ -477,11 +477,15 @@ class OpenAICompatModalityBackend:
             text, status, exc = _post_chat(url, headers, payload, timeout)
             if text is not None:
                 break
-            transient = (
-                (status is not None and (status == 429 or 500 <= status < 600))
-                or (exc is not None and _is_rate_limit_error(exc))
-                or (status is None and exc is not None)
-            )
+            if status is None:
+                # No HTTP response was received, so this was a transport
+                # failure. Retry it regardless of how an exception is worded.
+                transient = exc is not None
+            else:
+                # A received HTTP status is authoritative. In particular, do
+                # not let an incidental "429" in the exception text turn a
+                # terminal client error into a retry.
+                transient = status == 429 or 500 <= status < 600
             if transient and attempt < _MAX_ATTEMPTS - 1:
                 time.sleep(_retry_delay(attempt))
                 continue

--- a/tests/test_modality_openai_compat.py
+++ b/tests/test_modality_openai_compat.py
@@ -58,9 +58,12 @@ class _Stub:
                 raw = self.rfile.read(length)
                 outer.requests.append(json.loads(raw.decode()))
 
-                status, content = outer.replies.pop(0) if outer.replies else (200, "{}")
+                reply = outer.replies.pop(0) if outer.replies else (200, "{}")
+                status, content, *raw_body = reply
                 outer.response_statuses.append(status)
-                if status >= 400:
+                if raw_body:
+                    body = content.encode()
+                elif status >= 400:
                     body = json.dumps({"error": content}).encode()
                 else:
                     body = json.dumps(
@@ -462,6 +465,17 @@ def test_known_client_status_beats_429_in_exception_text(stub, configured, monke
     assert adapter.OpenAICompatModalityBackend().describe(_request()) is None
     assert len(server.requests) == 1
     assert server.response_statuses == [403]
+    assert server.replies == [(200, _OK_REPLY)]
+
+
+def test_received_malformed_json_is_not_retried(stub, configured, monkeypatch):
+    monkeypatch.setattr(adapter.time, "sleep", lambda _s: None)
+    server = stub([(200, "not JSON", True), (200, _OK_REPLY)])
+    configured(server.base_url)
+
+    assert adapter.OpenAICompatModalityBackend().describe(_request()) is None
+    assert len(server.requests) == 1
+    assert server.response_statuses == [200]
     assert server.replies == [(200, _OK_REPLY)]
 
 

--- a/tests/test_modality_openai_compat.py
+++ b/tests/test_modality_openai_compat.py
@@ -448,6 +448,23 @@ def test_client_errors_are_not_retried(stub, configured, monkeypatch, status):
     assert server.replies == [(200, _OK_REPLY)]
 
 
+def test_known_client_status_beats_429_in_exception_text(stub, configured, monkeypatch):
+    server = stub([(403, "forbidden"), (200, _OK_REPLY)])
+    configured(server.base_url)
+    post_chat = adapter._post_chat
+
+    def _post_with_misleading_exception(*args, **kwargs):
+        text, status, _ = post_chat(*args, **kwargs)
+        return text, status, RuntimeError("request URL included port 429")
+
+    monkeypatch.setattr(adapter, "_post_chat", _post_with_misleading_exception)
+
+    assert adapter.OpenAICompatModalityBackend().describe(_request()) is None
+    assert len(server.requests) == 1
+    assert server.response_statuses == [403]
+    assert server.replies == [(200, _OK_REPLY)]
+
+
 def test_an_unreachable_endpoint_degrades_to_none(configured, monkeypatch):
     monkeypatch.setattr(adapter.time, "sleep", lambda _s: None)
     configured("http://127.0.0.1:1/v1")


### PR DESCRIPTION
Fixes #841.

## Root cause

A terminal HTTP status could be retried when the exception text happened to contain `429`, including from an ephemeral localhost port such as `127.0.0.1:42959`. A real `403` could then consume the next queued successful response and return a result instead of `None`.

## Change

- Treat a known HTTP status as authoritative: retry only `429` and `5xx`.
- Use exception-based rate-limit classification only when no HTTP status is available, preserving transport-failure handling.
- Add a deterministic regression for a known `403` with misleading `429` exception text. It asserts one request, `None`, status `[403]`, and an unconsumed queued success response.

## Verification

- Immutable exact-commit selector: passed.
- Focused retry matrix: 5 passed.
- Repeated new selector: 5/5 passed.
- Ruff (`F,RUF022`) and `git diff --check`: passed.
- The full modality file still has two pre-existing `/models` preflight failures, reproduced unchanged on the exact base `f52a7b6`; they are outside this retry slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Makes HTTP status authoritative for modality retry decisions.
- Retries only `429`, `5xx`, and transport failures without an HTTP response.
- Does not retry terminal statuses such as `403`, even when exception text contains `"429"`.
- Adds regression coverage for misleading exception text and malformed response bodies.

## Architecture impact

- No changes to working, episodic, or BEAM memory tiers.
- No changes to retrieval, consolidation, veracity, synchronization, privacy, or local-first guarantees.
- No changes to Hermes, MCP, or CLI integration surfaces.
- No changes to benchmark methodology.
- Improves maintainability by separating HTTP-status handling from exception-text parsing.
- This is the right call because known server responses now control retry behavior deterministically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->