### PR TITLE
fix: make native consolidation-log imports idempotent

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -9955,23 +9955,40 @@ class BeamMemory:
         for item in data.get("consolidation_log", []):
             log_id = item.get("id")
             if log_id is not None:
-                cursor.execute("SELECT 1 FROM consolidation_log WHERE id = ?", (log_id,))
-                exists = cursor.fetchone() is not None
-                if exists and not force:
-                    stats["consolidation_log"]["skipped"] += 1
-                    continue
-                if exists and force:
-                    cursor.execute("DELETE FROM consolidation_log WHERE id = ?", (log_id,))
-                    stats["consolidation_log"]["overwritten"] += 1
+                exists = cursor.execute(
+                    "SELECT 1 FROM consolidation_log WHERE id = ?", (log_id,)
+                ).fetchone() is not None
+                if not force:
+                    cursor.execute(
+                        """
+                        INSERT OR IGNORE INTO consolidation_log
+                            (id, session_id, items_consolidated, summary_preview, created_at)
+                        VALUES (?, ?, ?, ?, ?)
+                        """,
+                        (log_id, item.get("session_id", "default"),
+                         item.get("items_consolidated", 0), item.get("summary_preview", ""),
+                         item.get("created_at")),
+                    )
+                    stats["consolidation_log"][
+                        "skipped" if cursor.rowcount == 0 else "inserted"
+                    ] += 1
                 else:
-                    stats["consolidation_log"]["inserted"] += 1
-                cursor.execute("""
-                    INSERT INTO consolidation_log
-                        (id, session_id, items_consolidated, summary_preview, created_at)
-                    VALUES (?, ?, ?, ?, ?)
-                """, (log_id, item.get("session_id", "default"),
-                      item.get("items_consolidated", 0), item.get("summary_preview", ""),
-                      item.get("created_at")))
+                    cursor.execute(
+                        """
+                        INSERT INTO consolidation_log
+                            (id, session_id, items_consolidated, summary_preview, created_at)
+                        VALUES (?, ?, ?, ?, ?)
+                        ON CONFLICT(id) DO UPDATE SET
+                            session_id=excluded.session_id,
+                            items_consolidated=excluded.items_consolidated,
+                            summary_preview=excluded.summary_preview,
+                            created_at=excluded.created_at
+                        """,
+                        (log_id, item.get("session_id", "default"),
+                         item.get("items_consolidated", 0), item.get("summary_preview", ""),
+                         item.get("created_at")),
+                    )
+                    stats["consolidation_log"]["overwritten" if exists else "inserted"] += 1
             else:
                 # Pre-ID exports cannot be matched to an existing log entry;
                 # preserve their historical append behavior.

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -9774,7 +9774,7 @@ class BeamMemory:
             "working_memory": {"inserted": 0, "skipped": 0, "overwritten": 0},
             "episodic_memory": {"inserted": 0, "skipped": 0, "overwritten": 0, "embeddings_inserted": 0},
             "scratchpad": {"inserted": 0, "updated": 0},
-            "consolidation_log": {"inserted": 0},
+            "consolidation_log": {"inserted": 0, "skipped": 0, "overwritten": 0},
         }
         cursor = self.conn.cursor()
 
@@ -9953,12 +9953,35 @@ class BeamMemory:
 
         # -- Consolidation log --
         for item in data.get("consolidation_log", []):
-            cursor.execute("""
-                INSERT INTO consolidation_log (session_id, items_consolidated, summary_preview, created_at)
-                VALUES (?, ?, ?, ?)
-            """, (item.get("session_id", "default"), item.get("items_consolidated", 0),
-                  item.get("summary_preview", ""), item.get("created_at")))
-            stats["consolidation_log"]["inserted"] += 1
+            log_id = item.get("id")
+            if log_id is not None:
+                cursor.execute("SELECT 1 FROM consolidation_log WHERE id = ?", (log_id,))
+                exists = cursor.fetchone() is not None
+                if exists and not force:
+                    stats["consolidation_log"]["skipped"] += 1
+                    continue
+                if exists and force:
+                    cursor.execute("DELETE FROM consolidation_log WHERE id = ?", (log_id,))
+                    stats["consolidation_log"]["overwritten"] += 1
+                else:
+                    stats["consolidation_log"]["inserted"] += 1
+                cursor.execute("""
+                    INSERT INTO consolidation_log
+                        (id, session_id, items_consolidated, summary_preview, created_at)
+                    VALUES (?, ?, ?, ?, ?)
+                """, (log_id, item.get("session_id", "default"),
+                      item.get("items_consolidated", 0), item.get("summary_preview", ""),
+                      item.get("created_at")))
+            else:
+                # Pre-ID exports cannot be matched to an existing log entry;
+                # preserve their historical append behavior.
+                cursor.execute("""
+                    INSERT INTO consolidation_log
+                        (session_id, items_consolidated, summary_preview, created_at)
+                    VALUES (?, ?, ?, ?)
+                """, (item.get("session_id", "default"), item.get("items_consolidated", 0),
+                      item.get("summary_preview", ""), item.get("created_at")))
+                stats["consolidation_log"]["inserted"] += 1
         self.conn.commit()
 
         return stats

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -1718,11 +1718,40 @@ class TestExportImport:
                     "SELECT COUNT(*) FROM consolidation_log"
                 ).fetchone()[0] == 1
 
+                target.conn.execute(
+                    """UPDATE consolidation_log
+                       SET session_id=?, items_consolidated=?, summary_preview=?, created_at=?
+                       WHERE id=?""",
+                    ("changed", 1, "changed", "2026-08-25T08:00:00", 1),
+                )
+                target.conn.commit()
                 forced = target.import_from_file(str(export_path), force=True)
                 assert forced["beam"]["consolidation_log"]["overwritten"] == 1
+                restored = target.conn.execute(
+                    """SELECT id, session_id, items_consolidated, summary_preview, created_at
+                       FROM consolidation_log WHERE id=?""",
+                    (1,),
+                ).fetchone()
+                assert tuple(restored) == (
+                    1, "s1", 209, "snapshot", "2026-08-24T08:00:00"
+                )
                 assert target.conn.execute(
                     "SELECT COUNT(*) FROM consolidation_log"
                 ).fetchone()[0] == 1
+
+                legacy = {
+                    "consolidation_log": [{
+                        "session_id": "legacy", "items_consolidated": 3,
+                        "summary_preview": "legacy", "created_at": "2026-08-26T08:00:00",
+                    }]
+                }
+                legacy_first = target.beam.import_from_dict(legacy)
+                legacy_second = target.beam.import_from_dict(legacy)
+                assert legacy_first["consolidation_log"]["inserted"] == 1
+                assert legacy_second["consolidation_log"]["inserted"] == 1
+                assert target.conn.execute(
+                    "SELECT COUNT(*) FROM consolidation_log WHERE session_id=?", ("legacy",)
+                ).fetchone()[0] == 2
             finally:
                 source.conn.close()
                 if target is not None:

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -7,6 +7,7 @@ import tempfile
 import sqlite3
 import time
 import os
+import gc
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 
@@ -1691,6 +1692,45 @@ class TestExportImport:
             stats = target.import_from_file(str(export_path))
             assert stats["legacy"]["inserted"] >= 1
             assert stats["beam"]["working_memory"]["inserted"] >= 1
+
+    def test_mnemosyne_import_is_idempotent_for_consolidation_log(self, temp_db):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Mnemosyne(session_id="s1", db_path=temp_db)
+            target = None
+            try:
+                source.conn.execute(
+                    """INSERT INTO consolidation_log
+                       (session_id, items_consolidated, summary_preview, created_at)
+                       VALUES (?, ?, ?, ?)""",
+                    ("s1", 209, "snapshot", "2026-08-24T08:00:00"),
+                )
+                source.conn.commit()
+                export_path = Path(tmpdir) / "export.json"
+                source.export_to_file(str(export_path))
+
+                target = Mnemosyne(session_id="s1", db_path=Path(tmpdir) / "target.db")
+                first = target.import_from_file(str(export_path))
+                second = target.import_from_file(str(export_path))
+
+                assert first["beam"]["consolidation_log"]["inserted"] == 1
+                assert second["beam"]["consolidation_log"]["skipped"] == 1
+                assert target.conn.execute(
+                    "SELECT COUNT(*) FROM consolidation_log"
+                ).fetchone()[0] == 1
+
+                forced = target.import_from_file(str(export_path), force=True)
+                assert forced["beam"]["consolidation_log"]["overwritten"] == 1
+                assert target.conn.execute(
+                    "SELECT COUNT(*) FROM consolidation_log"
+                ).fetchone()[0] == 1
+            finally:
+                source.conn.close()
+                if target is not None:
+                    target.conn.close()
+                # import_from_file constructs short-lived store connections
+                # for the auxiliary tables.  Release those objects before
+                # Windows removes the temporary directory.
+                gc.collect()
 
     def test_import_from_dict_canonicalizes_valid_until(self, temp_db):
         """#525: import_from_dict must normalize offset-bearing valid_until


### PR DESCRIPTION
## Summary

Native JSON exports include the primary key for each `consolidation_log` row, but imports ignored it and appended every row on every run. This made the documented idempotent import duplicate consolidation history.

This change uses the exported row ID for normal skip-on-existing behavior and for `force=True` replacement, while preserving append behavior for older payloads that do not contain an ID. Import statistics now report inserted, skipped, and overwritten consolidation-log rows.

## Testing

- `MNEMOSYNE_NO_EMBEDDINGS=1 uv run --frozen --with pytest python -m pytest tests/test_beam.py -k mnemosyne_import_is_idempotent_for_consolidation_log -q`
- Ruff CI fatal and changed-file rule checks pass.
- The regression test covers first import, repeated import, and forced replacement through `Mnemosyne.import_from_file()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Makes native `consolidation_log` imports idempotent when exported rows include IDs.
- Skips existing rows during normal imports.
- Replaces existing rows when `force=True`.
- Preserves append behavior for older exports without IDs.
- Reports `inserted`, `skipped`, and `overwritten` rows.
- Adds regression coverage through `Mnemosyne.import_from_file()`.

## Architecture impact

- **BEAM and consolidation pipeline:** Prevents duplicate consolidation-log rows during repeated imports. This improves consolidation history consistency.
- **Tiered memory:** Changes only BEAM consolidation-log import behavior. It does not change working memory, episodic memory, retrieval, or consolidation logic.
- **Local-first design:** Preserves local import and restore workflows. The change adds no remote dependency.
- **Privacy posture:** No change. Data remains in the existing local storage path.
- **Agent integration:** No direct changes to Hermes, MCP, or CLI surfaces. Existing import behavior and statistics become more reliable.
- **Sync layer:** No sync protocol changes. ID-based replacement supports safer future synchronization.
- **Veracity system and benchmarks:** No changes.
- **Maintainability:** Explicit import counters and compatibility handling make outcomes easier to inspect. Regression tests cover insert, skip, overwrite, and legacy append behavior.

This is the right call for native imports. It removes duplicate accumulation while preserving compatibility and the local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->