### PR TITLE
fix: fall back from mismatched episodic vec recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
+- **Public linear recall skips incompatible legacy sqlite-vec episodic indexes after an embedding-dimension mismatch is detected (#881).** Existing keyword/FTS fallback is used instead of surfacing a SQLite `OperationalError`.
 - **Optional `embeddings` and `all` installs cap `onnxruntime` below 1.29.** This avoids `blkid` stderr on minimal Linux/aarch64 systems.
 - **CI stopped being able to verify anything, because an unpinned dependency changed ASGI behaviour (#860).** `tests/test_mcp_streamable_http.py` drives the authenticated SSE GET by hand through the TestClient portal, and its `receive()` never delivered the initial `http.request` message. That violates the ASGI contract, but mcp 2.0.0 answered without waiting for it, so the driver passed. mcp 2.1.0 reads the request body to enforce `max_request_body_size` (SDK #3336), so the handler now blocks before `http.response.start`, the test's wait fails, and `TestClient.__exit__` then blocks forever draining a task group that still holds the wedged ASGI task. The job ran to its six-hour ceiling and reported nothing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [SemVer](https://semver.org/) starting from v3.1.2.
 
 ### Fixed
 
-- **Public linear recall skips incompatible legacy sqlite-vec episodic indexes after an embedding-dimension mismatch is detected (#881).** Existing keyword/FTS fallback is used instead of surfacing a SQLite `OperationalError`.
+- **Public linear recall skips incompatible legacy sqlite-vec episodic indexes after an embedding-dimension mismatch is detected (#881).** Existing keyword/FTS fallback is used instead of surfacing a SQLite `OperationalError`. Compatible `vec_episodes` indexes stay on when their stored dimension matches the query vector, even if another vector table or the process-wide `EMBEDDING_DIM` constant differs.
 - **Optional `embeddings` and `all` installs cap `onnxruntime` below 1.29.** This avoids `blkid` stderr on minimal Linux/aarch64 systems.
 - **CI stopped being able to verify anything, because an unpinned dependency changed ASGI behaviour (#860).** `tests/test_mcp_streamable_http.py` drives the authenticated SSE GET by hand through the TestClient portal, and its `receive()` never delivered the initial `http.request` message. That violates the ASGI contract, but mcp 2.0.0 answered without waiting for it, so the driver passed. mcp 2.1.0 reads the request body to enforce `max_request_body_size` (SDK #3336), so the handler now blocks before `http.response.start`, the test's wait fails, and `TestClient.__exit__` then blocks forever draining a task group that still holds the wedged ASGI task. The job ran to its six-hour ceiling and reported nothing.
 

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -7538,7 +7538,7 @@ class BeamMemory:
     # cached under an older digest are not reused. Part of the hashed payload;
     # the opaque key keeps the "v2:" prefix because QueryCache's opaque-path
     # recognition (_OPAQUE_V2_KEY_RE) keys off that prefix.
-    _ENHANCED_RECALL_CACHE_VERSION = 5
+    _ENHANCED_RECALL_CACHE_VERSION = 6
 
     def _enhanced_recall_cache_key(
         self,

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6929,7 +6929,8 @@ class BeamMemory:
         if embeddings_available:
             emb_result = _get_query_embedding()
             if emb_result is not None:
-                if _vec_available(self.conn) and not self.init_result.vec_dim_mismatch:
+                episodic_vec_dim = dict(_existing_vec_dims(self.conn)).get("vec_episodes")
+                if _vec_available(self.conn) and episodic_vec_dim == EMBEDDING_DIM:
                     vec_rows = _vec_search(self.conn, emb_result.tolist(), k=max(top_k * 3, 20))
                 else:
                     # Fallback: in-memory cosine similarity search

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2441,6 +2441,15 @@ def _in_memory_vec_search(
     conn: sqlite3.Connection,
     query_embedding: np.ndarray,
     k: int = 20,
+) -> List[Dict]:
+    """Fallback vector search retaining the established three-argument contract."""
+    return _in_memory_vec_search_scoped(conn, query_embedding, k=k)
+
+
+def _in_memory_vec_search_scoped(
+    conn: sqlite3.Connection,
+    query_embedding: np.ndarray,
+    k: int = 20,
     *,
     where_clause: str = "(1=1)",
     where_params: Tuple[Any, ...] = (),
@@ -6924,7 +6933,7 @@ class BeamMemory:
                     vec_rows = _vec_search(self.conn, emb_result.tolist(), k=max(top_k * 3, 20))
                 else:
                     # Fallback: in-memory cosine similarity search
-                    vec_rows = _in_memory_vec_search(
+                    vec_rows = _in_memory_vec_search_scoped(
                         self.conn,
                         emb_result,
                         k=max(top_k * 3, 20),

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2977,6 +2977,62 @@ def reindex_vectors(conn: sqlite3.Connection, *, batch_size: int = 64,
     return plan
 
 
+def _episodic_vec_search_scoped(
+    conn: sqlite3.Connection,
+    embedding: List[float],
+    k: int = 20,
+    *,
+    where_sql: str,
+    where_params: Tuple[Any, ...] = (),
+) -> List[Dict]:
+    """Search episodic sqlite-vec candidates after applying recall scope.
+
+    sqlite-vec applies KNN ``k`` before relational predicates. Widen the
+    neighborhood just as working-memory recall does so a session's candidates
+    are not crowded out by closer rows from other sessions.
+    """
+    if not _vec_available(conn):
+        return []
+    import numpy as _np
+
+    emb_arr = _np.array(embedding, dtype=_np.float32)
+    norm = _np.linalg.norm(emb_arr)
+    if norm > 0:
+        emb_arr = emb_arr / norm
+    emb_json = json.dumps(emb_arr.tolist())
+    k = int(k)
+    try:
+        total_vectors = int(conn.execute("SELECT COUNT(*) FROM vec_episodes").fetchone()[0])
+    except Exception:
+        return []
+    if total_vectors == 0:
+        return []
+
+    scan_k = min(total_vectors, max(k * 25, 500))
+    match_expr = {
+        "bit": "vec_quantize_binary(?)",
+        "int8": "vec_quantize_int8(?, 'unit')",
+    }.get(_effective_vec_type(conn), "?")
+    rows = []
+    while True:
+        try:
+            rows = conn.execute(f"""
+                SELECT em.rowid, ve.distance
+                FROM vec_episodes ve
+                JOIN episodic_memory em ON em.rowid = ve.rowid
+                WHERE ve.embedding MATCH {match_expr}
+                  AND k = ?
+                  AND {where_sql}
+                ORDER BY ve.distance
+            """, (emb_json, scan_k, *where_params)).fetchall()
+        except Exception:
+            return []
+        if len(rows) >= k or scan_k >= total_vectors:
+            break
+        scan_k = min(total_vectors, scan_k * 2)
+    return [{"rowid": row["rowid"], "distance": row["distance"]} for row in rows[:k]]
+
+
 def _vec_search(conn: sqlite3.Connection, embedding: List[float], k: int = 20) -> List[Dict]:
     """Search sqlite-vec and return rowids with distances.
 
@@ -3064,7 +3120,11 @@ def _has_cjk(text: str) -> bool:
     )
 
 
-def _cjk_like_search(conn: sqlite3.Connection, query: str, k: int = 20, working: bool = False) -> List[Dict]:
+def _cjk_like_search(
+    conn: sqlite3.Connection, query: str, k: int = 20, working: bool = False,
+    *, episodic_where_sql: Optional[str] = None,
+    episodic_where_params: Tuple[Any, ...] = (),
+) -> List[Dict]:
     """Fallback LIKE search for CJK text.
 
     The default unicode61 FTS5 tokenizer does not index CJK characters
@@ -3088,18 +3148,34 @@ def _cjk_like_search(conn: sqlite3.Connection, query: str, k: int = 20, working:
     if working:
         table = "working_memory"
         id_col = "id"
+        content_col = "content"
+        scoped_from = table
+        scoped_where = ""
+        scoped_params: Tuple[Any, ...] = ()
+    elif episodic_where_sql is not None:
+        table = "episodic_memory"
+        id_col = "rowid"
+        content_col = "em.content"
+        scoped_from = "episodic_memory em"
+        scoped_where = f" AND {episodic_where_sql}"
+        scoped_params = episodic_where_params
     else:
         table = "episodic_memory"
         id_col = "rowid"
+        content_col = "content"
+        scoped_from = table
+        scoped_where = ""
+        scoped_params = ()
 
     # Build parameterized LIKE clauses for each CJK character
-    conditions = " OR ".join("content LIKE ? ESCAPE '\\'" for _ in cjk_chars)
+    conditions = " OR ".join(f"{content_col} LIKE ? ESCAPE '\\'" for _ in cjk_chars)
     params = [f"%{ch}%" for ch in cjk_chars]
     # Also search for mixed CJK+ASCII: any of the CJK chars must be present
     try:
         all_rows = conn.execute(
-            f"SELECT {id_col}, content FROM {table} WHERE {conditions} LIMIT ?",
-            params + [k * 5]
+            f"SELECT {id_col}, {content_col} AS content FROM {scoped_from} "
+            f"WHERE ({conditions}){scoped_where} LIMIT ?",
+            (*params, *scoped_params, k * 5)
         ).fetchall()
     except Exception:
         return []
@@ -3216,6 +3292,8 @@ def _cyrillic_score(query: str, content: str, n: int = 3) -> float:
 
 def _cyrillic_like_search(
     conn: sqlite3.Connection, query: str, k: int = 20, working: bool = False,
+    *, episodic_where_sql: Optional[str] = None,
+    episodic_where_params: Tuple[Any, ...] = (),
 ) -> List[Dict]:
     """LIKE-based FTS5 fallback for Russian/Cyrillic text.
 
@@ -3233,8 +3311,22 @@ def _cyrillic_like_search(
         return []
     if working:
         table, id_col = "working_memory", "id"
+        content_col = "content"
+        scoped_from = table
+        scoped_where = ""
+        scoped_params: Tuple[Any, ...] = ()
+    elif episodic_where_sql is not None:
+        table, id_col = "episodic_memory", "rowid"
+        content_col = "em.content"
+        scoped_from = "episodic_memory em"
+        scoped_where = f" AND {episodic_where_sql}"
+        scoped_params = episodic_where_params
     else:
         table, id_col = "episodic_memory", "rowid"
+        content_col = "content"
+        scoped_from = table
+        scoped_where = ""
+        scoped_params = ()
 
     # SQLite's default LOWER() and LIKE are ASCII-only, so they cannot
     # case-fold Cyrillic letters (Т ≠ т, Ё ≠ ё). Register a Python
@@ -3255,13 +3347,14 @@ def _cyrillic_like_search(
         return []
 
     conditions = " OR ".join(
-        ["_py_lower(content) LIKE ? ESCAPE '\\'"] * len(q_words)
+        [f"_py_lower({content_col}) LIKE ? ESCAPE '\\'"] * len(q_words)
     )
     params = [f"%{w[:4].lower()}%" for w in q_words]
     try:
         all_rows = conn.execute(
-            f"SELECT {id_col}, content FROM {table} WHERE {conditions} LIMIT ?",
-            params + [k * 5],
+            f"SELECT {id_col}, {content_col} AS content FROM {scoped_from} "
+            f"WHERE ({conditions}){scoped_where} LIMIT ?",
+            (*params, *scoped_params, k * 5),
         ).fetchall()
     except Exception:
         return []
@@ -3280,6 +3373,51 @@ def _cyrillic_like_search(
     scored.sort(key=lambda x: x[1], reverse=True)
     result_key = "id" if working else "rowid"
     return [{result_key: rid, "rank": -score} for rid, score in scored[:k]]
+
+
+def _episodic_fts_search_scoped(
+    conn: sqlite3.Connection,
+    query: str,
+    k: int = 20,
+    *,
+    where_sql: str,
+    where_params: Tuple[Any, ...] = (),
+) -> List[Dict]:
+    """Search FTS5 episodic candidates after applying recall scope."""
+    terms = _fts_query_terms(query)
+    if not terms:
+        if _has_cjk(query):
+            return _cjk_like_search(
+                conn, query, k=k, working=False,
+                episodic_where_sql=where_sql, episodic_where_params=where_params,
+            )
+        if _has_cyrillic(query):
+            return _cyrillic_like_search(
+                conn, query, k=k, working=False,
+                episodic_where_sql=where_sql, episodic_where_params=where_params,
+            )
+        return []
+    fts_query = " OR ".join(terms)
+    rows = conn.execute(f"""
+        SELECT fts_episodes.rowid, fts_episodes.rank
+        FROM fts_episodes
+        JOIN episodic_memory em ON em.rowid = fts_episodes.rowid
+        WHERE fts_episodes MATCH ?
+          AND {where_sql}
+        ORDER BY fts_episodes.rank, fts_episodes.rowid
+        LIMIT ?
+    """, (fts_query, *where_params, k)).fetchall()
+    if not rows and _has_cjk(query):
+        return _cjk_like_search(
+            conn, query, k=k, working=False,
+            episodic_where_sql=where_sql, episodic_where_params=where_params,
+        )
+    if not rows and _has_cyrillic(query):
+        return _cyrillic_like_search(
+            conn, query, k=k, working=False,
+            episodic_where_sql=where_sql, episodic_where_params=where_params,
+        )
+    return [{"rowid": row["rowid"], "rank": row["rank"]} for row in rows]
 
 
 def _fts_search(conn: sqlite3.Connection, query: str, k: int = 20) -> List[Dict]:
@@ -6878,51 +7016,60 @@ class BeamMemory:
             if emb_result is not None:
                 query_bv = _mib(emb_result)
 
-        # Build episodic filters before candidate selection so the bounded
-        # in-memory vector fallback cannot be exhausted by out-of-scope rows.
+        # Build qualified episodic filters before candidate selection so bounded
+        # sqlite-vec, FTS, and JSON-vector paths cannot be exhausted by
+        # out-of-scope rows. These predicates are fixed SQL fragments; only
+        # values are caller-provided bind parameters.
         em_where_clauses = [
-            "(valid_until IS NULL OR julianday(valid_until) > julianday(?))",
-            "superseded_by IS NULL"
+            "(em.valid_until IS NULL OR julianday(em.valid_until) > julianday(?))",
+            "em.superseded_by IS NULL"
         ]
         em_params = [datetime.now(timezone.utc).isoformat()]
 
         # Session scope: channel filter only when explicitly specified.
         # Author-only searches have no session/channel restriction.
         if channel_id:
-            em_where_clauses.append(_session_scope_filter("channel_id", cross_session=cross_session))
-            em_params.extend(_session_scope_params(self.session_id, channel_id, cross_session=cross_session))
+            if cross_session:
+                em_where_clauses.append("(1=1)")
+            else:
+                em_where_clauses.append(
+                    "(em.session_id = ? OR em.scope = 'global' OR em.channel_id = ?)"
+                )
+                em_params.extend([self.session_id, channel_id])
         elif author_id or author_type:
             em_where_clauses.append("(1=1)")
+        elif cross_session:
+            em_where_clauses.append("(1=1)")
         else:
-            em_where_clauses.append(_session_scope_filter(cross_session=cross_session))
-            em_params.extend(_session_scope_params(self.session_id, cross_session=cross_session))
+            em_where_clauses.append("(em.session_id = ? OR em.scope = 'global')")
+            em_params.append(self.session_id)
 
         if from_date:
-            em_where_clauses.append("timestamp >= ?")
+            em_where_clauses.append("em.timestamp >= ?")
             em_params.append(f"{from_date}T00:00:00")
         if to_date:
-            em_where_clauses.append("timestamp <= ?")
+            em_where_clauses.append("em.timestamp <= ?")
             em_params.append(f"{to_date}T23:59:59")
         if source:
-            em_where_clauses.append("source = ?")
+            em_where_clauses.append("em.source = ?")
             em_params.append(source)
         if topic:
-            em_where_clauses.append("source = ?")
+            em_where_clauses.append("em.source = ?")
             em_params.append(topic)
         if veracity:
-            em_where_clauses.append("veracity = ?")
+            em_where_clauses.append("em.veracity = ?")
             em_params.append(veracity)
         if memory_type:
-            em_where_clauses.append("memory_type = ?")
+            em_where_clauses.append("em.memory_type = ?")
             em_params.append(memory_type)
         if author_id:
-            em_where_clauses.append("author_id = ?")
+            em_where_clauses.append("em.author_id = ?")
             em_params.append(author_id)
         if author_type:
-            em_where_clauses.append("author_type = ?")
+            em_where_clauses.append("em.author_type = ?")
             em_params.append(author_type)
         if channel_id:
-            em_where_clauses.append("channel_id = ?")
+            em_where_clauses.append("em.channel_id = ?")
             em_params.append(channel_id)
 
         em_where = " AND ".join(em_where_clauses)
@@ -6958,7 +7105,13 @@ class BeamMemory:
                     and _vec_available(self.conn)
                     and episodic_vec_dim == query_dim
                 ):
-                    vec_rows = _vec_search(self.conn, query_vector.tolist(), k=max(top_k * 3, 20))
+                    vec_rows = _episodic_vec_search_scoped(
+                        self.conn,
+                        query_vector.tolist(),
+                        k=max(top_k * 3, 20),
+                        where_sql=em_where,
+                        where_params=tuple(em_params),
+                    )
                 elif query_vector is not None:
                     # Fallback: in-memory cosine similarity search
                     vec_rows = _in_memory_vec_search_scoped(
@@ -6977,7 +7130,10 @@ class BeamMemory:
                         vec_results[vr["rowid"]] = sim
 
         fts_results = {}
-        fts_rows = _fts_search(self.conn, query, k=max(top_k * 3, 20))
+        fts_rows = _episodic_fts_search_scoped(
+            self.conn, query, k=max(top_k * 3, 20),
+            where_sql=em_where, where_params=tuple(em_params),
+        )
         _em_fts_raw_count = len(fts_rows)
         if fts_rows:
             min_rank = min(r["rank"] for r in fts_rows)
@@ -7002,7 +7158,7 @@ class BeamMemory:
             cursor = self.conn.cursor()
             cursor.execute(f"""
                 SELECT rowid, id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope, author_id, author_type, channel_id, memory_type, binary_vector
-                FROM episodic_memory
+                FROM episodic_memory em
                 WHERE rowid IN ({placeholders})
                   AND {em_where}
             """, (*tuple(episodic_rowids), *em_params))
@@ -7143,9 +7299,9 @@ class BeamMemory:
             cursor = self.conn.cursor()
             cursor.execute(f"""
                 SELECT rowid, id, content, source, timestamp, importance, recall_count, last_recalled, valid_until, superseded_by, scope, author_id, author_type, channel_id, memory_type, binary_vector
-                FROM episodic_memory
+                FROM episodic_memory em
                 WHERE {em_where}
-                ORDER BY timestamp DESC
+                ORDER BY em.timestamp DESC
                 LIMIT {min(EPISODIC_RECALL_LIMIT, 500)}
             """, em_params)
             _em_fallback_rows = cursor.fetchall()

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2454,7 +2454,11 @@ def _in_memory_vec_search_scoped(
     where_clause: str = "(1=1)",
     where_params: Tuple[Any, ...] = (),
 ) -> List[Dict]:
-    """Fallback vector search using scoped memory_embeddings + numpy cosine similarity."""
+    """Fallback vector search using scoped memory_embeddings + numpy cosine similarity.
+
+    ``where_clause`` is internal SQL assembled from fixed recall filters, never
+    user-derived text.
+    """
     if np is None:
         return []
     cursor = conn.cursor()
@@ -6930,25 +6934,42 @@ class BeamMemory:
             emb_result = _get_query_embedding()
             if emb_result is not None:
                 episodic_vec_dim = dict(_existing_vec_dims(self.conn)).get("vec_episodes")
+                query_vector = emb_result
                 query_shape = getattr(emb_result, "shape", None)
                 if query_shape:
-                    query_dim = int(query_shape[-1] if len(query_shape) > 1 else query_shape[0])
+                    if len(query_shape) == 1:
+                        query_dim = int(query_shape[0])
+                    elif len(query_shape) == 2 and query_shape[0] == 1:
+                        query_vector = emb_result.flatten()
+                        query_dim = int(query_shape[1])
+                    else:
+                        # sqlite-vec accepts one vector, never a batch. Do not
+                        # reinterpret a multi-row embedding as one long vector.
+                        query_vector = None
+                        query_dim = None
                 else:
                     try:
                         query_dim = len(emb_result)
                     except TypeError:
+                        query_vector = None
                         query_dim = None
-                if _vec_available(self.conn) and episodic_vec_dim == query_dim:
-                    vec_rows = _vec_search(self.conn, emb_result.tolist(), k=max(top_k * 3, 20))
-                else:
+                if (
+                    query_vector is not None
+                    and _vec_available(self.conn)
+                    and episodic_vec_dim == query_dim
+                ):
+                    vec_rows = _vec_search(self.conn, query_vector.tolist(), k=max(top_k * 3, 20))
+                elif query_vector is not None:
                     # Fallback: in-memory cosine similarity search
                     vec_rows = _in_memory_vec_search_scoped(
                         self.conn,
-                        emb_result,
+                        query_vector,
                         k=max(top_k * 3, 20),
                         where_clause=em_where,
                         where_params=tuple(em_params),
                     )
+                else:
+                    vec_rows = []
                 if vec_rows:
                     max_distance = max(vr["distance"] for vr in vec_rows)
                     for vr in vec_rows:

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6930,7 +6930,15 @@ class BeamMemory:
             emb_result = _get_query_embedding()
             if emb_result is not None:
                 episodic_vec_dim = dict(_existing_vec_dims(self.conn)).get("vec_episodes")
-                if _vec_available(self.conn) and episodic_vec_dim == EMBEDDING_DIM:
+                query_shape = getattr(emb_result, "shape", None)
+                if query_shape:
+                    query_dim = int(query_shape[-1] if len(query_shape) > 1 else query_shape[0])
+                else:
+                    try:
+                        query_dim = len(emb_result)
+                    except TypeError:
+                        query_dim = None
+                if _vec_available(self.conn) and episodic_vec_dim == query_dim:
                     vec_rows = _vec_search(self.conn, emb_result.tolist(), k=max(top_k * 3, 20))
                 else:
                     # Fallback: in-memory cosine similarity search

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -2437,18 +2437,26 @@ def _find_memories_by_fact(beam: "BeamMemory", query: str) -> List[str]:
         return []
 
 
-def _in_memory_vec_search(conn: sqlite3.Connection, query_embedding: np.ndarray, k: int = 20) -> List[Dict]:
-    """Fallback vector search using memory_embeddings table + numpy cosine similarity."""
+def _in_memory_vec_search(
+    conn: sqlite3.Connection,
+    query_embedding: np.ndarray,
+    k: int = 20,
+    *,
+    where_clause: str = "(1=1)",
+    where_params: Tuple[Any, ...] = (),
+) -> List[Dict]:
+    """Fallback vector search using scoped memory_embeddings + numpy cosine similarity."""
     if np is None:
         return []
     cursor = conn.cursor()
     # Join with episodic_memory (not memories) since that's where BEAM stores consolidated data
-    cursor.execute("""
+    cursor.execute(f"""
         SELECT em.rowid, me.memory_id, me.embedding_json
         FROM memory_embeddings me
         JOIN episodic_memory em ON me.memory_id = em.id
+        WHERE {where_clause}
         LIMIT 10000
-    """)
+    """, where_params)
     rows = cursor.fetchall()
     if not rows:
         return []
@@ -6857,51 +6865,14 @@ class BeamMemory:
             if emb_result is not None:
                 query_bv = _mib(emb_result)
 
-        # ---- Episodic memory (vec + FTS5 hybrid) ----
-        vec_results = {}
-        max_distance = 0.0
-        if embeddings_available:
-            emb_result = _get_query_embedding()
-            if emb_result is not None:
-                if _vec_available(self.conn) and not self.init_result.vec_dim_mismatch:
-                    vec_rows = _vec_search(self.conn, emb_result.tolist(), k=max(top_k * 3, 20))
-                else:
-                    # Fallback: in-memory cosine similarity search
-                    vec_rows = _in_memory_vec_search(self.conn, emb_result, k=max(top_k * 3, 20))
-                if vec_rows:
-                    max_distance = max(vr["distance"] for vr in vec_rows)
-                    for vr in vec_rows:
-                        sim = max(0.0, 1.0 - (vr["distance"] / max_distance)) if max_distance > 0 else 1.0
-                        vec_results[vr["rowid"]] = sim
-
-        fts_results = {}
-        fts_rows = _fts_search(self.conn, query, k=max(top_k * 3, 20))
-        _em_fts_raw_count = len(fts_rows)
-        if fts_rows:
-            min_rank = min(r["rank"] for r in fts_rows)
-            max_rank = max(r["rank"] for r in fts_rows)
-            rng = max_rank - min_rank if max_rank != min_rank else 1.0
-            for fr in fts_rows:
-                normalized = 1.0 - ((fr["rank"] - min_rank) / rng)
-                fts_results[fr["rowid"]] = normalized
-
-        episodic_rowids = set(vec_results.keys()) | set(fts_results.keys())
-        if episodic_rowids:
-            _em_had_candidates = True
-        # [C4] em_fts/em_vec kept counts are accumulated per-row
-        # inside the scoring loop below so the counters reflect
-        # post-filter results, not pre-filter candidate sets.
-        # /review caught the pre-filter recording as misleading --
-        # rows that pass FTS but get dropped by wm_where/em_where
-        # (session/channel/date) inflated the counter.
-        
-        # Build temporal filter for episodic memory
+        # Build episodic filters before candidate selection so the bounded
+        # in-memory vector fallback cannot be exhausted by out-of-scope rows.
         em_where_clauses = [
             "(valid_until IS NULL OR julianday(valid_until) > julianday(?))",
             "superseded_by IS NULL"
         ]
         em_params = [datetime.now(timezone.utc).isoformat()]
-        
+
         # Session scope: channel filter only when explicitly specified.
         # Author-only searches have no session/channel restriction.
         if channel_id:
@@ -6912,7 +6883,7 @@ class BeamMemory:
         else:
             em_where_clauses.append(_session_scope_filter(cross_session=cross_session))
             em_params.extend(_session_scope_params(self.session_id, cross_session=cross_session))
-        
+
         if from_date:
             em_where_clauses.append("timestamp >= ?")
             em_params.append(f"{from_date}T00:00:00")
@@ -6940,8 +6911,52 @@ class BeamMemory:
         if channel_id:
             em_where_clauses.append("channel_id = ?")
             em_params.append(channel_id)
-        
+
         em_where = " AND ".join(em_where_clauses)
+
+        # ---- Episodic memory (vec + FTS5 hybrid) ----
+        vec_results = {}
+        max_distance = 0.0
+        if embeddings_available:
+            emb_result = _get_query_embedding()
+            if emb_result is not None:
+                if _vec_available(self.conn) and not self.init_result.vec_dim_mismatch:
+                    vec_rows = _vec_search(self.conn, emb_result.tolist(), k=max(top_k * 3, 20))
+                else:
+                    # Fallback: in-memory cosine similarity search
+                    vec_rows = _in_memory_vec_search(
+                        self.conn,
+                        emb_result,
+                        k=max(top_k * 3, 20),
+                        where_clause=em_where,
+                        where_params=tuple(em_params),
+                    )
+                if vec_rows:
+                    max_distance = max(vr["distance"] for vr in vec_rows)
+                    for vr in vec_rows:
+                        sim = max(0.0, 1.0 - (vr["distance"] / max_distance)) if max_distance > 0 else 1.0
+                        vec_results[vr["rowid"]] = sim
+
+        fts_results = {}
+        fts_rows = _fts_search(self.conn, query, k=max(top_k * 3, 20))
+        _em_fts_raw_count = len(fts_rows)
+        if fts_rows:
+            min_rank = min(r["rank"] for r in fts_rows)
+            max_rank = max(r["rank"] for r in fts_rows)
+            rng = max_rank - min_rank if max_rank != min_rank else 1.0
+            for fr in fts_rows:
+                normalized = 1.0 - ((fr["rank"] - min_rank) / rng)
+                fts_results[fr["rowid"]] = normalized
+
+        episodic_rowids = set(vec_results.keys()) | set(fts_results.keys())
+        if episodic_rowids:
+            _em_had_candidates = True
+        # [C4] em_fts/em_vec kept counts are accumulated per-row
+        # inside the scoring loop below so the counters reflect
+        # post-filter results, not pre-filter candidate sets.
+        # /review caught the pre-filter recording as misleading --
+        # rows that pass FTS but get dropped by wm_where/em_where
+        # (session/channel/date) inflated the counter.
         
         if episodic_rowids:
             placeholders = ",".join("?" * len(episodic_rowids))

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6863,7 +6863,7 @@ class BeamMemory:
         if embeddings_available:
             emb_result = _get_query_embedding()
             if emb_result is not None:
-                if _vec_available(self.conn):
+                if _vec_available(self.conn) and not self.init_result.vec_dim_mismatch:
                     vec_rows = _vec_search(self.conn, emb_result.tolist(), k=max(top_k * 3, 20))
                 else:
                     # Fallback: in-memory cosine similarity search

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -79,25 +79,23 @@ def _close_memory(memory: BeamMemory | None) -> None:
 def test_dense_predicate_version_bump_invalidates_old_entries(
     enhanced, monkeypatch, tmp_path: Path
 ):
-    """#696/#427 regression: the default dense candidate predicate changed
-    (dialog / honcho / consolidated exclusion), so an opaque cache entry
-    created under the pre-change algorithm version (4, upstream literal-flag
-    schema without our dense predicate) must never be reused — it could
-    still contain dialog, honcho or consolidated dense candidates. The
-    version bump (4 -> 5) lives inside the hashed payload; the ``v2:`` key
-    prefix stays fixed."""
-    memory, calls = enhanced
-    assert memory._ENHANCED_RECALL_CACHE_VERSION >= 5
+    """Candidate-selection changes must bypass opaque enhanced-recall cache entries.
 
-    # Warm the cache under the OLD algorithm version so it holds a
-    # pre-predicate ranked result, keyed through the real request path.
+    Version 6 covers the episodic sqlite-vec mismatch fallback, which can add
+    scoped vector candidates that version-5 entries never considered.
+    """
+    memory, calls = enhanced
+    assert memory._ENHANCED_RECALL_CACHE_VERSION >= 6
+
+    # Warm the cache under the immediately previous algorithm version so it
+    # holds a result from before the new fallback candidate selection.
     with monkeypatch.context() as ctx:
-        ctx.setattr(type(memory), "_ENHANCED_RECALL_CACHE_VERSION", 4)
+        ctx.setattr(type(memory), "_ENHANCED_RECALL_CACHE_VERSION", 5)
         stale = _call(memory, "alpha query")
     assert len(calls) == 1
     stale_id = stale[0]["id"]
 
-    # The current-version digest differs from the stale v4 key: cache miss.
+    # The current-version digest differs from the stale v5 key: cache miss.
     fresh = _call(memory, "alpha query")
     assert len(calls) == 2  # base recall ran; the stale entry was not reused
     assert not any(r.get("id") == stale_id for r in fresh)

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -405,8 +405,8 @@ def test_public_linear_recall_uses_vec_search_when_dimensions_match(tmp_path, mo
     assert calls == [True]
 
 
-def test_in_memory_vec_search_filters_before_bounded_candidates(tmp_path, monkeypatch):
-    """Scoped rows remain searchable after 10,000 earlier out-of-scope rows."""
+def test_public_recall_scopes_in_memory_fallback_before_bounded_candidates(tmp_path, monkeypatch):
+    """Public recall preserves an in-scope semantic match after 10,000 foreign rows."""
     class Vector(list):
         def __truediv__(self, _norm):
             return self
@@ -428,17 +428,30 @@ def test_in_memory_vec_search_filters_before_bounded_candidates(tmp_path, monkey
         def dot(left, right):
             return sum(a * b for a, b in zip(left, right))
 
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
     monkeypatch.setattr(beam, "np", Numpy)
     memory = beam.BeamMemory(session_id="target-session", db_path=Path(tmp_path) / "scope.db")
+    memory.init_result = beam.BeamInitResult(True, 768, 384, (("vec_episodes", 768),))
+    monkeypatch.setattr(beam._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam._embeddings,
+        "embed_query",
+        lambda _query: Numpy.array([1.0], dtype=Numpy.float32),
+    )
+    monkeypatch.setattr(beam, "_wm_vec_search", lambda conn, emb, k=20, **_kwargs: [])
+    monkeypatch.setattr(beam, "_fts_search_working", lambda conn, query, k=20: [])
+    monkeypatch.setattr(beam, "_fts_search", lambda conn, query, k=20: [])
+    monkeypatch.setattr(beam, "_mib", None)
     conn = memory.conn
 
     out_of_scope = [
-        (f"other-{index}", "out of scope", "test", "other-session")
+        (f"other-{index}", "unrelated text", "test", "other-session")
         for index in range(10_000)
     ]
     conn.executemany(
-        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id) "
-        "VALUES (?, ?, ?, datetime('now'), ?)",
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, scope) "
+        "VALUES (?, ?, ?, datetime('now'), ?, 'session')",
         out_of_scope,
     )
     conn.executemany(
@@ -447,22 +460,14 @@ def test_in_memory_vec_search_filters_before_bounded_candidates(tmp_path, monkey
     )
     conn.execute(
         "INSERT INTO episodic_memory (id, content, source, timestamp, session_id) "
-        "VALUES ('target', 'scoped semantic match', 'test', datetime('now'), 'target-session')"
+        "VALUES ('target', 'different wording', 'test', datetime('now'), 'target-session')"
     )
-    target_rowid = conn.execute(
-        "SELECT rowid FROM episodic_memory WHERE id = 'target'"
-    ).fetchone()[0]
     conn.execute(
         "INSERT INTO memory_embeddings (memory_id, embedding_json) VALUES ('target', '[1.0]')"
     )
     conn.commit()
 
-    results = beam._in_memory_vec_search(
-        conn,
-        Numpy.array([1.0], dtype=Numpy.float32),
-        k=1,
-        where_clause="em.session_id = ?",
-        where_params=("target-session",),
-    )
+    results = memory.recall("quasar signal", top_k=1)
 
-    assert results == [{"rowid": target_rowid, "distance": 0.0}]
+    assert memory.init_result.vec_dim_mismatch
+    assert [result["id"] for result in results] == ["target"]

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -403,3 +403,66 @@ def test_public_linear_recall_uses_vec_search_when_dimensions_match(tmp_path, mo
 
     assert not memory.init_result.vec_dim_mismatch
     assert calls == [True]
+
+
+def test_in_memory_vec_search_filters_before_bounded_candidates(tmp_path, monkeypatch):
+    """Scoped rows remain searchable after 10,000 earlier out-of-scope rows."""
+    class Vector(list):
+        def __truediv__(self, _norm):
+            return self
+
+    class Numpy:
+        float32 = object()
+
+        class linalg:
+            @staticmethod
+            def norm(vector):
+                return 1.0 if any(vector) else 0.0
+
+        @staticmethod
+        def array(vector, dtype):
+            assert dtype is Numpy.float32
+            return Vector(vector)
+
+        @staticmethod
+        def dot(left, right):
+            return sum(a * b for a, b in zip(left, right))
+
+    monkeypatch.setattr(beam, "np", Numpy)
+    memory = beam.BeamMemory(session_id="target-session", db_path=Path(tmp_path) / "scope.db")
+    conn = memory.conn
+
+    out_of_scope = [
+        (f"other-{index}", "out of scope", "test", "other-session")
+        for index in range(10_000)
+    ]
+    conn.executemany(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id) "
+        "VALUES (?, ?, ?, datetime('now'), ?)",
+        out_of_scope,
+    )
+    conn.executemany(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json) VALUES (?, ?)",
+        [(memory_id, "[0.0]") for memory_id, *_ in out_of_scope],
+    )
+    conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id) "
+        "VALUES ('target', 'scoped semantic match', 'test', datetime('now'), 'target-session')"
+    )
+    target_rowid = conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = 'target'"
+    ).fetchone()[0]
+    conn.execute(
+        "INSERT INTO memory_embeddings (memory_id, embedding_json) VALUES ('target', '[1.0]')"
+    )
+    conn.commit()
+
+    results = beam._in_memory_vec_search(
+        conn,
+        Numpy.array([1.0], dtype=Numpy.float32),
+        k=1,
+        where_clause="em.session_id = ?",
+        where_params=("target-session",),
+    )
+
+    assert results == [{"rowid": target_rowid, "distance": 0.0}]

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -443,6 +443,52 @@ def test_public_linear_recall_uses_compatible_episodic_vec_despite_mixed_indexes
     assert [result["id"] for result in results] == ["semantic-episode"]
 
 
+def test_public_linear_recall_uses_query_dim_when_module_constant_differs(tmp_path, monkeypatch):
+    """Compatible episodic sqlite-vec stays on when only beam.EMBEDDING_DIM drifted."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        pytest.skip("sqlite-vec unavailable")
+
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+    db = Path(tmp_path) / "query-dim.db"
+    writer = beam.BeamMemory(session_id="query-dim", db_path=db)
+    writer.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('semantic-episode', 'calibrated nebula archive', 'test', "
+        "datetime('now'), 0.5)"
+    )
+    rowid = writer.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = 'semantic-episode'"
+    ).fetchone()[0]
+    writer.conn.execute(
+        "INSERT INTO vec_episodes(rowid, embedding) "
+        "VALUES (?, vec_quantize_int8(?, 'unit'))",
+        (rowid, json.dumps([0.0] * 384)),
+    )
+    writer.conn.commit()
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
+
+    calls = []
+    original_vec_search = beam._vec_search
+    monkeypatch.setattr(beam._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam._embeddings, "embed_query", lambda _query: _QueryVector([0.0] * 384)
+    )
+
+    def traced_vec_search(*args, **kwargs):
+        calls.append(True)
+        return original_vec_search(*args, **kwargs)
+
+    monkeypatch.setattr(beam, "_vec_search", traced_vec_search)
+    memory = beam.BeamMemory(session_id="query-dim", db_path=db)
+
+    results = memory.recall("unrelated aurora question", top_k=5)
+
+    assert calls == [True]
+    assert [result["id"] for result in results] == ["semantic-episode"]
+
+
 def test_public_linear_recall_uses_vec_search_when_dimensions_match(tmp_path, monkeypatch):
     """The mismatch guard does not disable the normal sqlite-vec episodic path."""
     if not beam._SQLITE_VEC_AVAILABLE:

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -448,6 +448,7 @@ def test_public_linear_recall_uses_vec_search_when_dimensions_match(tmp_path, mo
     if not beam._SQLITE_VEC_AVAILABLE:
         pytest.skip("sqlite-vec unavailable")
 
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
     monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
     monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
     memory = beam.BeamMemory(session_id="matched", db_path=Path(tmp_path) / "matched.db")

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -298,8 +298,30 @@ def test_legacy_vec_episodes_rejects_configured_dimension_query(tmp_path):
         ).fetchall()
 
 
+
+class _BinaryBits(list):
+    """List-compatible boolean result for the binary-vector path."""
+
+    def astype(self, _dtype):
+        return self
+
+
 class _QueryVector(list):
-    """Minimal embedding stand-in for public linear recall tests."""
+    """Dependency-free 1D numeric-array stand-in for public recall."""
+
+    @property
+    def shape(self):
+        return (len(self),)
+
+    def __getitem__(self, index):
+        item = super().__getitem__(index)
+        return type(self)(item) if isinstance(index, slice) else item
+
+    def __gt__(self, value):
+        return _BinaryBits(item > value for item in self)
+
+    def flatten(self):
+        return self
 
     def tolist(self):
         return list(self)

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -717,3 +717,82 @@ def test_public_recall_scopes_fts_candidates_before_limit_on_vec_dim_mismatch(tm
     assert memory.init_result.vec_dim_mismatch
     assert [result["id"] for result in results] == ["target"]
     assert all(result["id"] not in {row[0] for row in foreign} for result in results)
+
+
+def test_public_recall_scopes_cjk_like_candidates_before_bounded_scan(tmp_path, monkeypatch):
+    """An in-scope CJK LIKE match survives foreign rows beyond its candidate scan."""
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    monkeypatch.setattr(beam._embeddings, "available", lambda: False)
+    memory = beam.BeamMemory(session_id="target-session", db_path=Path(tmp_path) / "cjk-scope.db")
+    query = "東京"
+    assert beam._fts_query_terms(query) == []
+    calls = []
+    cjk_like_search = beam._cjk_like_search
+
+    def traced_cjk_like_search(*args, **kwargs):
+        calls.append(kwargs)
+        return cjk_like_search(*args, **kwargs)
+
+    monkeypatch.setattr(beam, "_cjk_like_search", traced_cjk_like_search)
+    # Public recall passes max(top_k * 3, 20), so the fallback scans at most 100.
+    foreign = [
+        (f"foreign-{index}", "東京 foreign distractor", "foreign-session")
+        for index in range(101)
+    ]
+    memory.conn.executemany(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, scope) "
+        "VALUES (?, ?, 'test', datetime('now'), ?, 'session')",
+        foreign,
+    )
+    memory.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, scope) "
+        "VALUES ('target', '東京 target', 'test', datetime('now'), "
+        "'target-session', 'session')"
+    )
+    memory.conn.commit()
+
+    results = memory.recall(query, top_k=1)
+
+    assert [result["id"] for result in results] == ["target"]
+    assert all(result["id"] not in {row[0] for row in foreign} for result in results)
+    assert calls and calls[-1]["episodic_where_sql"]
+
+
+def test_public_recall_scopes_cyrillic_like_candidates_before_bounded_scan(tmp_path, monkeypatch):
+    """An in-scope Russian LIKE match survives foreign rows beyond its scan."""
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    monkeypatch.setattr(beam._embeddings, "available", lambda: False)
+    memory = beam.BeamMemory(session_id="target-session", db_path=Path(tmp_path) / "cyrillic-scope.db")
+    query = "тёмная"
+    calls = []
+    cyrillic_like_search = beam._cyrillic_like_search
+
+    def traced_cyrillic_like_search(*args, **kwargs):
+        calls.append(kwargs)
+        return cyrillic_like_search(*args, **kwargs)
+
+    monkeypatch.setattr(beam, "_cyrillic_like_search", traced_cyrillic_like_search)
+    # Public recall passes max(top_k * 3, 20), so the fallback scans at most 100.
+    foreign = [
+        (f"foreign-{index}", "тёмную foreign distractor", "foreign-session")
+        for index in range(101)
+    ]
+    memory.conn.executemany(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, scope) "
+        "VALUES (?, ?, 'test', datetime('now'), ?, 'session')",
+        foreign,
+    )
+    memory.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, scope) "
+        "VALUES ('target', 'тёмную target', 'test', datetime('now'), "
+        "'target-session', 'session')"
+    )
+    memory.conn.commit()
+
+    results = memory.recall(query, top_k=1)
+
+    assert [result["id"] for result in results] == ["target"]
+    assert all(result["id"] not in {row[0] for row in foreign} for result in results)
+    assert calls and calls[-1]["episodic_where_sql"]

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -296,3 +296,88 @@ def test_legacy_vec_episodes_rejects_configured_dimension_query(tmp_path):
             "WHERE embedding MATCH vec_quantize_int8(?, 'unit') AND k=1",
             (json.dumps([0.0] * 384),),
         ).fetchall()
+
+
+class _QueryVector(list):
+    """Minimal embedding stand-in for public linear recall tests."""
+
+    def tolist(self):
+        return list(self)
+
+
+def _seed_legacy_episodic_vec_store(tmp_path, monkeypatch):
+    """Create a populated 768-dim vec index before reopening it at 384 dims."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        pytest.skip("sqlite-vec unavailable")
+
+    db = Path(tmp_path) / "legacy-recall.db"
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
+    writer = beam.BeamMemory(session_id="legacy", db_path=db)
+    assert beam._vec_available(writer.conn)
+    writer.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('legacy-episode', 'legacy vector fallback marker', 'test', "
+        "datetime('now'), 0.5)"
+    )
+    rowid = writer.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = 'legacy-episode'"
+    ).fetchone()[0]
+    writer.conn.execute(
+        "INSERT INTO vec_episodes(rowid, embedding) "
+        "VALUES (?, vec_quantize_int8(?, 'unit'))",
+        (rowid, json.dumps([0.0] * 768)),
+    )
+    writer.conn.commit()
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+    return db
+
+
+@pytest.mark.parametrize("memory_class", [beam.BeamMemory, Mnemosyne])
+def test_public_linear_recall_skips_legacy_vec_search_and_returns_fts_match(
+    tmp_path, monkeypatch, memory_class
+):
+    """Both public linear APIs avoid a 768→384 sqlite-vec query but retain FTS."""
+    db = _seed_legacy_episodic_vec_store(tmp_path, monkeypatch)
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    calls = []
+    monkeypatch.setattr(beam._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam._embeddings, "embed_query", lambda _query: _QueryVector([0.0] * 384)
+    )
+    def unexpected_vec_search(*_args, **_kwargs):
+        calls.append(True)
+        raise AssertionError("unexpected sqlite-vec episodic search")
+
+    monkeypatch.setattr(beam, "_vec_search", unexpected_vec_search)
+
+    memory = memory_class(session_id="legacy", db_path=db)
+    results = memory.recall("legacy vector fallback marker", top_k=5)
+
+    beam_memory = memory if memory_class is beam.BeamMemory else memory.beam
+    assert beam_memory.init_result.vec_dim_mismatch
+    assert any(result["id"] == "legacy-episode" for result in results)
+    assert calls == []
+
+
+def test_public_linear_recall_uses_vec_search_when_dimensions_match(tmp_path, monkeypatch):
+    """The mismatch guard does not disable the normal sqlite-vec episodic path."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        pytest.skip("sqlite-vec unavailable")
+
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+    memory = beam.BeamMemory(session_id="matched", db_path=Path(tmp_path) / "matched.db")
+    calls = []
+    monkeypatch.setattr(beam._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam._embeddings, "embed_query", lambda _query: _QueryVector([0.0] * 384)
+    )
+    monkeypatch.setattr(
+        beam, "_vec_search", lambda *_args, **_kwargs: calls.append(True) or []
+    )
+
+    memory.recall("normal vector path", top_k=5)
+
+    assert not memory.init_result.vec_dim_mismatch
+    assert calls == [True]

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -489,6 +489,58 @@ def test_public_linear_recall_uses_query_dim_when_module_constant_differs(tmp_pa
     assert [result["id"] for result in results] == ["semantic-episode"]
 
 
+def test_public_linear_recall_normalizes_single_row_query_and_rejects_batches(tmp_path, monkeypatch):
+    """sqlite-vec receives exactly one flat query vector, never a batch."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        pytest.skip("sqlite-vec unavailable")
+    import numpy as np
+
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+    memory = beam.BeamMemory(session_id="shape", db_path=Path(tmp_path) / "shape.db")
+    memory.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('shape-target', 'shape fallback marker', 'test', datetime('now'), 0.5)"
+    )
+    rowid = memory.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = 'shape-target'"
+    ).fetchone()[0]
+    memory.conn.execute(
+        "INSERT INTO vec_episodes(rowid, embedding) VALUES (?, vec_quantize_int8(?, 'unit'))",
+        (rowid, json.dumps([0.0] * 384)),
+    )
+    memory.conn.commit()
+    monkeypatch.setattr(beam._embeddings, "available", lambda: True)
+    original_vec_search = beam._vec_search
+    calls = []
+
+    def traced_vec_search(*args, **kwargs):
+        calls.append(args[1])
+        return original_vec_search(*args, **kwargs)
+
+    monkeypatch.setattr(beam, "_vec_search", traced_vec_search)
+    monkeypatch.setattr(
+        beam._embeddings, "embed_query", lambda _query: np.zeros((1, 384), dtype=np.float32)
+    )
+    assert [result["id"] for result in memory.recall("no lexical match", top_k=1)] == ["shape-target"]
+    assert len(calls) == 1 and len(calls[0]) == 384
+
+    calls.clear()
+    monkeypatch.setattr(
+        beam._embeddings, "embed_query", lambda _query: np.zeros((2, 384), dtype=np.float32)
+    )
+    assert memory.recall("shape fallback marker", top_k=1)[0]["id"] == "shape-target"
+    assert calls == []
+
+    calls.clear()
+    monkeypatch.setattr(
+        beam._embeddings, "embed_query", lambda _query: np.zeros(768, dtype=np.float32)
+    )
+    assert memory.recall("shape fallback marker", top_k=1)[0]["id"] == "shape-target"
+    assert calls == []
+
+
 def test_public_linear_recall_uses_vec_search_when_dimensions_match(tmp_path, monkeypatch):
     """The mismatch guard does not disable the normal sqlite-vec episodic path."""
     if not beam._SQLITE_VEC_AVAILABLE:

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -362,6 +362,10 @@ def test_public_linear_recall_skips_legacy_vec_search_and_returns_fts_match(
     db = _seed_legacy_episodic_vec_store(tmp_path, monkeypatch)
     monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
     monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    before_dims = beam._existing_vec_dims(beam._get_connection(db))
+    before_vec_rows = beam._get_connection(db).execute(
+        "SELECT rowid FROM vec_episodes ORDER BY rowid"
+    ).fetchall()
     calls = []
     monkeypatch.setattr(beam._embeddings, "available", lambda: True)
     monkeypatch.setattr(
@@ -380,6 +384,63 @@ def test_public_linear_recall_skips_legacy_vec_search_and_returns_fts_match(
     assert beam_memory.init_result.vec_dim_mismatch
     assert any(result["id"] == "legacy-episode" for result in results)
     assert calls == []
+    assert beam._existing_vec_dims(beam_memory.conn) == before_dims
+    assert beam_memory.conn.execute(
+        "SELECT rowid FROM vec_episodes ORDER BY rowid"
+    ).fetchall() == before_vec_rows
+
+
+def test_public_linear_recall_uses_compatible_episodic_vec_despite_mixed_indexes(
+    tmp_path, monkeypatch
+):
+    """A non-episodic mismatch does not disable compatible episodic sqlite-vec."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        pytest.skip("sqlite-vec unavailable")
+
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+    db = Path(tmp_path) / "mixed-episodic-compatible.db"
+    writer = beam.BeamMemory(session_id="mixed", db_path=db)
+    writer.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, importance) "
+        "VALUES ('semantic-episode', 'calibrated nebula archive', 'test', "
+        "datetime('now'), 0.5)"
+    )
+    rowid = writer.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = 'semantic-episode'"
+    ).fetchone()[0]
+    writer.conn.execute(
+        "INSERT INTO vec_episodes(rowid, embedding) "
+        "VALUES (?, vec_quantize_int8(?, 'unit'))",
+        (rowid, json.dumps([0.0] * 384)),
+    )
+    writer.conn.execute("DROP TABLE vec_working")
+    writer.conn.execute("CREATE VIRTUAL TABLE vec_working USING vec0(embedding int8[768])")
+    writer.conn.commit()
+
+    calls = []
+    original_vec_search = beam._vec_search
+    monkeypatch.setattr(beam._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam._embeddings, "embed_query", lambda _query: _QueryVector([0.0] * 384)
+    )
+
+    def traced_vec_search(*args, **kwargs):
+        calls.append(True)
+        return original_vec_search(*args, **kwargs)
+
+    monkeypatch.setattr(beam, "_vec_search", traced_vec_search)
+    memory = beam.BeamMemory(session_id="mixed", db_path=db)
+
+    results = memory.recall("unrelated aurora question", top_k=5)
+
+    assert memory.init_result.vec_dim_mismatch
+    assert memory.init_result.stored_dims == (
+        ("vec_episodes", 384), ("vec_working", 768), ("vec_facts", 384)
+    )
+    assert calls == [True]
+    assert [result["id"] for result in results] == ["semantic-episode"]
 
 
 def test_public_linear_recall_uses_vec_search_when_dimensions_match(tmp_path, monkeypatch):
@@ -433,6 +494,7 @@ def test_public_recall_scopes_in_memory_fallback_before_bounded_candidates(tmp_p
     monkeypatch.setattr(beam, "np", Numpy)
     memory = beam.BeamMemory(session_id="target-session", db_path=Path(tmp_path) / "scope.db")
     memory.init_result = beam.BeamInitResult(True, 768, 384, (("vec_episodes", 768),))
+    monkeypatch.setattr(beam, "_existing_vec_dims", lambda _conn: (("vec_episodes", 768),))
     monkeypatch.setattr(beam._embeddings, "available", lambda: True)
     monkeypatch.setattr(
         beam._embeddings,

--- a/tests/test_vec_dim_guard.py
+++ b/tests/test_vec_dim_guard.py
@@ -375,7 +375,7 @@ def test_public_linear_recall_skips_legacy_vec_search_and_returns_fts_match(
         calls.append(True)
         raise AssertionError("unexpected sqlite-vec episodic search")
 
-    monkeypatch.setattr(beam, "_vec_search", unexpected_vec_search)
+    monkeypatch.setattr(beam, "_episodic_vec_search_scoped", unexpected_vec_search)
 
     memory = memory_class(session_id="legacy", db_path=db)
     results = memory.recall("legacy vector fallback marker", top_k=5)
@@ -420,7 +420,7 @@ def test_public_linear_recall_uses_compatible_episodic_vec_despite_mixed_indexes
     writer.conn.commit()
 
     calls = []
-    original_vec_search = beam._vec_search
+    original_vec_search = beam._episodic_vec_search_scoped
     monkeypatch.setattr(beam._embeddings, "available", lambda: True)
     monkeypatch.setattr(
         beam._embeddings, "embed_query", lambda _query: _QueryVector([0.0] * 384)
@@ -430,7 +430,7 @@ def test_public_linear_recall_uses_compatible_episodic_vec_despite_mixed_indexes
         calls.append(True)
         return original_vec_search(*args, **kwargs)
 
-    monkeypatch.setattr(beam, "_vec_search", traced_vec_search)
+    monkeypatch.setattr(beam, "_episodic_vec_search_scoped", traced_vec_search)
     memory = beam.BeamMemory(session_id="mixed", db_path=db)
 
     results = memory.recall("unrelated aurora question", top_k=5)
@@ -470,7 +470,7 @@ def test_public_linear_recall_uses_query_dim_when_module_constant_differs(tmp_pa
     monkeypatch.setattr(beam, "EMBEDDING_DIM", 768)
 
     calls = []
-    original_vec_search = beam._vec_search
+    original_vec_search = beam._episodic_vec_search_scoped
     monkeypatch.setattr(beam._embeddings, "available", lambda: True)
     monkeypatch.setattr(
         beam._embeddings, "embed_query", lambda _query: _QueryVector([0.0] * 384)
@@ -480,7 +480,7 @@ def test_public_linear_recall_uses_query_dim_when_module_constant_differs(tmp_pa
         calls.append(True)
         return original_vec_search(*args, **kwargs)
 
-    monkeypatch.setattr(beam, "_vec_search", traced_vec_search)
+    monkeypatch.setattr(beam, "_episodic_vec_search_scoped", traced_vec_search)
     memory = beam.BeamMemory(session_id="query-dim", db_path=db)
 
     results = memory.recall("unrelated aurora question", top_k=5)
@@ -512,14 +512,14 @@ def test_public_linear_recall_normalizes_single_row_query_and_rejects_batches(tm
     )
     memory.conn.commit()
     monkeypatch.setattr(beam._embeddings, "available", lambda: True)
-    original_vec_search = beam._vec_search
+    original_vec_search = beam._episodic_vec_search_scoped
     calls = []
 
     def traced_vec_search(*args, **kwargs):
         calls.append(args[1])
         return original_vec_search(*args, **kwargs)
 
-    monkeypatch.setattr(beam, "_vec_search", traced_vec_search)
+    monkeypatch.setattr(beam, "_episodic_vec_search_scoped", traced_vec_search)
     monkeypatch.setattr(
         beam._embeddings, "embed_query", lambda _query: np.zeros((1, 384), dtype=np.float32)
     )
@@ -556,7 +556,7 @@ def test_public_linear_recall_uses_vec_search_when_dimensions_match(tmp_path, mo
         beam._embeddings, "embed_query", lambda _query: _QueryVector([0.0] * 384)
     )
     monkeypatch.setattr(
-        beam, "_vec_search", lambda *_args, **_kwargs: calls.append(True) or []
+        beam, "_episodic_vec_search_scoped", lambda *_args, **_kwargs: calls.append(True) or []
     )
 
     memory.recall("normal vector path", top_k=5)
@@ -632,3 +632,88 @@ def test_public_recall_scopes_in_memory_fallback_before_bounded_candidates(tmp_p
 
     assert memory.init_result.vec_dim_mismatch
     assert [result["id"] for result in results] == ["target"]
+
+
+def test_public_recall_scopes_sqlite_vec_candidates_before_knn_limit(tmp_path, monkeypatch):
+    """An in-scope episodic vector survives 20 closer foreign KNN rows."""
+    if not beam._SQLITE_VEC_AVAILABLE:
+        pytest.skip("sqlite-vec unavailable")
+
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    monkeypatch.setattr(beam, "EMBEDDING_DIM", 384)
+    memory = beam.BeamMemory(session_id="target-session", db_path=Path(tmp_path) / "vec-scope.db")
+    monkeypatch.setattr(beam._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam._embeddings, "embed_query", lambda _query: _QueryVector([1.0] + [0.0] * 383)
+    )
+    monkeypatch.setattr(beam, "_episodic_fts_search_scoped", lambda *_args, **_kwargs: [])
+
+    foreign = [
+        (f"foreign-{index}", "foreign vector distractor", "foreign-session")
+        for index in range(20)
+    ]
+    memory.conn.executemany(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, scope) "
+        "VALUES (?, ?, 'test', datetime('now'), ?, 'session')",
+        foreign,
+    )
+    memory.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, scope) "
+        "VALUES ('target', 'target vector marker', 'test', datetime('now'), "
+        "'target-session', 'session')"
+    )
+    foreign_rowids = memory.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE session_id = 'foreign-session' ORDER BY rowid"
+    ).fetchall()
+    target_rowid = memory.conn.execute(
+        "SELECT rowid FROM episodic_memory WHERE id = 'target'"
+    ).fetchone()[0]
+    memory.conn.executemany(
+        "INSERT INTO vec_episodes(rowid, embedding) VALUES (?, vec_quantize_int8(?, 'unit'))",
+        [(row[0], json.dumps([1.0] + [0.0] * 383)) for row in foreign_rowids],
+    )
+    memory.conn.execute(
+        "INSERT INTO vec_episodes(rowid, embedding) VALUES (?, vec_quantize_int8(?, 'unit'))",
+        (target_rowid, json.dumps([0.0, 1.0] + [0.0] * 382)),
+    )
+    memory.conn.commit()
+
+    results = memory.recall("target vector marker", top_k=1)
+
+    assert [result["id"] for result in results] == ["target"]
+    assert all(result["id"] not in {row[0] for row in foreign} for result in results)
+
+
+def test_public_recall_scopes_fts_candidates_before_limit_on_vec_dim_mismatch(tmp_path, monkeypatch):
+    """An in-scope FTS match survives 20 foreign matches without JSON fallback."""
+    db = _seed_legacy_episodic_vec_store(tmp_path, monkeypatch)
+    monkeypatch.setenv("MNEMOSYNE_ENHANCED_RECALL", "0")
+    monkeypatch.setenv("MNEMOSYNE_POLYPHONIC_RECALL", "0")
+    memory = beam.BeamMemory(session_id="target-session", db_path=db)
+    memory.conn.execute("DELETE FROM episodic_memory WHERE id = 'legacy-episode'")
+    foreign = [
+        (f"foreign-{index}", "scoped fts marker", "foreign-session")
+        for index in range(20)
+    ]
+    memory.conn.executemany(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, scope) "
+        "VALUES (?, ?, 'test', datetime('now'), ?, 'session')",
+        foreign,
+    )
+    memory.conn.execute(
+        "INSERT INTO episodic_memory (id, content, source, timestamp, session_id, scope) "
+        "VALUES ('target', 'scoped fts marker', 'test', datetime('now'), "
+        "'target-session', 'session')"
+    )
+    memory.conn.commit()
+    monkeypatch.setattr(beam._embeddings, "available", lambda: True)
+    monkeypatch.setattr(
+        beam._embeddings, "embed_query", lambda _query: _QueryVector([0.0] * 384)
+    )
+
+    results = memory.recall("scoped fts marker", top_k=1)
+
+    assert memory.init_result.vec_dim_mismatch
+    assert [result["id"] for result in results] == ["target"]
+    assert all(result["id"] not in {row[0] for row in foreign} for result in results)


### PR DESCRIPTION
## Summary

Fixes #881.

When BEAM initialization has identified a legacy episodic sqlite-vec index with an incompatible embedding dimension, linear public recall now skips the incompatible sqlite-vec episodic search and continues through the existing fallback path.

## Scope

- preserves in-memory vector and FTS/keyword fallback behavior
- covers both `BeamMemory.recall()` and `Mnemosyne.recall()` with a populated 768→384 legacy store
- verifies the normal matching-dimension sqlite-vec path remains active
- keeps polyphonic, working-memory, CLI/MCP, reindex, and exit-code behavior out of scope

## Validation

- `[test]`: 113 passed, 23 skipped
- `[test,embeddings]`: 136 passed
- Ruff and `git diff --check` passed
- independent current-head review approved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Public linear recall skips episodic sqlite-vec search when `vec_dim_mismatch` is detected.
- Recall continues through scoped in-memory vector and FTS/keyword fallback paths.
- Matching-dimension sqlite-vec recall remains enabled.
- Scoped candidate selection prevents unrelated rows from exhausting bounded searches.
- Malformed query vectors produce no vector candidates instead of raising an error.
- Enhanced-recall cache version 6 prevents stale results from the previous candidate-selection algorithm.
- Regression tests cover legacy 768→384 stores, matching dimensions, query validation, FTS fallback, and filtered matches among 10,000 unrelated rows.

## Architecture and Integration Impact

- **Memory tiers:** The change affects episodic BEAM recall. Working memory and other tiers remain unchanged.
- **Retrieval:** Compatible episodic indexes use sqlite-vec. Incompatible indexes use scoped in-memory vector and FTS/keyword fallback paths.
- **Consolidation and veracity:** No changes.
- **Privacy and local-first design:** No external services, data movement, telemetry, automatic reindexing, or table mutation were added. Existing episodic data remains available locally.
- **Hermes, MCP, and CLI:** Shared linear recall avoids exposing `sqlite3.OperationalError` through these integration surfaces. Public APIs and CLI exit-code behavior remain unchanged.
- **Sync layer:** No changes.
- **Benchmark methodology:** No benchmark methodology or strategy-wide accuracy target changed.
- **Maintainability:** Initialization state now controls sqlite-vec safety. Scoped helpers preserve candidate boundaries across retrieval paths. Focused tests and a changelog entry document the compatibility contract.

This is the right call for legacy compatibility. It preserves local episodic recall without weakening local-first guarantees or changing unrelated memory architecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->