### PR TITLE
fix(hooks): inspect added staged PII lines

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,9 +4,18 @@ HOOK_FILE=".githooks/pre-commit"
 
 PII_PATTERNS="1641797+AxDSan@users.noreply.github.com"
 
-if git diff --cached --no-color --text -U0 --output-indicator-new='!' -- . ":(exclude)$HOOK_FILE" \
-  | grep -a '^!' \
-  | grep -a -F -q "$PII_PATTERNS"; then
+DIFF_OUTPUT=$(mktemp "${TMPDIR:-/tmp}/pre-commit.XXXXXX") || {
+  echo "ERROR: Unable to create temporary file for staged-diff PII check. Aborting commit." >&2
+  exit 1
+}
+trap 'rm -f "$DIFF_OUTPUT"' 0 HUP INT TERM
+
+if ! git diff --cached --no-color --text -U0 --output-indicator-new='!' -- . ":(exclude)$HOOK_FILE" > "$DIFF_OUTPUT"; then
+  echo "ERROR: Unable to inspect staged changes; git diff failed. Aborting commit." >&2
+  exit 1
+fi
+
+if grep -a '^!' "$DIFF_OUTPUT" | grep -a -F -q "$PII_PATTERNS"; then
   echo "ERROR: PII detected in staged files. Remove before committing."
   echo "Found pattern: $PII_PATTERNS"
   exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,13 +4,12 @@ HOOK_FILE=".githooks/pre-commit"
 
 PII_PATTERNS="1641797+AxDSan@users.noreply.github.com"
 
-staged=$(git diff --cached --name-only | grep -v "^$HOOK_FILE$" || true)
-if [ -n "$staged" ]; then
-  if echo "$staged" | xargs grep -l "$PII_PATTERNS" 2>/dev/null; then
-    echo "ERROR: PII detected in staged files. Remove before committing."
-    echo "Found pattern: $PII_PATTERNS"
-    exit 1
-  fi
+if git diff --cached --no-color --text -U0 --output-indicator-new='!' -- . ":(exclude)$HOOK_FILE" \
+  | grep -a '^!' \
+  | grep -a -F -q "$PII_PATTERNS"; then
+  echo "ERROR: PII detected in staged files. Remove before committing."
+  echo "Found pattern: $PII_PATTERNS"
+  exit 1
 fi
 
 # Also check git config

--- a/tests/test_precommit_pii.py
+++ b/tests/test_precommit_pii.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -42,13 +43,16 @@ def _hook_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def _run_hook(repo: Path) -> subprocess.CompletedProcess[str]:
+def _run_hook(
+    repo: Path, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["/bin/sh", ".githooks/pre-commit"],
         cwd=repo,
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
 
 
@@ -105,3 +109,31 @@ def test_precommit_ignores_removed_historical_pii(tmp_path):
     result = _run_hook(repo)
 
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_precommit_fails_closed_when_git_diff_fails(tmp_path):
+    repo = _hook_repo(tmp_path)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "diff" ]; then\n'
+        '  echo "simulated git diff failure" >&2\n'
+        "  exit 128\n"
+        "fi\n"
+        'exec "$REAL_GIT" "$@"\n',
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    real_git = shutil.which("git")
+    assert real_git is not None
+    env = os.environ | {
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "REAL_GIT": real_git,
+    }
+
+    result = _run_hook(repo, env)
+
+    assert result.returncode != 0
+    assert "ERROR: Unable to inspect staged changes; git diff failed. Aborting commit." in result.stderr

--- a/tests/test_precommit_pii.py
+++ b/tests/test_precommit_pii.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -15,7 +18,14 @@ PII = "1641797+AxDSan" + "@users.noreply.github.com"
 
 def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["git", *args],
+        [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
         cwd=repo,
         capture_output=True,
         text=True,
@@ -160,3 +170,44 @@ def test_precommit_fails_closed_when_git_diff_fails(tmp_path):
 
     assert result.returncode != 0
     assert "ERROR: Unable to inspect staged changes; git diff failed. Aborting commit." in result.stderr
+
+
+@pytest.mark.parametrize(
+    "global_config",
+    [
+        "[core]\n\thooksPath = .githooks\n",
+        "[commit]\n\tgpgsign = true\n",
+    ],
+    ids=["hooks-path", "gpg-signing"],
+)
+def test_precommit_hook_tests_ignore_hostile_global_git_config(tmp_path, global_config):
+    config_path = tmp_path / "global.gitconfig"
+    config_path.write_text(global_config, encoding="utf-8")
+    hook_tests = (
+        "test_precommit_allows_harmless_pyproject_change_with_historical_pii",
+        "test_precommit_rejects_newly_added_pii",
+        "test_precommit_rejects_added_pii_with_diff_header_prefix",
+        "test_precommit_rejects_pii_in_staged_binary_content",
+        "test_precommit_ignores_removed_historical_pii",
+        "test_precommit_fails_closed_when_temp_file_creation_fails",
+        "test_precommit_excludes_hook_file_from_pii_check",
+        "test_precommit_fails_closed_when_git_diff_fails",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            *(f"{__file__}::{test}" for test in hook_tests),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=os.environ | {"GIT_CONFIG_GLOBAL": str(config_path)},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "8 passed" in result.stdout

--- a/tests/test_precommit_pii.py
+++ b/tests/test_precommit_pii.py
@@ -161,15 +161,19 @@ def test_precommit_fails_closed_when_git_diff_fails(tmp_path):
     fake_git.chmod(0o755)
     real_git = shutil.which("git")
     assert real_git is not None
+    hook_tmpdir = tmp_path / "hook-tmpdir"
+    hook_tmpdir.mkdir()
     env = os.environ | {
         "PATH": f"{fake_bin}:{os.environ['PATH']}",
         "REAL_GIT": real_git,
+        "TMPDIR": str(hook_tmpdir),
     }
 
     result = _run_hook(repo, env)
 
     assert result.returncode != 0
     assert "ERROR: Unable to inspect staged changes; git diff failed. Aborting commit." in result.stderr
+    assert not list(hook_tmpdir.glob("pre-commit.*"))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_precommit_pii.py
+++ b/tests/test_precommit_pii.py
@@ -1,0 +1,107 @@
+"""Regression tests for the staged-diff PII check in the pre-commit hook."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / ".githooks" / "pre-commit"
+PII = "1641797+AxDSan" + "@users.noreply.github.com"
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _hook_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "hook-repo"
+    (repo / ".githooks").mkdir(parents=True)
+    shutil.copy2(HOOK, repo / ".githooks" / "pre-commit")
+    (repo / "pyproject.toml").write_text(
+        f'[project]\nauthors = [{{name = "Maintainer", email = "{PII}"}}]\n',
+        encoding="utf-8",
+    )
+    for args in (
+        ("init", "-q"),
+        ("config", "user.email", "hook-test@example.test"),
+        ("config", "user.name", "Hook Test"),
+        ("add", "."),
+        ("commit", "-qm", "fixture"),
+    ):
+        result = _run(repo, *args)
+        assert result.returncode == 0, result.stderr
+    return repo
+
+
+def _run_hook(repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["/bin/sh", ".githooks/pre-commit"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_precommit_allows_harmless_pyproject_change_with_historical_pii(tmp_path):
+    repo = _hook_repo(tmp_path)
+    pyproject = repo / "pyproject.toml"
+    pyproject.write_text(pyproject.read_text(encoding="utf-8") + 'version = "1.0.0"\n', encoding="utf-8")
+    assert _run(repo, "add", "pyproject.toml").returncode == 0
+
+    result = _run_hook(repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_precommit_rejects_newly_added_pii(tmp_path):
+    repo = _hook_repo(tmp_path)
+    (repo / "new-contact.txt").write_text(f"contact: {PII}\n", encoding="utf-8")
+    assert _run(repo, "add", "new-contact.txt").returncode == 0
+
+    result = _run_hook(repo)
+
+    assert result.returncode != 0
+    assert "ERROR: PII detected in staged files." in result.stdout
+
+
+def test_precommit_rejects_added_pii_with_diff_header_prefix(tmp_path):
+    repo = _hook_repo(tmp_path)
+    (repo / "header-prefix.txt").write_text(f"+++{PII}\n", encoding="utf-8")
+    assert _run(repo, "add", "header-prefix.txt").returncode == 0
+
+    result = _run_hook(repo)
+
+    assert result.returncode != 0
+    assert "ERROR: PII detected in staged files." in result.stdout
+
+
+def test_precommit_rejects_pii_in_staged_binary_content(tmp_path):
+    repo = _hook_repo(tmp_path)
+    (repo / "contact.bin").write_bytes(b"\x00binary\xff" + PII.encode() + b"\x00")
+    assert _run(repo, "add", "contact.bin").returncode == 0
+
+    result = _run_hook(repo)
+
+    assert result.returncode != 0
+    assert "ERROR: PII detected in staged files." in result.stdout
+
+
+def test_precommit_ignores_removed_historical_pii(tmp_path):
+    repo = _hook_repo(tmp_path)
+    pyproject = repo / "pyproject.toml"
+    pyproject.write_text('[project]\nauthors = []\n', encoding="utf-8")
+    assert _run(repo, "add", "pyproject.toml").returncode == 0
+
+    result = _run_hook(repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_precommit_pii.py
+++ b/tests/test_precommit_pii.py
@@ -111,6 +111,29 @@ def test_precommit_ignores_removed_historical_pii(tmp_path):
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_precommit_fails_closed_when_temp_file_creation_fails(tmp_path):
+    repo = _hook_repo(tmp_path)
+    missing_tmpdir = tmp_path / "missing-tmpdir"
+    assert not missing_tmpdir.exists()
+
+    result = _run_hook(repo, os.environ | {"TMPDIR": str(missing_tmpdir)})
+
+    assert result.returncode != 0
+    assert "ERROR: Unable to create temporary file for staged-diff PII check. Aborting commit." in result.stderr
+    assert not missing_tmpdir.exists()
+
+
+def test_precommit_excludes_hook_file_from_pii_check(tmp_path):
+    repo = _hook_repo(tmp_path)
+    hook = repo / ".githooks" / "pre-commit"
+    hook.write_text(hook.read_text(encoding="utf-8") + f"# contact: {PII}\n", encoding="utf-8")
+    assert _run(repo, "add", ".githooks/pre-commit").returncode == 0
+
+    result = _run_hook(repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_precommit_fails_closed_when_git_diff_fails(tmp_path):
     repo = _hook_repo(tmp_path)
     fake_bin = tmp_path / "fake-bin"


### PR DESCRIPTION
## Summary

Fix the repository pre-commit PII guard so it scans only newly added content in the staged index rather than the whole current contents of changed files.

## Why this path

`pyproject.toml` legitimately contains the maintainer's GitHub noreply address. The old whole-file scan therefore blocked every unrelated staged edit to that file.

The guard remains fail-closed:

- ordinary added PII is rejected;
- added content beginning with `+++` is rejected;
- staged binary/NUL content is scanned and rejected when it contains PII;
- a `git diff` failure aborts the hook rather than being treated as no match.

The existing git-config INFO behavior is unchanged.

Closes #869.

## Verification

- `uv run --frozen pytest -q tests/test_precommit_pii.py tests/test_release_gates.py` — 17 passed
- `/bin/sh -n .githooks/pre-commit`
- focused Ruff: `uvx --from ruff==0.15.22 ruff check --select F,RUF022 -- tests/test_precommit_pii.py`
- `git diff --check`
- independent spec review and final security review: approved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `.githooks/pre-commit` to scan only added lines in the staged diff.
- Excluded diff headers and expected `pyproject.toml` metadata from false-positive detection.
- Preserved fail-closed behavior for diff failures, added PII, and staged binary content.
- Added regression tests for historical, added, removed, binary, header-prefixed, excluded-file, and failure cases.

## Architectural impact

- No changes to working, episodic, or BEAM memory tiers.
- No changes to retrieval, consolidation, veracity, sync, Hermes, MCP, CLI, or benchmark methodology.
- No erosion of local-first guarantees.
- The change improves local maintainability by allowing valid `pyproject.toml` edits while retaining the PII guard.
- Keeping the guard fail-closed is the right call for the repository’s privacy posture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->