### PR TITLE
fix: avoid onnxruntime blkid stderr regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Optional `embeddings` and `all` installs cap `onnxruntime` below 1.29.** This avoids `blkid` stderr on minimal Linux/aarch64 systems.
 - **CI stopped being able to verify anything, because an unpinned dependency changed ASGI behaviour (#860).** `tests/test_mcp_streamable_http.py` drives the authenticated SSE GET by hand through the TestClient portal, and its `receive()` never delivered the initial `http.request` message. That violates the ASGI contract, but mcp 2.0.0 answered without waiting for it, so the driver passed. mcp 2.1.0 reads the request body to enforce `max_request_body_size` (SDK #3336), so the handler now blocks before `http.response.start`, the test's wait fails, and `TestClient.__exit__` then blocks forever draining a task group that still holds the wedged ASGI task. The job ran to its six-hour ceiling and reported nothing.
 
   The dependency is declared `mcp>=2.0.0` with no upper bound, so every run resolves the newest release at install time. mcp 2.1.0 was published on 2026-08-24 at 19:04 UTC; every green run predates it and every hung run follows it. This was not intermittent and not a race: 0 hangs in 22 consecutive runs on 2.0.0, then 4 hangs in 4 runs on 2.1.x, and the same boundary reproduces locally on the unmodified test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,12 @@ classifiers = [
 
 [project.optional-dependencies]
 llm = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20"]
-embeddings = ["fastembed>=0.3.0", "sqlite-vec>=0.1.0"]
+embeddings = ["fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.0"]
 mcp = ["mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"]
 openclaw = ["openclaw>=0.1.0; python_version >= '3.10'"]
 sync = ["cryptography>=41.0"]
 test = ["pytest>=7.0", "pytest-timeout>=2.1", "build"]
-all = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "sqlite-vec>=0.1.0", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'", "cryptography>=41.0"]
+all = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.0", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'", "cryptography>=41.0"]
 dev = ["pytest>=7.0", "pytest-timeout>=2.1", "build", "twine", "ruff==0.15.22"]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -68,11 +68,11 @@ setup(
     },
     extras_require={
         "llm": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20"],
-        "embeddings": ["fastembed>=0.3.0", "sqlite-vec>=0.1.0"],
+        "embeddings": ["fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.0"],
         "mcp": ["mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
         "openclaw": ["openclaw>=0.1.0; python_version >= '3.10'"],
         "test": ["pytest>=7.0"],
-        "all": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "sqlite-vec>=0.1.0", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
+        "all": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.0", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
         "dev": ["pytest>=7.0", "build", "twine"],
     },
     entry_points={

--- a/tests/test_optional_dependency_metadata.py
+++ b/tests/test_optional_dependency_metadata.py
@@ -1,0 +1,60 @@
+"""Regression coverage for optional dependency constraints."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ONNXRUNTIME_REQUIREMENT = "onnxruntime>=1.21.0,<1.29"
+EXPECTED_EXTRAS = {"embeddings", "all"}
+
+
+def _pyproject_optional_dependencies() -> dict[str, list[str]]:
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    optional_dependencies = pyproject.split("[project.optional-dependencies]", 1)[1].split(
+        "\n[", 1
+    )[0]
+    assignments = re.findall(
+        r"^(embeddings|all)\s*=\s*(\[[^\n]+\])$", optional_dependencies, re.MULTILINE
+    )
+    dependencies = {
+        extra: ast.literal_eval(requirements) for extra, requirements in assignments
+    }
+    assert set(dependencies) == EXPECTED_EXTRAS
+    assert optional_dependencies.count(ONNXRUNTIME_REQUIREMENT) == len(EXPECTED_EXTRAS)
+    return dependencies
+
+
+def _setup_py_optional_dependencies() -> dict[str, list[str]]:
+    tree = ast.parse((ROOT / "setup.py").read_text(encoding="utf-8"))
+    setup_call = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and ((isinstance(node.func, ast.Name) and node.func.id == "setup")
+             or (isinstance(node.func, ast.Attribute) and node.func.attr == "setup"))
+    )
+    extras_keyword = next(
+        keyword for keyword in setup_call.keywords if keyword.arg == "extras_require"
+    )
+    return ast.literal_eval(extras_keyword.value)
+
+
+def test_embedding_extras_bound_onnxruntime_below_1_29():
+    """Avoid onnxruntime 1.29, whose import invokes unavailable ``blkid``."""
+    for optional_dependencies in (
+        _pyproject_optional_dependencies(),
+        _setup_py_optional_dependencies(),
+    ):
+        for extra in EXPECTED_EXTRAS:
+            assert optional_dependencies[extra].count(ONNXRUNTIME_REQUIREMENT) == 1
+
+        extras_with_requirement = {
+            extra
+            for extra, requirements in optional_dependencies.items()
+            if ONNXRUNTIME_REQUIREMENT in requirements
+        }
+        assert extras_with_requirement == EXPECTED_EXTRAS

--- a/uv.lock
+++ b/uv.lock
@@ -1041,16 +1041,21 @@ all = [
     { name = "huggingface-hub" },
     { name = "llama-cpp-python" },
     { name = "mcp" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sqlite-vec" },
 ]
 dev = [
     { name = "build" },
     { name = "pytest" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "twine" },
 ]
 embeddings = [
     { name = "fastembed" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sqlite-vec" },
 ]
 llm = [
@@ -1069,7 +1074,9 @@ sync = [
     { name = "cryptography" },
 ]
 test = [
+    { name = "build" },
     { name = "pytest" },
+    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -1077,6 +1084,7 @@ requires-dist = [
     { name = "anyio", marker = "python_full_version >= '3.10' and extra == 'all'", specifier = ">=4.0" },
     { name = "anyio", marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=4.0" },
     { name = "build", marker = "extra == 'dev'" },
+    { name = "build", marker = "extra == 'test'" },
     { name = "cryptography", marker = "extra == 'all'", specifier = ">=41.0" },
     { name = "cryptography", marker = "extra == 'sync'", specifier = ">=41.0" },
     { name = "ctransformers", marker = "extra == 'all'", specifier = ">=0.2.27" },
@@ -1089,9 +1097,13 @@ requires-dist = [
     { name = "llama-cpp-python", marker = "extra == 'llm'", specifier = ">=0.2.0" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'all'", specifier = ">=2.0.0" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=2.0.0" },
+    { name = "onnxruntime", marker = "extra == 'all'", specifier = ">=1.21.0,<1.29" },
+    { name = "onnxruntime", marker = "extra == 'embeddings'", specifier = ">=1.21.0,<1.29" },
     { name = "openclaw", marker = "python_full_version >= '3.10' and extra == 'openclaw'", specifier = ">=0.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.1" },
+    { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.22" },
     { name = "sqlite-vec", marker = "extra == 'all'", specifier = ">=0.1.0" },
@@ -1798,6 +1810,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pins `onnxruntime` below 1.29 in the `embeddings` and `all` extras. On minimal Linux/aarch64, importing 1.29.0 emits `sh: 1: blkid: not found`; a fresh install resolves 1.28.0 instead.

Closes #850.

## Why this path

`fastembed` permits onnxruntime 1.29.0, while Mnemosyne does not call `blkid` itself. A package-level upper bound is the narrowest mitigation for the affected optional embedding path.

## Non-goals

- No change to runtime initialization or shell behavior.
- No direct FastEmbed-install documentation rewrite.
- No unrelated packaging-surface alignment.

## Verification

- Regression test passed on Python 3.10 and 3.13.
- Fresh wheel install with `[embeddings]` resolved `onnxruntime 1.28.0`; isolated import had empty stderr.
- Wheel metadata contains the bound for both extras.
- `ruff`, `uv lock --check`, and `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Pins `onnxruntime` to `>=1.21.0,<1.29` in the `embeddings` and `all` extras.
- Prevents `onnxruntime` 1.29.0 from emitting `blkid: not found` on minimal Linux/aarch64 systems.
- Adds metadata regression tests for `pyproject.toml` and `setup.py`.
- Documents the dependency bound in `CHANGELOG.md`.

## Architectural impact

- Core memory architecture is unchanged.
- Working, episodic, and BEAM memory tiers are unchanged.
- Retrieval, consolidation, veracity, and sync systems are unchanged.
- Hermes, MCP, and CLI integration surfaces are unchanged.
- Privacy posture and local-first guarantees are preserved.
- The PR adds no hosted service, telemetry, remote dependency, or runtime behavior change.
- The dependency bound is the right call. It removes a known optional-path stderr regression without changing runtime initialization or shell behavior.
- The package-level constraint, changelog entry, and regression tests improve long-term maintainability.
- Benchmark methodology is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->