### PR TITLE
docs(maintainers): state that either maintainer may review any PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,17 @@ Pull requests are reviewed by the maintainers and merged when they:
 - Follow the principles above
 - Include a clear description of what changed and why
 
+Either maintainer may review any pull request, and an approval means the code is
+correct rather than that the change ships.
+
+Some pull requests raise a question that review cannot settle, because the answer is
+a project decision rather than a matter of whether the code works. A pull request
+that changes a supported public API, the storage schema, or a configuration contract
+gets the `needs-decision` label. Review carries on as normal while the label is
+there; the label holds the merge, not the discussion. Applying it early is helpful
+rather than obstructive, because it surfaces the question while changing the answer
+is still cheap.
+
 See [MAINTAINERS.md](MAINTAINERS.md) for the canonical decision framework, including who has authority over which areas of the codebase.
 
 ## Areas of Interest

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -29,6 +29,17 @@
 | Repo settings / org admin | AJ only |
 | Docs, tests, CI | Either maintainer |
 
+## Review and Merge
+
+Either maintainer may review any pull request, including one opened by an outside
+contributor. There is no routing restriction on who reviews what.
+
+An approval means the code is correct. It does not by itself decide that the change
+ships. Merge authority follows the Decision Framework above, so a pull request that
+changes a supported public API, the storage schema, or a configuration contract
+carries the `needs-decision` label and escalates to that table rather than being
+settled in review. Review continues while it is labelled; only the merge waits.
+
 ## Governance
 
 - All contributors must sign the [CLA](CLA.md) before contributions are accepted
@@ -38,4 +49,4 @@
 
 ---
 
-*Last updated: 2026-08-01*
+*Last updated: 2026-08-24*


### PR DESCRIPTION
## Description

Retires the contributor review-routing norm and replaces it with a rule that separates review from merge.

The norm said not to route other contributors' pull requests to the co-maintainer, to protect his throughput and to avoid two non-owners settling a design the project lead never sanctioned.

The second concern is real. The routing rule is not the way to address it, and it was never actually in force. `.github/CODEOWNERS` has `* @AxDSan @dplush`, so GitHub has been requesting @dplush's review on every pull request the entire time. The review he has given is substantive, multi-round work:

| PR | Author | Review by @dplush |
|----|--------|-------------------|
| #839 | bayhnf | 3x changes requested, then approved |
| #830 | dwmb5055 | 2x changes requested |
| #829 | bayhnf | changes requested |
| #814 | bayhnf | changes requested, then approved |
| #810 | ddddddddwp | 2x changes requested, then approved |

That is the expensive kind of review and the useful kind, and with intake currently outrunning merge it is a large part of what keeps the board moving.

So this keeps the concern and drops the routing rule, by separating the two things the rule conflated:

- **Review** answers whether the code is correct. Either maintainer may review any pull request. No routing restriction.
- **Merge** answers whether the change ships. That already has a home in the Decision Framework, so nothing new is invented here.

A pull request that changes a supported public API, the storage schema, or a configuration contract gets `needs-decision`, which holds the merge while review carries on.

### Notes

- **No new label.** `needs-decision` already exists with the right description and is in active use on 10+ items. Adding `needs-owner-decision` would fork the taxonomy.
- **Escalates to the Decision Framework, not to one person.** The table already says breaking public-API changes need consensus from both maintainers, and this does not narrow that.
- **CODEOWNERS unchanged.** It already describes the arrangement this documents.

## Related Issue

None. Came out of an audit of which written norms are actually in force.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / performance
- [ ] Test improvement
- [ ] CI / build tooling

## How Has This Been Tested?

- [x] Manual verification (describe what you tested)

Documentation only, no code paths touched. The review history above was read from the GitHub API across the last 40 pull requests rather than from memory.

## Checklist

- [ ] Version bumped in `mnemosyne/__init__.py`
- [ ] `CHANGELOG.md` updated with a brief entry
- [ ] README updated if user-facing behavior changed
- [x] Code follows the project's principles

## One thing that is not routine

`MAINTAINERS.md` says it "may be amended by mutual written agreement of both maintainers." This amends it, so @dplush's approval is that written agreement. Please do not merge this on a green build alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates `CONTRIBUTING.md` and `MAINTAINERS.md` with unrestricted maintainer review guidance.
- Separates review approval from merge authority.
- Keeps `needs-decision` for public API, storage schema, and configuration contract changes.
- Does not change `.github/CODEOWNERS`.

## Architectural impact

- No changes to tiered memory, retrieval, consolidation, veracity, sync, or benchmark systems.
- No changes to Hermes, MCP, or CLI integration surfaces.
- No changes to privacy posture or local-first guarantees.
- Improves long-term maintainability by clarifying review and merge responsibilities.
- Removing review routing is the right call because either maintainer can review any pull request.
- The PR does not erode local-first design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->