### PR TITLE
fix: cap sqlite-vec before nonportable 0.1.10 alphas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,12 @@ classifiers = [
 
 [project.optional-dependencies]
 llm = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20"]
-embeddings = ["fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.9,<0.1.10a0"]
+embeddings = ["fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.9,<0.1.10"]
 mcp = ["mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"]
 openclaw = ["openclaw>=0.1.0; python_version >= '3.10'"]
 sync = ["cryptography>=41.0"]
 test = ["pytest>=7.0", "pytest-timeout>=2.1", "build"]
-all = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.9,<0.1.10a0", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'", "cryptography>=41.0"]
+all = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.9,<0.1.10", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'", "cryptography>=41.0"]
 dev = ["pytest>=7.0", "pytest-timeout>=2.1", "build", "twine", "ruff==0.15.22"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,12 @@ classifiers = [
 
 [project.optional-dependencies]
 llm = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20"]
-embeddings = ["fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.0"]
+embeddings = ["fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.9,<0.1.10a0"]
 mcp = ["mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"]
 openclaw = ["openclaw>=0.1.0; python_version >= '3.10'"]
 sync = ["cryptography>=41.0"]
 test = ["pytest>=7.0", "pytest-timeout>=2.1", "build"]
-all = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.0", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'", "cryptography>=41.0"]
+all = ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.9,<0.1.10a0", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'", "cryptography>=41.0"]
 dev = ["pytest>=7.0", "pytest-timeout>=2.1", "build", "twine", "ruff==0.15.22"]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -68,11 +68,11 @@ setup(
     },
     extras_require={
         "llm": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20"],
-        "embeddings": ["fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.0"],
+        "embeddings": ["fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.9,<0.1.10"],
         "mcp": ["mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
         "openclaw": ["openclaw>=0.1.0; python_version >= '3.10'"],
         "test": ["pytest>=7.0"],
-        "all": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.0", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
+        "all": ["ctransformers>=0.2.27", "llama-cpp-python>=0.2.0", "huggingface-hub>=0.20", "fastembed>=0.3.0", "onnxruntime>=1.21.0,<1.29", "sqlite-vec>=0.1.9,<0.1.10", "mcp>=2.0.0; python_version >= '3.10'", "anyio>=4.0; python_version >= '3.10'"],
         "dev": ["pytest>=7.0", "build", "twine"],
     },
     entry_points={

--- a/uv.lock
+++ b/uv.lock
@@ -1106,8 +1106,8 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.22" },
-    { name = "sqlite-vec", marker = "extra == 'all'", specifier = ">=0.1.9,<0.1.10a0" },
-    { name = "sqlite-vec", marker = "extra == 'embeddings'", specifier = ">=0.1.9,<0.1.10a0" },
+    { name = "sqlite-vec", marker = "extra == 'all'", specifier = ">=0.1.9,<0.1.10" },
+    { name = "sqlite-vec", marker = "extra == 'embeddings'", specifier = ">=0.1.9,<0.1.10" },
     { name = "twine", marker = "extra == 'dev'" },
 ]
 provides-extras = ["llm", "embeddings", "mcp", "openclaw", "sync", "test", "all", "dev"]

--- a/uv.lock
+++ b/uv.lock
@@ -1106,8 +1106,8 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.22" },
-    { name = "sqlite-vec", marker = "extra == 'all'", specifier = ">=0.1.0" },
-    { name = "sqlite-vec", marker = "extra == 'embeddings'", specifier = ">=0.1.0" },
+    { name = "sqlite-vec", marker = "extra == 'all'", specifier = ">=0.1.9,<0.1.10a0" },
+    { name = "sqlite-vec", marker = "extra == 'embeddings'", specifier = ">=0.1.9,<0.1.10a0" },
     { name = "twine", marker = "extra == 'dev'" },
 ]
 provides-extras = ["llm", "embeddings", "mcp", "openclaw", "sync", "test", "all", "dev"]


### PR DESCRIPTION
## Summary

Caps `sqlite-vec` in the `embeddings` and `all` extras at the known-good 0.1.9 line, excluding non-portable 0.1.10 alpha wheels that can raise `SIGILL` on non-AVX2 x86_64.

Closes #889.

## Why this path

The resolver boundary is the smallest intervention: it protects new installs without touching databases or recall behavior. `<0.1.10` deliberately excludes every `0.1.10` pre-release and final release under PEP 440, including `0.1.10a4`.

## Non-goals and rollback

- Does not change sqlite-vec runtime code, stored vectors, or fallback behavior.
- Keeps the cap until sqlite-vec #302 has a portable release and a fresh CPU-compatibility smoke supports lifting it.
- Rollback is reverting this one metadata-only commit.

## Verification

- Fresh `.[embeddings]` resolution selected `sqlite-vec==0.1.9`.
- Independent current-diff review: approved.
- Built wheel and sdist; wheel and sdist-built metadata both expose the capped requirement for both extras; `twine check` passed.
- Fresh `--no-deps` wheel install metadata smoke passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Constrains `sqlite-vec` in the `embeddings` and `all` extras to `>=0.1.9,<0.1.10`.
- Prevents non-portable `0.1.10` wheels from causing `SIGILL` on non-AVX2 x86_64 CPUs.
- Preserves local-first operation through supported local vector dependencies.

## Architectural impact

- Changes dependency metadata only.
- Does not change working, episodic, or BEAM memory tiers.
- Does not change retrieval, consolidation, veracity, sync, databases, stored vectors, or fallback behavior.
- Does not change Hermes, MCP, or CLI integration surfaces.
- Does not change the privacy posture or local-first guarantees.
- Does not change benchmark methodology.
- Improves maintainability through a temporary compatibility boundary until upstream provides portable wheels.
- This dependency cap is the right call because it prevents a hardware-specific crash without changing runtime architecture or data.
- The change does not erode local-first design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
