### PR TITLE
fix: validate wrapper --python environment

### DIFF
--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -2400,7 +2400,10 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  Skill state: {skill.status}")
                 print(f"  Skill action: {skill_plan.message}")
                 if getattr(args, "mode", "symlink") == "wrapper":
-                    wrapper_python = Path(getattr(args, "python", None) or sys.executable).expanduser()
+                    # Match run_install(): wrapper metadata and validation use
+                    # the discovered Hermes runtime unless --python selected one.
+                    # Preserve a venv's python symlink; absolute() is lexical.
+                    wrapper_python = (hermes_python or Path(sys.executable)).absolute()
                     print(f"  Wrapper Python: {wrapper_python}")
                     if wrapper_python.is_file():
                         print(

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -1551,7 +1551,16 @@ def _validated_wrapper_environment(
     import_timeout: float = DEFAULT_WRAPPER_IMPORT_TIMEOUT,
 ) -> tuple[Path, Path]:
     """Validate the selected wrapper runtime before touching an installed plugin."""
-    wrapper_python = Path(python).expanduser() if python else Path(sys.executable)
+    if python is None:
+        wrapper_python = Path(sys.executable)
+    else:
+        selected = str(python)
+        if not selected.strip():
+            raise ValueError(
+                "--python was given an empty value. Pass the path to Hermes' "
+                "interpreter, or omit --python to let the installer find it."
+            )
+        wrapper_python = Path(selected).expanduser()
     if not wrapper_python.is_file():
         raise FileNotFoundError(f"Python interpreter not found: {wrapper_python}")
     import_timeout = _validated_import_timeout(import_timeout)

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -483,22 +483,26 @@ def _check_wrapper_import(
         + "print(getattr(mnemosyne_hermes, '__version__', 'unknown'))\n"
     )
     try:
-        result = subprocess.run(
-            [str(runner), "-S", "-c", code],
-            capture_output=True,
-            text=True,
-            timeout=import_timeout,
-            # -S and a selected site directory isolate imports from the runner's
-            # ambient site/user directories. Filtering PYTHONPATH prevents a
-            # caller-controlled package shadowing that contract; filtering
-            # PYTHONOPTIMIZE keeps assertion elision from changing probe behavior.
-            env={
-                key: value
-                for key, value in os.environ.items()
-                if key not in {"PYTHONPATH", "PYTHONOPTIMIZE"}
-            },
-            cwd=site_packages,
-        )
+        # Python puts the subprocess working directory on sys.path.  Use a
+        # fresh empty directory so validation cannot borrow a checkout or the
+        # installer's current directory to satisfy the selected runtime.
+        with tempfile.TemporaryDirectory(prefix="mnemosyne-wrapper-import-") as probe_cwd:
+            result = subprocess.run(
+                [str(runner), "-S", "-c", code],
+                capture_output=True,
+                text=True,
+                timeout=import_timeout,
+                # -S and a selected site directory isolate imports from the runner's
+                # ambient site/user directories. Filtering PYTHONPATH prevents a
+                # caller-controlled package shadowing that contract; filtering
+                # PYTHONOPTIMIZE keeps assertion elision from changing probe behavior.
+                env={
+                    key: value
+                    for key, value in os.environ.items()
+                    if key not in {"PYTHONPATH", "PYTHONOPTIMIZE"}
+                },
+                cwd=probe_cwd,
+            )
     except OSError as exc:
         return False, f"could not run wrapper Python {runner}: {exc}", True
     except subprocess.TimeoutExpired:

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -2196,9 +2196,12 @@ def run_install(
     if mode is None:
         mode = default_install_mode()
 
-    # Check core library first (installer's own Python)
-    core_ok = check_mnemosyne_core()
-    if not core_ok:
+    # A wrapper activates the selected --python environment itself. Its
+    # validation belongs in _validated_wrapper_environment(), so an installer
+    # launched from an unrelated Python must not preempt that selected runtime.
+    # Symlink installs still expose this process directly to Hermes and retain
+    # the historical installer-Python core preflight.
+    if mode != "wrapper" and not check_mnemosyne_core():
         print(
             "  mnemosyne-memory NOT found in this Python. Install it first:\n"
             "    pip install mnemosyne-hermes[all]",

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -2196,12 +2196,12 @@ def run_install(
     if mode is None:
         mode = default_install_mode()
 
-    # A wrapper activates the selected --python environment itself. Its
-    # validation belongs in _validated_wrapper_environment(), so an installer
+    # An explicit wrapper --python activates that selected environment itself.
+    # Its validation belongs in _validated_wrapper_environment(), so an installer
     # launched from an unrelated Python must not preempt that selected runtime.
-    # Symlink installs still expose this process directly to Hermes and retain
-    # the historical installer-Python core preflight.
-    if mode != "wrapper" and not check_mnemosyne_core():
+    # Wrapper installs without --python still use this process and retain the
+    # historical installer-Python core preflight.
+    if not (mode == "wrapper" and python is not None) and not check_mnemosyne_core():
         print(
             "  mnemosyne-memory NOT found in this Python. Install it first:\n"
             "    pip install mnemosyne-hermes[all]",

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -469,6 +469,11 @@ def _check_wrapper_import(
         f"selected_site = Path({str(site_packages)!r}).resolve()\n"
         "site.addsitedir(str(selected_site))\n"
         "import mnemosyne_hermes\n"
+        # mnemosyne_hermes deliberately degrades when its optional core imports
+        # are unavailable. A wrapper needs the actual runtime, not merely that
+        # importable fallback package, so prove the same core entry point as the
+        # installer's CLI preflight in the selected interpreter.
+        "import mnemosyne.core.beam\n"
         "origin = getattr(mnemosyne_hermes, '__file__', None)\n"
         "if not origin:\n"
         "    raise SystemExit('mnemosyne_hermes package has no file origin')\n"
@@ -1070,7 +1075,7 @@ def check_mnemosyne_core() -> bool:
 
 
 def check_mnemosyne_core_for_hermes_python(hermes_python: Path) -> Optional[str]:
-    """Check if Hermes' Python can import mnemosyne core.
+    """Check if Hermes' Python can import Mnemosyne's operational dependencies.
 
     Returns the version string if importable, None otherwise.
     """
@@ -1078,7 +1083,7 @@ def check_mnemosyne_core_for_hermes_python(hermes_python: Path) -> Optional[str]
         result = subprocess.run(
             [str(hermes_python), "-c",
              "import mnemosyne; print(mnemosyne.__version__); "
-             "import sqlite_vec"],
+             "import mnemosyne.core.beam; import sqlite_vec"],
             capture_output=True, text=True, timeout=10,
         )
         if result.returncode == 0:
@@ -1552,7 +1557,8 @@ def _validated_wrapper_environment(
     )
     if not import_ok:
         raise RuntimeError(
-            f"Selected Python environment cannot import mnemosyne_hermes: {import_error}"
+            "Selected Python environment cannot import required mnemosyne core "
+            f"(mnemosyne.core.beam): {import_error}"
         )
     return wrapper_python, site_packages
 

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -939,6 +939,15 @@ def _is_validated_venv_python(candidate: Path) -> bool:
     )
 
 
+def _validate_explicit_python(explicit_python: str | Path | None) -> None:
+    """Reject a supplied --python value that names no interpreter."""
+    if explicit_python is not None and not str(explicit_python).strip():
+        raise ValueError(
+            "--python was given an empty value. Pass the path to Hermes' "
+            "interpreter, or omit --python to let the installer find it."
+        )
+
+
 def _find_hermes_python(explicit_python: str | Path | None = None) -> Optional[Path]:
     """Try to find Hermes' python executable for dep validation.
 
@@ -964,16 +973,12 @@ def _find_hermes_python(explicit_python: str | Path | None = None) -> Optional[P
     #    would answer with a different interpreter than the one the user asked
     #    for -- exactly the silent substitution this branch exists to prevent.
     if explicit_python is not None:
+        _validate_explicit_python(explicit_python)
         selected = str(explicit_python)
         # Strip only to decide whether anything was named. A POSIX path may
         # legitimately begin or end with whitespace, so stripping the value we
         # return would select a different interpreter than the one requested,
         # or fail to find it at all.
-        if not selected.strip():
-            raise ValueError(
-                "--python was given an empty value. Pass the path to Hermes' "
-                "interpreter, or omit --python to let the installer find it."
-            )
         return Path(selected).expanduser()
 
     hermes_home_path = hermes_home()
@@ -2220,6 +2225,11 @@ def run_install(
     if mode is None:
         mode = default_install_mode()
 
+    # Validate supplied input before the symlink-mode installer preflight. A
+    # blank value is explicit, not an omitted --python request, and must never
+    # be hidden by an earlier preflight return.
+    _validate_explicit_python(python)
+
     # Wrapper validation belongs to its selected environment, including the
     # interpreter discovered when --python is omitted. Only symlink installs
     # retain the installer-Python core preflight and bootstrap path.
@@ -2235,6 +2245,14 @@ def run_install(
     # it when needed; wrapper installs validate it and record its metadata. An
     # explicit --python remains authoritative through _find_hermes_python().
     hermes_python = _find_hermes_python(explicit_python=python)
+    if mode == "wrapper" and hermes_python is None:
+        print(
+            "\n  ⚠ Could not identify Hermes' Python for wrapper mode.\n"
+            "     Pass --python /path/to/hermes/venv/bin/python to select the "
+            "environment the wrapper must import from.",
+            file=sys.stderr,
+        )
+        return 1
     if mode == "symlink" and hermes_python is None:
         # Discovery found no validated Hermes runtime, so there is nothing safe
         # to bootstrap into. Before #618 this path guessed at the launcher's
@@ -2368,6 +2386,14 @@ def main(argv: list[str] | None = None) -> int:
             hermes_python = _find_hermes_python(
                 explicit_python=getattr(args, "python", None)
             )
+            if args.mode == "wrapper" and hermes_python is None:
+                print(
+                    "\n  ⚠ Could not identify Hermes' Python for wrapper mode.\n"
+                    "     Pass --python /path/to/hermes/venv/bin/python to select "
+                    "the environment the wrapper must import from.",
+                    file=sys.stderr,
+                )
+                return 1
             target = plugin_target_dir(args.hermes_home)
             if getattr(args, "dry_run", False):
                 invalid_wrapper_migration_args = (
@@ -2401,7 +2427,8 @@ def main(argv: list[str] | None = None) -> int:
                     # Match run_install(): wrapper metadata and validation use
                     # the discovered Hermes runtime unless --python selected one.
                     # Preserve a venv's python symlink; absolute() is lexical.
-                    wrapper_python = (hermes_python or Path(sys.executable)).absolute()
+                    assert hermes_python is not None
+                    wrapper_python = hermes_python.absolute()
                     print(f"  Wrapper Python: {wrapper_python}")
                     if wrapper_python.is_file():
                         print(

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -1560,7 +1560,12 @@ def _validated_wrapper_environment(
                 "--python was given an empty value. Pass the path to Hermes' "
                 "interpreter, or omit --python to let the installer find it."
             )
-        wrapper_python = Path(selected).expanduser()
+        # The import probe runs from an isolated temporary working directory.
+        # Make an explicit relative path independent of that cwd before either
+        # validation or the probe uses it.  ``absolute()`` is lexical here:
+        # ``resolve()`` would follow a venv's bin/python symlink to its base
+        # interpreter and lose the selected virtual environment.
+        wrapper_python = Path(selected).expanduser().absolute()
     if not wrapper_python.is_file():
         raise FileNotFoundError(f"Python interpreter not found: {wrapper_python}")
     import_timeout = _validated_import_timeout(import_timeout)
@@ -2228,9 +2233,10 @@ def run_install(
         )
         return 1
 
-    # Symlink installs need Hermes' own Python to contain the package. Wrapper
-    # installs validate the explicitly selected interpreter in install_plugin().
-    hermes_python = _find_hermes_python(explicit_python=python) if mode == "symlink" else None
+    # Both install modes need a Hermes interpreter. Symlink installs bootstrap
+    # it when needed; wrapper installs validate it and record its metadata. An
+    # explicit --python remains authoritative through _find_hermes_python().
+    hermes_python = _find_hermes_python(explicit_python=python)
     if mode == "symlink" and hermes_python is None:
         # Discovery found no validated Hermes runtime, so there is nothing safe
         # to bootstrap into. Before #618 this path guessed at the launcher's
@@ -2256,7 +2262,7 @@ def run_install(
     # to its base interpreter, so resolving both sides reports a venv and the
     # base install as the same runtime and skips the check that bootstraps
     # Hermes' venv (#618).
-    if hermes_python and hermes_python != Path(sys.executable):
+    if mode == "symlink" and hermes_python and hermes_python != Path(sys.executable):
         hermes_core = check_mnemosyne_core_for_hermes_python(hermes_python)
         if hermes_core is None:
             print(f"\n  ⚠ Hermes' Python at {hermes_python} can't import mnemosyne core.")
@@ -2285,7 +2291,7 @@ def run_install(
             hermes_home_path=hermes_home_path,
             force=force,
             mode=mode,
-            python=python,
+            python=hermes_python if mode == "wrapper" else python,
             import_timeout=import_timeout,
             migrate_wrapper_to_symlink=migrate_wrapper_to_symlink,
             link_profiles=link_profiles,

--- a/integrations/hermes/src/mnemosyne_hermes/install.py
+++ b/integrations/hermes/src/mnemosyne_hermes/install.py
@@ -2220,12 +2220,10 @@ def run_install(
     if mode is None:
         mode = default_install_mode()
 
-    # An explicit wrapper --python activates that selected environment itself.
-    # Its validation belongs in _validated_wrapper_environment(), so an installer
-    # launched from an unrelated Python must not preempt that selected runtime.
-    # Wrapper installs without --python still use this process and retain the
-    # historical installer-Python core preflight.
-    if not (mode == "wrapper" and python is not None) and not check_mnemosyne_core():
+    # Wrapper validation belongs to its selected environment, including the
+    # interpreter discovered when --python is omitted. Only symlink installs
+    # retain the installer-Python core preflight and bootstrap path.
+    if mode == "symlink" and not check_mnemosyne_core():
         print(
             "  mnemosyne-memory NOT found in this Python. Install it first:\n"
             "    pip install mnemosyne-hermes[all]",

--- a/integrations/hermes/tests/test_find_hermes_python.py
+++ b/integrations/hermes/tests/test_find_hermes_python.py
@@ -831,6 +831,62 @@ def test_wrapper_dry_run_does_not_report_a_bootstrap(tmp_path, monkeypatch, caps
     assert "Will bootstrap: True" in capsys.readouterr().out
 
 
+def test_wrapper_dry_run_uses_discovered_interpreter_for_display_and_probe(
+    tmp_path, monkeypatch, capsys
+):
+    """The public dry-run path matches wrapper install's discovered runtime."""
+    discovered = _make_venv(tmp_path / "hermes-venv")
+    installer_python = tmp_path / "installer-python"
+    _write_executable(installer_python, "#!/bin/sh\nexit 0\n")
+    site_packages = tmp_path / "site-packages"
+    probed: list[Path] = []
+
+    monkeypatch.setattr(sys, "executable", str(installer_python))
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: discovered)
+    monkeypatch.setattr(
+        install,
+        "_site_packages_for_python",
+        lambda python, **kwargs: (probed.append(Path(python)), site_packages)[1],
+    )
+
+    rc = install.main(["install", "--mode", "wrapper", "--dry-run"])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert f"Wrapper Python: {discovered}" in out
+    assert f"Wrapper site-packages: {site_packages}" in out
+    assert str(installer_python) not in out
+    assert probed == [discovered]
+
+
+def test_wrapper_dry_run_makes_explicit_relative_python_absolute_before_probe(
+    tmp_path, monkeypatch, capsys
+):
+    """The public dry-run path probes and reports relative --python lexically."""
+    selected = _make_venv(tmp_path / "hermes-venv")
+    site_packages = tmp_path / "site-packages"
+    relative_python = os.path.relpath(selected, start=tmp_path)
+    probed: list[Path] = []
+
+    monkeypatch.chdir(tmp_path)
+    expected = Path(relative_python).absolute()
+    monkeypatch.setattr(
+        install,
+        "_site_packages_for_python",
+        lambda python, **kwargs: (probed.append(Path(python)), site_packages)[1],
+    )
+
+    rc = install.main(
+        ["install", "--mode", "wrapper", "--dry-run", "--python", relative_python]
+    )
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert f"Wrapper Python: {expected}" in out
+    assert f"Wrapper site-packages: {site_packages}" in out
+    assert probed == [expected]
+
+
 def test_run_install_honours_explicit_python(hermes_world, tmp_path, monkeypatch):
     """--python reaches discovery in symlink mode, not just wrapper mode."""
     bootstrapped: list[Path] = []

--- a/integrations/hermes/tests/test_find_hermes_python.py
+++ b/integrations/hermes/tests/test_find_hermes_python.py
@@ -755,9 +755,9 @@ def test_run_install_honours_explicit_python(hermes_world, tmp_path, monkeypatch
 @pytest.mark.parametrize(
     ("mode", "cli_core_present", "selected_core_present", "expected_rc"),
     [
-        pytest.param("wrapper", False, False, None, id="wrapper-cli-missing-selected-missing"),
+        pytest.param("wrapper", False, False, 0, id="wrapper-cli-missing-selected-missing"),
         pytest.param("wrapper", False, True, 0, id="wrapper-cli-missing-selected-present"),
-        pytest.param("wrapper", True, False, None, id="wrapper-cli-present-selected-missing"),
+        pytest.param("wrapper", True, False, 0, id="wrapper-cli-present-selected-missing"),
         pytest.param("wrapper", True, True, 0, id="wrapper-cli-present-selected-present"),
         pytest.param("symlink", False, False, 1, id="symlink-cli-missing-selected-missing"),
         pytest.param("symlink", False, True, 1, id="symlink-cli-missing-selected-present"),
@@ -774,7 +774,7 @@ def test_explicit_python_core_preflight_matrix(
     selected_core_present,
     expected_rc,
 ):
-    """Wrapper mode validates only --python; symlink mode retains CLI preflight."""
+    """Wrapper --python bypasses CLI preflight; symlink mode retains it."""
     selected_python = tmp_path / "selected-python"
     selected_python.write_text("#!/bin/sh\n", encoding="utf-8")
     selected_python.chmod(0o755)
@@ -799,13 +799,6 @@ def test_explicit_python_core_preflight_matrix(
 
     def install_selected(**kwargs):
         install_calls.append(kwargs)
-        if mode == "wrapper" and not selected_core_present:
-            # This is the selected-runtime failure raised by
-            # _validated_wrapper_environment(), not the CLI-runtime preflight.
-            raise RuntimeError(
-                "Selected Python environment cannot import mnemosyne_hermes: "
-                "No module named 'mnemosyne_hermes'"
-            )
         return target if mode == "wrapper" else symlink_target
 
     monkeypatch.setattr(install, "check_mnemosyne_core", check_cli_core)
@@ -825,24 +818,12 @@ def test_explicit_python_core_preflight_matrix(
         ),
     )
 
-    wrapper_failure = ""
-    if mode == "wrapper" and not selected_core_present:
-        with pytest.raises(RuntimeError, match="Selected Python environment cannot import") as exc_info:
-            install.run_install(
-                hermes_home_path=tmp_path / "home",
-                mode=mode,
-                python=selected_python,
-                no_bootstrap=True,
-            )
-        wrapper_failure = str(exc_info.value)
-        rc = None
-    else:
-        rc = install.run_install(
-            hermes_home_path=tmp_path / "home",
-            mode=mode,
-            python=selected_python,
-            no_bootstrap=True,
-        )
+    rc = install.run_install(
+        hermes_home_path=tmp_path / "home",
+        mode=mode,
+        python=selected_python,
+        no_bootstrap=True,
+    )
 
     captured = capsys.readouterr()
     stderr = captured.err
@@ -852,10 +833,7 @@ def test_explicit_python_core_preflight_matrix(
         assert cli_checks == []
         assert selected_checks == []
         assert install_calls and install_calls[0]["python"] == selected_python
-        if selected_core_present:
-            assert "mnemosyne-memory NOT found in this Python" not in stderr
-        else:
-            assert "Selected Python environment cannot import mnemosyne_hermes" in wrapper_failure
+        assert "mnemosyne-memory NOT found in this Python" not in stderr
     else:
         assert cli_checks == [True]
         if not cli_core_present:

--- a/integrations/hermes/tests/test_find_hermes_python.py
+++ b/integrations/hermes/tests/test_find_hermes_python.py
@@ -1011,22 +1011,66 @@ def test_explicit_python_core_preflight_matrix(
                 assert "Hermes' Python at" in stdout
 
 
-def test_default_wrapper_without_explicit_python_retains_cli_core_preflight(
-    tmp_path, monkeypatch, capsys
+def test_default_wrapper_without_explicit_python_defers_core_validation_to_wrapper(
+    tmp_path, monkeypatch
 ):
-    """Windows' default wrapper mode must not bypass the CLI core check."""
+    """The discovered wrapper runtime reaches its own selected-env validation."""
+    cli_checks: list[bool] = []
+    discovered = _make_venv(tmp_path / "hermes-venv")
+    selected: list[Path | None] = []
+    target = tmp_path / "wrapper-target"
+    target.mkdir()
+
+    class _SkillResult:
+        message = "skipped"
+
+    def check_cli_core():
+        cli_checks.append(True)
+        return False
+
+    monkeypatch.setattr(install, "default_install_mode", lambda: "wrapper")
+    monkeypatch.setattr(install, "check_mnemosyne_core", check_cli_core)
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: discovered)
+    monkeypatch.setattr(
+        install,
+        "install_plugin",
+        lambda **kwargs: (selected.append(kwargs["python"]), target)[1],
+    )
+    monkeypatch.setattr(install, "install_bundled_skill", lambda **kwargs: _SkillResult())
+    monkeypatch.setattr(
+        install,
+        "plugin_state",
+        lambda **kwargs: install.PluginState(
+            status="installed",
+            installed=True,
+            target=target,
+            mode="wrapper",
+            message="ok",
+        ),
+    )
+
+    rc = install.run_install(hermes_home_path=tmp_path / "home")
+
+    assert rc == 0
+    assert cli_checks == []
+    assert selected == [discovered]
+
+
+def test_default_symlink_retains_cli_core_preflight(tmp_path, monkeypatch, capsys):
+    """The default symlink path still stops before discovery or installation."""
     cli_checks: list[bool] = []
 
     def check_cli_core():
         cli_checks.append(True)
         return False
 
-    def selected_environment_validation(**kwargs):
-        raise AssertionError("must not validate selected wrapper environment")
+    def fail(*args, **kwargs):
+        raise AssertionError("symlink preflight must stop before later install work")
 
-    monkeypatch.setattr(install, "default_install_mode", lambda: "wrapper")
+    monkeypatch.setattr(install, "default_install_mode", lambda: "symlink")
     monkeypatch.setattr(install, "check_mnemosyne_core", check_cli_core)
-    monkeypatch.setattr(install, "install_plugin", selected_environment_validation)
+    monkeypatch.setattr(install, "_find_hermes_python", fail)
+    monkeypatch.setattr(install, "install_plugin", fail)
 
     rc = install.run_install(hermes_home_path=tmp_path / "home")
 

--- a/integrations/hermes/tests/test_find_hermes_python.py
+++ b/integrations/hermes/tests/test_find_hermes_python.py
@@ -871,6 +871,30 @@ def test_explicit_python_core_preflight_matrix(
                 assert "Hermes' Python at" in stdout
 
 
+def test_default_wrapper_without_explicit_python_retains_cli_core_preflight(
+    tmp_path, monkeypatch, capsys
+):
+    """Windows' default wrapper mode must not bypass the CLI core check."""
+    cli_checks: list[bool] = []
+
+    def check_cli_core():
+        cli_checks.append(True)
+        return False
+
+    def selected_environment_validation(**kwargs):
+        raise AssertionError("must not validate selected wrapper environment")
+
+    monkeypatch.setattr(install, "default_install_mode", lambda: "wrapper")
+    monkeypatch.setattr(install, "check_mnemosyne_core", check_cli_core)
+    monkeypatch.setattr(install, "install_plugin", selected_environment_validation)
+
+    rc = install.run_install(hermes_home_path=tmp_path / "home")
+
+    assert rc == 1
+    assert cli_checks == [True]
+    assert "mnemosyne-memory NOT found in this Python" in capsys.readouterr().err
+
+
 def _make_windows_venv(root: Path) -> Path:
     """Create a native Windows venv layout without changing ``os.name``."""
     scripts = root / "Scripts"

--- a/integrations/hermes/tests/test_find_hermes_python.py
+++ b/integrations/hermes/tests/test_find_hermes_python.py
@@ -752,6 +752,125 @@ def test_run_install_honours_explicit_python(hermes_world, tmp_path, monkeypatch
     assert bootstrapped == [chosen]
 
 
+@pytest.mark.parametrize(
+    ("mode", "cli_core_present", "selected_core_present", "expected_rc"),
+    [
+        pytest.param("wrapper", False, False, None, id="wrapper-cli-missing-selected-missing"),
+        pytest.param("wrapper", False, True, 0, id="wrapper-cli-missing-selected-present"),
+        pytest.param("wrapper", True, False, None, id="wrapper-cli-present-selected-missing"),
+        pytest.param("wrapper", True, True, 0, id="wrapper-cli-present-selected-present"),
+        pytest.param("symlink", False, False, 1, id="symlink-cli-missing-selected-missing"),
+        pytest.param("symlink", False, True, 1, id="symlink-cli-missing-selected-present"),
+        pytest.param("symlink", True, False, 1, id="symlink-cli-present-selected-missing"),
+        pytest.param("symlink", True, True, 0, id="symlink-cli-present-selected-present"),
+    ],
+)
+def test_explicit_python_core_preflight_matrix(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    mode,
+    cli_core_present,
+    selected_core_present,
+    expected_rc,
+):
+    """Wrapper mode validates only --python; symlink mode retains CLI preflight."""
+    selected_python = tmp_path / "selected-python"
+    selected_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    selected_python.chmod(0o755)
+    target = tmp_path / "plugin-target"
+    target.mkdir()
+    symlink_target = tmp_path / "plugin-link"
+    symlink_target.symlink_to(target, target_is_directory=True)
+    cli_checks: list[bool] = []
+    selected_checks: list[Path] = []
+    install_calls: list[dict[str, object]] = []
+
+    class _SkillResult:
+        message = "skipped"
+
+    def check_cli_core():
+        cli_checks.append(True)
+        return cli_core_present
+
+    def check_selected_core(python):
+        selected_checks.append(Path(python))
+        return "4.0" if selected_core_present else None
+
+    def install_selected(**kwargs):
+        install_calls.append(kwargs)
+        if mode == "wrapper" and not selected_core_present:
+            # This is the selected-runtime failure raised by
+            # _validated_wrapper_environment(), not the CLI-runtime preflight.
+            raise RuntimeError(
+                "Selected Python environment cannot import mnemosyne_hermes: "
+                "No module named 'mnemosyne_hermes'"
+            )
+        return target if mode == "wrapper" else symlink_target
+
+    monkeypatch.setattr(install, "check_mnemosyne_core", check_cli_core)
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: selected_python)
+    monkeypatch.setattr(install, "check_mnemosyne_core_for_hermes_python", check_selected_core)
+    monkeypatch.setattr(install, "install_plugin", install_selected)
+    monkeypatch.setattr(install, "install_bundled_skill", lambda **kwargs: _SkillResult())
+    monkeypatch.setattr(
+        install,
+        "plugin_state",
+        lambda **kwargs: install.PluginState(
+            status="installed",
+            installed=True,
+            target=target,
+            mode="wrapper",
+            message="ok",
+        ),
+    )
+
+    wrapper_failure = ""
+    if mode == "wrapper" and not selected_core_present:
+        with pytest.raises(RuntimeError, match="Selected Python environment cannot import") as exc_info:
+            install.run_install(
+                hermes_home_path=tmp_path / "home",
+                mode=mode,
+                python=selected_python,
+                no_bootstrap=True,
+            )
+        wrapper_failure = str(exc_info.value)
+        rc = None
+    else:
+        rc = install.run_install(
+            hermes_home_path=tmp_path / "home",
+            mode=mode,
+            python=selected_python,
+            no_bootstrap=True,
+        )
+
+    captured = capsys.readouterr()
+    stderr = captured.err
+    stdout = captured.out
+    assert rc == expected_rc
+    if mode == "wrapper":
+        assert cli_checks == []
+        assert selected_checks == []
+        assert install_calls and install_calls[0]["python"] == selected_python
+        if selected_core_present:
+            assert "mnemosyne-memory NOT found in this Python" not in stderr
+        else:
+            assert "Selected Python environment cannot import mnemosyne_hermes" in wrapper_failure
+    else:
+        assert cli_checks == [True]
+        if not cli_core_present:
+            assert selected_checks == []
+            assert install_calls == []
+            assert "mnemosyne-memory NOT found in this Python" in stderr
+        else:
+            assert selected_checks == [selected_python]
+            if selected_core_present:
+                assert install_calls and install_calls[0]["python"] == selected_python
+            else:
+                assert install_calls == []
+                assert "Hermes' Python at" in stdout
+
+
 def _make_windows_venv(root: Path) -> Path:
     """Create a native Windows venv layout without changing ``os.name``."""
     scripts = root / "Scripts"

--- a/integrations/hermes/tests/test_find_hermes_python.py
+++ b/integrations/hermes/tests/test_find_hermes_python.py
@@ -599,6 +599,33 @@ def test_no_bootstrap_continues_without_a_validated_interpreter(tmp_path, monkey
     assert "Continuing without dependency validation" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize("mode", ["symlink", "wrapper"])
+@pytest.mark.parametrize("blank_python", ["", " \t\n "])
+def test_run_install_rejects_blank_python_before_any_preflight(
+    tmp_path, monkeypatch, blank_python, mode
+):
+    """A supplied blank --python never reaches preflight, discovery, or install."""
+    calls: list[str] = []
+
+    def fail(name):
+        def _fail(*args, **kwargs):
+            calls.append(name)
+            raise AssertionError(f"blank --python reached {name}")
+
+        return _fail
+
+    monkeypatch.setattr(install, "check_mnemosyne_core", fail("core preflight"))
+    monkeypatch.setattr(install, "_find_hermes_python", fail("discovery"))
+    monkeypatch.setattr(install, "install_plugin", fail("plugin install"))
+
+    with pytest.raises(ValueError, match="--python was given an empty value"):
+        install.run_install(
+            hermes_home_path=tmp_path / "home", mode=mode, python=blank_python
+        )
+
+    assert calls == []
+
+
 @pytest.mark.parametrize("blank_python", ["", " \t\n "])
 def test_wrapper_explicit_blank_python_fails_without_target_or_fallback(
     tmp_path, monkeypatch, capsys, blank_python
@@ -631,42 +658,6 @@ def test_wrapper_explicit_blank_python_fails_without_target_or_fallback(
     assert rc == 1
     assert "--python was given an empty value" in capsys.readouterr().err
     assert not target.exists()
-
-
-def test_wrapper_mode_is_unaffected_by_failed_discovery(tmp_path, monkeypatch):
-    """Wrapper installs validate their own interpreter and must not be blocked."""
-    system_bin = tmp_path / "usr" / "bin"
-    _write_executable(system_bin / "hermes", "#!/bin/sh\nexit 0\n")
-
-    class _SkillResult:
-        message = "skipped"
-
-    target = tmp_path / "wrapper-target"
-    target.mkdir()
-
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "empty-home"))
-    monkeypatch.setenv("PATH", str(system_bin))
-    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
-    monkeypatch.setattr(sys, "prefix", sys.base_prefix)
-    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "user-home"))
-    monkeypatch.setattr(install, "check_mnemosyne_core", lambda: True)
-    monkeypatch.setattr(install, "install_plugin", lambda **kwargs: target)
-    monkeypatch.setattr(install, "install_bundled_skill", lambda **kwargs: _SkillResult())
-    monkeypatch.setattr(
-        install,
-        "plugin_state",
-        lambda **kwargs: install.PluginState(
-            status="installed",
-            installed=True,
-            target=target,
-            mode="wrapper",
-            message="ok",
-        ),
-    )
-
-    rc = install.run_install(hermes_home_path=tmp_path / "empty-home", mode="wrapper")
-
-    assert rc == 0
 
 
 def test_wrapper_without_python_uses_discovered_hermes_interpreter(
@@ -707,6 +698,33 @@ def test_wrapper_without_python_uses_discovered_hermes_interpreter(
     assert install.run_install(hermes_home_path=tmp_path / "home", mode="wrapper") == 0
     assert selected == [discovered]
     assert selected != [Path(sys.executable)]
+
+
+def test_wrapper_without_discovered_python_fails_closed(tmp_path, monkeypatch, capsys):
+    """An omitted wrapper --python must not fall back to this Python or mutate."""
+    fallback_python = tmp_path / "installer-python"
+    _write_executable(fallback_python, "#!/bin/sh\nexit 0\n")
+    target = install.plugin_target_dir(tmp_path / "home")
+    calls: list[str] = []
+
+    def fail(name):
+        def _fail(*args, **kwargs):
+            calls.append(name)
+            raise AssertionError(f"missing wrapper runtime reached {name}")
+
+        return _fail
+
+    monkeypatch.setattr(sys, "executable", str(fallback_python))
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: None)
+    monkeypatch.setattr(install, "check_mnemosyne_core", fail("core preflight"))
+    monkeypatch.setattr(install, "_site_packages_for_python", fail("fallback probe"))
+    monkeypatch.setattr(install, "install_plugin", fail("plugin install"))
+    monkeypatch.setattr(install, "install_bundled_skill", fail("skill install"))
+
+    assert install.run_install(hermes_home_path=tmp_path / "home", mode="wrapper") == 1
+    assert "Pass --python" in capsys.readouterr().err
+    assert calls == []
+    assert not target.exists()
 
 
 def test_relative_wrapper_python_is_lexically_absolute_before_isolated_probe(
@@ -857,6 +875,32 @@ def test_wrapper_dry_run_uses_discovered_interpreter_for_display_and_probe(
     assert f"Wrapper site-packages: {site_packages}" in out
     assert str(installer_python) not in out
     assert probed == [discovered]
+
+
+def test_wrapper_dry_run_without_discovered_python_fails_without_fallback_or_probe(
+    tmp_path, monkeypatch, capsys
+):
+    """Dry-run has the same fail-closed wrapper-runtime boundary as installation."""
+    fallback_python = tmp_path / "installer-python"
+    _write_executable(fallback_python, "#!/bin/sh\nexit 0\n")
+    calls: list[str] = []
+
+    def fail(name):
+        def _fail(*args, **kwargs):
+            calls.append(name)
+            raise AssertionError(f"missing wrapper runtime reached {name}")
+
+        return _fail
+
+    monkeypatch.setattr(sys, "executable", str(fallback_python))
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: None)
+    monkeypatch.setattr(install, "_site_packages_for_python", fail("fallback probe"))
+    monkeypatch.setattr(install, "install_bundled_skill", fail("skill planning"))
+    monkeypatch.setattr(install, "plugin_target_dir", fail("target planning"))
+
+    assert install.main(["install", "--mode", "wrapper", "--dry-run"]) == 1
+    assert "Pass --python" in capsys.readouterr().err
+    assert calls == []
 
 
 def test_wrapper_dry_run_makes_explicit_relative_python_absolute_before_probe(

--- a/integrations/hermes/tests/test_find_hermes_python.py
+++ b/integrations/hermes/tests/test_find_hermes_python.py
@@ -599,6 +599,40 @@ def test_no_bootstrap_continues_without_a_validated_interpreter(tmp_path, monkey
     assert "Continuing without dependency validation" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize("blank_python", ["", " \t\n "])
+def test_wrapper_explicit_blank_python_fails_without_target_or_fallback(
+    tmp_path, monkeypatch, capsys, blank_python
+):
+    """An explicit blank wrapper --python is invalid, not a request for this Python."""
+    fallback_python = tmp_path / "fallback-python"
+    _write_executable(fallback_python, "#!/bin/sh\nexit 0\n")
+    hermes_home = tmp_path / "hermes-home"
+    target = install.plugin_target_dir(hermes_home)
+
+    monkeypatch.setattr(sys, "executable", str(fallback_python))
+
+    def fail_if_fallback_is_validated(*args, **kwargs):
+        raise AssertionError("blank --python must not fall back to sys.executable")
+
+    monkeypatch.setattr(install, "_site_packages_for_python", fail_if_fallback_is_validated)
+
+    rc = install.main(
+        [
+            "--hermes-home",
+            str(hermes_home),
+            "install",
+            "--mode",
+            "wrapper",
+            "--python",
+            blank_python,
+        ]
+    )
+
+    assert rc == 1
+    assert "--python was given an empty value" in capsys.readouterr().err
+    assert not target.exists()
+
+
 def test_wrapper_mode_is_unaffected_by_failed_discovery(tmp_path, monkeypatch):
     """Wrapper installs validate their own interpreter and must not be blocked."""
     system_bin = tmp_path / "usr" / "bin"

--- a/integrations/hermes/tests/test_find_hermes_python.py
+++ b/integrations/hermes/tests/test_find_hermes_python.py
@@ -669,6 +669,78 @@ def test_wrapper_mode_is_unaffected_by_failed_discovery(tmp_path, monkeypatch):
     assert rc == 0
 
 
+def test_wrapper_without_python_uses_discovered_hermes_interpreter(
+    tmp_path, monkeypatch
+):
+    """An omitted wrapper --python records and validates Hermes' runtime, not ours."""
+    discovered = _make_venv(tmp_path / "hermes-venv")
+    installer_python = tmp_path / "installer-python"
+    _write_executable(installer_python, "#!/bin/sh\nexit 0\n")
+    selected: list[Path | None] = []
+    target = tmp_path / "wrapper-target"
+    target.mkdir()
+
+    class _SkillResult:
+        message = "skipped"
+
+    monkeypatch.setattr(sys, "executable", str(installer_python))
+    monkeypatch.setattr(install, "check_mnemosyne_core", lambda: True)
+    monkeypatch.setattr(install, "_find_hermes_python", lambda **kwargs: discovered)
+    monkeypatch.setattr(
+        install,
+        "install_plugin",
+        lambda **kwargs: (selected.append(kwargs["python"]), target)[1],
+    )
+    monkeypatch.setattr(install, "install_bundled_skill", lambda **kwargs: _SkillResult())
+    monkeypatch.setattr(
+        install,
+        "plugin_state",
+        lambda **kwargs: install.PluginState(
+            status="installed",
+            installed=True,
+            target=target,
+            mode="wrapper",
+            message="ok",
+        ),
+    )
+
+    assert install.run_install(hermes_home_path=tmp_path / "home", mode="wrapper") == 0
+    assert selected == [discovered]
+    assert selected != [Path(sys.executable)]
+
+
+def test_relative_wrapper_python_is_lexically_absolute_before_isolated_probe(
+    tmp_path, monkeypatch
+):
+    """A relative --python survives the probe's different temporary cwd intact."""
+    selected = tmp_path / "venv" / "bin" / "python"
+    selected.parent.mkdir(parents=True)
+    selected.symlink_to(Path(sys.executable))
+    site_packages = tmp_path / "site-packages"
+    _write_executable(site_packages / "mnemosyne_hermes" / "__init__.py", "__version__ = 'test'\n")
+    (site_packages / "mnemosyne" / "core").mkdir(parents=True)
+    (site_packages / "mnemosyne" / "__init__.py").write_text("", encoding="utf-8")
+    (site_packages / "mnemosyne" / "core" / "__init__.py").write_text("", encoding="utf-8")
+    (site_packages / "mnemosyne" / "core" / "beam.py").write_text("", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    relative_python = os.path.relpath(selected, start=tmp_path)
+    expected = Path(relative_python).absolute()
+    seen: list[Path] = []
+
+    def site_for_python(python, **kwargs):
+        seen.append(Path(python))
+        return site_packages
+
+    monkeypatch.setattr(install, "_site_packages_for_python", site_for_python)
+
+    wrapper_python, returned_site = install._validated_wrapper_environment(relative_python)
+
+    assert wrapper_python == expected == selected
+    assert wrapper_python.resolve() == Path(sys.executable).resolve()
+    assert seen == [expected]
+    assert returned_site == site_packages
+
+
 def test_run_install_bootstraps_hermes_venv_not_path_sibling(
     hermes_world, tmp_path, monkeypatch
 ):

--- a/integrations/hermes/tests/test_install_hermes.py
+++ b/integrations/hermes/tests/test_install_hermes.py
@@ -1176,6 +1176,12 @@ def test_wrapper_preflight_and_bootstrap_support_real_pep660_editable_install(tm
 
     site_packages = install_mod._site_packages_for_python(python)
     assert not (site_packages / "mnemosyne_hermes").exists()
+    # The wrapper's selected interpreter must contain both the editable Hermes
+    # package and the operational Mnemosyne core. Model the latter with a
+    # second editable-style .pth entry, without downloading dependencies.
+    (site_packages / "mnemosyne-memory.pth").write_text(
+        f"{project.parent.parent}\n", encoding="utf-8"
+    )
     assert install_mod._check_wrapper_import(site_packages, python) == (True, None, False)
 
     wrapper = tmp_path / "hermes-home" / "plugins" / "mnemosyne"

--- a/integrations/hermes/tests/test_install_status.py
+++ b/integrations/hermes/tests/test_install_status.py
@@ -411,6 +411,11 @@ def test_check_wrapper_import_accepts_direct_package_without_dist_metadata(tmp_p
     package = site_packages / "mnemosyne_hermes"
     package.mkdir(parents=True)
     (package / "__init__.py").write_text("__version__ = 'test'\n", encoding="utf-8")
+    core = site_packages / "mnemosyne" / "core"
+    core.mkdir(parents=True)
+    (core.parent / "__init__.py").write_text("", encoding="utf-8")
+    (core / "__init__.py").write_text("", encoding="utf-8")
+    (core / "beam.py").write_text("", encoding="utf-8")
 
     ok, error, invalid_runtime = install._check_wrapper_import(site_packages, Path(sys.executable))
 

--- a/integrations/hermes/tests/test_wrapper_import_timeout.py
+++ b/integrations/hermes/tests/test_wrapper_import_timeout.py
@@ -56,6 +56,35 @@ def test_wrapper_validation_timeout_reaches_both_probes(tmp_path, monkeypatch, i
     assert observed_timeouts == [import_timeout, import_timeout]
 
 
+def test_wrapper_validation_rejects_selected_python_without_mnemosyne_core(
+    tmp_path, monkeypatch
+):
+    """Wrapper --python must prove core imports, not only the fallback package."""
+    selected_python = tmp_path / "selected-python"
+    selected_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    selected_python.chmod(0o755)
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    commands = []
+
+    def probe(command, **kwargs):
+        commands.append(command)
+        if "-S" not in command:
+            return subprocess.CompletedProcess(command, 0, f"{site_packages}\n", "")
+        if "import mnemosyne.core.beam" in command[-1]:
+            return subprocess.CompletedProcess(
+                command, 1, "", "ModuleNotFoundError: No module named 'mnemosyne.core'"
+            )
+        return subprocess.CompletedProcess(command, 0, "0.0-test\n", "")
+
+    monkeypatch.setattr(install.subprocess, "run", probe)
+
+    with pytest.raises(RuntimeError, match="cannot import required mnemosyne core"):
+        install._validated_wrapper_environment(selected_python)
+
+    assert any("import mnemosyne.core.beam" in command[-1] for command in commands)
+
+
 def test_plugin_state_accepts_11_second_healthy_wrapper_import(tmp_path, monkeypatch):
     """Status must share the 60-second wrapper-validation policy with install."""
     target = tmp_path / "plugins" / "mnemosyne"

--- a/integrations/hermes/tests/test_wrapper_import_timeout.py
+++ b/integrations/hermes/tests/test_wrapper_import_timeout.py
@@ -1,5 +1,6 @@
 """Focused coverage for wrapper validation timeout configuration."""
 
+import os
 import subprocess
 import sys
 import venv
@@ -100,6 +101,8 @@ def test_wrapper_validation_rejects_real_selected_venv_without_mnemosyne_core(tm
     assert install_result.returncode == 0, install_result.stderr
 
     site_packages = install._site_packages_for_python(python)
+    probe_cwd = tmp_path / "fallback-probe-cwd"
+    probe_cwd.mkdir()
     fallback_probe = subprocess.run(
         [
             str(python),
@@ -113,6 +116,8 @@ def test_wrapper_validation_rejects_real_selected_venv_without_mnemosyne_core(tm
         ],
         capture_output=True,
         text=True,
+        cwd=probe_cwd,
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
     )
     assert fallback_probe.returncode != 0
     assert fallback_probe.stdout.strip() == "fallback-imported"

--- a/integrations/hermes/tests/test_wrapper_import_timeout.py
+++ b/integrations/hermes/tests/test_wrapper_import_timeout.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import sys
+import venv
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -83,6 +84,42 @@ def test_wrapper_validation_rejects_selected_python_without_mnemosyne_core(
         install._validated_wrapper_environment(selected_python)
 
     assert any("import mnemosyne.core.beam" in command[-1] for command in commands)
+
+
+def test_wrapper_validation_rejects_real_selected_venv_without_mnemosyne_core(tmp_path):
+    """A selected venv may import the graceful fallback without containing core."""
+    environment = tmp_path / "selected-environment"
+    venv.EnvBuilder(with_pip=True).create(environment)
+    python = environment / ("Scripts/python.exe" if sys.platform.startswith("win32") else "bin/python")
+    project = Path(__file__).resolve().parent.parent
+    install_result = subprocess.run(
+        [str(python), "-m", "pip", "install", "--no-deps", "-e", str(project)],
+        capture_output=True,
+        text=True,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    site_packages = install._site_packages_for_python(python)
+    fallback_probe = subprocess.run(
+        [
+            str(python),
+            "-S",
+            "-c",
+            "import site\n"
+            f"site.addsitedir({str(site_packages)!r})\n"
+            "import mnemosyne_hermes\n"
+            "print('fallback-imported')\n"
+            "import mnemosyne.core.beam\n",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert fallback_probe.returncode != 0
+    assert fallback_probe.stdout.strip() == "fallback-imported"
+    assert "No module named 'mnemosyne'" in fallback_probe.stderr
+
+    with pytest.raises(RuntimeError, match=r"mnemosyne\.core\.beam"):
+        install._validated_wrapper_environment(python)
 
 
 def test_plugin_state_accepts_11_second_healthy_wrapper_import(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #883

Wrapper installs with an explicit `--python` now validate Mnemosyne core in that selected interpreter instead of preflighting the CLI interpreter. The probe is isolated from the installer checkout and fails closed when `mnemosyne.core.beam` is unavailable.

Wrapper installs without `--python` and non-wrapper modes retain the existing CLI-interpreter preflight.

Tests: `uv run --no-sync --with pytest --with-editable . --with-editable integrations/hermes pytest integrations/hermes/tests/test_install_hermes.py integrations/hermes/tests/test_find_hermes_python.py integrations/hermes/tests/test_install_status.py integrations/hermes/tests/test_wrapper_import_timeout.py integrations/hermes/tests/test_windows_default_install_mode.py integrations/hermes/tests/test_windows_symlink_privilege.py -q` (176 passed).

No migration or data changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Validates `mnemosyne.core.beam` in the interpreter selected by explicit wrapper `--python`.
- Rejects blank and whitespace-only explicit `--python` values without fallback.
- Preserves existing preflight behavior for omitted `--python` and non-wrapper modes.
- Isolates wrapper validation from the installer checkout and sanitizes its environment.
- Adds regression coverage for interpreter discovery, relative paths, dry-run behavior, symlink boundaries, and missing core dependencies.

## Architectural impact

- No changes to working, episodic, or BEAM memory tiers.
- No changes to retrieval, consolidation, veracity, sync, or benchmark methodology.
- No changes to the core memory data model.
- Hermes now validates the interpreter that performs the wrapper import. This is the right call for explicit interpreter selection.
- MCP and CLI integration surfaces have no functional changes beyond corrected wrapper installation behavior.
- The change preserves local-first behavior. It adds no network dependency, telemetry, migration, or data change.
- Isolated validation reduces accidental imports and improves long-term maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->