### PR TITLE
ci: bound job runtime and cancel superseded pull request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,19 @@ on:
   pull_request:
     branches: [main, master]
 
+# One live run per pull request. Pushing again cancels the superseded run
+# instead of leaving it to finish against a commit nobody will merge. Runs on
+# main are never cancelled: those are the ones we check tags and releases
+# against.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   docs-check:
     runs-on: ubuntu-latest
+    # Runs in seconds; a minute-scale budget is already generous.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
@@ -32,6 +42,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    # Runs in seconds; a minute-scale budget is already generous.
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -128,6 +140,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # About 9 minutes uncontended and roughly 25 under load, so 50
+    # leaves headroom while still killing a hang inside the hour.
+    timeout-minutes: 50
     permissions:
       contents: read
     strategy:
@@ -198,6 +213,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    # Runs in seconds; a minute-scale budget is already generous.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 


### PR DESCRIPTION
A hung job currently holds a runner for GitHub's **six-hour default**. That happened four times today (#860), and while those runners are occupied everyone else's checks crawl.

```
06:01:45  job starts
06:07:01  ... PASSED [ 61%]
          ... nothing for 5h 55m ...
12:01:58  ##[error]The operation was canceled.
```

Four jobs per run, six hours each: roughly **24 runner-hours burned per occurrence**, and the PR reports `cancelled` rather than a real result.

### Two changes, both about the queue

**Per-job timeouts**, measured against real runs on `main` rather than guessed:

| job | actual | budget |
|---|---|---|
| `test (3.10-3.13)` | ~9 min uncontended, ~25 under load | **50 min** |
| `build` | 21 s | 15 min |
| `lint` | 6 s | 15 min |
| `docs-check` | 5 s | 15 min |

50 leaves real headroom for a contended run while still killing a hang inside the hour.

**A concurrency group.** There was none. Pushing a second commit to a PR left the first run to finish against a commit nobody will merge. Runs now supersede within a PR:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Pushes to `main` are explicitly **never** cancelled, since those are what tags and releases are verified against.

### What this does not do

It does not fix the hang. #860 covers that, and the half of #860 that matters most is the pytest-level timeout, which turns a future hang into a named failing test instead of a silent stall. This change bounds the cost in the meantime, and keeps bounding it for whatever hangs next.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] CI / build tooling

## How Has This Been Tested?

- [x] `ci.yml` parses as valid YAML with all four jobs carrying a `timeout-minutes`
- [x] Budgets derived from measured job durations on `main`, not estimates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds CI timeouts for test, build, lint, and documentation jobs.
- Cancels superseded pull request runs while preserving concurrent `main` runs.
- Reduces runner usage from hung jobs and obsolete checks.
- Does not change Mnemosyne’s memory architecture, retrieval, consolidation, veracity, sync, privacy, local-first guarantees, or agent integrations.
- Does not change Hermes, MCP, CLI, or benchmark methodology.
- This is the right call for CI maintainability. The underlying hang remains assigned to issue `#860`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->