### PR TITLE
fix: invalidate enhanced recall cache for staged FTS

### DIFF
--- a/mnemosyne/core/beam.py
+++ b/mnemosyne/core/beam.py
@@ -8332,11 +8332,11 @@ class BeamMemory:
 
         return final_results
 
-    # Bump whenever the enhanced-recall ranking algorithm changes so entries
-    # cached under an older digest are not reused. Part of the hashed payload;
-    # the opaque key keeps the "v2:" prefix because QueryCache's opaque-path
-    # recognition (_OPAQUE_V2_KEY_RE) keys off that prefix.
-    _ENHANCED_RECALL_CACHE_VERSION = 6
+    # Bump whenever the enhanced-recall candidate or ranking algorithm changes
+    # so entries cached under an older digest are not reused. Part of the
+    # hashed payload; the opaque key keeps the "v2:" prefix because QueryCache's
+    # opaque-path recognition (_OPAQUE_V2_KEY_RE) keys off that prefix.
+    _ENHANCED_RECALL_CACHE_VERSION = 7
 
     def _enhanced_recall_cache_key(
         self,
@@ -8466,12 +8466,11 @@ class BeamMemory:
             },
         }
         material = json.dumps(canonicalize(payload), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-        # The default dense candidate predicate changed (dialog / honcho /
-        # consolidated exclusion, #696 / #427), so pre-change opaque cache
-        # entries could still contain dialog, honcho or consolidated dense
-        # candidates. _ENHANCED_RECALL_CACHE_VERSION is part of the hashed
-        # payload; bumping it guarantees those entries are never
-        # reused. The "v2:" prefix stays fixed — QueryCache's opaque-path
+        # Staged FTS candidate membership/order changed (#896), so pre-change
+        # opaque cache entries can contain candidates the current pipeline
+        # would not select. _ENHANCED_RECALL_CACHE_VERSION is part of the
+        # hashed payload; bumping it guarantees those entries are never reused.
+        # The "v2:" prefix stays fixed because QueryCache's opaque-path
         # recognition keys off that exact prefix.
         return "v2:" + hashlib.sha256(material.encode("utf-8")).hexdigest()
 

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -99,6 +99,13 @@ def test_staged_fts_candidate_version_bump_invalidates_old_entries(
     fresh = _call(memory, "alpha query")
     assert len(calls) == 2  # base recall ran; the stale entry was not reused
     assert not any(r.get("id") == stale_id for r in fresh)
+    assert memory._query_cache is not None
+    cache_keys = [
+        row[0]
+        for row in memory._query_cache._conn.execute("SELECT normalized FROM query_cache")
+    ]
+    assert len(cache_keys) == 2
+    assert all(key.startswith("v2:") for key in cache_keys)
 
     # The current-version entry is now cached and reused.
     again = _call(memory, "alpha query")

--- a/tests/test_enhanced_recall_cache.py
+++ b/tests/test_enhanced_recall_cache.py
@@ -76,23 +76,21 @@ def _close_memory(memory: BeamMemory | None) -> None:
         memory.conn.close()
 
 
-def test_dense_predicate_version_bump_invalidates_old_entries(
+def test_staged_fts_candidate_version_bump_invalidates_old_entries(
     enhanced, monkeypatch, tmp_path: Path
 ):
-    """#696/#427 regression: the default dense candidate predicate changed
-    (dialog / honcho / consolidated exclusion), so an opaque cache entry
-    created under the pre-change algorithm version (4, upstream literal-flag
-    schema without our dense predicate) must never be reused — it could
-    still contain dialog, honcho or consolidated dense candidates. The
-    version bump (5 -> 6) lives inside the hashed payload; the ``v2:`` key
-    prefix stays fixed."""
-    memory, calls = enhanced
-    assert memory._ENHANCED_RECALL_CACHE_VERSION >= 6
+    """#896 regression: staged FTS candidate membership/order changed.
 
-    # Warm the cache under the OLD algorithm version so it holds a
-    # pre-predicate ranked result, keyed through the real request path.
+    An opaque entry made under version 6 can contain the old candidate set, so
+    version 7 must produce a distinct digest and execute the updated pipeline.
+    The ``v2:`` key prefix remains fixed for QueryCache's opaque-key path.
+    """
+    memory, calls = enhanced
+    assert memory._ENHANCED_RECALL_CACHE_VERSION == 7
+
+    # Warm the persistent cache under the old candidate-selection version.
     with monkeypatch.context() as ctx:
-        ctx.setattr(type(memory), "_ENHANCED_RECALL_CACHE_VERSION", 5)
+        ctx.setattr(type(memory), "_ENHANCED_RECALL_CACHE_VERSION", 6)
         stale = _call(memory, "alpha query")
     assert len(calls) == 1
     stale_id = stale[0]["id"]


### PR DESCRIPTION
## Summary
- bump the enhanced-recall cache version from 6 to 7
- invalidate persistent opaque entries created before the staged FTS candidate membership/order change in #896
- cover the real cache path with a focused regression

## Why not
This is intentionally separate from #918. The stale-cache behavior was introduced on `main` by #896 and does not belong to the self-echo change.

## Verification
- `uv run --extra test pytest -q tests/test_enhanced_recall_cache.py`
- `uv run --extra dev ruff check --select F,RUF022 -- mnemosyne/core/beam.py tests/test_enhanced_recall_cache.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Bumps the enhanced-recall cache version from 6 to 7.
- Prevents reuse of opaque cache entries created before the staged FTS candidate membership and ordering change.
- Adds regression coverage for stale-entry rejection, new-entry reuse, cache-key prefixes, and persisted cache entries.

## Architectural impact

- Preserves BEAM enhanced-recall correctness without changing retrieval logic.
- Does not change working, episodic, or tiered memory behavior.
- Does not change consolidation, veracity, sync, Hermes, MCP, or CLI integration surfaces.
- Preserves the local-first design because cache invalidation remains local and persistent.
- Does not change the privacy posture or benchmark methodology.
- Improves maintainability by documenting the invalidation reason and testing the cache version boundary.

This is the right call because it isolates cache invalidation from unrelated self-echo work and prevents stale retrieval results after the staged FTS change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->