### PR TITLE
test: avoid root plugin import shadowing under pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ select = [
 ]  # NOTE: F covers F63, F7, F82 but NOT E9 — the E9 fatal gate lives in ci.yml only
 
 [tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
 # No single test should take five minutes. The cap exists so a deadlock is
 # reported as one named failing test within minutes instead of stalling the
 # job until the workflow timeout, which tells us nothing about where it hung.

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -1205,7 +1205,7 @@ def test_hygiene_suite_does_not_leak_config_into_subagent_provider(tmp_path, mon
     process: the autouse cleanup must discard that singleton before a subagent
     provider resolves its temporary data-directory configuration.
     """
-    from conftest import _close_cached_connections
+    from tests.conftest import _close_cached_connections
     from hermes_memory_provider import MnemosyneMemoryProvider
     from mnemosyne.core.config import MnemosyneConfig
 

--- a/tests/test_mcp_import_plugin_layout.py
+++ b/tests/test_mcp_import_plugin_layout.py
@@ -1,0 +1,60 @@
+"""Regression coverage for #868's parent-directory import shadowing."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_mcp_server_resolves_to_inner_package_from_plugin_layout(tmp_path):
+    """Pytest collection must not make the plugin stub shadow the core package."""
+    plugin_parent = tmp_path / "plugins"
+    plugin_dir = plugin_parent / "mnemosyne"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text((REPO_ROOT / "__init__.py").read_text())
+    (plugin_dir / "mnemosyne").symlink_to(REPO_ROOT / "mnemosyne", target_is_directory=True)
+    tests_dir = plugin_dir / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "__init__.py").touch()
+
+    test_file = tests_dir / "test_mcp_server_import.py"
+    test_file.write_text(
+        textwrap.dedent(
+            f"""\
+            from pathlib import Path
+
+            import mnemosyne.mcp_server
+
+
+            def test_mcp_server_comes_from_inner_package(pytestconfig):
+                assert pytestconfig.getoption("importmode") == "importlib"
+                assert Path(mnemosyne.mcp_server.__file__).resolve() == Path({str(REPO_ROOT / "mnemosyne" / "mcp_server.py")!r}).resolve()
+            """
+        )
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "-c",
+            str(REPO_ROOT / "pyproject.toml"),
+            str(test_file),
+        ],
+        cwd=plugin_dir,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, (
+        f"plugin-layout MCP import failed (exit {result.returncode}):\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Fixes #868 by running pytest in importlib mode. This prevents pytest's prepend import mode from binding the repository-root Hermes plugin stub as top-level `mnemosyne` during local checkout collection.

## Why this path

The root `__init__.py` must remain for Hermes plugin and memory-provider discovery. Importlib mode avoids the collection-time path mutation while exercising the same inner package contract that CI's editable install provides.

## Why not a root conftest.py path fix

A pytest-only `sys.path` mutation depends on collection order and can mask packaging/import-isolation mistakes.

## Non-goals

- No changes to the root plugin stub or Hermes discovery.
- No production `sys.path` mutation.
- No changes to existing root-stub/plugin tests.

## Reproduction and verification

Starting from a parent/plugin-layout path, pytest prepend mode can load the root stub as `mnemosyne`, after which `mnemosyne.mcp_server` cannot resolve. The new subprocess regression runs pytest with importlib mode and asserts the import resolves to the inner package.

- focused import, root-stub/provider, and MCP tests: `12 passed, 3 skipped`
- changed-file Ruff and `git diff --check`: passed
- `tests/test_plugins.py` has the same pre-existing logging-module pollution failure on base and candidate: `1 failed, 69 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Configures pytest to use `importlib` mode.
- Adds a subprocess regression test for MCP imports in a Hermes-style plugin layout.
- Preserves the repository-root Hermes plugin stub and discovery contract.
- Makes no production `sys.path` changes.

## Architectural impact

- **Core memory architecture:** No changes to working, episodic, or BEAM memory tiers.
- **Retrieval, consolidation, veracity, and sync:** No changes.
- **Privacy and local-first guarantees:** Preserved. The PR changes only local test collection and adds no network, telemetry, or production path logic.
- **Agent integration:** Preserves Hermes discovery and ensures `mnemosyne.mcp_server` resolves to the inner core package.
- **CLI and package contract:** Preserved for Hermes and editable-install workflows.
- **Maintainability:** This is the right call. A small, collection-order-independent configuration change fixes the package collision without moving or weakening the Hermes integration surface. Regression coverage protects the MCP import contract.
- **Benchmark methodology:** No changes.

Focused tests passed with `12 passed, 3 skipped`. Changed-file Ruff checks and `git diff --check` passed. An existing logging-module pollution failure remains in `tests/test_plugins.py`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->