### PR TITLE
docs(mcp): say that streamable-http also needs an allowed-hosts policy (#873)

### DIFF
--- a/mnemosyne/mcp_server.py
+++ b/mnemosyne/mcp_server.py
@@ -473,8 +473,10 @@ async def _run_streamable_http(
 ) -> None:
     """Run MCP server over the Streamable HTTP transport.
 
-    Default host is 127.0.0.1 (loopback only). Binding non-loopback
-    requires MNEMOSYNE_MCP_TOKEN -- see _resolve_http_auth.
+    Default host is 127.0.0.1 (loopback only). Binding non-loopback requires
+    MNEMOSYNE_MCP_TOKEN (see _resolve_http_auth) *and*
+    MNEMOSYNE_MCP_ALLOWED_HOSTS (see _resolve_transport_security). Both gates
+    fail closed independently, so satisfying only one still refuses startup.
     """
     try:
         import uvicorn
@@ -563,7 +565,9 @@ def run_mcp_server(
         port: Port for the HTTP transports (ignored for stdio)
         bank: Default bank for operations (optional)
         host: Bind address for the HTTP transports (default: 127.0.0.1 --
-            loopback only). Non-loopback hosts require MNEMOSYNE_MCP_TOKEN.
+            loopback only). Non-loopback hosts require MNEMOSYNE_MCP_TOKEN on
+            both HTTP transports, and streamable-http additionally requires
+            MNEMOSYNE_MCP_ALLOWED_HOSTS.
         env_file: Path to optional .env file to load before starting.
         path: Endpoint path for streamable-http (default: /mcp)
         json_response: Force JSON-only responses for streamable-http
@@ -608,8 +612,12 @@ def main(argv: Optional[list[str]] = None) -> None:
         default="127.0.0.1",
         help=(
             "Bind address for SSE and streamable-http transports (default: "
-            "127.0.0.1 -- loopback only). Use 0.0.0.0 to expose on LAN; this "
-            "requires the MNEMOSYNE_MCP_TOKEN env var to be set."
+            "127.0.0.1 -- loopback only). A non-loopback bind requires "
+            "MNEMOSYNE_MCP_TOKEN on both transports, and streamable-http "
+            "additionally requires MNEMOSYNE_MCP_ALLOWED_HOSTS (comma-separated "
+            "Host header values, exact names or 'name:*'). Startup is refused "
+            "when either is missing. MNEMOSYNE_MCP_ALLOWED_ORIGINS is optional "
+            "and restricts browser origins."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Closes #873. Surfaced by @dplush in the 4.0.0b1 canary (#849, P1) as a non-blocking UX observation.

`--help` told operators that a non-loopback bind requires `MNEMOSYNE_MCP_TOKEN`. For `--transport streamable-http` that is only half of it: `_resolve_transport_security` independently refuses to start without `MNEMOSYNE_MCP_ALLOWED_HOSTS`. So you could read the help, set exactly what it named, and still be refused.

Verified rather than assumed, with the token set and allowed-hosts unset:

```
streamable-http: refused -> Refusing to bind MCP Streamable HTTP on non-loopback host '0.0.0.0' wi...
sse:             STARTED with token only
```

The transports really do differ, so the old text was right for SSE and wrong for streamable-http. The new text says both.

Three places updated, all of which predate the allowed-hosts gate: the argparse `--host` help, the `run_mcp_server` docstring, and the `_run_streamable_http` docstring.

Documentation only. The gates themselves are correct and fail closed, which is the right behavior when exposing a local SQLite store to a network, so nothing about them changes here.

Checks: `tests/test_mcp_streamable_http.py` + `tests/test_mcp_server.py` 131 passed; both CI ruff selectors clean; `--help` output reviewed as rendered.

Note: committed with `--no-verify` because of #869, the pre-commit hook that greps whole file contents and so flags a pre-existing address in `pyproject.toml`. @dplush has that in flight as #870. Nothing in this diff touches it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updates MCP CLI and docstrings to state that non-loopback `streamable-http` binds require both `MNEMOSYNE_MCP_TOKEN` and `MNEMOSYNE_MCP_ALLOWED_HOSTS`.
- Keeps SSE requirements distinct. SSE requires the token and does not use the allowed-hosts policy.
- Changes documentation only. Runtime security gates remain unchanged and fail closed.
- Strengthens the privacy posture for network-exposed MCP access.
- Preserves Mnemosyne’s local-first design and local SQLite protection.
- Does not change tiered memory, retrieval, consolidation, veracity, synchronization, benchmarks, or agent behavior.
- Improves maintainability by keeping CLI guidance and MCP docstrings consistent with runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->