### PR TITLE
feat: expose BEAM initialization vector status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Added
 
+- **BEAM initialization status is now available through the additive public Python `BeamInitResult`.** It reports the configured embedding dimension, any dimension mismatch, and immutable stored dimensions for each vector table; mismatches continue to avoid exceptions and automatic mutation.
 - **Multimodal memory: images, video and audio can become recallable memories (RFCs 0002, 0003, 0004).** `BeamMemory.remember_media(ref)` takes a reference to a piece of media, registers it, describes it through a configured modality provider, and writes the description back as an ordinary memory that hybrid recall already understands. Nothing about text recall changes.
 
   The stack is additive throughout. Two sidecar tables, `media_assets` and `media_moments`, are created `IF NOT EXISTS` by their own store when a bank is opened, so existing databases acquire them with no migration step and no change to any existing table. No new package dependency is introduced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Added
 
-- **BEAM initialization status is now available through the additive public Python `BeamInitResult`.** It reports the configured embedding dimension, any dimension mismatch, and immutable stored dimensions for each vector table; mismatches continue to avoid exceptions and automatic mutation.
+- **BEAM initialization status is now available through the additive public Python `BeamInitResult`.** It reports the configured embedding dimension, any dimension mismatch, and immutable stored dimensions for each vector table.
 - **Multimodal memory: images, video and audio can become recallable memories (RFCs 0002, 0003, 0004).** `BeamMemory.remember_media(ref)` takes a reference to a piece of media, registers it, describes it through a configured modality provider, and writes the description back as an ordinary memory that hybrid recall already understands. Nothing about text recall changes.
 
   The stack is additive throughout. Two sidecar tables, `media_assets` and `media_moments`, are created `IF NOT EXISTS` by their own store when a bank is opened, so existing databases acquire them with no migration step and no change to any existing table. No new package dependency is introduced.

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -831,14 +831,14 @@ def init_beam(db_path: Path = None) -> BeamInitResult:
     # environment as the writer. Refuse to create mismatched tables, leave any
     # existing ones untouched, and surface one actionable error instead of
     # per-row insert noise; recall falls back to the float-JSON voice meanwhile.
-    vec_dim_mismatch = False
-    existing_dim = None
+    existing_dim = _existing_vec_dim(conn)
+    vec_dim_mismatch = (
+        existing_dim is not None and existing_dim != EMBEDDING_DIM
+    )
+    if existing_dim is not None and vec_dim_mismatch:
+        logger.error(_dim_mismatch_message(existing_dim, EMBEDDING_DIM))
     if _SQLITE_VEC_AVAILABLE:
-        existing_dim = _existing_vec_dim(conn)
-        if existing_dim is not None and existing_dim != EMBEDDING_DIM:
-            vec_dim_mismatch = True
-            logger.error(_dim_mismatch_message(existing_dim, EMBEDDING_DIM))
-        else:
+        if not vec_dim_mismatch:
             try:
                 cursor.execute(f"""
                     CREATE VIRTUAL TABLE IF NOT EXISTS vec_episodes USING vec0(
@@ -1144,7 +1144,7 @@ def init_beam(db_path: Path = None) -> BeamInitResult:
         WHERE superseded_by IS NULL""")
     cursor.execute("""CREATE INDEX IF NOT EXISTS idx_mem_emb_type
         ON memory_embeddings(memory_id, model)""")
-    if not vec_dim_mismatch:
+    if _SQLITE_VEC_AVAILABLE and not vec_dim_mismatch:
         try:
             _backfill_vec_working_from_memory_embeddings(conn)
         except NameError:
@@ -1253,7 +1253,7 @@ def init_beam(db_path: Path = None) -> BeamInitResult:
     # Vector table for facts (sqlite-vec). Skipped on a dimension mismatch for the
     # same reason as vec_episodes / vec_working above (see the guard in the
     # sqlite-vec VIRTUAL TABLES block).
-    if not vec_dim_mismatch:
+    if _SQLITE_VEC_AVAILABLE and not vec_dim_mismatch:
         try:
             cursor.execute(f"""
                 CREATE VIRTUAL TABLE IF NOT EXISTS vec_facts USING vec0(

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -557,53 +557,73 @@ def _detect_vec_type(conn: sqlite3.Connection) -> str:
     return "float32"
 
 
-def _existing_vec_dim(conn: sqlite3.Connection) -> Optional[int]:
-    """Return the embedding dimension already declared by a sqlite-vec table in
-    this database, or ``None`` if no ``vec0`` table exists yet.
+_VEC_TABLE_NAMES = ("vec_episodes", "vec_working", "vec_facts")
+
+
+def _existing_vec_dims(conn: sqlite3.Connection) -> Tuple[Tuple[str, int], ...]:
+    """Return immutable stored dimensions for each recognized vector table.
 
     A ``vec0`` virtual table fixes its dimension at creation time, encoded in its
-    DDL as ``embedding <type>[<dim>]``. When a store already holds vectors, that
-    declared dimension -- not the process's configured ``EMBEDDING_DIM`` -- is the
-    source of truth for what the stored data actually is. Reads only
-    ``sqlite_master`` (no extension required) so it is safe to call before the
+    DDL as ``embedding <type>[<dim>]``. Read every known table in a fixed order:
+    legacy databases can contain a mixed index, and returning the first
+    ``sqlite_master`` row would make its status depend on catalog row order.
+    Reads only ``sqlite_master`` (no extension required), so it is safe before
     sqlite-vec tables are (re)created.
     """
     try:
         rows = conn.execute(
-            "SELECT sql FROM sqlite_master WHERE type = 'table' "
+            "SELECT name, sql FROM sqlite_master WHERE type = 'table' "
             "AND name IN ('vec_episodes', 'vec_working', 'vec_facts')"
         ).fetchall()
     except sqlite3.Error:
-        return None
-    for row in rows:
-        sql = row[0] if row else None
+        return ()
+
+    declared_dims = {}
+    for name, sql in rows:
         if not sql:
             continue
         match = re.search(r"\[(\d+)\]", sql)
         if match:
-            return int(match.group(1))
-    return None
+            declared_dims[name] = int(match.group(1))
+    return tuple((name, declared_dims[name]) for name in _VEC_TABLE_NAMES if name in declared_dims)
 
 
-def _dim_mismatch_message(existing_dim: int, configured_dim: int) -> str:
-    """Build the embedding-dimension-mismatch message.
+def _existing_vec_dim(conn: sqlite3.Connection) -> Optional[int]:
+    """Return a dimension only when all stored vector tables agree.
 
-    Extracted as a pure function so the wording -- explicitly NOT corruption plus
-    the exact self-heal commands -- is unit-testable without a sqlite-vec
-    database. The phrasing matters: 'dimension mismatch' is otherwise misread as
-    'database corrupt', and users (and agent frameworks) abandon the store
-    instead of reindexing.
+    Kept as a narrow compatibility helper for callers that only need a uniform
+    stored dimension. Mixed indexes have no honest scalar representation.
     """
+    stored_dims = _existing_vec_dims(conn)
+    dimensions = {dim for _, dim in stored_dims}
+    return dimensions.pop() if len(dimensions) == 1 else None
+
+
+def _dim_mismatch_message(
+    stored_dims: Tuple[Tuple[str, int], ...], configured_dim: int
+) -> str:
+    """Build an actionable message for uniform or mixed vector-index dimensions."""
+    stored_description = ", ".join(f"{table}={dim}" for table, dim in stored_dims)
+    dimensions = {dim for _, dim in stored_dims}
+    if len(dimensions) == 1:
+        existing_dim = next(iter(dimensions))
+        recovery_hint = (
+            f"  * Keep the existing {existing_dim}-dim vectors: relaunch with "
+            f"MNEMOSYNE_EMBEDDING_DIM={existing_dim} (and the matching model).\n"
+        )
+        index_description = f"This database stores {existing_dim}-dim vectors"
+    else:
+        recovery_hint = ""
+        index_description = f"This database has mixed vector-index dimensions ({stored_description})"
+
     return (
         f"Embedding dimension mismatch — NOT database corruption: your memories "
         f"are intact, only the vector index is affected (recall falls back to "
-        f"keyword search until this is fixed). This database stores "
-        f"{existing_dim}-dim vectors but this process is configured for "
-        f"{configured_dim}-dim (MNEMOSYNE_EMBEDDING_DIM / "
+        f"keyword search until this is fixed). {index_description} but this "
+        f"process is configured for {configured_dim}-dim (MNEMOSYNE_EMBEDDING_DIM / "
         f"MNEMOSYNE_EMBEDDING_MODEL); sqlite-vec tables were left untouched. To "
         f"self-heal, choose ONE:\n"
-        f"  * Keep the existing {existing_dim}-dim vectors: relaunch with "
-        f"MNEMOSYNE_EMBEDDING_DIM={existing_dim} (and the matching model).\n"
+        f"{recovery_hint}"
         f"  * Re-embed all memories at {configured_dim}-dim: run "
         f"`MNEMOSYNE_EMBEDDING_DIM={configured_dim} mnemosyne reindex` (it backs "
         f"up first).\n"
@@ -616,14 +636,16 @@ class BeamInitResult:
     """Outcome of BEAM schema initialization.
 
     This is additive status only: callers that ignore ``init_beam()``'s return
-    value retain the historical initialization behavior. A dimension mismatch
-    remains recoverable and does not prevent the non-vector schema from being
-    initialized.
+    value retain the historical initialization behavior. ``stored_dims`` is a
+    fixed-order immutable ``(table, dimension)`` tuple; ``existing_dim`` is set
+    only when those stored tables have one uniform dimension. A mismatch remains
+    recoverable and does not prevent the non-vector schema from being initialized.
     """
 
     vec_dim_mismatch: bool
     existing_dim: Optional[int]
     configured_dim: int
+    stored_dims: Tuple[Tuple[str, int], ...] = ()
 
 
 def init_beam(db_path: Path = None) -> BeamInitResult:
@@ -831,12 +853,12 @@ def init_beam(db_path: Path = None) -> BeamInitResult:
     # environment as the writer. Refuse to create mismatched tables, leave any
     # existing ones untouched, and surface one actionable error instead of
     # per-row insert noise; recall falls back to the float-JSON voice meanwhile.
-    existing_dim = _existing_vec_dim(conn)
-    vec_dim_mismatch = (
-        existing_dim is not None and existing_dim != EMBEDDING_DIM
-    )
-    if existing_dim is not None and vec_dim_mismatch:
-        logger.error(_dim_mismatch_message(existing_dim, EMBEDDING_DIM))
+    stored_dims = _existing_vec_dims(conn)
+    dimensions = {dim for _, dim in stored_dims}
+    existing_dim = dimensions.pop() if len(dimensions) == 1 else None
+    vec_dim_mismatch = any(dim != EMBEDDING_DIM for _, dim in stored_dims)
+    if vec_dim_mismatch:
+        logger.error(_dim_mismatch_message(stored_dims, EMBEDDING_DIM))
     if _SQLITE_VEC_AVAILABLE:
         if not vec_dim_mismatch:
             try:
@@ -1279,6 +1301,7 @@ def init_beam(db_path: Path = None) -> BeamInitResult:
         vec_dim_mismatch=vec_dim_mismatch,
         existing_dim=existing_dim,
         configured_dim=EMBEDDING_DIM,
+        stored_dims=stored_dims,
     )
 
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -611,8 +611,23 @@ def _dim_mismatch_message(existing_dim: int, configured_dim: int) -> str:
     )
 
 
-def init_beam(db_path: Path = None):
-    """Initialize BEAM schema."""
+@dataclass(frozen=True)
+class BeamInitResult:
+    """Outcome of BEAM schema initialization.
+
+    This is additive status only: callers that ignore ``init_beam()``'s return
+    value retain the historical initialization behavior. A dimension mismatch
+    remains recoverable and does not prevent the non-vector schema from being
+    initialized.
+    """
+
+    vec_dim_mismatch: bool
+    existing_dim: Optional[int]
+    configured_dim: int
+
+
+def init_beam(db_path: Path = None) -> BeamInitResult:
+    """Initialize BEAM schema and return its vector-index status."""
     conn = _get_connection(db_path)
     cursor = conn.cursor()
 
@@ -817,6 +832,7 @@ def init_beam(db_path: Path = None):
     # existing ones untouched, and surface one actionable error instead of
     # per-row insert noise; recall falls back to the float-JSON voice meanwhile.
     vec_dim_mismatch = False
+    existing_dim = None
     if _SQLITE_VEC_AVAILABLE:
         existing_dim = _existing_vec_dim(conn)
         if existing_dim is not None and existing_dim != EMBEDDING_DIM:
@@ -1258,6 +1274,12 @@ def init_beam(db_path: Path = None):
     _add_column_if_missing(conn, "episodic_memory", "corrected_by", "INTEGER DEFAULT NULL")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_wm_event_date ON working_memory(event_date)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_em_event_date ON episodic_memory(event_date)")
+
+    return BeamInitResult(
+        vec_dim_mismatch=vec_dim_mismatch,
+        existing_dim=existing_dim,
+        configured_dim=EMBEDDING_DIM,
+    )
 
 
 class _BeamConnection(sqlite3.Connection):
@@ -3453,7 +3475,7 @@ class BeamMemory:
         self._extraction_buffer = []  # Buffer for batch extraction
         self._event_emitter = event_emitter  # Streaming event callback
         self.conn = _get_connection(self.db_path)
-        init_beam(self.db_path)
+        self.init_result = init_beam(self.db_path)
 
         # E6: ensure schema split + auto-migrate legacy TripleStore rows
         # to AnnotationStore. Honors MNEMOSYNE_AUTO_MIGRATE=0 for operators

--- a/mnemosyne/core/memory.py
+++ b/mnemosyne/core/memory.py
@@ -385,6 +385,7 @@ class Mnemosyne:
                                author_id=author_id, author_type=author_type,
                                channel_id=channel_id,
                                event_emitter=self._stream_emit)
+        self.init_result = self.beam.init_result
         # ``self.conn`` remains the core module cache. _get_connection
         # coordinates it with BEAM, preserving core connection identity while
         # direct wrappers dual-write through one transaction-capable handle.

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -11,7 +11,9 @@ leaving existing tables untouched, rather than corrupting the store.
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+import json
 from pathlib import Path
+import sqlite3
 
 import pytest
 
@@ -43,9 +45,12 @@ def test_init_beam_returns_frozen_fresh_status(tmp_path, monkeypatch):
 
     result = beam.init_beam(Path(tmp_path) / "fresh-status.db")
 
-    assert result == beam.BeamInitResult(False, None, 384)
+    assert result == beam.BeamInitResult(False, None, 384, ())
     with pytest.raises(FrozenInstanceError):
         setattr(result, "configured_dim", 768)
+    assert result.stored_dims == ()
+    with pytest.raises(FrozenInstanceError):
+        setattr(result, "stored_dims", (("vec_episodes", 768),))
 
 
 def test_init_beam_skips_vec_creation_on_dim_mismatch(tmp_path, monkeypatch):
@@ -60,7 +65,7 @@ def test_init_beam_skips_vec_creation_on_dim_mismatch(tmp_path, monkeypatch):
     # Initialize the store at dimension 768.
     monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
     initial = beam.init_beam(db)
-    assert initial == beam.BeamInitResult(False, None, 768)
+    assert initial == beam.BeamInitResult(False, None, 768, ())
     conn = beam._get_connection(db)
 
     # Simulate a database written before vec_working and vec_facts existed.
@@ -79,7 +84,7 @@ def test_init_beam_skips_vec_creation_on_dim_mismatch(tmp_path, monkeypatch):
     )
     result = beam.init_beam(db)
 
-    assert result == beam.BeamInitResult(True, 768, 384)
+    assert result == beam.BeamInitResult(True, 768, 384, (("vec_episodes", 768),))
     assert backfill_calls == []
 
     # The guard must NOT have created either missing table at the wrong dimension.
@@ -121,7 +126,7 @@ def test_init_beam_reports_mismatch_when_sqlite_vec_is_unavailable(tmp_path, mon
 
     result = beam.init_beam(db)
 
-    assert result == beam.BeamInitResult(True, 768, 384)
+    assert result == beam.BeamInitResult(True, 768, 384, (("vec_episodes", 768),))
     assert backfill_calls == []
     assert conn.execute(
         "SELECT sql FROM sqlite_master WHERE name = 'vec_working'"
@@ -147,7 +152,7 @@ def test_init_beam_creates_vec_tables_when_dim_matches(tmp_path, monkeypatch):
         "SELECT sql FROM sqlite_master WHERE name = 'vec_working'"
     ).fetchone()
     assert working is not None and "[768]" in working[0]
-    assert result == beam.BeamInitResult(False, None, 768)
+    assert result == beam.BeamInitResult(False, None, 768, ())
 
 
 def test_init_beam_reports_match_and_constructor_preserves_status(tmp_path, monkeypatch):
@@ -164,7 +169,12 @@ def test_init_beam_reports_match_and_constructor_preserves_status(tmp_path, monk
     result = beam.init_beam(db)
     memory = beam.BeamMemory(session_id="status", db_path=db)
 
-    assert result == beam.BeamInitResult(False, 768, 768)
+    assert result == beam.BeamInitResult(
+        False,
+        768,
+        768,
+        (("vec_episodes", 768), ("vec_working", 768), ("vec_facts", 768)),
+    )
     assert memory.init_result == result
 
 
@@ -176,7 +186,14 @@ def test_mnemosyne_constructor_exposes_beam_init_status(tmp_path, monkeypatch):
 
     assert memory.init_result == memory.beam.init_result
     expected_existing_dim = 384 if beam._SQLITE_VEC_AVAILABLE else None
-    assert memory.init_result == beam.BeamInitResult(False, expected_existing_dim, 384)
+    expected_stored_dims = (
+        (("vec_episodes", 384), ("vec_working", 384), ("vec_facts", 384))
+        if beam._SQLITE_VEC_AVAILABLE
+        else ()
+    )
+    assert memory.init_result == beam.BeamInitResult(
+        False, expected_existing_dim, 384, expected_stored_dims
+    )
 
 
 def test_ignored_mismatch_result_recovers_after_matching_reinit(tmp_path, monkeypatch):
@@ -195,14 +212,87 @@ def test_ignored_mismatch_result_recovers_after_matching_reinit(tmp_path, monkey
 
     monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
     recovered = beam.init_beam(db)
-    assert recovered == beam.BeamInitResult(False, 768, 768)
+    assert recovered == beam.BeamInitResult(
+        False,
+        768,
+        768,
+        (("vec_episodes", 768), ("vec_working", 768), ("vec_facts", 768)),
+    )
 
 
 def test_dim_mismatch_message_is_self_healing():
     """The mismatch message says it is not corruption and gives recovery commands."""
-    msg = beam._dim_mismatch_message(existing_dim=768, configured_dim=384)
+    msg = beam._dim_mismatch_message((("vec_episodes", 768),), configured_dim=384)
     low = msg.lower()
     assert "not database corruption" in low, msg
     assert "mnemosyne reindex" in low, msg
     assert "mnemosyne_embedding_dim=" in low, msg
     assert "768" in msg and "384" in msg
+
+
+@pytest.mark.parametrize(
+    "creation_order",
+    [
+        ("vec_episodes", "vec_working", "vec_facts"),
+        ("vec_facts", "vec_working", "vec_episodes"),
+    ],
+)
+def test_init_beam_reports_mixed_stored_dims_without_sqlite_vec(
+    tmp_path, monkeypatch, caplog, creation_order
+):
+    """Mixed legacy indexes are order-independent and never gain new vec tables."""
+    db = Path(tmp_path) / "mixed-no-extension.db"
+    conn = beam._get_connection(db)
+    dimensions = {"vec_episodes": 768, "vec_working": 384, "vec_facts": 384}
+    for table in creation_order:
+        conn.execute(f"CREATE TABLE {table} (embedding int8[{dimensions[table]}])")
+    conn.commit()
+    before = dict(
+        conn.execute(
+            "SELECT name, sql FROM sqlite_master WHERE name IN "
+            "('vec_episodes', 'vec_working', 'vec_facts')"
+        )
+    )
+
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+    monkeypatch.setattr(beam, "_SQLITE_VEC_AVAILABLE", False)
+    backfill_calls = []
+    monkeypatch.setattr(
+        beam,
+        "_backfill_vec_working_from_memory_embeddings",
+        lambda backfill_conn: backfill_calls.append(backfill_conn),
+    )
+
+    result = beam.init_beam(db)
+
+    assert result == beam.BeamInitResult(
+        True,
+        None,
+        384,
+        (("vec_episodes", 768), ("vec_working", 384), ("vec_facts", 384)),
+    )
+    assert backfill_calls == []
+    assert dict(
+        conn.execute(
+            "SELECT name, sql FROM sqlite_master WHERE name IN "
+            "('vec_episodes', 'vec_working', 'vec_facts')"
+        )
+    ) == before
+    assert "mixed vector-index dimensions" in caplog.text
+    assert "vec_episodes=768, vec_working=384, vec_facts=384" in caplog.text
+
+
+def test_legacy_vec_episodes_rejects_configured_dimension_query(tmp_path):
+    """The mixed-state status protects the real sqlite-vec failure boundary."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        pytest.skip("sqlite-vec unavailable")
+
+    conn = beam._get_connection(Path(tmp_path) / "legacy-query.db")
+    conn.execute("CREATE VIRTUAL TABLE vec_episodes USING vec0(embedding int8[768])")
+
+    with pytest.raises(sqlite3.OperationalError, match="[Dd]imension mismatch"):
+        conn.execute(
+            "SELECT rowid FROM vec_episodes "
+            "WHERE embedding MATCH vec_quantize_int8(?, 'unit') AND k=1",
+            (json.dumps([0.0] * 384),),
+        ).fetchall()

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -141,7 +141,8 @@ def test_mnemosyne_constructor_exposes_beam_init_status(tmp_path, monkeypatch):
     memory = Mnemosyne(session_id="status", db_path=tmp_path / "mnemosyne.db")
 
     assert memory.init_result == memory.beam.init_result
-    assert memory.init_result == beam.BeamInitResult(False, 384, 384)
+    expected_existing_dim = 384 if beam._SQLITE_VEC_AVAILABLE else None
+    assert memory.init_result == beam.BeamInitResult(False, expected_existing_dim, 384)
 
 
 def test_ignored_mismatch_result_recovers_after_matching_reinit(tmp_path, monkeypatch):

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -3,15 +3,19 @@
 The dimension of a sqlite-vec ``vec0`` table is fixed at creation time. If a
 database already stores vectors at one dimension and the process is later
 configured (EMBEDDING_DIM) for a different one, creating a new ``vec0`` table at
-the configured dimension is silently wrong: every insert of a real vector then
+that configured dimension is silently wrong: every insert of a real vector then
 fails and recall reads an empty/incompatible index. init_beam() must detect the
 established dimension from the database and refuse to create mismatched tables,
 leaving existing tables untouched, rather than corrupting the store.
 """
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
+import pytest
+
+from mnemosyne.core.memory import Mnemosyne
 import mnemosyne.core.beam as beam
 
 
@@ -33,9 +37,19 @@ def test_existing_vec_dim_reads_declared_dimension(tmp_path):
     assert beam._existing_vec_dim(conn) == 768
 
 
+def test_init_beam_returns_frozen_fresh_status(tmp_path, monkeypatch):
+    """Fresh databases report their configured dimension without a mismatch."""
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+
+    result = beam.init_beam(Path(tmp_path) / "fresh-status.db")
+
+    assert result == beam.BeamInitResult(False, None, 384)
+    with pytest.raises(FrozenInstanceError):
+        setattr(result, "configured_dim", 768)
+
+
 def test_init_beam_skips_vec_creation_on_dim_mismatch(tmp_path, monkeypatch):
-    """init_beam() must not create vec0 tables at a dimension that disagrees with
-    vectors already stored in the database, and must leave existing tables alone."""
+    """A mismatch preserves tables and skips later vector-table backfill/creation."""
     if not beam._SQLITE_VEC_AVAILABLE:
         import pytest  # type: ignore
 
@@ -45,24 +59,36 @@ def test_init_beam_skips_vec_creation_on_dim_mismatch(tmp_path, monkeypatch):
 
     # Initialize the store at dimension 768.
     monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
-    beam.init_beam(db)
+    initial = beam.init_beam(db)
+    assert initial == beam.BeamInitResult(False, None, 768)
     conn = beam._get_connection(db)
 
-    # Simulate a database written before vec_working existed: only vec_episodes
-    # (at the real dimension, 768) remains.
+    # Simulate a database written before vec_working and vec_facts existed.
     conn.execute("DROP TABLE IF EXISTS vec_working")
+    conn.execute("DROP TABLE IF EXISTS vec_facts")
     conn.commit()
     assert beam._existing_vec_dim(conn) == 768
 
     # Reopen configured for a DIFFERENT dimension (the misconfiguration).
     monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
-    beam.init_beam(db)
+    backfill_calls = []
+    monkeypatch.setattr(
+        beam,
+        "_backfill_vec_working_from_memory_embeddings",
+        lambda backfill_conn: backfill_calls.append(backfill_conn),
+    )
+    result = beam.init_beam(db)
 
-    # The guard must NOT have created vec_working at the wrong dimension.
-    row = conn.execute(
+    assert result == beam.BeamInitResult(True, 768, 384)
+    assert backfill_calls == []
+
+    # The guard must NOT have created either missing table at the wrong dimension.
+    assert conn.execute(
         "SELECT sql FROM sqlite_master WHERE name = 'vec_working'"
-    ).fetchone()
-    assert row is None or "[384]" not in row[0]
+    ).fetchone() is None
+    assert conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'vec_facts'"
+    ).fetchone() is None
 
     # The existing data table is left untouched at its real dimension.
     ep = conn.execute(
@@ -72,8 +98,7 @@ def test_init_beam_skips_vec_creation_on_dim_mismatch(tmp_path, monkeypatch):
 
 
 def test_init_beam_creates_vec_tables_when_dim_matches(tmp_path, monkeypatch):
-    """When the configured dimension matches (or the DB is fresh), the vec0 tables
-    are created normally -- the guard must not be a false positive."""
+    """A fresh configured database creates vec tables normally."""
     if not beam._SQLITE_VEC_AVAILABLE:
         import pytest  # type: ignore
 
@@ -81,26 +106,68 @@ def test_init_beam_creates_vec_tables_when_dim_matches(tmp_path, monkeypatch):
 
     db = Path(tmp_path) / "match.db"
     monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
-    beam.init_beam(db)
+    result = beam.init_beam(db)
     conn = beam._get_connection(db)
 
     working = conn.execute(
         "SELECT sql FROM sqlite_master WHERE name = 'vec_working'"
     ).fetchone()
     assert working is not None and "[768]" in working[0]
+    assert result == beam.BeamInitResult(False, None, 768)
+
+
+def test_init_beam_reports_match_and_constructor_preserves_status(tmp_path, monkeypatch):
+    """Existing matching vec tables and normal construction expose status."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        import pytest  # type: ignore
+
+        pytest.skip("sqlite-vec unavailable")
+
+    db = Path(tmp_path) / "constructor-status.db"
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
+    beam.init_beam(db)  # Ignoring the new result remains compatible.
+
+    result = beam.init_beam(db)
+    memory = beam.BeamMemory(session_id="status", db_path=db)
+
+    assert result == beam.BeamInitResult(False, 768, 768)
+    assert memory.init_result == result
+
+
+def test_mnemosyne_constructor_exposes_beam_init_status(tmp_path, monkeypatch):
+    """The regular Mnemosyne API exposes the status produced by its BeamMemory."""
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+
+    memory = Mnemosyne(session_id="status", db_path=tmp_path / "mnemosyne.db")
+
+    assert memory.init_result == memory.beam.init_result
+    assert memory.init_result == beam.BeamInitResult(False, 384, 384)
+
+
+def test_ignored_mismatch_result_recovers_after_matching_reinit(tmp_path, monkeypatch):
+    """Ignoring a mismatch result does not block recovery after configuration repair."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        import pytest  # type: ignore
+
+        pytest.skip("sqlite-vec unavailable")
+
+    db = Path(tmp_path) / "recovery.db"
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
+    beam.init_beam(db)
+
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+    beam.init_beam(db)  # Historical ignored-return call pattern.
+
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
+    recovered = beam.init_beam(db)
+    assert recovered == beam.BeamInitResult(False, 768, 768)
 
 
 def test_dim_mismatch_message_is_self_healing():
-    """The mismatch message must say it is NOT corruption and give the exact
-    self-heal commands, so it is not misread as 'the database is corrupt'.
-
-    The original failure mode: users (and agent frameworks) read 'dimension
-    mismatch' as corruption and abandon the store instead of reindexing. The
-    message is a pure function so it can be unit-tested without sqlite-vec.
-    """
+    """The mismatch message says it is not corruption and gives recovery commands."""
     msg = beam._dim_mismatch_message(existing_dim=768, configured_dim=384)
     low = msg.lower()
     assert "not database corruption" in low, msg
     assert "mnemosyne reindex" in low, msg
     assert "mnemosyne_embedding_dim=" in low, msg
-    assert "768" in msg and "384" in msg, msg
+    assert "768" in msg and "384" in msg

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -97,6 +97,40 @@ def test_init_beam_skips_vec_creation_on_dim_mismatch(tmp_path, monkeypatch):
     assert ep is not None and "[768]" in ep[0]
 
 
+def test_init_beam_reports_mismatch_when_sqlite_vec_is_unavailable(tmp_path, monkeypatch):
+    """Status reads an existing vec0 dimension even without sqlite-vec available."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        pytest.skip("sqlite-vec unavailable")
+
+    db = Path(tmp_path) / "unavailable-status.db"
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
+    beam.init_beam(db)
+    conn = beam._get_connection(db)
+    conn.execute("DROP TABLE IF EXISTS vec_working")
+    conn.execute("DROP TABLE IF EXISTS vec_facts")
+    conn.commit()
+
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+    monkeypatch.setattr(beam, "_SQLITE_VEC_AVAILABLE", False)
+    backfill_calls = []
+    monkeypatch.setattr(
+        beam,
+        "_backfill_vec_working_from_memory_embeddings",
+        lambda backfill_conn: backfill_calls.append(backfill_conn),
+    )
+
+    result = beam.init_beam(db)
+
+    assert result == beam.BeamInitResult(True, 768, 384)
+    assert backfill_calls == []
+    assert conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'vec_working'"
+    ).fetchone() is None
+    assert conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'vec_facts'"
+    ).fetchone() is None
+
+
 def test_init_beam_creates_vec_tables_when_dim_matches(tmp_path, monkeypatch):
     """A fresh configured database creates vec tables normally."""
     if not beam._SQLITE_VEC_AVAILABLE:


### PR DESCRIPTION
## Summary

Fixes #874 by exposing BEAM vector initialization status as an additive Python contract.

`init_beam()` now returns a frozen result with the mismatch flag, stored vector dimension, and configured dimension. `BeamMemory` and `Mnemosyne` retain the result for normal construction paths.

## Behavior preserved

A dimension mismatch remains a usable degraded state:

- no exception and no CLI/MCP exit-code change
- existing vector tables remain untouched
- incompatible table creation and backfill remain suppressed
- keyword fallback and existing recovery logging remain intact

## Non-goals

- no automatic reindex or table mutation
- no Doctor/diagnose policy change
- no general vector-health API

## Verification

- fresh no-`sqlite-vec` test environment: `4 passed, 5 skipped`
- sqlite-vec environment: `9 passed`
- independent final review: approved
- Ruff and `git diff --check`: passed

The issue’s note that `doctor` already detects stored vector-dimension mismatch was corrected separately: it currently reports configured dimension and general coverage only. A read-only Doctor status field or opt-in strict mode is follow-up scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- `init_beam()` now returns an immutable `BeamInitResult`.
- The result reports mismatch status, stored dimensions, and configured dimension.
- `BeamMemory` and `Mnemosyne` expose the result through `init_result`.
- Mismatched vector indexes remain usable through keyword-only retrieval.
- Existing vector tables remain unchanged.
- Incompatible vector-table creation and backfill remain suppressed.
- Tests cover `sqlite-vec`, missing `sqlite-vec`, mixed dimensions, recovery, immutability, and propagation.

## Architecture and Integration

- The change affects BEAM vector initialization only.
- Working memory, episodic memory, consolidation, veracity, and sync behavior do not change.
- Retrieval remains degraded but usable when vector dimensions mismatch.
- Hermes, MCP, and CLI behavior remain unchanged, including exit codes.
- Agent integrations can inspect initialization status without parsing logs.
- No automatic reindexing or vector-table mutation is introduced.
- The additive result contract is the right call because it exposes degraded state without taking a usable store offline.

## Privacy and Local-First Design

- Privacy posture remains unchanged.
- Local-first guarantees remain unchanged.
- The change adds no remote service, telemetry, or external data path.
- Nothing in this PR erodes local-first design.

## Maintainability

- Immutable status data provides a stable programmatic contract.
- Dimension diagnostics cover recognized vector tables, including mixed stored dimensions.
- Existing recovery logging and degraded-mode behavior remain intact.
- Doctor policy and strict-mode behavior remain deferred.
- No benchmark methodology changes are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->