### PR TITLE
docs(readme): add the Trendshift badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 *Zero-cloud AI memory that works everywhere. SQLite-backed. One pure-Python dependency.*
 
+<a href="https://trendshift.io/repositories/27293?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-27293" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/27293/daily?language=Python" alt="mnemosyne-oss/mnemosyne | Trendshift" width="250" height="55"/></a>
+
 [![Python](https://img.shields.io/badge/Python-3.10+-blue.svg)](https://python.org)
 [![PyPI](https://img.shields.io/pypi/v/mnemosyne-memory.svg)](https://pypi.org/project/mnemosyne-memory/)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)


### PR DESCRIPTION
Adds the Trendshift badge to the README header.

Placed on its own line under the tagline rather than inside the shields row: it is 250x55 and the shields are roughly 20 tall, so folding it in would leave the row ragged. It sits above the sponsor block, which keeps its position.

Two small things done to the supplied snippet:

- **Alt text decoded.** It arrived as `mnemosyne-oss%2Fmnemosyne | Trendshift`, which a screen reader reads out as "percent two F". Now `mnemosyne-oss/mnemosyne | Trendshift`.
- **Both URLs verified before embedding**, rather than trusted. The badge returns `200` with `content-type: image/svg+xml` and the repository page returns `200`.

`target`/`rel` are kept as supplied; GitHub strips them when rendering README HTML, so they are harmless either way.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update

## How Has This Been Tested?

- [x] Manual verification (both URLs curled for status and content type)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a Trendshift badge to the README header.
- Preserved the sponsor block position.
- Verified badge accessibility text and HTTP 200 responses.

## Architecture Impact

- No changes to tiered memory, retrieval, consolidation, veracity, sync, or benchmark systems.
- No changes to local-first guarantees or privacy posture.
- No changes to Hermes, MCP, or CLI integration surfaces.
- The documentation-only change does not erode local-first design.
- The focused README update supports long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->