### PR TITLE
fix: preserve day-first English named dates

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -5384,7 +5384,7 @@ class BeamMemory:
                 r')'
                 r'\s+([^.,;!?\n]{10,200})',
             'event_keywords': ['meeting', 'call', 'scheduled', 'happened', 'occurred', 'plan to', 'will be on', 'due on', 'release', 'deadline', 'launched', 'deployed', 'released', 'published', 'posted', 'started', 'began', 'finished', 'completed', 'ended', 'event', 'conference', 'workshop', 'appointment'],
-            'named_months': r'((?:\d{1,2}(?:st|nd|rd|th)?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*,?\s*(?:\d{4})?|(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{1,2}(?:st|nd|rd|th)?,?\s*(?:\d{4})?))',
+            'named_months': r'((?:(?<!\d)\d{1,2}(?:st|nd|rd|th)?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b,?\s*(?:\d{4})?|\b(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b\s+\d{1,2}(?:st|nd|rd|th)?(?!\d),?\s*(?:\d{4})?))',
         },
         'de': {
             'negation': r'(Ich(?: habe|\'ve)?\s+(?:nie|niemals|nicht)\s+[^.,;!?\n]{15,120})',

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -5384,7 +5384,7 @@ class BeamMemory:
                 r')'
                 r'\s+([^.,;!?\n]{10,200})',
             'event_keywords': ['meeting', 'call', 'scheduled', 'happened', 'occurred', 'plan to', 'will be on', 'due on', 'release', 'deadline', 'launched', 'deployed', 'released', 'published', 'posted', 'started', 'began', 'finished', 'completed', 'ended', 'event', 'conference', 'workshop', 'appointment'],
-            'named_months': r'((?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{1,2}(?:st|nd|rd|th)?,?\s*(?:\d{4})?)',
+            'named_months': r'((?:\d{1,2}(?:st|nd|rd|th)?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*,?\s*(?:\d{4})?|(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{1,2}(?:st|nd|rd|th)?,?\s*(?:\d{4})?))',
         },
         'de': {
             'negation': r'(Ich(?: habe|\'ve)?\s+(?:nie|niemals|nicht)\s+[^.,;!?\n]{15,120})',

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -5384,7 +5384,7 @@ class BeamMemory:
                 r')'
                 r'\s+([^.,;!?\n]{10,200})',
             'event_keywords': ['meeting', 'call', 'scheduled', 'happened', 'occurred', 'plan to', 'will be on', 'due on', 'release', 'deadline', 'launched', 'deployed', 'released', 'published', 'posted', 'started', 'began', 'finished', 'completed', 'ended', 'event', 'conference', 'workshop', 'appointment'],
-            'named_months': r'((?:(?<!\w)\d{1,2}(?:st|nd|rd|th)?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b(?:,?\s*\d{4}(?!\w)|,?(?!\s*\d)(?!\w))|(?<!\w)(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b\s+\d{1,2}(?:st|nd|rd|th)?(?:,?\s*\d{4}(?!\w)|,?(?!\s*\d)(?!\w))))',
+            'named_months': r'((?:(?<!\w)\d{1,2}(?:st|nd|rd|th)?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b(?:(?:,\s*|\s+)\d{4}(?!\w)|(?!,?\s*\d)(?!\w))|(?<!\w)(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b\s+\d{1,2}(?:st|nd|rd|th)?(?:(?:,\s*|\s+)\d{4}(?!\w)|(?!,?\s*\d)(?!\w))))',
         },
         'de': {
             'negation': r'(Ich(?: habe|\'ve)?\s+(?:nie|niemals|nicht)\s+[^.,;!?\n]{15,120})',

--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -5384,7 +5384,7 @@ class BeamMemory:
                 r')'
                 r'\s+([^.,;!?\n]{10,200})',
             'event_keywords': ['meeting', 'call', 'scheduled', 'happened', 'occurred', 'plan to', 'will be on', 'due on', 'release', 'deadline', 'launched', 'deployed', 'released', 'published', 'posted', 'started', 'began', 'finished', 'completed', 'ended', 'event', 'conference', 'workshop', 'appointment'],
-            'named_months': r'((?:(?<!\d)\d{1,2}(?:st|nd|rd|th)?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b,?\s*(?:\d{4})?|\b(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b\s+\d{1,2}(?:st|nd|rd|th)?(?!\d),?\s*(?:\d{4})?))',
+            'named_months': r'((?:(?<!\w)\d{1,2}(?:st|nd|rd|th)?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b(?:,?\s*\d{4}(?!\w)|,?(?!\s*\d)(?!\w))|(?<!\w)(?:January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b\s+\d{1,2}(?:st|nd|rd|th)?(?:,?\s*\d{4}(?!\w)|,?(?!\s*\d)(?!\w))))',
         },
         'de': {
             'negation': r'(Ich(?: habe|\'ve)?\s+(?:nie|niemals|nicht)\s+[^.,;!?\n]{15,120})',

--- a/tests/test_issue_907_day_first_dates.py
+++ b/tests/test_issue_907_day_first_dates.py
@@ -41,7 +41,16 @@ def test_remember_extracts_complete_english_named_date(
     assert values == [expected_value]
 
 
-@pytest.mark.parametrize("invalid_date_text", ["12 marching", "312 March 2024"])
+@pytest.mark.parametrize(
+    "invalid_date_text",
+    [
+        "12 marching",
+        "312 March 2024",
+        "x12 March 2024",
+        "March 12x",
+        "12 March 2024x",
+    ],
+)
 def test_remember_does_not_extract_named_date_from_invalid_boundary(
     tmp_path, invalid_date_text
 ):

--- a/tests/test_issue_907_day_first_dates.py
+++ b/tests/test_issue_907_day_first_dates.py
@@ -10,6 +10,9 @@ from mnemosyne.core.memory import Mnemosyne
 @pytest.mark.parametrize(
     ("date_text", "expected_value"),
     [
+        ("March 29, 2024", "March 29, 2024"),
+        ("March 29 2024", "March 29 2024"),
+        ("12 Mar 2024", "12 Mar 2024"),
         ("March 12, 1985", "March 12, 1985"),
         ("12 March 1985", "12 March 1985"),
         ("21st February 1999", "21st February 1999"),
@@ -48,6 +51,10 @@ def test_remember_extracts_complete_english_named_date(
         "312 March 2024",
         "x12 March 2024",
         "March 12x",
+        "xMarch 12, 1985",
+        "March 12, 1985x",
+        "March 292024",
+        "12 March 292024",
         "12 March 2024x",
     ],
 )

--- a/tests/test_issue_907_day_first_dates.py
+++ b/tests/test_issue_907_day_first_dates.py
@@ -39,3 +39,29 @@ def test_remember_extracts_complete_english_named_date(
         ]
 
     assert values == [expected_value]
+
+
+@pytest.mark.parametrize("invalid_date_text", ["12 marching", "312 March 2024"])
+def test_remember_does_not_extract_named_date_from_invalid_boundary(
+    tmp_path, invalid_date_text
+):
+    """The public remember path rejects partial named-date matches."""
+    db_path = tmp_path / "mnemosyne.db"
+    memory = Mnemosyne(session_id="issue-907", db_path=db_path)
+    try:
+        memory.remember(
+            f"The event happened on {invalid_date_text}.", source="user", extract=True
+        )
+    finally:
+        memory.conn.close()
+
+    with sqlite3.connect(db_path) as conn:
+        values = [
+            row[0]
+            for row in conn.execute(
+                "SELECT value FROM memoria_facts WHERE fact_type = 'date' "
+                "AND key = 'named_date'"
+            )
+        ]
+
+    assert values == []

--- a/tests/test_issue_907_day_first_dates.py
+++ b/tests/test_issue_907_day_first_dates.py
@@ -1,0 +1,41 @@
+"""Regression coverage for English day-first named dates (#907)."""
+
+import sqlite3
+
+import pytest
+
+from mnemosyne.core.memory import Mnemosyne
+
+
+@pytest.mark.parametrize(
+    ("date_text", "expected_value"),
+    [
+        ("March 12, 1985", "March 12, 1985"),
+        ("12 March 1985", "12 March 1985"),
+        ("21st February 1999", "21st February 1999"),
+        ("30 Dec 2018", "30 Dec 2018"),
+    ],
+)
+def test_remember_extracts_complete_english_named_date(
+    tmp_path, date_text, expected_value
+):
+    """The public remember path preserves either English named-date order."""
+    db_path = tmp_path / "mnemosyne.db"
+    memory = Mnemosyne(session_id="issue-907", db_path=db_path)
+    try:
+        memory.remember(
+            f"The event happened on {date_text}.", source="user", extract=True
+        )
+    finally:
+        memory.conn.close()
+
+    with sqlite3.connect(db_path) as conn:
+        values = [
+            row[0]
+            for row in conn.execute(
+                "SELECT value FROM memoria_facts WHERE fact_type = 'date' "
+                "AND key = 'named_date'"
+            )
+        ]
+
+    assert values == [expected_value]


### PR DESCRIPTION
## Summary
- preserve full English named dates written day-first, including ordinals and abbreviated months
- keep existing month-first extraction intact
- require complete date tokens to avoid partial matches inside larger words or alphanumeric strings

## Scope
- English `named_months` extraction only
- no historical-data backfill or date normalization

## Verification
- `uv run --no-sync pytest -q tests/test_memoria_instruction_boundaries.py tests/test_version_regex_backtracking.py tests/test_issue_907_day_first_dates.py`
- 41 passed

Fixes #907


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes English `named_months` extraction for complete day-first dates.
- Supports abbreviated months and ordinal day suffixes.
- Preserves month-first extraction.
- Prevents partial matches in larger words and alphanumeric strings.
- Adds public-path regression tests.

## Architecture impact

- Limits the change to the BEAM date-extraction pattern.
- Does not change working, episodic, or tiered-memory behavior.
- Does not change retrieval, consolidation, veracity, sync, or benchmark methodology.
- Does not change Hermes, MCP, CLI, or other agent integration surfaces.
- Preserves local-first processing and introduces no new data flow or privacy risk.
- Improves maintainability through a focused regex fix and regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->