### PR TITLE
fix: cache Hermes config reads

### DIFF
--- a/mnemosyne/hermes_config.py
+++ b/mnemosyne/hermes_config.py
@@ -7,6 +7,52 @@ from pathlib import Path
 from typing import Any
 
 
+_ConfigFingerprint = tuple[int, int, int, int, int]
+_CONFIG_CACHE: dict[Path, tuple[_ConfigFingerprint, dict[str, Any]]] = {}
+
+
+def _config_fingerprint(config_path: Path) -> _ConfigFingerprint:
+    """Return a replacement-sensitive fingerprint for a config file."""
+    stat = config_path.stat()
+    return (stat.st_dev, stat.st_ino, stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
+
+
+def _load_hermes_config(config_path: Path, yaml: Any) -> dict[str, Any] | None:
+    """Load a safe YAML mapping, reusing it only while its file is unchanged."""
+    try:
+        fingerprint = _config_fingerprint(config_path)
+    except OSError:
+        _CONFIG_CACHE.pop(config_path, None)
+        return None
+
+    cached = _CONFIG_CACHE.get(config_path)
+    if cached is not None and cached[0] == fingerprint:
+        return cached[1]
+
+    try:
+        loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+        with config_path.open() as config_file:
+            config = yaml.load(config_file, Loader=loader)
+    except Exception:
+        _CONFIG_CACHE.pop(config_path, None)
+        return None
+
+    if config is None:
+        config = {}
+    if not isinstance(config, dict):
+        return {}
+
+    try:
+        parsed_fingerprint = _config_fingerprint(config_path)
+    except OSError:
+        _CONFIG_CACHE.pop(config_path, None)
+        return None
+    if parsed_fingerprint != fingerprint:
+        return config
+    _CONFIG_CACHE[config_path] = (parsed_fingerprint, config)
+    return config
+
+
 def read_hermes_config_key(hermes_home: str | None, key: str) -> Any:
     """Read ``memory.mnemosyne.<key>`` from a Hermes ``config.yaml``.
 
@@ -18,20 +64,18 @@ def read_hermes_config_key(hermes_home: str | None, key: str) -> Any:
     # hermes_home=...). HERMES_HOME is the explicit active-profile authority in
     # that phase; do not fall back to ~/.hermes, which could cross profiles.
     resolved_home = hermes_home or os.environ.get("HERMES_HOME")
-    config_path = os.path.join(resolved_home, "config.yaml") if resolved_home else ""
-    if not config_path or not os.path.exists(config_path):
+    config_path = Path(resolved_home, "config.yaml").resolve() if resolved_home else None
+    if config_path is None:
         return None
     try:
         import yaml
     except ImportError:
-        return read_config_key_without_yaml(config_path, key)
+        return read_config_key_without_yaml(str(config_path), key)
 
-    try:
-        with open(config_path) as f:
-            config = yaml.safe_load(f) or {}
-    except Exception:
+    config = _load_hermes_config(config_path, yaml)
+    if config is None:
         return None
-    memory = config.get("memory") if isinstance(config, dict) else None
+    memory = config.get("memory")
     memory = memory if isinstance(memory, dict) else {}
     mnemosyne = memory.get("mnemosyne")
     mnemosyne = mnemosyne if isinstance(mnemosyne, dict) else {}

--- a/mnemosyne/hermes_config.py
+++ b/mnemosyne/hermes_config.py
@@ -11,10 +11,14 @@ _ConfigFingerprint = tuple[int, int, int, int, int]
 _CONFIG_CACHE: dict[Path, tuple[_ConfigFingerprint, dict[str, Any]]] = {}
 
 
+def _fingerprint_from_stat(stat: os.stat_result) -> _ConfigFingerprint:
+    """Return a replacement-sensitive fingerprint from a stat result."""
+    return (stat.st_dev, stat.st_ino, stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
+
+
 def _config_fingerprint(config_path: Path) -> _ConfigFingerprint:
     """Return a replacement-sensitive fingerprint for a config file."""
-    stat = config_path.stat()
-    return (stat.st_dev, stat.st_ino, stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
+    return _fingerprint_from_stat(config_path.stat())
 
 
 def _load_hermes_config(config_path: Path, yaml: Any) -> dict[str, Any] | None:
@@ -32,6 +36,7 @@ def _load_hermes_config(config_path: Path, yaml: Any) -> dict[str, Any] | None:
     try:
         loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
         with config_path.open() as config_file:
+            read_fingerprint = _fingerprint_from_stat(os.fstat(config_file.fileno()))
             config = yaml.load(config_file, Loader=loader)
     except Exception:
         _CONFIG_CACHE.pop(config_path, None)
@@ -40,6 +45,7 @@ def _load_hermes_config(config_path: Path, yaml: Any) -> dict[str, Any] | None:
     if config is None:
         config = {}
     if not isinstance(config, dict):
+        _CONFIG_CACHE.pop(config_path, None)
         return {}
 
     try:
@@ -47,9 +53,10 @@ def _load_hermes_config(config_path: Path, yaml: Any) -> dict[str, Any] | None:
     except OSError:
         _CONFIG_CACHE.pop(config_path, None)
         return None
-    if parsed_fingerprint != fingerprint:
+    if parsed_fingerprint != read_fingerprint:
+        _CONFIG_CACHE.pop(config_path, None)
         return config
-    _CONFIG_CACHE[config_path] = (parsed_fingerprint, config)
+    _CONFIG_CACHE[config_path] = (read_fingerprint, config)
     return config
 
 
@@ -64,8 +71,11 @@ def read_hermes_config_key(hermes_home: str | None, key: str) -> Any:
     # hermes_home=...). HERMES_HOME is the explicit active-profile authority in
     # that phase; do not fall back to ~/.hermes, which could cross profiles.
     resolved_home = hermes_home or os.environ.get("HERMES_HOME")
-    config_path = Path(resolved_home, "config.yaml").resolve() if resolved_home else None
-    if config_path is None:
+    if not resolved_home:
+        return None
+    try:
+        config_path = Path(resolved_home, "config.yaml").resolve()
+    except (OSError, RuntimeError):
         return None
     try:
         import yaml

--- a/tests/test_hermes_config.py
+++ b/tests/test_hermes_config.py
@@ -1,0 +1,115 @@
+"""Regression coverage for Hermes config reads shared by both providers."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import yaml
+
+import mnemosyne.hermes_config as hermes_config
+
+
+def _write_config(home, value: str) -> None:
+    (home / "config.yaml").write_text(
+        "memory:\n"
+        "  mnemosyne:\n"
+        f"    default_scope: {value}\n"
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_config_cache():
+    getattr(hermes_config, "_CONFIG_CACHE", {}).clear()
+    yield
+    getattr(hermes_config, "_CONFIG_CACHE", {}).clear()
+
+
+def test_repeated_reads_parse_unchanged_config_once(tmp_path, monkeypatch):
+    _write_config(tmp_path, "first")
+    calls = 0
+    original_load = yaml.load
+
+    def counting_load(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_load(*args, **kwargs)
+
+    monkeypatch.setattr(yaml, "load", counting_load)
+
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+    assert calls == 1
+
+
+def test_atomic_same_size_replacement_invalidates_cached_config(tmp_path):
+    _write_config(tmp_path, "first")
+    config_path = tmp_path / "config.yaml"
+    original_size = config_path.stat().st_size
+
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+    replacement = tmp_path / "replacement.yaml"
+    replacement.write_text(
+        "memory:\n"
+        "  mnemosyne:\n"
+        "    default_scope: other\n"
+    )
+    assert replacement.stat().st_size == original_size
+    os.replace(replacement, config_path)
+
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "other"
+
+
+def test_replacement_during_parse_does_not_poison_cache(tmp_path, monkeypatch):
+    _write_config(tmp_path, "first")
+    config_path = tmp_path / "config.yaml"
+    original_load = yaml.load
+
+    def replace_after_load(*args, **kwargs):
+        loaded = original_load(*args, **kwargs)
+        replacement = tmp_path / "replacement.yaml"
+        replacement.write_text(
+            "memory:\n"
+            "  mnemosyne:\n"
+            "    default_scope: other\n"
+        )
+        os.replace(replacement, config_path)
+        return loaded
+
+    monkeypatch.setattr(yaml, "load", replace_after_load)
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "other"
+
+
+def test_cached_config_fails_closed_after_malformed_or_deleted_file(tmp_path):
+    _write_config(tmp_path, "first")
+    config_path = tmp_path / "config.yaml"
+
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+    config_path.write_text("memory: [\n")
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") is None
+
+    _write_config(tmp_path, "first")
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+    config_path.unlink()
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") is None
+
+
+def test_prefers_c_safe_loader_and_falls_back_to_safe_loader(tmp_path, monkeypatch):
+    _write_config(tmp_path, "first")
+    original_load = yaml.load
+    loaders = []
+
+    def recording_load(*args, **kwargs):
+        loaders.append(kwargs.get("Loader", args[1] if len(args) > 1 else None))
+        return original_load(*args, **kwargs)
+
+    monkeypatch.setattr(yaml, "load", recording_load)
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+    assert loaders == [yaml.CSafeLoader]
+
+    getattr(hermes_config, "_CONFIG_CACHE", {}).clear()
+    loaders.clear()
+    monkeypatch.delattr(yaml, "CSafeLoader")
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+    assert loaders == [yaml.SafeLoader]

--- a/tests/test_hermes_config.py
+++ b/tests/test_hermes_config.py
@@ -162,11 +162,14 @@ def test_prefers_c_safe_loader_and_falls_back_to_safe_loader(tmp_path, monkeypat
         return original_load(*args, **kwargs)
 
     monkeypatch.setattr(yaml, "load", recording_load)
-    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
-    assert loaders == [yaml.CSafeLoader]
 
-    getattr(hermes_config, "_CONFIG_CACHE", {}).clear()
-    loaders.clear()
-    monkeypatch.delattr(yaml, "CSafeLoader")
+    if hasattr(yaml, "CSafeLoader"):
+        assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+        assert loaders == [yaml.CSafeLoader]
+
+        getattr(hermes_config, "_CONFIG_CACHE", {}).clear()
+        loaders.clear()
+        monkeypatch.delattr(yaml, "CSafeLoader")
+
     assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
     assert loaders == [yaml.SafeLoader]

--- a/tests/test_hermes_config.py
+++ b/tests/test_hermes_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 import yaml
@@ -92,6 +93,62 @@ def test_cached_config_fails_closed_after_malformed_or_deleted_file(tmp_path):
     _write_config(tmp_path, "first")
     assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
     config_path.unlink()
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") is None
+
+
+def test_stat_open_aba_does_not_cache_replaced_file_content(tmp_path, monkeypatch):
+    _write_config(tmp_path, "first")
+    config_path = (tmp_path / "config.yaml").resolve()
+    replacement = tmp_path / "replacement.yaml"
+    _write_config(tmp_path, "first")
+    replacement.write_text(
+        "memory:\n"
+        "  mnemosyne:\n"
+        "    default_scope: other\n"
+    )
+    saved_original = tmp_path / "saved-original.yaml"
+    original_open = Path.open
+    original_load = yaml.load
+    replaced = False
+
+    def replace_before_open(path, *args, **kwargs):
+        nonlocal replaced
+        if path == config_path and not replaced:
+            replaced = True
+            os.replace(config_path, saved_original)
+            os.replace(replacement, config_path)
+        return original_open(path, *args, **kwargs)
+
+    def restore_after_load(*args, **kwargs):
+        loaded = original_load(*args, **kwargs)
+        if saved_original.exists():
+            os.replace(saved_original, config_path)
+        return loaded
+
+    monkeypatch.setattr(Path, "open", replace_before_open)
+    monkeypatch.setattr(yaml, "load", restore_after_load)
+    monkeypatch.setattr(hermes_config, "_config_fingerprint", lambda path: (1, 2, 3, 4, 5))
+
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "other"
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+
+
+def test_non_mapping_config_evicts_prior_cached_entry(tmp_path):
+    _write_config(tmp_path, "first")
+    config_path = (tmp_path / "config.yaml").resolve()
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") == "first"
+    assert config_path in hermes_config._CONFIG_CACHE
+
+    config_path.write_text("- not\n- a mapping\n")
+    assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") is None
+    assert config_path not in hermes_config._CONFIG_CACHE
+
+
+def test_resolve_error_fails_closed(tmp_path, monkeypatch):
+    def fail_resolve(self, *args, **kwargs):
+        raise OSError("symlink resolution failed")
+
+    monkeypatch.setattr(Path, "resolve", fail_resolve)
     assert hermes_config.read_hermes_config_key(str(tmp_path), "default_scope") is None
 
 


### PR DESCRIPTION
## Goal

Eliminate repeated full Hermes `config.yaml` parses in `read_hermes_config_key()` while preserving the existing configuration precedence and provider interfaces.

## Why the shared helper

Both `hermes_memory_provider` and the packaged `mnemosyne_hermes` provider already route their config reads through `mnemosyne.hermes_config.read_hermes_config_key`. The cache is therefore kept solely in that shared helper, so the two provider surfaces retain identical behavior without duplicated cache state or logic.

## Implementation

- Prefer `yaml.CSafeLoader` when PyYAML exposes it, otherwise use `yaml.SafeLoader`.
- Cache successful parsed mapping values by resolved config path.
- Validate the cache before each use with `(device, inode, mtime_ns, ctime_ns, size)`, which detects atomic replacements and rapid same-size writes.
- Evict/fail closed when a previously valid file disappears or becomes unreadable/malformed; a stale mapping is never returned.
- Avoid caching a mapping if the file changes while it is parsed.
- Preserve the existing no-PyYAML fallback parser unchanged.

## Non-goals

No change to config precedence, provider API, migrations, or core runtime config semantics. This does not optimize or alter the no-PyYAML fallback parser.

## Test evidence

```text
/opt/data/tmp/mnemosyne-865-venv/bin/python -m pytest -q \
  tests/test_hermes_config.py tests/test_hermes_provider_parity.py
73 passed in 7.94s
```

The new regressions cover one parse for unchanged repeated reads, same-size atomic replacement, replacement during parse without cache poisoning, malformed/deleted fail-closed behavior after a cache hit, and C-safe-loader preference with SafeLoader fallback. The existing dual-provider/Hermes-home parity suite remains green.

Closes #865


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Caches successful Hermes `config.yaml` parses by resolved path.
- Detects file changes with device, inode, nanosecond timestamps, and size.
- Uses `yaml.CSafeLoader` when available, with `SafeLoader` fallback.
- Fails closed for missing, unreadable, malformed, non-mapping, or race-affected files.
- Preserves configuration precedence, provider interfaces, and the no-PyYAML fallback.

## Architecture and integration impact

- Tiered memory, retrieval, consolidation, BEAM, veracity, and sync systems are unchanged.
- Hermes agent initialization avoids repeated YAML parsing.
- MCP and CLI interfaces are unchanged.
- Local-first behavior and privacy posture are unchanged. The cache stores local configuration data only.
- The cache is the right call because it improves Hermes startup performance without changing memory behavior or public APIs.

## Maintainability and validation

- The cache binds parsed data to the file opened for parsing.
- Tests cover repeated reads, atomic replacement, parse-time changes, ABA races, invalidation, failure handling, loader selection, and cache eviction.
- The reported test suite passes 73 tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->