### PR TITLE
docs(skill): stop publishing deployment topology and named routing rules

### DIFF
--- a/.claude/skills/mnemosyne-context/SKILL.md
+++ b/.claude/skills/mnemosyne-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mnemosyne-context
-description: Load this when working on the mnemosyne memory system — its repo, sync server, memory databases, CI, or the hermes-vps deployment. Covers architecture, the surface/sync data model, dev workflow (tests/ruff/CI matrix), the Tailscale/systemd devops topology, release policy, contributor norms, and known gotchas that are easy to get wrong. Use for any "mnemosyne" dev or devops task, or when a sync/import/recall behaves unexpectedly.
+description: Load this when working on the mnemosyne memory system — its repo, sync server, memory databases, or CI. Covers architecture, the surface/sync data model, dev workflow (tests/ruff/CI matrix), release policy, and known gotchas that are easy to get wrong. Use for any "mnemosyne" dev or devops task, or when a sync/import/recall behaves unexpectedly.
 ---
 
 # Mnemosyne context
@@ -15,7 +15,6 @@ Mnemosyne is a persistent memory system for AI agents (SQLite-backed, hybrid rec
 - **Architecture-first, and ship DONE work.** Ask "does this need a version bump / is this the right layer?" before implementing. Deliver tested, complete implementations — not partial work.
 - **Em-dashes are a HARD BAN** in any prose written under Abdias's name (—/– auto-rejected). This is a personal quality standard, not a style suggestion. (Terminal/code output is exempt; this is about public-facing text.)
 - **"Draft" means preview, do not send.** For anything outward-facing (issue/PR comments, announcements, emails, posts), show the draft and wait for explicit "post it"/"send it" before publishing. Reversible repo ops (branch, CI re-run, local edits) don't need this; outward comments do.
-- **Contributor review routing**: do NOT ask **dplush (Denis H)** to review other contributors' PRs (avoids contributor-on-contributor drift); AJ reviews. dplush stays focused on shipping core-layer work.
 - **CLA gotcha**: the CLA bot validates **commit** authors, not PR authors — agent-identity commits (e.g. `Hermes Pi <…>`) break it; contributor must `git commit --amend --author="Name <github-email>"` + force-push. If CLA won't re-trigger after a branch update, **close/reopen the PR** (comments like "recheckcla" don't work).
 
 ## Verify before trusting
@@ -50,16 +49,25 @@ Any point-in-time fact here (open issues/PRs, endpoints, versions) may be stale 
 - **Cadence**: bundle substantial fixes + features into the **next MAJOR**; do **not** drip-feed into incremental MINORs. Meaningful new-surface PRs get review now but merge is deferred to the MAJOR cycle. MINORs ship only when enough additive opt-in features accumulate.
 - Local pipx installs track **PyPI releases** — a merged fix isn't in your local CLI until a release ships (or you reinstall from source). Don't `pipx reinstall` from PyPI expecting an unreleased fix; it silently reverts it.
 
-## DevOps — hermes-vps (Tailscale)
-- Host `vmi3272367.tail9293de.ts.net` (IP `100.88.216.42`); services exposed **tailnet-only** via `tailscale serve` (HTTPS :443, **prefix-stripped**).
-- systemd units: `mnemosyne-sync.service`, `mnemosyne-dashboard.service`, `mnemosyne-bot.service`.
-- **Sync server**: `mnemosyne sync-serve` on `127.0.0.1:8766` (dedicated relay DB `/root/.hermes/mnemosyne/data/sync-relay.db`, `--api-key-file /root/.hermes/mnemosyne/sync-api-key`, `600`). Endpoint: `https://vmi3272367.tail9293de.ts.net/mnemosyne-sync` → routes `/sync/pull|push|status`, `/healthz`.
-- **Dashboard** (`.../mnemosyne` → `:8765`) is a **read-only UI** (`MnemosyneDashboard`), *not* a sync server — every `/sync/*` 404s. Don't point `sync_remote` at it.
-- **tirith gotcha**: the security scanner blocks **raw Tailscale IP URLs** in cron/automation. Use the Tailscale **hostname**, never `100.x.x.x`.
-- SSH: `ssh hermes-vps`. `sqlite3` is available on the box for quick DB inspection.
+## DevOps
+
+The deployment topology (sync server, dashboard, bot, and the host they run on)
+is operator-specific and is **not documented in this public repository**. Hosts,
+addresses, service definitions and credential paths live in the operator's
+private runbook.
+
+What is safe to know here: the sync server is `mnemosyne sync-serve` bound to
+loopback and reverse-proxied; it serves `/sync/pull|push|status` and `/healthz`,
+and it requires a dedicated relay DB rather than a private `mnemosyne.db`. The
+dashboard is a read-only UI on a separate port and is **not** a sync server, so
+pointing `sync_remote` at it 404s on every `/sync/*` route.
 
 ## Contributor norms
-- **dplush (Denis H)** is the highest-velocity core-layer contributor — keep them shipping; **do NOT** ask dplush to review other contributors' PRs (avoids contributor-on-contributor drift). AJ reviews.
+
+Review-routing conventions name individuals and are therefore kept in the
+operator's private notes rather than here. What is safe to state publicly: the
+merge gate is green CI, external review is not required, and the CLA bot
+validates **commit** authors rather than PR authors.
 
 ## Known gotchas / decided designs
 - **Config precedence (#482)**: `config.yaml` > env > default. Runtime reads `MnemosyneConfig.get()` directly — **no** YAML→env bridge / `apply_to_env()`. Many config keys need a **process restart** to take effect.

--- a/.claude/skills/mnemosyne-context/SKILL.md
+++ b/.claude/skills/mnemosyne-context/SKILL.md
@@ -36,7 +36,7 @@ Any point-in-time fact here (open issues/PRs, endpoints, versions) may be stale 
 - To actually share existing memories you must put them on the surface (`sync-init --claim-existing` on an all-global DB, or write global memories to the surface). To mirror an entire DB (incl. session memories) use **export/import**, not sync.
 
 ## Dev workflow
-- **Local `mnemosyne` CLI + MCP server run from the pipx install** (`~/.local/share/pipx/venvs/mnemosyne-memory`), **NOT** the repo. Editing the repo does not affect them unless installed editable. (On hermes-vps the install *is* editable at `/root/.hermes/projects/mnemosyne`.)
+- **Local `mnemosyne` CLI + MCP server run from the pipx install** (`~/.local/share/pipx/venvs/mnemosyne-memory`), **NOT** the repo. Editing the repo does not affect them unless installed editable. (Some operator deployments install it editable instead, in which case repo edits do take effect; check before assuming either.)
 - **Tests**: use the repo venv — `.venv/bin/python -m pytest tests/<file> -q`. Running from the repo dir makes `import mnemosyne` resolve to the repo source (shadows pipx). pytest lives in `.venv`, not pipx.
 - Set **`MNEMOSYNE_NO_EMBEDDINGS=1`** for fast test runs; embedding-dependent tests are flaky because Hugging Face rate-limits (`429`) the `BAAI/bge-small-en-v1.5` download. CI defaults to this and caches `~/.hermes/cache/fastembed`.
 - **`tests/test_temporal_recall.py::...::test_performance_overhead` is a flaky wall-clock gate** (<10ms). A single-version red on it is almost always load noise — re-run the job.


### PR DESCRIPTION
## Description

`.claude/skills/mnemosyne-context/SKILL.md` ships in a public repository with 226 forks. It carried:

- the sync host's DNS name and tailnet address
- the systemd unit names
- the relay database path
- the API-key **file path**
- the SSH alias

None of that is credential material. It is infrastructure reconnaissance, and a public repo has no reason to publish it.

Replaced with a pointer to the operator's private runbook, keeping the part contributors actually benefit from: that the sync server binds loopback and is reverse-proxied, that it serves `/sync/pull|push|status` and `/healthz`, that it needs a dedicated relay DB rather than a private `mnemosyne.db`, and that the dashboard is a read-only UI which 404s every `/sync/*` route. That last one is the mistake people actually make, so it stays.

Also removed two lines naming an individual contributor and prescribing how their reviews should be routed. That is a real policy, but it belongs in private notes rather than a public file where the person named cannot see the surrounding context. The publicly safe half is kept: green CI is the gate, external review is not required, and the CLA bot validates commit authors rather than PR authors.

Frontmatter updated so the description no longer advertises the sections that were removed.

## Related Issue

No issue. Found while auditing what this repository publishes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Existing tests still pass (`pytest tests/ -v`)
- [ ] New tests added for any new functionality
- [x] Manual verification (describe what you tested)

Documentation only, no code paths touched. Verified after the edit that no reference to the host, address, key path, SSH alias, or the named contributor remains in the file.

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py`
- [ ] `CHANGELOG.md` updated with a brief entry
- [ ] README updated if user-facing behavior changed
- [x] Code follows the project's principles:
  - No new external dependencies without good reason
  - No cloud / API key requirement for core functionality
  - SQLite is the only database dependency

No version bump and no CHANGELOG entry: this changes what an internal skill file publishes, not shipped behavior.

## Important caveat

**This only changes `HEAD`.** The values remain in git history and in every existing fork. Removing them here reduces discoverability; it does not withdraw them. Anything that was treated as secret should be rotated rather than assumed retracted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2pLMWfZENtNZYZW4oVsxN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates public `mnemosyne-context` documentation.
- Removes private deployment topology, infrastructure paths, SSH aliases, host names, and contributor review-routing instructions.
- Directs operators to a private runbook for deployment details.
- Retains public guidance for loopback binding, reverse proxying, sync and health endpoints, relay database requirements, dashboard behavior, CI, external review, and CLA validation.
- Updates frontmatter and editable-install guidance.

## Architecture and Privacy Impact

- No changes to working, episodic, or BEAM memory tiers.
- No changes to retrieval, consolidation, veracity, sync implementation, or benchmark methodology.
- No changes to Hermes, MCP, or CLI integration surfaces.
- Improves privacy posture by removing infrastructure reconnaissance and private contributor-routing policy from public documentation.
- Preserves local-first guidance, including loopback binding. Nothing erodes local-first design.
- Improves maintainability by separating stable public guidance from private operational procedures.
- Historical commits and existing forks still contain removed values. Secrets must be rotated if applicable.

## Validation

- Documentation-only change.
- Existing tests pass.
- Manual review confirms removal of host names, absolute paths, tailnet addresses, SSH invocations, and contributor names.
- No exported or public code entities changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->