### PR TITLE
fix: prevent entity-only recall candidates

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6613,7 +6613,8 @@ class BeamMemory:
             """, (*tuple(entity_memory_ids), *wm_params))
             entity_rows = cursor.fetchall()
             
-            # Add entity-matched memories with boosted scores
+            # Entity matches can strengthen an existing query candidate, but
+            # must not introduce annotation-only rows with no query evidence.
             existing_ids = {r["id"] for r in results}
             for row in entity_rows:
                 if row["id"] in existing_ids:
@@ -6623,38 +6624,7 @@ class BeamMemory:
                             r["score"] = round(min(r["score"] * 1.3, 1.0), 4)
                             r["entity_match"] = True
                             break
-                else:
-                    decay = _recency_decay(row["timestamp"])
-                    score = (0.6 + row["importance"] * 0.2) * (0.7 + 0.3 * decay)
-                    score += _current_state_recency_bonus(query_words, row["content"])
-                    # Temporal boost (Phase 3)
-                    if temporal_weight > 0.0:
-                        t_boost = _temporal_boost(row["timestamp"], parsed_query_time, th_halflife)
-                        score *= (1.0 + temporal_weight * t_boost)
-                    _track_literal_content("working", row["id"], row["content"])
-                    results.append({
-                        "id": row["id"],
-                        "content": row["content"][:500],
-                        "source": row["source"],
-                        "timestamp": row["timestamp"],
-                        "tier": "working",
-                        "score": round(score, 4),
-                        "keyword_score": 0.0,
-                        "dense_score": round(wm_vec_sims.get(row["id"], 0.0), 4),
-                        "fts_score": 0.0,
-                        "importance": row["importance"],
-                        "recall_count": row["recall_count"] or 0,
-                        "last_recalled": row["last_recalled"],
-                        "recency_decay": round(decay, 4),
-                        "scope": row["scope"] if "scope" in row.keys() else "session",
-                        "author_id": row["author_id"] if "author_id" in row.keys() else None,
-                        "author_type": row["author_type"] if "author_type" in row.keys() else None,
-                        "channel_id": row["channel_id"] if "channel_id" in row.keys() else None,
-                        "veracity": row["veracity"] if "veracity" in row.keys() else "unknown",
-                        "valid_until": row["valid_until"] if "valid_until" in row.keys() else None,
-                        "superseded_by": row["superseded_by"] if "superseded_by" in row.keys() else None,
-                        "entity_match": True
-                    })
+
             
             # Also check episodic memory for entity matches
             em_placeholders = ",".join("?" * len(entity_memory_ids))
@@ -6686,45 +6656,7 @@ class BeamMemory:
                             r["score"] = round(min(r["score"] * 1.3, 1.0), 4)
                             r["entity_match"] = True
                             break
-                else:
-                    decay = _recency_decay(row["timestamp"])
-                    score = (0.6 + row["importance"] * 0.2) * (0.7 + 0.3 * decay)
-                    score += _current_state_recency_bonus(query_words, row["content"])
-                    # Temporal boost (Phase 3)
-                    if temporal_weight > 0.0:
-                        t_boost = _temporal_boost(row["timestamp"], parsed_query_time, th_halflife)
-                        score *= (1.0 + temporal_weight * t_boost)
-                    _track_literal_content("episodic", row["id"], row["content"])
-                    results.append({
-                        "id": row["id"],
-                        "content": row["content"][:500],
-                        "source": row["source"],
-                        "timestamp": row["timestamp"],
-                        "tier": "episodic",
-                        "score": round(score, 4),
-                        "keyword_score": 0.0,
-                        # C30: episodic rows never key into wm_vec_sims
-                        # (that dict holds working_memory ids only). Set
-                        # 0.0 explicitly rather than lookup-that-always-
-                        # returns-default, so post-run analysis isn't
-                        # misled into thinking dense similarity was
-                        # computed. The entity/fact-matched episodic
-                        # paths don't compute ep dense sim themselves.
-                        "dense_score": 0.0,
-                        "fts_score": 0.0,
-                        "importance": row["importance"],
-                        "recall_count": row["recall_count"] or 0,
-                        "last_recalled": row["last_recalled"],
-                        "recency_decay": round(decay, 4),
-                        "scope": row["scope"] if "scope" in row.keys() else "session",
-                        "author_id": row["author_id"] if "author_id" in row.keys() else None,
-                        "author_type": row["author_type"] if "author_type" in row.keys() else None,
-                        "channel_id": row["channel_id"] if "channel_id" in row.keys() else None,
-                        "veracity": row["veracity"] if "veracity" in row.keys() else "unknown",
-                        "valid_until": row["valid_until"] if "valid_until" in row.keys() else None,
-                        "superseded_by": row["superseded_by"] if "superseded_by" in row.keys() else None,
-                        "entity_match": True
-                    })
+
 
         # ---- Fact-aware recall ----
         fact_memory_ids = _find_memories_by_fact(self, query)

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -6615,12 +6615,12 @@ class BeamMemory:
             
             # Entity matches can strengthen an existing query candidate, but
             # must not introduce annotation-only rows with no query evidence.
-            existing_ids = {r["id"] for r in results}
+            existing_ids = {r["id"] for r in results if r.get("tier") == "working"}
             for row in entity_rows:
                 if row["id"] in existing_ids:
                     # Boost existing result
                     for r in results:
-                        if r["id"] == row["id"]:
+                        if r.get("tier") == "working" and r["id"] == row["id"]:
                             r["score"] = round(min(r["score"] * 1.3, 1.0), 4)
                             r["entity_match"] = True
                             break
@@ -6648,16 +6648,6 @@ class BeamMemory:
             """, (*em_entity_params,))
             em_entity_rows = cursor.fetchall()
             
-            em_existing_ids = {r["id"] for r in results}
-            for row in em_entity_rows:
-                if row["id"] in em_existing_ids:
-                    for r in results:
-                        if r["id"] == row["id"]:
-                            r["score"] = round(min(r["score"] * 1.3, 1.0), 4)
-                            r["entity_match"] = True
-                            break
-
-
         # ---- Fact-aware recall ----
         fact_memory_ids = _find_memories_by_fact(self, query)
         if fact_memory_ids:
@@ -7127,6 +7117,20 @@ class BeamMemory:
                     fallback_used=True,
                 )
 
+        # Entity lookup runs before episodic candidate assembly, so apply its
+        # annotation only after both primary and fallback episodic candidates
+        # are present. Match the tier as well as the id: ids are not a
+        # cross-tier identity contract.
+        if entity_memory_ids:
+            episodic_entity_ids = {row["id"] for row in em_entity_rows}
+            for result in results:
+                if (
+                    result.get("tier") == "episodic"
+                    and result["id"] in episodic_entity_ids
+                ):
+                    result["score"] = round(min(result["score"] * 1.3, 1.0), 4)
+                    result["entity_match"] = True
+
         # --- Tiered degradation weighting: apply tier multiplier to episodic scores ---
         weight_map = {1: TIER1_WEIGHT, 2: TIER2_WEIGHT, 3: TIER3_WEIGHT}
         veracity_map = {"stated": STATED_WEIGHT, "inferred": INFERRED_WEIGHT,
@@ -7416,7 +7420,7 @@ class BeamMemory:
     # cached under an older digest are not reused. Part of the hashed payload;
     # the opaque key keeps the "v2:" prefix because QueryCache's opaque-path
     # recognition (_OPAQUE_V2_KEY_RE) keys off that prefix.
-    _ENHANCED_RECALL_CACHE_VERSION = 5
+    _ENHANCED_RECALL_CACHE_VERSION = 6
 
     def _enhanced_recall_cache_key(
         self,
@@ -7550,7 +7554,7 @@ class BeamMemory:
         # consolidated exclusion, #696 / #427), so pre-change opaque cache
         # entries could still contain dialog, honcho or consolidated dense
         # candidates. _ENHANCED_RECALL_CACHE_VERSION is part of the hashed
-        # payload; bumping it (4 -> 5) guarantees those entries are never
+        # payload; bumping it guarantees those entries are never
         # reused. The "v2:" prefix stays fixed — QueryCache's opaque-path
         # recognition keys off that exact prefix.
         return "v2:" + hashlib.sha256(material.encode("utf-8")).hexdigest()

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -743,16 +743,24 @@ class TestWorkingMemory:
         lexical_id = beam.remember("Atlas deployment notes", importance=0.1)
         entity_only_id = beam.remember("unrelated status update", importance=1.0)
 
+        baseline = beam.recall("Atlas", top_k=1)
+        assert [row["id"] for row in baseline] == [lexical_id]
+        baseline_score = baseline[0]["score"]
+
         monkeypatch.setattr(
             beam_module,
             "_find_memories_by_entity",
             lambda _beam, _query: [lexical_id, entity_only_id],
         )
 
-        results = beam.recall("Atlas", top_k=1)
+        results = beam.recall("Atlas", top_k=2)
+        result_ids = {row["id"] for row in results}
+        lexical_result = next(row for row in results if row["id"] == lexical_id)
 
-        assert [row["id"] for row in results] == [lexical_id]
-        assert results[0]["entity_match"] is True
+        assert entity_only_id not in result_ids
+        assert lexical_id in result_ids
+        assert lexical_result["entity_match"] is True
+        assert baseline_score < lexical_result["score"] <= min(baseline_score * 1.3, 1.0) + 0.0001
 
     def test_entity_annotations_do_not_append_episodic_only_candidates(self, temp_db, monkeypatch):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
@@ -763,15 +771,27 @@ class TestWorkingMemory:
             summary="unrelated status update", source_wm_ids=["wm-other"], importance=1.0,
         )
 
-        monkeypatch.setattr(
-            beam_module,
-            "_find_memories_by_entity",
-            lambda _beam, _query: [lexical_id, entity_only_id],
-        )
+        baseline = beam.recall("Atlas", top_k=1)
+        assert [row["id"] for row in baseline] == [lexical_id]
+        baseline_score = baseline[0]["score"]
 
-        results = beam.recall("Atlas", top_k=1)
+        entity_calls = []
 
-        assert [row["id"] for row in results] == [lexical_id]
+        def entity_matches(_beam, query):
+            entity_calls.append(query)
+            return [lexical_id, entity_only_id]
+
+        monkeypatch.setattr(beam_module, "_find_memories_by_entity", entity_matches)
+
+        results = beam.recall("Atlas", top_k=2)
+        result_ids = {row["id"] for row in results}
+        lexical_result = next(row for row in results if row["id"] == lexical_id)
+
+        assert entity_calls == ["Atlas"]
+        assert entity_only_id not in result_ids
+        assert lexical_id in result_ids
+        assert lexical_result["entity_match"] is True
+        assert baseline_score < lexical_result["score"] <= min(baseline_score * 1.3, 1.0) + 0.0001
 
     def test_get_context_keeps_global_first_then_session_order(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -738,6 +738,41 @@ class TestWorkingMemory:
         assert len(ctx) == 1
         assert ctx[0]["content"] == "Prefers Neovim"
 
+    def test_entity_annotations_only_boost_existing_recall_candidates(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        lexical_id = beam.remember("Atlas deployment notes", importance=0.1)
+        entity_only_id = beam.remember("unrelated status update", importance=1.0)
+
+        monkeypatch.setattr(
+            beam_module,
+            "_find_memories_by_entity",
+            lambda _beam, _query: [lexical_id, entity_only_id],
+        )
+
+        results = beam.recall("Atlas", top_k=1)
+
+        assert [row["id"] for row in results] == [lexical_id]
+        assert results[0]["entity_match"] is True
+
+    def test_entity_annotations_do_not_append_episodic_only_candidates(self, temp_db, monkeypatch):
+        beam = BeamMemory(session_id="s1", db_path=temp_db)
+        lexical_id = beam.consolidate_to_episodic(
+            summary="Atlas deployment notes", source_wm_ids=["wm-atlas"], importance=0.1,
+        )
+        entity_only_id = beam.consolidate_to_episodic(
+            summary="unrelated status update", source_wm_ids=["wm-other"], importance=1.0,
+        )
+
+        monkeypatch.setattr(
+            beam_module,
+            "_find_memories_by_entity",
+            lambda _beam, _query: [lexical_id, entity_only_id],
+        )
+
+        results = beam.recall("Atlas", top_k=1)
+
+        assert [row["id"] for row in results] == [lexical_id]
+
     def test_get_context_keeps_global_first_then_session_order(self, temp_db):
         beam = BeamMemory(session_id="s1", db_path=temp_db)
         now = datetime.now()

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -84,20 +84,20 @@ def test_dense_predicate_version_bump_invalidates_old_entries(
     created under the pre-change algorithm version (4, upstream literal-flag
     schema without our dense predicate) must never be reused — it could
     still contain dialog, honcho or consolidated dense candidates. The
-    version bump (4 -> 5) lives inside the hashed payload; the ``v2:`` key
+    version bump (5 -> 6) lives inside the hashed payload; the ``v2:`` key
     prefix stays fixed."""
     memory, calls = enhanced
-    assert memory._ENHANCED_RECALL_CACHE_VERSION >= 5
+    assert memory._ENHANCED_RECALL_CACHE_VERSION >= 6
 
     # Warm the cache under the OLD algorithm version so it holds a
     # pre-predicate ranked result, keyed through the real request path.
     with monkeypatch.context() as ctx:
-        ctx.setattr(type(memory), "_ENHANCED_RECALL_CACHE_VERSION", 4)
+        ctx.setattr(type(memory), "_ENHANCED_RECALL_CACHE_VERSION", 5)
         stale = _call(memory, "alpha query")
     assert len(calls) == 1
     stale_id = stale[0]["id"]
 
-    # The current-version digest differs from the stale v4 key: cache miss.
+    # The current-version digest differs from the stale v5 key: cache miss.
     fresh = _call(memory, "alpha query")
     assert len(calls) == 2  # base recall ran; the stale entry was not reused
     assert not any(r.get("id") == stale_id for r in fresh)

--- a/tests/test_telemetry_and_env_followups.py
+++ b/tests/test_telemetry_and_env_followups.py
@@ -20,12 +20,10 @@ Three small fidelity fixes surfaced by the /review army on PRs #89 and
 from __future__ import annotations
 
 import logging
-import os
 import sys
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
-from typing import List
 from unittest.mock import MagicMock
 
 import pytest
@@ -133,20 +131,15 @@ class TestC30ExtendedToEntityFactPaths:
         from pathlib import Path
         import mnemosyne.core.beam as beam_module
         src = Path(beam_module.__file__).read_text()
-        # Count remaining wrong-pattern sites that target ep rows.
-        # The two valid `wm_vec_sims.get` lines (`tier: "working"` at
-        # ~2238 and ~2359) should remain; the two ep-tier sites we
-        # fixed should be gone.
+        # Count the remaining working fact-append use. The production diff
+        # removed the former entity-only append path, so there is no episodic
+        # occurrence to guard here.
         wrong_pattern_count = src.count(
             'dense_score": round(wm_vec_sims.get(row["id"], 0.0), 4)'
         )
-        # Only the two `tier: "working"` sites should match the old pattern.
-        # If a future change adds a new `tier: "episodic"` site with the
-        # wrong pattern, this count rises and the test fails.
-        assert wrong_pattern_count == 2, (
-            f"Expected exactly 2 `wm_vec_sims.get(row[id], 0.0)` sites "
-            f"(both `tier: working`); found {wrong_pattern_count}. A new "
-            f"episodic site may have reintroduced the C30 bug pattern."
+        assert wrong_pattern_count == 1, (
+            f"Expected exactly 1 `wm_vec_sims.get(row[id], 0.0)` site "
+            f"(the working fact-append path); found {wrong_pattern_count}."
         )
 
 


### PR DESCRIPTION
## Bug Description

`recall()` appended entity-annotated memories that were absent from the normal lexical/dense candidate set. Those rows received a synthetic importance/recency score despite having no query-fit evidence and could displace topical results when `top_k` was limited.

Fixes #891

## Root Cause

The entity-aware stage treated entity annotations as a second candidate source, not solely as a signal for already selected query candidates.

## Fix

- Keep the existing entity marker and bounded 1.3× boost for working-memory candidates already returned by normal recall.
- Stop appending entity-only working or episodic rows.
- Add public `BeamMemory.recall(..., top_k=1)` regressions for both stores: a lexical Atlas result must remain ahead of an entity-only, higher-importance distractor.

## Why this path

This is the smallest reversible mitigation for the verified precision failure. It preserves current entity annotations and candidate boosts without changing extraction, fuzzy matching, schemas, stored data, or fact recall.

## Why not extract entities from the query first

The issue measurements show the current mention vocabulary is too noisy and high-breadth for that broader redesign to be safe. Extraction and mention hygiene remain separate follow-ups.

## How to Verify

1. Run `uv run --extra test pytest -q tests/test_beam.py::TestWorkingMemory::test_entity_annotations_only_boost_existing_recall_candidates tests/test_beam.py::TestWorkingMemory::test_entity_annotations_do_not_append_episodic_only_candidates`.
2. Confirm each public `recall("Atlas", top_k=1)` result contains only the lexical Atlas memory rather than the entity-only distractor.

## Test Plan

- [x] Added working-memory public recall regression
- [x] Added episodic-memory public recall regression
- [x] `uv run --extra test pytest -q tests/test_beam.py tests/test_entity_integration.py tests/test_temporal_recall.py tests/test_c4_recall_diagnostics.py` — 171 passed, 13 skipped, 3 subtests passed
- [x] `uv run --with ruff ruff check mnemosyne/core/beam.py tests/test_beam.py`
- [x] `git diff --check`

## Risk Assessment

Low — the change removes only annotation-only candidate injection. It does not mutate persisted data or alter the normal candidate generators, extraction, matching, or fact recall.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- `BeamMemory.recall()` no longer injects entity-only working-memory or episodic rows.
- Entity matches boost only candidates selected by lexical or dense recall.
- Existing entity markers and the bounded `1.3×` boost remain unchanged.
- Regression tests protect query-relevant results when `top_k` is limited.
- The enhanced-recall cache version increases from 5 to 6.

## Architectural impact

The change preserves tiered working-memory and episodic-memory retrieval. It does not change BEAM schemas, entity extraction, fuzzy matching, fact recall, consolidation, veracity, or sync behavior.

This is the right call for retrieval quality. Entity annotations now provide ranking evidence for query-selected candidates. They no longer act as an independent retrieval source with synthetic scores.

The cache version bump invalidates stale entries after the retrieval change.

## Privacy and integration impact

The PR adds no data collection, external service, or network behavior. It preserves Mnemosyne’s local-first and privacy posture.

Hermes, MCP, and CLI surfaces remain unchanged. The PR adds no agent-facing schema changes or stored-data migration.

## Maintainability and validation

The PR removes the harmful candidate-injection path and simplifies entity-aware recall. Tests cover working-memory and episodic-memory behavior, including episodic fallback score correctness.

The test updates also preserve environment parsing and veracity-weight override behavior. They do not change the veracity system.

The linked measurements support this design. Boost-only behavior preserved observed top-k results, while appended entity candidates displaced topical matches. The PR adds no new benchmark methodology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->